### PR TITLE
feat: pedido fornecedor — cadastro de produtos junto com gasto

### DIFF
--- a/app/admin/gastos/page.tsx
+++ b/app/admin/gastos/page.tsx
@@ -5,6 +5,8 @@ import { useAdmin } from "@/components/admin/AdminShell";
 import { CATEGORIAS_GASTO } from "@/lib/admin-types";
 import { useTabParam } from "@/lib/useTabParam";
 import type { Gasto, Banco } from "@/lib/admin-types";
+import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
+import { STRUCTURED_CATS, buildProdutoName } from "@/lib/produto-specs";
 
 const BANCOS: Banco[] = ["ITAU", "INFINITE", "MERCADO_PAGO", "ESPECIE"];
 const fmt = (v: number) => `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
@@ -12,10 +14,10 @@ const fmt = (v: number) => `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
 type BancoValores = Record<Banco, string>;
 const emptyBancoValores = (): BancoValores => ({ ITAU: "", INFINITE: "", MERCADO_PAGO: "", ESPECIE: "" });
 
-/** Agrupa gastos por grupo_id. Gastos sem grupo ficam sozinhos. */
 interface GastoGrupo {
-  key: string; // grupo_id ou id do gasto avulso
+  key: string;
   grupo_id: string | null;
+  pedido_fornecedor_id: string | null;
   items: Gasto[];
   totalValor: number;
   data: string;
@@ -48,6 +50,7 @@ function agruparGastos(gastos: Gasto[]): GastoGrupo[] {
     result.push({
       key: grupoId,
       grupo_id: grupoId,
+      pedido_fornecedor_id: first.pedido_fornecedor_id || null,
       items,
       totalValor: items.reduce((s, i) => s + Number(i.valor), 0),
       data: first.data,
@@ -64,6 +67,7 @@ function agruparGastos(gastos: Gasto[]): GastoGrupo[] {
     result.push({
       key: g.id,
       grupo_id: null,
+      pedido_fornecedor_id: g.pedido_fornecedor_id || null,
       items: [g],
       totalValor: Number(g.valor),
       data: g.data,
@@ -80,6 +84,56 @@ function agruparGastos(gastos: Gasto[]): GastoGrupo[] {
   return result;
 }
 
+// Componente para mostrar produtos vinculados no histórico
+function ProdutosVinculados({ pedidoFornecedorId, password, dm }: { pedidoFornecedorId: string; password: string; dm: boolean }) {
+  const [produtos, setProdutos] = useState<{ id: string; produto: string; cor: string; qnt: number; custo_unitario: number; status: string; fornecedor: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch(`/api/estoque?pedido_fornecedor_id=${pedidoFornecedorId}`, {
+          headers: { "x-admin-password": password },
+        });
+        if (res.ok) {
+          const json = await res.json();
+          setProdutos(json.data ?? []);
+        }
+      } catch { /* ignore */ }
+      setLoading(false);
+    })();
+  }, [pedidoFornecedorId, password]);
+
+  if (loading) return <p className={`text-xs ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Carregando produtos...</p>;
+  if (produtos.length === 0) return null;
+
+  return (
+    <div className="col-span-2 md:col-span-3 mt-2">
+      <p className={`text-xs font-semibold uppercase tracking-wider mb-2 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
+        Produtos do pedido ({produtos.length})
+      </p>
+      <div className="space-y-1.5">
+        {produtos.map((p) => (
+          <div key={p.id} className={`flex items-center justify-between px-3 py-2 rounded-lg text-xs ${dm ? "bg-[#3A3A3C]" : "bg-[#F0F0F5]"}`}>
+            <div className="flex items-center gap-2 flex-1 min-w-0">
+              <span className={`inline-block px-2 py-0.5 rounded text-[10px] font-bold ${p.status === "A CAMINHO" ? "bg-yellow-100 text-yellow-700" : "bg-green-100 text-green-700"}`}>
+                {p.status}
+              </span>
+              <span className={`font-medium truncate ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>
+                {p.produto}{p.cor ? ` — ${p.cor}` : ""}
+              </span>
+            </div>
+            <div className="flex items-center gap-3 shrink-0">
+              <span className={dm ? "text-[#98989D]" : "text-[#86868B]"}>x{p.qnt}</span>
+              <span className="font-bold text-[#E8740E]">{fmt(p.custo_unitario)}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function GastosPage() {
   const { password, user, darkMode: dm } = useAdmin();
   const [gastos, setGastos] = useState<Gasto[]>([]);
@@ -92,6 +146,9 @@ export default function GastosPage() {
   const [editSaving, setEditSaving] = useState(false);
   const [viewingKey, setViewingKey] = useState<string | null>(null);
 
+  // Fornecedores
+  const [fornecedores, setFornecedores] = useState<{ id: string; nome: string }[]>([]);
+
   // Form state
   const [form, setForm] = useState({
     data: new Date().toISOString().split("T")[0],
@@ -102,6 +159,9 @@ export default function GastosPage() {
     is_dep_esp: false,
   });
   const [bancoValores, setBancoValores] = useState<BancoValores>(emptyBancoValores());
+
+  // Produtos do pedido fornecedor
+  const [pedidoProdutos, setPedidoProdutos] = useState<ProdutoRowState[]>([]);
 
   // Edit form state
   const [editForm, setEditForm] = useState({
@@ -128,12 +188,28 @@ export default function GastosPage() {
     setLoading(false);
   }, [password]);
 
+  // Buscar fornecedores
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("/api/fornecedores", { headers: { "x-admin-password": password } });
+        if (res.ok) {
+          const json = await res.json();
+          setFornecedores(json.data ?? []);
+        }
+      } catch { /* ignore */ }
+    })();
+  }, [password]);
+
   useEffect(() => { fetchGastos(); }, [fetchGastos]);
 
   const set = (field: string, value: string | boolean) => setForm((f) => ({ ...f, [field]: value }));
   const setBanco = (banco: Banco, value: string) => setBancoValores((bv) => ({ ...bv, [banco]: value }));
 
   const totalForm = BANCOS.reduce((s, b) => s + (parseFloat(bancoValores[b]) || 0), 0);
+  const totalProdutos = pedidoProdutos.reduce((s, p) => s + (parseFloat(p.custo_unitario) || 0) * (parseInt(p.qnt) || 0), 0);
+
+  const isFornecedor = form.categoria === "FORNECEDOR";
 
   const handleSubmit = async () => {
     const filled = BANCOS.filter((b) => parseFloat(bancoValores[b]) > 0);
@@ -158,19 +234,39 @@ export default function GastosPage() {
       is_dep_esp: form.is_dep_esp,
     };
 
-    let payload;
+    // Montar gastos (single ou multi-banco)
+    let gastoItems;
     if (filled.length === 1) {
-      // Gasto simples — sem grupo
-      payload = { ...base, valor: parseFloat(bancoValores[filled[0]]), banco: filled[0] };
+      gastoItems = { ...base, valor: parseFloat(bancoValores[filled[0]]), banco: filled[0] };
     } else {
-      // Gasto dividido — com grupo_id
       const grupoId = crypto.randomUUID();
-      payload = filled.map((b) => ({
+      gastoItems = filled.map((b) => ({
         ...base,
         valor: parseFloat(bancoValores[b]),
         banco: b,
         grupo_id: grupoId,
       }));
+    }
+
+    // Se tem produtos de fornecedor, enviar no formato especial
+    let payload;
+    if (isFornecedor && pedidoProdutos.length > 0) {
+      const produtos = pedidoProdutos.map((p) => {
+        const nome = p.produto || (STRUCTURED_CATS.includes(p.categoria) ? buildProdutoName(p.categoria, p.spec) : "");
+        return {
+          produto: nome,
+          categoria: p.categoria,
+          qnt: parseInt(p.qnt) || 1,
+          custo_unitario: parseFloat(p.custo_unitario) || 0,
+          cor: p.cor || null,
+          fornecedor: p.fornecedor || null,
+          imei: p.imei || null,
+          serial_no: p.serial_no || null,
+        };
+      });
+      payload = { gastos: gastoItems, produtos };
+    } else {
+      payload = gastoItems;
     }
 
     const res = await fetch("/api/gastos", {
@@ -180,9 +276,13 @@ export default function GastosPage() {
     });
     const json = await res.json();
     if (json.ok) {
-      setMsg("Gasto registrado!");
+      const prodMsg = isFornecedor && pedidoProdutos.length > 0
+        ? ` + ${pedidoProdutos.length} produto(s) adicionados como A Caminho`
+        : "";
+      setMsg(`Gasto registrado!${prodMsg}`);
       setForm((f) => ({ ...f, descricao: "", observacao: "", is_dep_esp: false, horario: new Date().toTimeString().slice(0, 5) }));
       setBancoValores(emptyBancoValores());
+      setPedidoProdutos([]);
       fetchGastos();
     } else {
       setMsg("Erro: " + json.error);
@@ -234,9 +334,7 @@ export default function GastosPage() {
     let payload;
 
     if (grupo.grupo_id) {
-      // Era grupo — editar como grupo (deletar antigos + inserir novos)
       if (filled.length === 1) {
-        // Reduziu para 1 banco — sem grupo_id
         payload = {
           grupo_id: grupo.grupo_id,
           items: [{ ...base, valor: parseFloat(editBancoValores[filled[0]]), banco: filled[0] }],
@@ -254,9 +352,7 @@ export default function GastosPage() {
         };
       }
     } else {
-      // Era avulso
       if (filled.length === 1) {
-        // Continua avulso — PATCH simples
         payload = {
           id: grupo.items[0].id,
           ...base,
@@ -264,14 +360,11 @@ export default function GastosPage() {
           banco: filled[0],
         };
       } else {
-        // Virou grupo — deletar o avulso e criar novos com grupo_id
-        // Primeiro deletar o antigo
         await fetch("/api/gastos", {
           method: "DELETE",
           headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": user?.nome || "sistema" },
           body: JSON.stringify({ id: grupo.items[0].id }),
         });
-        // Depois criar novos
         const novoGrupoId = crypto.randomUUID();
         const items = filled.map((b) => ({
           ...base,
@@ -312,8 +405,17 @@ export default function GastosPage() {
   };
 
   const handleDelete = async (g: GastoGrupo) => {
-    if (!confirm("Excluir este gasto?")) return;
-    const body = g.grupo_id ? { grupo_id: g.grupo_id } : { id: g.items[0].id };
+    const hasProdutos = !!g.pedido_fornecedor_id;
+    const confirmMsg = hasProdutos
+      ? "Excluir este gasto e os produtos A CAMINHO vinculados?"
+      : "Excluir este gasto?";
+    if (!confirm(confirmMsg)) return;
+
+    const body: Record<string, string> = {};
+    if (g.grupo_id) body.grupo_id = g.grupo_id;
+    else body.id = g.items[0].id;
+    if (g.pedido_fornecedor_id) body.pedido_fornecedor_id = g.pedido_fornecedor_id;
+
     await fetch("/api/gastos", {
       method: "DELETE",
       headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": user?.nome || "sistema" },
@@ -325,7 +427,6 @@ export default function GastosPage() {
   const inputCls = `w-full px-3 py-2 rounded-xl border text-sm focus:outline-none focus:border-[#E8740E] transition-colors ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-[#F5F5F7] border-[#D2D2D7] text-[#1D1D1F]"}`;
   const labelCls = `text-xs font-semibold uppercase tracking-wider mb-1 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`;
 
-  // Totais
   const totalSaida = gastos.reduce((s, g) => s + Number(g.valor), 0);
 
   const BancoInputGrid = ({ valores, onChange, cls }: { valores: BancoValores; onChange: (b: Banco, v: string) => void; cls: string }) => (
@@ -333,13 +434,7 @@ export default function GastosPage() {
       {BANCOS.map((b) => (
         <div key={b}>
           <p className={labelCls}>{b.replace("_", " ")}</p>
-          <input
-            type="number"
-            placeholder="0"
-            value={valores[b]}
-            onChange={(e) => onChange(b, e.target.value)}
-            className={cls}
-          />
+          <input type="number" placeholder="0" value={valores[b]} onChange={(e) => onChange(b, e.target.value)} className={cls} />
         </div>
       ))}
     </div>
@@ -357,7 +452,7 @@ export default function GastosPage() {
 
       {tab === "novo" ? (
         <div className={`${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-white border-[#D2D2D7]"} border rounded-2xl p-6 shadow-sm space-y-6`}>
-          <h2 className="text-lg font-bold text-[#1D1D1F]">Registrar Saída</h2>
+          <h2 className={`text-lg font-bold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>Registrar Saída</h2>
 
           {msg && <div className={`px-4 py-3 rounded-xl text-sm ${msg.includes("Erro") ? "bg-red-50 text-red-700" : "bg-green-50 text-green-700"}`}>{msg}</div>}
 
@@ -388,18 +483,63 @@ export default function GastosPage() {
             </p>
           </div>
 
+          {/* Seção de produtos do pedido — só aparece para FORNECEDOR */}
+          {isFornecedor && (
+            <div className={`p-4 rounded-xl border-2 border-dashed ${dm ? "border-[#E8740E]/40 bg-[#E8740E]/5" : "border-[#E8740E]/30 bg-[#FFF8F0]"} space-y-4`}>
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className={`text-sm font-bold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>Produtos do Pedido</p>
+                  <p className={`text-xs ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
+                    Cadastre os produtos comprados. Eles entram no estoque como &quot;A Caminho&quot;.
+                  </p>
+                </div>
+                {pedidoProdutos.length > 0 && totalProdutos > 0 && (
+                  <div className="text-right">
+                    <p className={`text-[10px] ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Custo total produtos</p>
+                    <p className="text-sm font-bold text-[#E8740E]">{fmt(totalProdutos)}</p>
+                  </div>
+                )}
+              </div>
+
+              {pedidoProdutos.map((row, i) => (
+                <ProdutoSpecFields
+                  key={i}
+                  row={row}
+                  onChange={(updated) => {
+                    const next = [...pedidoProdutos];
+                    next[i] = updated;
+                    setPedidoProdutos(next);
+                  }}
+                  onRemove={() => setPedidoProdutos(pedidoProdutos.filter((_, j) => j !== i))}
+                  fornecedores={fornecedores}
+                  inputCls={inputCls}
+                  labelCls={labelCls}
+                  darkMode={dm}
+                  index={i}
+                />
+              ))}
+
+              <button
+                type="button"
+                onClick={() => setPedidoProdutos([...pedidoProdutos, createEmptyProdutoRow()])}
+                className={`w-full py-3 rounded-xl border-2 border-dashed font-semibold text-sm transition-colors ${dm ? "border-[#3A3A3C] text-[#98989D] hover:border-[#E8740E] hover:text-[#E8740E]" : "border-[#D2D2D7] text-[#86868B] hover:border-[#E8740E] hover:text-[#E8740E]"}`}
+              >
+                + Adicionar Produto
+              </button>
+            </div>
+          )}
+
           <label className="flex items-center gap-2 text-sm text-[#86868B]">
             <input type="checkbox" checked={form.is_dep_esp} onChange={(e) => set("is_dep_esp", e.target.checked)} className="accent-[#E8740E]" />
             Deposito de especie (sai do caixa, entra no banco)
           </label>
 
           <button onClick={handleSubmit} disabled={saving} className="w-full py-3 rounded-xl bg-[#E8740E] text-white font-semibold hover:bg-[#F5A623] transition-colors disabled:opacity-50">
-            {saving ? "Salvando..." : "Registrar"}
+            {saving ? "Salvando..." : isFornecedor && pedidoProdutos.length > 0 ? `Registrar Gasto + ${pedidoProdutos.length} Produto(s)` : "Registrar"}
           </button>
         </div>
       ) : (
         <div className="space-y-4">
-          {/* Total Saidas */}
           <div className={`${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-white border-[#D2D2D7]"} border rounded-2xl p-4 shadow-sm inline-block`}>
             <p className="text-xs text-[#86868B]">Total Saidas</p>
             <p className="text-xl font-bold text-red-500">{fmt(totalSaida)}</p>
@@ -430,7 +570,14 @@ export default function GastosPage() {
                         }}
                       >
                         <td className="px-4 py-3 text-xs text-[#86868B]">{g.data}</td>
-                        <td className="px-4 py-3 text-xs">{g.categoria}</td>
+                        <td className="px-4 py-3 text-xs">
+                          <span className="flex items-center gap-1">
+                            {g.categoria}
+                            {g.pedido_fornecedor_id && (
+                              <span className="inline-block w-2 h-2 rounded-full bg-blue-500" title="Pedido com produtos" />
+                            )}
+                          </span>
+                        </td>
                         <td className="px-4 py-3 max-w-[200px] truncate">{g.descricao || "—"}</td>
                         <td className="px-4 py-3 font-bold text-red-500">{fmt(g.totalValor)}</td>
                         <td className="px-4 py-3 text-xs">
@@ -517,6 +664,10 @@ export default function GastosPage() {
                                   </span>
                                 </div>
                               )}
+                              {/* Produtos vinculados */}
+                              {g.pedido_fornecedor_id && (
+                                <ProdutosVinculados pedidoFornecedorId={g.pedido_fornecedor_id} password={password} dm={dm} />
+                              )}
                             </div>
                           </td>
                         </tr>
@@ -536,7 +687,6 @@ export default function GastosPage() {
                                 <div><p className={labelCls}>Descricao</p><input value={editForm.descricao} onChange={(e) => editSet("descricao", e.target.value)} className={inputCls} /></div>
                                 <div><p className={labelCls}>Observacao</p><input value={editForm.observacao} onChange={(e) => editSet("observacao", e.target.value)} className={inputCls} /></div>
                               </div>
-                              {/* Distribuição por banco na edição */}
                               <div className={`p-3 rounded-xl border ${dm ? "bg-[#2C2C2E] border-[#3A3A3C]" : "bg-[#FAFAFA] border-[#E8E8ED]"}`}>
                                 <p className={`text-xs font-semibold uppercase tracking-wider mb-2 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Valor por banco</p>
                                 <BancoInputGrid valores={editBancoValores} onChange={editSetBanco} cls={inputCls} />

--- a/app/api/estoque/route.ts
+++ b/app/api/estoque/route.ts
@@ -83,6 +83,18 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Acao nao pode ser desfeita" }, { status: 400 });
   }
 
+  // Buscar por pedido_fornecedor_id (usado pelo histórico de gastos)
+  const pedidoFornecedorId = searchParams.get("pedido_fornecedor_id");
+  if (pedidoFornecedorId) {
+    const { data, error } = await supabase
+      .from("estoque")
+      .select("*")
+      .eq("pedido_fornecedor_id", pedidoFornecedorId)
+      .order("produto");
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ data });
+  }
+
   let query = supabase.from("estoque").select("*").order("categoria").order("produto");
   if (categoria) query = query.eq("categoria", categoria);
 

--- a/app/api/gastos/route.ts
+++ b/app/api/gastos/route.ts
@@ -46,19 +46,77 @@ export async function POST(req: NextRequest) {
 
   const body = await req.json();
 
-  // Suporta array (gasto dividido) ou objeto único (retrocompatível)
-  const items = Array.isArray(body) ? body : [body];
+  // Novo formato: { gastos: [...], produtos: [...] } para pedido fornecedor
+  // Formato antigo: array de gastos ou objeto único (retrocompatível)
+  const hasProdutos = body.gastos && Array.isArray(body.produtos);
+  const gastoItems = hasProdutos
+    ? (Array.isArray(body.gastos) ? body.gastos : [body.gastos])
+    : (Array.isArray(body) ? body : [body]);
 
-  const { data, error } = await supabase.from("gastos").insert(items).select();
+  // Se tem produtos, gerar pedido_fornecedor_id e injetar nos gastos
+  let pedidoFornecedorId: string | null = null;
+  if (hasProdutos && body.produtos.length > 0) {
+    pedidoFornecedorId = crypto.randomUUID();
+    for (const item of gastoItems) {
+      item.pedido_fornecedor_id = pedidoFornecedorId;
+    }
+  }
+
+  // Inserir gastos
+  const { data, error } = await supabase.from("gastos").insert(gastoItems).select();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  const totalValor = items.reduce((s: number, i: { valor?: number }) => s + Number(i.valor || 0), 0);
-  const desc = items[0]?.descricao || "?";
-  const bancos = items.map((i: { banco?: string }) => i.banco).filter(Boolean).join(", ");
+  // Log de atividade do gasto
+  const totalValor = gastoItems.reduce((s: number, i: { valor?: number }) => s + Number(i.valor || 0), 0);
+  const desc = gastoItems[0]?.descricao || "?";
+  const bancos = gastoItems.map((i: { banco?: string }) => i.banco).filter(Boolean).join(", ");
   await logActivity(usuario, "Registrou gasto", `${desc} R$ ${totalValor.toLocaleString("pt-BR")} (${bancos})`, "gastos", data?.[0]?.id);
 
+  // Inserir produtos no estoque (se pedido fornecedor)
+  if (pedidoFornecedorId && hasProdutos && body.produtos.length > 0) {
+    const dataCompra = gastoItems[0]?.data || new Date().toISOString().split("T")[0];
+    const estoqueItems = body.produtos.map((p: {
+      produto: string;
+      categoria: string;
+      qnt: number;
+      custo_unitario: number;
+      cor?: string;
+      fornecedor?: string;
+      imei?: string;
+      serial_no?: string;
+    }) => ({
+      produto: p.produto,
+      categoria: p.categoria,
+      qnt: p.qnt,
+      custo_unitario: p.custo_unitario,
+      cor: p.cor || null,
+      fornecedor: p.fornecedor || null,
+      imei: p.imei || null,
+      serial_no: p.serial_no || null,
+      status: "A CAMINHO",
+      tipo: "A_CAMINHO",
+      data_compra: dataCompra,
+      pedido_fornecedor_id: pedidoFornecedorId,
+    }));
+
+    const { error: estErr } = await supabase.from("estoque").insert(estoqueItems);
+    if (estErr) {
+      // Gasto já foi criado, logar erro mas não falhar
+      console.error("Erro ao inserir produtos no estoque:", estErr.message);
+      return NextResponse.json({ ok: true, data, estoqueError: estErr.message });
+    }
+
+    await logActivity(
+      usuario,
+      "Pedido fornecedor",
+      `${body.produtos.length} produto(s) adicionados como A CAMINHO — ${desc}`,
+      "estoque",
+      pedidoFornecedorId
+    );
+  }
+
   // Recalcular saldos do dia automaticamente
-  const dataISO = items[0]?.data;
+  const dataISO = gastoItems[0]?.data;
   if (dataISO) recalcularSaldoDia(supabase, dataISO).catch(() => {});
 
   return NextResponse.json({ ok: true, data });
@@ -109,7 +167,16 @@ export async function PATCH(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { id, grupo_id } = await req.json();
+  const { id, grupo_id, pedido_fornecedor_id } = await req.json();
+
+  // Se tem pedido_fornecedor_id, excluir produtos A CAMINHO vinculados
+  if (pedido_fornecedor_id) {
+    await supabase
+      .from("estoque")
+      .delete()
+      .eq("pedido_fornecedor_id", pedido_fornecedor_id)
+      .eq("status", "A CAMINHO");
+  }
 
   // Se tem grupo_id, excluir todos do grupo
   if (grupo_id) {
@@ -126,8 +193,17 @@ export async function DELETE(req: NextRequest) {
   if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });
 
   // Buscar data antes de excluir para recalcular saldo
-  const { data: gasto } = await supabase.from("gastos").select("data").eq("id", id).single();
+  const { data: gasto } = await supabase.from("gastos").select("data, pedido_fornecedor_id").eq("id", id).single();
   const gastoData = gasto?.data;
+
+  // Se gasto individual tem pedido_fornecedor_id, limpar produtos A CAMINHO
+  if (gasto?.pedido_fornecedor_id) {
+    await supabase
+      .from("estoque")
+      .delete()
+      .eq("pedido_fornecedor_id", gasto.pedido_fornecedor_id)
+      .eq("status", "A CAMINHO");
+  }
 
   const { error } = await supabase.from("gastos").delete().eq("id", id);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -1,0 +1,326 @@
+"use client";
+
+import React from "react";
+import {
+  CATEGORIAS,
+  CAT_LABELS,
+  STRUCTURED_CATS,
+  IPHONE_STORAGES,
+  MACBOOK_CHIPS,
+  MACBOOK_RAMS,
+  MACBOOK_STORAGES,
+  MAC_MINI_CHIPS,
+  MAC_MINI_RAMS,
+  MAC_MINI_STORAGES,
+  IPAD_TELAS,
+  IPAD_STORAGES,
+  AIRPODS_MODELOS,
+  type ProdutoSpec,
+  DEFAULT_SPEC,
+  buildProdutoName,
+} from "@/lib/produto-specs";
+
+// Modelos atualizados (iguais ao estoque)
+const IPHONE_MODELOS_FULL = [
+  "11", "11 PRO", "11 PRO MAX", "12", "12 PRO", "12 PRO MAX",
+  "13", "13 PRO", "13 PRO MAX", "14", "14 PLUS", "14 PRO", "14 PRO MAX",
+  "15", "15 PLUS", "15 PRO", "15 PRO MAX",
+  "16", "16 PLUS", "16 PRO", "16 PRO MAX", "16E",
+  "17", "17 AIR", "17 PRO", "17 PRO MAX",
+];
+const MACBOOK_CHIPS_FULL = ["M1", "M2", "M3", "M4", "M4 PRO", "M4 MAX", "M5", "M5 PRO"];
+const WATCH_MODELOS_FULL = ["SE 2", "SE 3", "SERIES 11", "ULTRA 3", "ULTRA 3 MILANES"];
+const WATCH_TAMANHOS = ["40mm", "42mm", "44mm", "45mm", "46mm", "49mm"];
+
+export interface ProdutoRowState {
+  categoria: string;
+  spec: ProdutoSpec;
+  produto: string; // nome gerado ou livre
+  cor: string;
+  qnt: string;
+  custo_unitario: string;
+  fornecedor: string;
+  imei: string;
+  serial_no: string;
+}
+
+export function createEmptyProdutoRow(): ProdutoRowState {
+  return {
+    categoria: "IPHONES",
+    spec: { ...DEFAULT_SPEC },
+    produto: "",
+    cor: "",
+    qnt: "1",
+    custo_unitario: "",
+    fornecedor: "",
+    imei: "",
+    serial_no: "",
+  };
+}
+
+interface ProdutoSpecFieldsProps {
+  row: ProdutoRowState;
+  onChange: (updated: ProdutoRowState) => void;
+  onRemove: () => void;
+  fornecedores: { id: string; nome: string }[];
+  inputCls: string;
+  labelCls: string;
+  darkMode: boolean;
+  index: number;
+}
+
+export default function ProdutoSpecFields({
+  row,
+  onChange,
+  onRemove,
+  fornecedores,
+  inputCls,
+  labelCls,
+  darkMode: dm,
+  index,
+}: ProdutoSpecFieldsProps) {
+  const bgSection = dm ? "bg-[#2C2C2E]" : "bg-[#F9F9FB]";
+
+  const set = (field: keyof ProdutoRowState, value: string) => {
+    const updated = { ...row, [field]: value };
+    // Quando mudar categoria, resetar spec e produto
+    if (field === "categoria") {
+      updated.spec = { ...DEFAULT_SPEC };
+      updated.produto = "";
+    }
+    onChange(updated);
+  };
+
+  const setSpec = (field: keyof ProdutoSpec, value: string) => {
+    const newSpec = { ...row.spec, [field]: value };
+    const updated = { ...row, spec: newSpec };
+    // Auto-gerar nome do produto
+    if (STRUCTURED_CATS.includes(row.categoria)) {
+      updated.produto = buildProdutoName(row.categoria, newSpec);
+    }
+    onChange(updated);
+  };
+
+  const hasStructured = STRUCTURED_CATS.includes(row.categoria);
+
+  return (
+    <div className={`p-4 rounded-xl border ${dm ? "bg-[#2C2C2E] border-[#3A3A3C]" : "bg-white border-[#E8E8ED]"} space-y-3`}>
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <span className={`text-xs font-bold ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
+          Produto {index + 1}
+        </span>
+        <button
+          onClick={onRemove}
+          className="text-red-400 hover:text-red-600 text-sm font-bold transition-colors"
+          title="Remover produto"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Categoria + Cor */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <div>
+          <p className={labelCls}>Categoria</p>
+          <select value={row.categoria} onChange={(e) => set("categoria", e.target.value)} className={inputCls}>
+            {CATEGORIAS.map((c) => (
+              <option key={c} value={c}>{CAT_LABELS[c] || c}</option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <p className={labelCls}>Cor</p>
+          <input value={row.cor} onChange={(e) => set("cor", e.target.value)} placeholder="Ex: Silver, Azul..." className={inputCls} />
+        </div>
+        <div>
+          <p className={labelCls}>Fornecedor</p>
+          <select value={row.fornecedor} onChange={(e) => set("fornecedor", e.target.value)} className={inputCls}>
+            <option value="">— Selecionar —</option>
+            {fornecedores.map((f) => (
+              <option key={f.id} value={f.nome}>{f.nome}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Spec fields por categoria */}
+      {row.categoria === "IPHONES" && (
+        <div className={`grid grid-cols-2 gap-3 p-3 ${bgSection} rounded-lg`}>
+          <div>
+            <p className={labelCls}>Modelo</p>
+            <select value={row.spec.ip_modelo} onChange={(e) => setSpec("ip_modelo", e.target.value)} className={inputCls}>
+              {IPHONE_MODELOS_FULL.map((m) => <option key={m} value={m}>{`iPhone ${m}`}</option>)}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Armazenamento</p>
+            <select value={row.spec.ip_storage} onChange={(e) => setSpec("ip_storage", e.target.value)} className={inputCls}>
+              {IPHONE_STORAGES.map((s) => <option key={s}>{s}</option>)}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {row.categoria === "MACBOOK" && (
+        <div className={`grid grid-cols-2 md:grid-cols-3 gap-3 p-3 ${bgSection} rounded-lg`}>
+          <div>
+            <p className={labelCls}>Modelo</p>
+            <select value={row.spec.mb_modelo} onChange={(e) => setSpec("mb_modelo", e.target.value)} className={inputCls}>
+              <option value="AIR">MacBook Air</option>
+              <option value="PRO">MacBook Pro</option>
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Tela</p>
+            <select value={row.spec.mb_tela} onChange={(e) => setSpec("mb_tela", e.target.value)} className={inputCls}>
+              {(row.spec.mb_modelo === "AIR" ? ['13"', '15"'] : ['14"', '16"']).map((t) => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Chip</p>
+            <select value={row.spec.mb_chip} onChange={(e) => setSpec("mb_chip", e.target.value)} className={inputCls}>
+              {MACBOOK_CHIPS_FULL.map((c) => <option key={c}>{c}</option>)}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>RAM</p>
+            <select value={row.spec.mb_ram} onChange={(e) => setSpec("mb_ram", e.target.value)} className={inputCls}>
+              {MACBOOK_RAMS.map((r) => <option key={r}>{r}</option>)}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Armazenamento</p>
+            <select value={row.spec.mb_storage} onChange={(e) => setSpec("mb_storage", e.target.value)} className={inputCls}>
+              {MACBOOK_STORAGES.map((s) => <option key={s}>{s}</option>)}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {row.categoria === "MAC_MINI" && (
+        <div className={`grid grid-cols-3 gap-3 p-3 ${bgSection} rounded-lg`}>
+          <div>
+            <p className={labelCls}>Chip</p>
+            <select value={row.spec.mm_chip} onChange={(e) => setSpec("mm_chip", e.target.value)} className={inputCls}>
+              {MAC_MINI_CHIPS.map((c) => <option key={c}>{c}</option>)}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>RAM</p>
+            <select value={row.spec.mm_ram} onChange={(e) => setSpec("mm_ram", e.target.value)} className={inputCls}>
+              {MAC_MINI_RAMS.map((r) => <option key={r}>{r}</option>)}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Armazenamento</p>
+            <select value={row.spec.mm_storage} onChange={(e) => setSpec("mm_storage", e.target.value)} className={inputCls}>
+              {MAC_MINI_STORAGES.map((s) => <option key={s}>{s}</option>)}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {row.categoria === "IPADS" && (
+        <div className={`grid grid-cols-2 md:grid-cols-4 gap-3 p-3 ${bgSection} rounded-lg`}>
+          <div>
+            <p className={labelCls}>Modelo</p>
+            <select value={row.spec.ipad_modelo} onChange={(e) => setSpec("ipad_modelo", e.target.value)} className={inputCls}>
+              <option value="IPAD">iPad</option>
+              <option value="MINI">iPad Mini</option>
+              <option value="AIR">iPad Air</option>
+              <option value="PRO">iPad Pro</option>
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Tela</p>
+            <select value={row.spec.ipad_tela} onChange={(e) => setSpec("ipad_tela", e.target.value)} className={inputCls}>
+              {IPAD_TELAS.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Armazenamento</p>
+            <select value={row.spec.ipad_storage} onChange={(e) => setSpec("ipad_storage", e.target.value)} className={inputCls}>
+              {IPAD_STORAGES.map((s) => <option key={s}>{s}</option>)}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Conectividade</p>
+            <select value={row.spec.ipad_conn} onChange={(e) => setSpec("ipad_conn", e.target.value)} className={inputCls}>
+              <option value="WIFI">WiFi</option>
+              <option value="WIFI+CELL">WiFi + Cellular</option>
+            </select>
+          </div>
+        </div>
+      )}
+
+      {row.categoria === "APPLE_WATCH" && (
+        <div className={`grid grid-cols-3 gap-3 p-3 ${bgSection} rounded-lg`}>
+          <div>
+            <p className={labelCls}>Modelo</p>
+            <select value={row.spec.aw_modelo} onChange={(e) => setSpec("aw_modelo", e.target.value)} className={inputCls}>
+              {WATCH_MODELOS_FULL.map((m) => <option key={m}>{m}</option>)}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Tamanho</p>
+            <select value={row.spec.aw_tamanho} onChange={(e) => setSpec("aw_tamanho", e.target.value)} className={inputCls}>
+              {WATCH_TAMANHOS.map((t) => <option key={t}>{t}</option>)}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Conectividade</p>
+            <select value={row.spec.aw_conn} onChange={(e) => setSpec("aw_conn", e.target.value)} className={inputCls}>
+              <option value="GPS">GPS</option>
+              <option value="GPS+CELL">GPS + Cellular</option>
+            </select>
+          </div>
+        </div>
+      )}
+
+      {row.categoria === "AIRPODS" && (
+        <div className={`grid grid-cols-2 gap-3 p-3 ${bgSection} rounded-lg`}>
+          <div>
+            <p className={labelCls}>Modelo</p>
+            <select value={row.spec.air_modelo} onChange={(e) => setSpec("air_modelo", e.target.value)} className={inputCls}>
+              {AIRPODS_MODELOS.map((m) => <option key={m}>{m}</option>)}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {/* Nome do produto (livre para categorias sem spec, auto-gerado para outras) */}
+      <div>
+        <p className={labelCls}>Nome do Produto</p>
+        <input
+          value={row.produto || (hasStructured ? buildProdutoName(row.categoria, row.spec) : "")}
+          onChange={(e) => set("produto", e.target.value)}
+          placeholder={hasStructured ? "Auto-gerado pelos specs" : "Ex: Cabo USB-C Lightning 1m"}
+          className={inputCls}
+        />
+      </div>
+
+      {/* Qtd + Custo + IMEI + Serial */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div>
+          <p className={labelCls}>Quantidade</p>
+          <input type="number" value={row.qnt} onChange={(e) => set("qnt", e.target.value)} min="1" className={inputCls} />
+        </div>
+        <div>
+          <p className={labelCls}>Custo unitário (R$)</p>
+          <input type="number" value={row.custo_unitario} onChange={(e) => set("custo_unitario", e.target.value)} className={inputCls} />
+        </div>
+        <div>
+          <p className={labelCls}>IMEI</p>
+          <input value={row.imei} onChange={(e) => set("imei", e.target.value)} placeholder="Opcional" className={inputCls} />
+        </div>
+        <div>
+          <p className={labelCls}>Serial</p>
+          <input value={row.serial_no} onChange={(e) => set("serial_no", e.target.value)} placeholder="Opcional" className={inputCls} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -90,6 +90,18 @@ export interface Gasto {
   observacao: string | null;
   is_dep_esp: boolean;
   grupo_id: string | null;
+  pedido_fornecedor_id: string | null;
+}
+
+export interface PedidoFornecedorItem {
+  categoria: string;
+  produto: string;
+  cor: string;
+  qnt: number;
+  custo_unitario: number;
+  fornecedor: string;
+  imei: string | null;
+  serial_no: string | null;
 }
 
 export interface SaldoBancario {

--- a/sql/phase5-pedido-fornecedor.sql
+++ b/sql/phase5-pedido-fornecedor.sql
@@ -1,0 +1,8 @@
+-- Liga gastos e estoque via um ID de pedido de fornecedor compartilhado.
+-- Quando um gasto de categoria FORNECEDOR é registrado com produtos,
+-- ambos recebem o mesmo pedido_fornecedor_id.
+ALTER TABLE gastos ADD COLUMN IF NOT EXISTS pedido_fornecedor_id UUID;
+ALTER TABLE estoque ADD COLUMN IF NOT EXISTS pedido_fornecedor_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_gastos_pedido_fornecedor ON gastos(pedido_fornecedor_id);
+CREATE INDEX IF NOT EXISTS idx_estoque_pedido_fornecedor ON estoque(pedido_fornecedor_id);


### PR DESCRIPTION
## Summary
- Quando a categoria do gasto for **FORNECEDOR**, abre uma seção para cadastrar os produtos do pedido
- Produtos entram no estoque como **A CAMINHO** e quando chegarem basta marcar como recebido
- Evita duplicação de valores (registrar gasto + dar entrada no estoque separado)

## Mudanças
- ✅ Migration SQL: `pedido_fornecedor_id` nas tabelas `gastos` e `estoque`
- ✅ Types: `PedidoFornecedorItem` e `pedido_fornecedor_id` no `Gasto`
- ✅ Componente `ProdutoSpecFields` com specs estruturados (iPhone, MacBook, iPad, etc.)
- ✅ API gastos: POST cria gasto + produtos no estoque; DELETE remove produtos A CAMINHO vinculados
- ✅ API estoque: filtro por `pedido_fornecedor_id`
- ✅ UI: seção de produtos condicional no formulário de gastos
- ✅ Histórico: mostra produtos vinculados ao expandir gasto FORNECEDOR

## Fluxo
1. Registrar gasto com categoria FORNECEDOR
2. Adicionar produtos do pedido (com specs, cor, quantidade, custo, IMEI, serial)
3. Clicar em "Registrar Gasto + N Produto(s)"
4. Produtos aparecem na aba "A Caminho" do estoque
5. Quando chegarem, marcar como recebido → vão para "EM ESTOQUE"

## Migration necessária
```sql
ALTER TABLE gastos ADD COLUMN IF NOT EXISTS pedido_fornecedor_id UUID;
ALTER TABLE estoque ADD COLUMN IF NOT EXISTS pedido_fornecedor_id UUID;
CREATE INDEX IF NOT EXISTS idx_gastos_pedido_fornecedor ON gastos(pedido_fornecedor_id);
CREATE INDEX IF NOT EXISTS idx_estoque_pedido_fornecedor ON estoque(pedido_fornecedor_id);
```

## Test plan
- [ ] Criar gasto FORNECEDOR com produtos → gasto no histórico + produtos na aba A Caminho
- [ ] Expandir gasto FORNECEDOR no histórico → mostra produtos com status
- [ ] Marcar produto como chegou no estoque → status muda pra EM ESTOQUE
- [ ] Excluir gasto FORNECEDOR → remove produtos A CAMINHO vinculados
- [ ] Gasto de outra categoria → funciona como antes (sem seção de produtos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)