### PR TITLE
fix: lucro real com taxa, auto-detecao categoria, balanco modelo

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -8,6 +8,7 @@ import { getCategoriasEstoque, addCategoriaEstoque, removeCategoriaEstoque, edit
 import type { Categoria } from "@/lib/categorias";
 
 import BarcodeScanner from "@/components/BarcodeScanner";
+import { detectCategoria } from "@/lib/barcode";
 import { buildProdutoName as buildProdutoNameFromSpec, CORES_POR_CATEGORIA, COR_OBRIGATORIA, IPHONE_ORIGENS, WATCH_PULSEIRAS, getIphoneCores, type ProdutoSpec } from "@/lib/produto-specs";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 import type { Banco } from "@/lib/admin-types";
@@ -1984,6 +1985,12 @@ export default function EstoquePage() {
                             const showMover = tab === "acaminho" || isPendenciasTab;
                             const prodTotal = prodItems.reduce((s, p) => s + p.qnt, 0);
                             const prodValor = prodItems.reduce((s, p) => s + p.qnt * (p.custo_unitario || 0), 0);
+                            const prodCustoMedio = prodTotal > 0 ? Math.round(prodValor / prodTotal) : 0;
+                            // Verificar se há variação de custo entre unidades (fornecedores diferentes)
+                            const custosUnicos = new Set(prodItems.filter(p => p.custo_unitario).map(p => p.custo_unitario));
+                            const temVariacaoCusto = custosUnicos.size > 1;
+                            const custoMin = Math.min(...prodItems.filter(p => p.custo_unitario).map(p => p.custo_unitario));
+                            const custoMax = Math.max(...prodItems.filter(p => p.custo_unitario).map(p => p.custo_unitario));
 
                             return (
                               <React.Fragment key={prodNome}>
@@ -2020,7 +2027,14 @@ export default function EstoquePage() {
                                   <td className="px-4 py-2 text-right">
                                     <span className="text-xs font-bold text-white/90">{prodTotal} un.</span>
                                   </td>
-                                  <td className="px-4 py-2 text-xs text-white/50">{prodItems[0]?.custo_unitario ? fmt(prodItems[0].custo_unitario) : ""}</td>
+                                  <td className="px-4 py-2 text-xs">
+                                    {prodCustoMedio > 0 ? (
+                                      <div className="flex flex-col">
+                                        <span className="text-white/80 font-semibold">{fmt(prodCustoMedio)}{temVariacaoCusto ? " med." : ""}</span>
+                                        {temVariacaoCusto && <span className="text-white/40 text-[10px]">{fmt(custoMin)} ~ {fmt(custoMax)}</span>}
+                                      </div>
+                                    ) : ""}
+                                  </td>
                                   <td className="px-4 py-2 text-xs font-semibold text-white/90">{fmt(prodValor)}</td>
                                   <td colSpan={2}></td>
                                 </tr>
@@ -2803,7 +2817,11 @@ function ScanEntradaTab({ password, userName, onSuccess }: { password: string; u
           {/* Produto (nome completo) */}
           <div>
             <p className={labelCls}>Produto (nome completo)</p>
-            <input value={form.produto} onChange={e => setForm(f => ({ ...f, produto: e.target.value }))} placeholder="Ex: IPHONE 17 PRO MAX 256GB" className={inputCls} />
+            <input value={form.produto} onChange={e => {
+              const val = e.target.value;
+              const cat = detectCategoria(val);
+              setForm(f => ({ ...f, produto: val, ...(cat ? { categoria: cat } : {}) }));
+            }} placeholder="Ex: IPHONE 17 PRO MAX 256GB" className={inputCls} />
           </div>
 
           <div className="grid grid-cols-2 gap-3">

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -11,6 +11,45 @@ import type { Venda } from "@/lib/admin-types";
 import BarcodeScanner from "@/components/BarcodeScanner";
 
 const fmt = (v: number) => `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
+const fmtCents = (v: number) => `R$ ${v.toFixed(2).replace(".", ",")}`;
+
+/** Calcula o lucro real de uma venda, descontando a taxa da maquininha */
+function calcLucroReal(v: { custo: number; preco_vendido: number; forma: string; banco: string; qnt_parcelas: number | null; bandeira: string | null; valor_comprovante: number | null; entrada_pix: number; entrada_especie: number; produto_na_troca: string | null; comp_alt: number | null; banco_alt: string | null; parc_alt: number | null; band_alt: string | null; lucro: number }): { lucro: number; margem: number } {
+  const forma = v.forma;
+
+  // PIX, DINHEIRO, FIADO: sem taxa, lucro do banco está correto
+  if (forma === "PIX" || forma === "DINHEIRO" || forma === "FIADO") {
+    return { lucro: v.lucro, margem: v.preco_vendido > 0 ? (v.lucro / v.preco_vendido) * 100 : 0 };
+  }
+
+  const taxa = forma === "CARTAO"
+    ? getTaxa(v.banco, v.bandeira, v.qnt_parcelas, "CARTAO")
+    : forma === "DEBITO" ? 0.75
+    : 0;
+
+  if (taxa <= 0) {
+    return { lucro: v.lucro, margem: v.preco_vendido > 0 ? (v.lucro / v.preco_vendido) * 100 : 0 };
+  }
+
+  const pix = v.entrada_pix || 0;
+  const especie = v.entrada_especie || 0;
+  const troca = parseFloat(v.produto_na_troca || "0") || 0;
+  const compAlt = v.comp_alt || 0;
+  const taxaAlt = compAlt > 0 ? getTaxa(v.banco_alt || "ITAU", v.band_alt || null, v.parc_alt || 0, "CARTAO") : 0;
+  const liqAlt = compAlt > 0 ? (taxaAlt > 0 ? calcularLiquido(compAlt, taxaAlt) : compAlt) : 0;
+
+  // Usar valor_comprovante salvo, ou estimar a parte do cartão
+  const comp = v.valor_comprovante || (v.preco_vendido - pix - especie - troca - compAlt);
+  if (comp <= 0) {
+    return { lucro: v.lucro, margem: v.preco_vendido > 0 ? (v.lucro / v.preco_vendido) * 100 : 0 };
+  }
+
+  const liqPrincipal = calcularLiquido(comp, taxa);
+  const totalReal = liqPrincipal + liqAlt + pix + especie + troca;
+  const lucro = totalReal - v.custo;
+  const margem = totalReal > 0 ? (lucro / totalReal) * 100 : 0;
+  return { lucro: Math.round(lucro * 100) / 100, margem: Math.round(margem * 10) / 10 };
+}
 
 const VENDAS_PASSWORD = "tigrao$vendas";
 
@@ -737,40 +776,46 @@ export default function VendasPage() {
     for (const prod of allProducts) {
       payloads.push(buildPayload(prod));
     }
-    if (payloads.length > 1) {
+    // Recalcular preco_vendido = total real recebido (liquido apos taxa)
+    // O banco calcula lucro = preco_vendido - custo, entao preco_vendido
+    // precisa ser o valor liquido real, nao o preco cheio
+    {
       const comprovanteTotal = Number(payloads[0]?.valor_comprovante || 0);
-      if (comprovanteTotal > 0) {
-        // Calculate total custo for proportional distribution
+      const gForma = form.forma;
+      const gBanco = gForma === "LINK" ? "MERCADO_PAGO" : form.banco;
+      const gParcelas = parseInt(form.qnt_parcelas) || 0;
+      const gBandeira = form.bandeira || null;
+      const gTaxa = (gForma === "CARTAO" || gForma === "LINK")
+        ? getTaxa(gBanco, gBandeira, gParcelas, gForma === "LINK" ? "CARTAO" : gForma)
+        : gForma === "DEBITO" ? 0.75
+        : 0;
+
+      // Total líquido from comprovante after tax
+      const totalLiquido = gTaxa > 0 && comprovanteTotal > 0
+        ? calcularLiquido(comprovanteTotal, gTaxa)
+        : comprovanteTotal;
+
+      // Cartão alternativo (2o cartão)
+      const gCompAlt = parseFloat(form.comp_alt) || 0;
+      const gTaxaAlt = gCompAlt > 0
+        ? getTaxa(form.banco_alt || "ITAU", form.band_alt || null, parseInt(form.parc_alt) || 0, "CARTAO")
+        : 0;
+      const liqAlt = gCompAlt > 0 ? (gTaxaAlt > 0 ? calcularLiquido(gCompAlt, gTaxaAlt) : gCompAlt) : 0;
+
+      // Add entradas (pix, especie) — these are global
+      const gEntradaPix = parseFloat(form.entrada_pix) || 0;
+      const gEntradaEspecie = parseFloat(form.entrada_especie) || 0;
+      // Trocas são por produto — somar todas as trocas de todos os produtos
+      const totalTrocas = payloads.reduce((s, p) => s + (parseFloat(String(p.produto_na_troca)) || 0), 0);
+      const totalRecebido = totalLiquido + liqAlt + gEntradaPix + gEntradaEspecie + totalTrocas;
+
+      if (payloads.length === 1) {
+        // Produto único: preco_vendido = total real recebido (líquido)
+        payloads[0].preco_vendido = Math.round(totalRecebido * 100) / 100;
+      } else if (comprovanteTotal > 0) {
+        // Multi-produto: distribuir proporcionalmente pelo custo
         const totalCusto = payloads.reduce((s, p) => s + Number(p.custo || 0), 0);
-
         if (totalCusto > 0) {
-          // Calculate taxa from form (same for all products since payment is global)
-          const gForma = form.forma;
-          const gBanco = gForma === "LINK" ? "MERCADO_PAGO" : form.banco;
-          const gParcelas = parseInt(form.qnt_parcelas) || 0;
-          const gBandeira = form.bandeira || null;
-          const gTaxa = (gForma === "CARTAO" || gForma === "LINK")
-            ? getTaxa(gBanco, gBandeira, gParcelas, gForma === "LINK" ? "CARTAO" : gForma)
-            : gForma === "DEBITO" ? 0.75
-            : 0;
-
-          // Total líquido from comprovante after tax
-          const totalLiquido = gTaxa > 0 ? calcularLiquido(comprovanteTotal, gTaxa) : comprovanteTotal;
-
-          // Cartão alternativo (2o cartão)
-          const gCompAlt = parseFloat(form.comp_alt) || 0;
-          const gTaxaAlt = gCompAlt > 0
-            ? getTaxa(form.banco_alt || "ITAU", form.band_alt || null, parseInt(form.parc_alt) || 0, "CARTAO")
-            : 0;
-          const liqAlt = gCompAlt > 0 ? (gTaxaAlt > 0 ? calcularLiquido(gCompAlt, gTaxaAlt) : gCompAlt) : 0;
-
-          // Add entradas (pix, especie) — these are global
-          const gEntradaPix = parseFloat(form.entrada_pix) || 0;
-          const gEntradaEspecie = parseFloat(form.entrada_especie) || 0;
-          // Trocas são por produto — somar todas as trocas de todos os produtos
-          const totalTrocas = payloads.reduce((s, p) => s + (parseFloat(String(p.produto_na_troca)) || 0), 0);
-          const totalRecebido = totalLiquido + liqAlt + gEntradaPix + gEntradaEspecie + totalTrocas;
-
           let comprovanteDistribuido = 0;
           let vendidoDistribuido = 0;
           for (let i = 0; i < payloads.length; i++) {
@@ -1679,7 +1724,7 @@ export default function VendasPage() {
               </div>
             ) : (
               <div className="space-y-3">
-                <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   <div>
                     <p className={labelCls}>Categoria</p>
                     <select value={catSel} onChange={(e) => { setCatSel(e.target.value); setEstoqueId(""); set("produto", ""); set("custo", ""); set("fornecedor", ""); }} className={selectCls}>
@@ -1687,10 +1732,6 @@ export default function VendasPage() {
                       {categorias.map(c => <option key={c.key} value={c.key}>{c.label}</option>)}
                     </select>
                   </div>
-                  <div><p className={labelCls}>Fornecedor</p><select value={form.fornecedor} onChange={(e) => set("fornecedor", e.target.value)} className={selectCls}>
-                  <option value="">— Selecionar —</option>
-                  {fornecedores.map((f) => <option key={f.id} value={f.nome}>{f.nome}</option>)}
-                </select></div>
                 </div>
 
                 {/* Produtos agrupados por modelo */}
@@ -1928,8 +1969,18 @@ export default function VendasPage() {
                   <div><p className={labelCls}>Maquina</p><select value={form.banco} onChange={(e) => set("banco", e.target.value)} className={selectCls}>
                     <option>ITAU</option><option>INFINITE</option>
                   </select></div>
-                  <div><p className={labelCls}>Parcelas</p><input type="number" value={form.qnt_parcelas} onChange={(e) => set("qnt_parcelas", e.target.value)} placeholder="1" className={inputCls} /></div>
-                  <div><p className={labelCls}>Bandeira</p><select value={form.bandeira} onChange={(e) => set("bandeira", e.target.value)} className={selectCls}>
+                  <div><p className={labelCls}>Parcelas</p><input type="number" value={form.qnt_parcelas} onChange={(e) => {
+                    set("qnt_parcelas", e.target.value);
+                    // Recalcular preco_vendido quando parcelas mudam
+                    const newVendido = recalcVendido({ comp: form.valor_comprovante_input });
+                    if (newVendido && produtosCarrinho.length === 0) set("preco_vendido", newVendido);
+                  }} placeholder="1" className={inputCls} /></div>
+                  <div><p className={labelCls}>Bandeira</p><select value={form.bandeira} onChange={(e) => {
+                    set("bandeira", e.target.value);
+                    // Recalcular preco_vendido quando bandeira muda
+                    const newVendido = recalcVendido({ comp: form.valor_comprovante_input });
+                    if (newVendido && produtosCarrinho.length === 0) set("preco_vendido", newVendido);
+                  }} className={selectCls}>
                     <option value="">Selecionar</option><option>VISA</option><option>MASTERCARD</option><option>ELO</option><option>AMEX</option>
                   </select></div>
                   {taxa > 0 && (
@@ -2534,7 +2585,7 @@ export default function VendasPage() {
 
           const titulo = tab === "andamento" ? "Vendas em Andamento" : tab === "hoje" ? "Finalizadas Hoje" : "Histórico de Vendas";
           const totalVendido = filtered.reduce((s, v) => s + (v.preco_vendido || 0), 0);
-          const totalLucro = filtered.reduce((s, v) => s + (v.lucro || 0), 0);
+          const totalLucro = filtered.reduce((s, v) => s + calcLucroReal(v).lucro, 0);
 
           return (
             <div className={`${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-white border-[#D2D2D7]"} border rounded-2xl overflow-hidden shadow-sm`}>
@@ -2654,7 +2705,7 @@ export default function VendasPage() {
                     <div className="px-4 py-8 text-center text-[#86868B]">Nenhuma venda {tab === "andamento" ? "em andamento" : tab === "hoje" ? "finalizada hoje" : "finalizada"}</div>
                   ) : datasOrdenadas.map((dataKey) => {
                     const vendasDoDia = vendasPorData.get(dataKey) || [];
-                    const lucroDia = vendasDoDia.reduce((s, v) => s + (v.lucro || 0), 0);
+                    const lucroDia = vendasDoDia.reduce((s, v) => s + calcLucroReal(v).lucro, 0);
                     const vendidoDia = vendasDoDia.reduce((s, v) => s + (v.preco_vendido || 0), 0);
                     const qtdDia = vendasDoDia.length;
                     const [y, m, d] = (dataKey || "").split("-");
@@ -2774,8 +2825,7 @@ export default function VendasPage() {
                               </td>
                               <td className="px-3 py-2.5 text-[#86868B] text-xs">{fmt(v.custo)}</td>
                               <td className="px-3 py-2.5 font-medium text-xs">{fmt(v.preco_vendido)}</td>
-                              <td className={`px-3 py-2.5 font-bold text-xs ${v.lucro >= 0 ? "text-green-600" : "text-red-500"}`}>{fmt(v.lucro)}</td>
-                              <td className="px-3 py-2.5 text-[#86868B] text-xs">{Number(v.margem_pct || 0).toFixed(1)}%</td>
+                              {(() => { const lr = calcLucroReal(v); return (<><td className={`px-3 py-2.5 font-bold text-xs ${lr.lucro >= 0 ? "text-green-600" : "text-red-500"}`}>{fmtCents(lr.lucro)}</td><td className="px-3 py-2.5 text-[#86868B] text-xs">{lr.margem.toFixed(1)}%</td></>); })()}
                               <td className="px-3 py-2.5 text-xs max-w-[250px]">
                                 <div className="space-y-0.5">
                                   {pagParts.map((p, i) => (
@@ -2815,9 +2865,31 @@ export default function VendasPage() {
                                                 e.stopPropagation();
                                                 setEditSaving(true);
                                                 // lucro e margem_pct são GENERATED ALWAYS no Supabase — NÃO enviar!
-                                                const pv = parseFloat(ef.preco_vendido) || 0;
                                                 const c = parseFloat(ef.custo) || 0;
-                                                // Lucro = total real recebido - custo (preco_vendido já é o total real)
+                                                // Recalcular preco_vendido = total real recebido (liquido apos taxa)
+                                                const efForma = ef.forma;
+                                                const efBanco = ef.banco;
+                                                const efParcelas = parseInt(ef.qnt_parcelas) || 0;
+                                                const efBandeira = ef.bandeira || null;
+                                                const efTaxa = (efForma === "CARTAO")
+                                                  ? getTaxa(efBanco, efBandeira, efParcelas, efForma)
+                                                  : efForma === "DEBITO" ? 0.75
+                                                  : 0;
+                                                const efComprovante = parseFloat(ef.valor_comprovante) || 0;
+                                                const efLiquido = efTaxa > 0 && efComprovante > 0
+                                                  ? calcularLiquido(efComprovante, efTaxa)
+                                                  : efComprovante;
+                                                const efCompAlt = parseFloat(ef.comp_alt) || 0;
+                                                const efTaxaAlt = efCompAlt > 0
+                                                  ? getTaxa(ef.banco_alt || "ITAU", ef.band_alt || null, parseInt(ef.parc_alt) || 0, "CARTAO")
+                                                  : 0;
+                                                const efLiqAlt = efCompAlt > 0 ? (efTaxaAlt > 0 ? calcularLiquido(efCompAlt, efTaxaAlt) : efCompAlt) : 0;
+                                                const efPix = parseFloat(ef.entrada_pix) || 0;
+                                                const efEspecie = parseFloat(ef.entrada_especie) || 0;
+                                                const efTroca = parseFloat(ef.produto_na_troca) || 0;
+                                                const pv = efForma === "PIX" || efForma === "DINHEIRO"
+                                                  ? (parseFloat(ef.preco_vendido) || 0)
+                                                  : Math.round((efLiquido + efLiqAlt + efPix + efEspecie + efTroca) * 100) / 100;
                                                 const newLucro = pv - c;
                                                 const newMargem = pv > 0 ? Math.round(((pv - c) / pv) * 1000) / 10 : 0;
                                                 const updates: Record<string, unknown> = {

--- a/app/api/estoque/route.ts
+++ b/app/api/estoque/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { logActivity } from "@/lib/activity-log";
 import { hasPermission } from "@/lib/permissions";
+import { detectCategoria } from "@/lib/barcode";
 
 function auth(req: NextRequest) {
   return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
@@ -118,6 +119,18 @@ export async function GET(req: NextRequest) {
 
   const { data, error } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Auto-corrigir categorias incorretas (ex: AirTag cadastrado como IPHONES → ACESSORIOS)
+  if (data) {
+    for (const item of data) {
+      const catCorreta = detectCategoria(item.produto);
+      if (catCorreta && catCorreta !== item.categoria) {
+        await supabase.from("estoque").update({ categoria: catCorreta }).eq("id", item.id);
+        item.categoria = catCorreta;
+      }
+    }
+  }
+
   return NextResponse.json({ data });
 }
 

--- a/lib/barcode.ts
+++ b/lib/barcode.ts
@@ -117,6 +117,28 @@ export const CORES_ETIQUETA: Record<string, string[]> = {
 };
 
 /**
+ * Detecta a categoria correta baseada no nome do produto.
+ * Retorna a categoria detectada ou null se nao conseguir detectar.
+ */
+export function detectCategoria(produtoNome: string): string | null {
+  if (!produtoNome) return null;
+  const nome = produtoNome.toUpperCase();
+
+  // Verificar por palavras-chave especificas (ordem importa — mais especifico primeiro)
+  if (nome.includes("AIRTAG")) return "ACESSORIOS";
+  if (nome.includes("MAGIC KEYBOARD")) return "ACESSORIOS";
+  if (nome.includes("APPLE PENCIL")) return "ACESSORIOS";
+  if (nome.includes("MAC MINI")) return "MAC_MINI";
+  if (nome.includes("MACBOOK")) return "MACBOOK";
+  if (nome.includes("AIRPODS") || nome.includes("AIRPOD")) return "AIRPODS";
+  if (nome.includes("IPAD")) return "IPADS";
+  if (nome.includes("IPHONE")) return "IPHONES";
+  if (nome.includes("WATCH")) return "APPLE_WATCH";
+
+  return null;
+}
+
+/**
  * Status da etiqueta/produto
  */
 export const STATUS_ETIQUETA = {


### PR DESCRIPTION
## Summary
- **Lucro real**: desconta taxa da maquininha no display de todas as vendas (existentes e futuras)
- **Auto-detecao categoria**: AirTag, Magic Keyboard → ACESSORIOS automaticamente
- **Balanco por modelo**: custo medio ponderado + faixa min~max nos cards do estoque
- **Vendas**: removido dropdown de fornecedor desnecessario na selecao por estoque

## Detalhes
- `calcLucroReal()` recalcula lucro em tempo de exibicao, mesmo para vendas antigas sem valor_comprovante
- `preco_vendido` salvo como valor liquido (apos taxa) em vendas futuras
- `detectCategoria()` corrige categorias erradas no banco ao carregar estoque
- Scan: auto-detecta categoria ao digitar nome do produto

## Test plan
- [ ] Verificar lucro da Ivete (iPhone 17 Pro Max) — deve mostrar ~R$ 907,94 em vez de R$ 910
- [ ] Verificar lucro do Pierre — deve descontar taxa INFINITE 12x ELO
- [ ] Criar nova venda com cartao — preco_vendido deve ser calculado automaticamente
- [ ] Verificar AirTag/Magic Keyboard aparecem em ACESSORIOS no estoque
- [ ] Verificar balanco no card do estoque mostra custo medio quando ha variacao

🤖 Generated with [Claude Code](https://claude.com/claude-code)