### PR TITLE
WhatsApp Formulários, fix nomes MacBook Neo/iPad Pro M5, bateria seminovos

### DIFF
--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -15,6 +15,7 @@ export default function ConfiguracoesPage() {
 
   // Contato do formulário de troca
   const [principal, setPrincipal] = useState("5521972461357"); // Bianca default
+  const [formularios, setFormularios] = useState(""); // WhatsApp formulários (troca, seminovos, links de compra)
   const [vendedores, setVendedores] = useState(VENDEDORES_PADRAO.map(v => ({ ...v })));
 
   const [loading, setLoading] = useState(true);
@@ -28,6 +29,7 @@ export default function ConfiguracoesPage() {
       .then(({ data }) => {
         if (!data) return;
         if (data.whatsapp_principal) setPrincipal(String(data.whatsapp_principal));
+        if (data.whatsapp_formularios) setFormularios(String(data.whatsapp_formularios));
         // whatsapp_vendedores pode ser objeto {nome: numero} ou array
         const raw = data.whatsapp_vendedores;
         if (raw && typeof raw === "object" && !Array.isArray(raw)) {
@@ -55,7 +57,7 @@ export default function ConfiguracoesPage() {
       const res = await fetch("/api/admin/tradein-config", {
         method: "PUT",
         headers: { "x-admin-password": password, "Content-Type": "application/json" },
-        body: JSON.stringify({ whatsapp_principal: principal, whatsapp_vendedores: waMap }),
+        body: JSON.stringify({ whatsapp_principal: principal, whatsapp_formularios: formularios || principal, whatsapp_vendedores: waMap }),
       });
       const j = await res.json();
       setMsg(j.ok ? "✅ Salvo com sucesso!" : "❌ Erro: " + (j.error || "desconhecido"));
@@ -125,6 +127,55 @@ export default function ConfiguracoesPage() {
               className="inline-flex items-center gap-1 text-xs text-[#E8740E] hover:underline"
             >
               🔗 Testar: wa.me/{principal}
+            </a>
+          )}
+        </div>
+
+        {/* WhatsApp Formulários */}
+        <div className="bg-white rounded-xl p-5 shadow-sm border border-[#E8E8ED] space-y-3">
+          <div>
+            <p className="font-bold text-[#1D1D1F]">📋 WhatsApp Formulários</p>
+            <p className="text-xs text-[#86868B] mt-1">
+              Número padrão para receber formulários de troca de lacrados, seminovos e links de compra. Se vazio, usa o número do Formulário de Troca.
+            </p>
+          </div>
+
+          <div className="flex gap-2 flex-wrap">
+            {vendedores.filter(v => v.numero).map(v => (
+              <button
+                key={v.nome}
+                type="button"
+                onClick={() => setFormularios(v.numero)}
+                className={`px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
+                  formularios === v.numero
+                    ? "bg-[#E8740E] text-white shadow-sm"
+                    : "bg-[#F5F5F7] border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E]"
+                }`}
+              >
+                {v.nome} {formularios === v.numero && "✓"}
+              </button>
+            ))}
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-[#86868B] mb-1">Número formulários (DDI + DDD + número)</label>
+            <input
+              value={formularios}
+              onChange={e => setFormularios(e.target.value.replace(/\D/g, ""))}
+              placeholder="5521972461357"
+              className={inputCls}
+              inputMode="numeric"
+            />
+          </div>
+
+          {formularios && (
+            <a
+              href={`https://wa.me/${formularios}`}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-[#E8740E] hover:underline"
+            >
+              🔗 Testar: wa.me/{formularios}
             </a>
           )}
         </div>

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -236,8 +236,22 @@ function extractCorPT(nome: string): string | null {
  * - Substitui cor em português pelo equivalente em inglês (ex: AZUL PROFUNDO → DEEP BLUE)
  * - Quando cor=null, tenta encontrar cor PT no próprio nome do produto
  */
+/** Corrige nomes de produto que foram cadastrados com formato antigo/errado */
+function fixProdutoName(nome: string, categoria?: string | null): string {
+  let n = nome;
+  // MacBook Neo: "MACBOOK PRO A18 PRO ..." → "MACBOOK NEO ..."
+  if (categoria === "MACBOOK" && /\bA18\b/i.test(n)) {
+    n = n.replace(/MACBOOK\s+PRO\s+A18\s*PRO?\s*/gi, "MACBOOK NEO ");
+  }
+  // iPad Pro: "IPAD PRO 11"" sem chip → adiciona M5 se ausente
+  if (categoria === "IPADS" && /IPAD\s+PRO\s+\d/i.test(n) && !/IPAD\s+PRO\s+[MA]\d/i.test(n)) {
+    n = n.replace(/IPAD\s+PRO\s+/gi, "IPAD PRO M5 ");
+  }
+  return n;
+}
+
 function displayNomeProduto(nome: string, cor: string | null | undefined, categoria?: string | null): string {
-  let display = stripOrigem(nome, categoria);
+  let display = stripOrigem(fixProdutoName(nome, categoria), categoria);
   if (!cor) {
     // Sem campo cor: tenta encontrar e traduzir cor PT embutida no nome
     const upper = display.toUpperCase();
@@ -406,10 +420,11 @@ function getModeloBase(produto: string, categoria: string): string {
   if (baseCat === "MACBOOK") {
     const mem = getMem();
     const size = getSize();
-    // Extrair chip (M4, M5, M4 Pro, M5 Pro)
+    // Extrair chip M-series (M4, M5, M4 Pro, M5 Pro)
     const chipMatch = p.match(/M(\d+)(\s*PRO)?/i);
     const chip = chipMatch ? ` M${chipMatch[1]}${chipMatch[2] ? " Pro" : ""}` : "";
-    if (p.includes("NEO")) return `MacBook Neo${chip}${size}${mem}`;
+    // MacBook Neo: detectar por "NEO" ou chip A18 (exclusivo do Neo)
+    if (p.includes("NEO") || /\bA18\b/i.test(p)) return `MacBook Neo${size}${mem}`;
     if (p.includes("AIR")) return `MacBook Air${chip}${size}${mem}`;
     if (p.includes("PRO") && !chipMatch?.[2]) return `MacBook Pro${chip}${size}${mem}`;
     if (p.includes("PRO")) return `MacBook Pro${chip}${size}${mem}`;
@@ -1604,6 +1619,7 @@ export default function EstoquePage() {
   const isPendenciasTab = tab === "pendencias";
   const isACaminhoTab = tab === "acaminho";
   const isEditableItemTab = isPendenciasTab || isACaminhoTab;
+  const isBateriaEditable = isEditableItemTab || tab === "seminovos" || tab === "estoque";
 
   // renderProductRow removido — agora renderizado inline com agrupamento por produto/cor
 
@@ -3255,12 +3271,12 @@ export default function EstoquePage() {
                                             })()}
                                             {/* Bateria (só seminovo/pendência) */}
                                             {(p.tipo === "SEMINOVO" || p.tipo === "PENDENCIA") && (
-                                              isEditableItemTab && isEditingField(p.id, "bateria") ? (
+                                              isBateriaEditable && isEditingField(p.id, "bateria") ? (
                                                 <div className="flex items-center gap-0.5">
                                                   <input type="number" value={getEditVal(p.id, "bateria") || ""} onChange={(e) => startEditField(p.id, "bateria", e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") saveField(p.id, "bateria"); if (e.key === "Escape") cancelEditField(p.id, "bateria"); }} className="w-14 px-1 py-0.5 rounded border border-[#0071E3] text-[10px]" autoFocus placeholder="%" />
                                                   <button onClick={() => saveField(p.id, "bateria")} className="text-[10px] text-[#E8740E] font-bold">OK</button>
                                                 </div>
-                                              ) : isEditableItemTab ? (
+                                              ) : isBateriaEditable ? (
                                                 <button onClick={(e) => { e.stopPropagation(); startEditField(p.id, "bateria", String(p.bateria || "")); }} className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${p.bateria ? "bg-green-50 text-green-600" : `${dm ? "bg-[#2C2C2E] text-[#636366]" : "bg-gray-100 text-[#86868B]"}`} hover:ring-1 hover:ring-[#E8740E]`}>
                                                   {p.bateria ? `🔋 ${p.bateria}%` : "+ Bateria"}
                                                 </button>

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -100,8 +100,17 @@ const COR_PT: Record<string, string> = {
   "CORAL": "Coral",
   "PRODUCT RED": "Vermelho",
   "(PRODUCT)RED": "Vermelho",
-  "TEAL": "Azul-petróleo",
-  "ULTRAMARINE": "Ultramarino",
+  "TEAL": "Verde",
+  "ULTRAMARINE": "Azul",
+  "CLOUD WHITE": "Branco",
+  "SKY BLUE": "Azul Céu",
+  "SAGE": "Verde",
+  "MIST BLUE": "Azul Névoa",
+  "HAZE BLUE": "Azul Névoa",
+  "BLUSH": "Rosa",
+  "CITRUS": "Cítrico",
+  "INDIGO": "Índigo",
+  "BRANCO NUVEM": "Branco",
   "PEBBLE": "Pedregulho",
   "LIGHT BLUE": "Azul Claro",
   "DARK BLUE": "Azul Escuro",
@@ -196,6 +205,12 @@ const PT_TO_EN: Record<string, string> = {
   "NATURAL": "Natural",
   "ULTRAMARINO": "Ultramarine",
   "LAVANDA": "Lavender",
+  "BRANCO NUVEM": "Cloud White",
+  "AZUL CEU": "Sky Blue",
+  "AZUL CÉU": "Sky Blue",
+  "AZUL NEVOA": "Mist Blue",
+  "AZUL NÉVOA": "Mist Blue",
+  "INDIGO": "Indigo",
 };
 
 const ORIGEM_CODES = ["AA","BE","BR","BZ","CH","E","HN","J","LL","LZ","N","QL","VC","ZD","ZP"];
@@ -2101,7 +2116,7 @@ export default function EstoquePage() {
       {/* ===== ABA REPOSIÇÃO ===== */}
       {tab === "reposicao" ? (() => {
         const stripOrigemRepo = (nome: string) => nome
-          .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ)\s*(\([^)]*\))?/gi, "")
+          .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ)(?=\s|$|\()/gi, "")
           .replace(/[-–]\s*(CHIP\s+(F[ÍI]SICO\s*\+\s*)?)?E-?SIM/gi, "")
           .replace(/[-–]\s*CHIP\s+VIRTUAL/gi, "")
           .replace(/\s*\(\d+C\s*CPU\/\d+C\s*GPU\)\s*/gi, " ")
@@ -2964,7 +2979,7 @@ export default function EstoquePage() {
                   return modeloEntries.map(([modelo, items]) => {
                   // Sub-agrupar por nome do produto (sem origem VC/LL/J/BE/BR/HN/IN/ZA)
                   const stripOrigem = (nome: string) => nome
-                    .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ)\s*(\([^)]*\))?/gi, "")
+                    .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ)(?=\s|$|\()/gi, "")
                     .replace(/[-–]\s*(CHIP\s+(F[ÍI]SICO\s*\+\s*)?)?E-?SIM/gi, "")
                     .replace(/[-–]\s*CHIP\s+VIRTUAL/gi, "")
                     .replace(/\s*\(\d+C\s*CPU\/\d+C\s*GPU\)\s*/gi, " ")  // (10C CPU/10C GPU)

--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -846,6 +846,7 @@ const VENDEDORES_DEFAULT: { nome: string; label: string; numero: string }[] = [
 
 function WhatsAppConfigPanel({ password }: { password: string }) {
   const [principal, setPrincipal] = useState("5521967442665");
+  const [formularios, setFormularios] = useState(""); // WhatsApp para formulários (troca, seminovos, links de compra)
   const defaultVendedores: Record<string, { numero: string; ativo: boolean }> = {};
   for (const v of VENDEDORES_DEFAULT) defaultVendedores[v.nome] = { numero: v.numero, ativo: true };
   const [vendedores, setVendedores] = useState<Record<string, { numero: string; ativo: boolean }>>(defaultVendedores);
@@ -859,6 +860,7 @@ function WhatsAppConfigPanel({ password }: { password: string }) {
       .then(j => {
         if (j.data) {
           setPrincipal(j.data.whatsapp_principal || "5521967442665");
+          if (j.data.whatsapp_formularios) setFormularios(j.data.whatsapp_formularios);
           // Converter formato antigo (string) pra novo (objeto com ativo)
           const raw = j.data.whatsapp_vendedores || {};
           const mapped: Record<string, { numero: string; ativo: boolean }> = {};
@@ -897,7 +899,7 @@ function WhatsAppConfigPanel({ password }: { password: string }) {
       const res = await fetch("/api/admin/tradein-config", {
         method: "PUT",
         headers: { "Content-Type": "application/json", "x-admin-password": password },
-        body: JSON.stringify({ whatsapp_principal: principal, whatsapp_vendedores: waMap }),
+        body: JSON.stringify({ whatsapp_principal: principal, whatsapp_formularios: formularios || principal, whatsapp_vendedores: waMap }),
       });
       const j = await res.json();
       if (j.ok) { setMsg("Salvo!"); setTimeout(() => setMsg(""), 3000); }
@@ -944,8 +946,42 @@ function WhatsAppConfigPanel({ password }: { password: string }) {
 
         <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[#F5F5F7] text-sm">
           <span className="text-[#86868B]">Numero ativo:</span>
-          <span className="font-mono font-semibold text-[#1D1D1F]">+{principal.replace(/^55/, "55 ").replace(/(\d{2})\s(\d{2})(\d{5})(\d{4})/, "+$1 ($2) $3-$4")}</span>
+          <span className="font-mono font-semibold text-[#1D1D1F]">{principal.replace(/^55/, "+55 ").replace(/\+(\d{2})\s(\d{2})(\d{5})(\d{4})/, "+$1 ($2) $3-$4")}</span>
         </div>
+
+        <button onClick={salvar} disabled={saving}
+          className={`w-full py-3 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50 ${msg === "Salvo!" ? "bg-green-500 text-white" : "bg-[#E8740E] text-white hover:bg-[#F5A623]"}`}>
+          {saving ? "Salvando..." : msg === "Salvo!" ? "&#x2705; Salvo!" : "Salvar"}
+        </button>
+      </div>
+
+      {/* WhatsApp Formulários */}
+      <div className="bg-white border border-[#D2D2D7] rounded-2xl p-5 shadow-sm space-y-4">
+        <div>
+          <h2 className="font-bold text-[#1D1D1F] text-lg">WhatsApp Formulários</h2>
+          <p className="text-xs text-[#86868B] mt-0.5">Número padrão para receber formulários de troca de lacrados, seminovos e links de compra. Se vazio, usa o WhatsApp Principal.</p>
+        </div>
+
+        {/* Seletor rapido */}
+        <div className="flex gap-2">
+          {Object.entries(vendedores).filter(([, v]) => v.ativo).map(([nome, v]) => {
+            const isActive = formularios === v.numero;
+            return (
+              <button key={nome} onClick={() => setFormularios(v.numero)}
+                className={`flex-1 py-3 rounded-xl text-sm font-semibold transition-all ${isActive ? "bg-[#E8740E] text-white shadow-md" : "bg-[#F5F5F7] border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E]"}`}>
+                {nome.charAt(0).toUpperCase() + nome.slice(1)}
+                {isActive && <span className="ml-1.5">&#x2705;</span>}
+              </button>
+            );
+          })}
+        </div>
+
+        {formularios && (
+          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[#F5F5F7] text-sm">
+            <span className="text-[#86868B]">Numero ativo:</span>
+            <span className="font-mono font-semibold text-[#1D1D1F]">{formularios.replace(/^55/, "+55 ").replace(/\+(\d{2})\s(\d{2})(\d{5})(\d{4})/, "+$1 ($2) $3-$4")}</span>
+          </div>
+        )}
 
         <button onClick={salvar} disabled={saving}
           className={`w-full py-3 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50 ${msg === "Salvo!" ? "bg-green-500 text-white" : "bg-[#E8740E] text-white hover:bg-[#F5A623]"}`}>
@@ -965,7 +1001,7 @@ function WhatsAppConfigPanel({ password }: { password: string }) {
             <div key={nome} className={`flex items-center justify-between p-4 rounded-xl border transition-colors ${v.ativo ? "bg-white border-[#D2D2D7]" : "bg-[#F5F5F7] border-[#E8E8ED] opacity-60"}`}>
               <div className="flex-1">
                 <p className="text-sm font-semibold text-[#1D1D1F]">{nome.charAt(0).toUpperCase() + nome.slice(1)}</p>
-                <p className="text-xs font-mono text-[#86868B]">+{v.numero.replace(/^55(\d{2})/, "55 ($1) ").replace(/(\d{5})(\d{4})$/, "$1-$2")}</p>
+                <p className="text-xs font-mono text-[#86868B]">{v.numero.replace(/^55(\d{2})/, "+55 ($1) ").replace(/(\d{5})(\d{4})$/, "$1-$2")}</p>
               </div>
               {/* Toggle estilo iOS */}
               <button onClick={() => toggleVendedor(nome)}

--- a/app/api/admin/tradein-config/route.ts
+++ b/app/api/admin/tradein-config/route.ts
@@ -20,6 +20,7 @@ export async function GET(req: NextRequest) {
   const labels = (data?.labels && typeof data.labels === "object") ? data.labels as Record<string, unknown> : {};
   const result = { ...data };
   if (labels._whatsapp_principal) result.whatsapp_principal = labels._whatsapp_principal;
+  if (labels._whatsapp_formularios) result.whatsapp_formularios = labels._whatsapp_formularios;
   if (labels._whatsapp_vendedores) result.whatsapp_vendedores = labels._whatsapp_vendedores;
 
   return NextResponse.json({ data: result });
@@ -36,12 +37,13 @@ export async function PUT(req: NextRequest) {
   if (body.origens !== undefined) updates.origens = body.origens;
 
   // Salvar whatsapp config dentro do campo labels (JSONB) pra não depender de colunas novas
-  if (body.whatsapp_principal !== undefined || body.whatsapp_vendedores !== undefined || body.labels !== undefined) {
+  if (body.whatsapp_principal !== undefined || body.whatsapp_formularios !== undefined || body.whatsapp_vendedores !== undefined || body.labels !== undefined) {
     const { data: current } = await supabase.from("tradein_config").select("labels").limit(1).single();
     const currentLabels = (current?.labels && typeof current.labels === "object") ? current.labels as Record<string, unknown> : {};
     const newLabels = { ...currentLabels };
     if (body.labels !== undefined) Object.assign(newLabels, body.labels);
     if (body.whatsapp_principal !== undefined) newLabels._whatsapp_principal = body.whatsapp_principal;
+    if (body.whatsapp_formularios !== undefined) newLabels._whatsapp_formularios = body.whatsapp_formularios;
     if (body.whatsapp_vendedores !== undefined) newLabels._whatsapp_vendedores = body.whatsapp_vendedores;
     updates.labels = newLabels;
   }

--- a/app/api/tradein-config/route.ts
+++ b/app/api/tradein-config/route.ts
@@ -43,6 +43,7 @@ export async function GET() {
     const labels = (data.labels && typeof data.labels === "object") ? data.labels as Record<string, unknown> : {};
     const result = { ...data };
     if (labels._whatsapp_principal) result.whatsapp_principal = labels._whatsapp_principal;
+    if (labels._whatsapp_formularios) result.whatsapp_formularios = labels._whatsapp_formularios;
     if (labels._whatsapp_vendedores) result.whatsapp_vendedores = labels._whatsapp_vendedores;
 
     return NextResponse.json({ data: result });

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -101,10 +101,10 @@ function CompraForm() {
   const [precoAuto, setPrecoAuto] = useState(precoParam ? parseInt(precoParam) : 0);
 
   // WhatsApp pode vir do URL ou ser buscado da config
-  const [whatsappConfig, setWhatsappConfig] = useState("");
-  // Sempre André como default. Config sobrescreve se disponível.
-  // Prioridade: param URL (do gerador de link) > config DB > fallback André
-  const whatsappFinal = whatsapp || whatsappConfig || WHATSAPP_FORMULARIO;
+  const [whatsappFormConfig, setWhatsappFormConfig] = useState("");
+  const [whatsappPrincipalConfig, setWhatsappPrincipalConfig] = useState("");
+  // Prioridade: param URL (do gerador de link) > whatsapp_formularios > whatsapp_principal > fallback
+  const whatsappFinal = whatsapp || whatsappFormConfig || whatsappPrincipalConfig || WHATSAPP_FORMULARIO;
 
   // Fetch products + config
   useEffect(() => {
@@ -115,7 +115,8 @@ function CompraForm() {
     ]).then(([prodRes, catRes, cfgRes]) => {
       if (prodRes.data) setAllProducts(prodRes.data);
       if (catRes.categorias) setCatalogo(catRes.categorias);
-      if (cfgRes.data?.whatsapp_principal) setWhatsappConfig(cfgRes.data.whatsapp_principal);
+      if (cfgRes.data?.whatsapp_formularios) setWhatsappFormConfig(cfgRes.data.whatsapp_formularios);
+      if (cfgRes.data?.whatsapp_principal) setWhatsappPrincipalConfig(cfgRes.data.whatsapp_principal);
     });
   }, []);
 

--- a/components/TradeInCalculator.tsx
+++ b/components/TradeInCalculator.tsx
@@ -96,14 +96,15 @@ export default function TradeInCalculator({ vendedor: vendedorProp, temaParam }:
 
   const [questionsConfig, setQuestionsConfig] = useState<TradeInQuestion[] | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
+  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
   // Mapa dinâmico de WhatsApp por vendedor — usa DB se disponível
   const VENDEDOR_WHATSAPP = useMemo(() => {
     const dbMap = tradeinConfig?.whatsapp_vendedores;
     return dbMap && Object.keys(dbMap).length > 0 ? { ...DEFAULT_VENDEDOR_WHATSAPP, ...dbMap } : DEFAULT_VENDEDOR_WHATSAPP;
   }, [tradeinConfig]);
-  // WhatsApp principal — usa DB se disponível
+  // WhatsApp formulários — usa campo dedicado se disponível, senão principal
   const whatsappPrincipal: string = tradeinConfig?.whatsapp_principal || config.whatsappNumero;
+  const whatsappFormularios: string = tradeinConfig?.whatsapp_formularios || whatsappPrincipal;
   const [deviceType, setDeviceType] = useState<DeviceType>("iphone");
   const [usedModel, setUsedModel] = useState("");
   const [usedStorage, setUsedStorage] = useState("");
@@ -396,7 +397,7 @@ export default function TradeInCalculator({ vendedor: vendedorProp, temaParam }:
           )}
 
           {step === 2 && (
-            <StepNewDevice products={products} tradeInValue={totalTradeInValue} onNext={handleStep2Complete} onBack={() => setStep(hasSecondDevice ? 1.7 : 1)} usedModel={usedModel} usedStorage={usedStorage} whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappPrincipal} condition={condition} deviceType={deviceType} tradeinConfig={tradeinConfig} />
+            <StepNewDevice products={products} tradeInValue={totalTradeInValue} onNext={handleStep2Complete} onBack={() => setStep(hasSecondDevice ? 1.7 : 1)} usedModel={usedModel} usedStorage={usedStorage} whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormularios} condition={condition} deviceType={deviceType} tradeinConfig={tradeinConfig} />
           )}
 
           {step === 3 && (
@@ -416,7 +417,7 @@ export default function TradeInCalculator({ vendedor: vendedorProp, temaParam }:
               condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined}
               tradeInValue1={hasSecondDevice ? tradeInValue : undefined} tradeInValue2={hasSecondDevice ? tradeInValue2 : undefined}
               clienteNome={clienteNome} clienteWhatsApp={clienteWhatsApp} clienteInstagram={clienteInstagram} clienteOrigem={clienteOrigem}
-              whatsappNumero={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappPrincipal}
+              whatsappNumero={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormularios}
               validadeHoras={config.validadeHoras} vendedor={vendedor}
               onReset={handleReset} onCotarOutro={handleCotarOutro}
               onGoToStep={handleGoToStep}

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -87,8 +87,13 @@ function inferSpecFromCatalogModel(nome: string, categoria: string): Partial<Pro
     if (/air/i.test(nome)) s.mb_modelo = "AIR";
     else if (/neo/i.test(nome)) s.mb_modelo = "NEO";
     else s.mb_modelo = "PRO";
-    const chip = nome.match(/\b(M\d+(\s+(PRO|MAX))?)\b/i);
-    s.mb_chip = chip ? chip[1].toUpperCase() : "";
+    // MacBook Neo sempre usa A18 PRO (chip fixo)
+    if (s.mb_modelo === "NEO") {
+      s.mb_chip = "A18 PRO";
+    } else {
+      const chip = nome.match(/\b(M\d+(\s+(PRO|MAX))?)\b/i);
+      s.mb_chip = chip ? chip[1].toUpperCase() : "";
+    }
     s.mb_nucleos = ""; // hide nucleos when using catalog model
   } else if (categoria === "MAC_MINI") {
     const chip = nome.match(/\b(M\d+(\s+(PRO|MAX))?)\b/i);
@@ -619,7 +624,7 @@ export default function ProdutoSpecFields({
               <div>
                 <p className={labelCls}>Chip</p>
                 <select value={row.spec.mb_chip} onChange={(e) => setSpec("mb_chip", e.target.value)} className={inputCls}>
-                  {["M1","M2","M2 PRO","M3","M3 PRO","M3 MAX","M4","M4 PRO","M4 MAX","M5","M5 PRO","M5 MAX"].map((c) => <option key={c}>{c}</option>)}
+                  {["A18","A18 PRO","M1","M2","M2 PRO","M3","M3 PRO","M3 MAX","M4","M4 PRO","M4 MAX","M5","M5 PRO","M5 MAX"].map((c) => <option key={c}>{c}</option>)}
                 </select>
               </div>
             </>

--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -182,7 +182,7 @@ export const MACBOOK_TIPOS = ["AIR", "PRO", "NEO"] as const;
 export const MACBOOK_TELAS_AIR = ['13"', '15"'];
 export const MACBOOK_TELAS_PRO = ['14"', '16"'];
 export const MACBOOK_TELAS_NEO = ['14"'];
-export const MACBOOK_CHIPS = ["M1", "M2", "M2 PRO", "M3", "M3 PRO", "M3 MAX", "M4", "M4 PRO", "M4 MAX", "M5", "M5 PRO", "M5 MAX"];
+export const MACBOOK_CHIPS = ["A18", "A18 PRO", "M1", "M2", "M2 PRO", "M3", "M3 PRO", "M3 MAX", "M4", "M4 PRO", "M4 MAX", "M5", "M5 PRO", "M5 MAX"];
 export const MACBOOK_RAMS = ["8GB", "16GB", "18GB", "24GB", "32GB", "36GB", "48GB", "64GB", "128GB"];
 export const MACBOOK_STORAGES = ["256GB", "512GB", "1TB", "2TB", "4TB", "8TB"];
 export const MACBOOK_NUCLEOS = [
@@ -208,7 +208,7 @@ export const IPAD_MODELOS = [
   { value: "AIR", label: "iPad Air" },
   { value: "PRO", label: "iPad Pro" },
 ];
-export const IPAD_CHIPS = ["A15", "A16", "M1", "M2", "M3", "M4"];
+export const IPAD_CHIPS = ["A15", "A16", "M1", "M2", "M3", "M4", "M5"];
 export const IPAD_TELAS = ['8.3"', '10.9"', '11"', '13"'];
 export const IPAD_STORAGES = ["64GB", "128GB", "256GB", "512GB", "1TB", "2TB"];
 export const IPAD_CONNS = [
@@ -254,13 +254,16 @@ export const COR_PT_TO_EN: Record<string, string> = {
   "AZUL PACIFICO": "PACIFIC BLUE",
   "AZUL PROFUNDO": "DEEP BLUE",
   "AZUL SIERRA": "SIERRA BLUE",
+  "BLUSH": "BLUSH",
   "BRANCO": "WHITE",
   "BRANCO NUVEM": "CLOUD WHITE",
+  "CITRUS": "CITRUS",
   "CINZA ESPACIAL": "SPACE GRAY",
   "DOURADO": "GOLD",
   "DOURADO CLARO": "LIGHT GOLD",
   "ESTELAR": "STARLIGHT",
   "GRAFITE": "GRAPHITE",
+  "INDIGO": "INDIGO",
   "LARANJA COSMICO": "COSMIC ORANGE",
   "LAVANDA": "LAVENDER",
   "MEIA-NOITE": "MIDNIGHT",
@@ -313,11 +316,13 @@ export function buildProdutoName(cat: string, spec: ProdutoSpec, cor?: string): 
     }
     case "MACBOOK": {
       const tipo = spec.mb_modelo === "AIR" ? "MACBOOK AIR" : spec.mb_modelo === "NEO" ? "MACBOOK NEO" : "MACBOOK PRO";
+      // MacBook Neo: chip fica só nos detalhes (spec), não no nome do produto
+      const chip = spec.mb_modelo === "NEO" ? "" : ` ${spec.mb_chip}`;
       const nucleos = spec.mb_nucleos ? ` (${spec.mb_nucleos})` : "";
       const tela = spec.mb_tela ? ` ${spec.mb_tela}` : "";
       const ram = spec.mb_ram ? ` ${spec.mb_ram}` : "";
       const storage = spec.mb_storage ? ` ${spec.mb_storage}` : "";
-      return `${tipo} ${spec.mb_chip}${nucleos}${tela}${ram}${storage}${c}`.toUpperCase();
+      return `${tipo}${chip}${nucleos}${tela}${ram}${storage}${c}`.toUpperCase();
     }
     case "IPADS": {
       const modelo = spec.ipad_modelo === "IPAD" ? "IPAD" : `IPAD ${spec.ipad_modelo}`;


### PR DESCRIPTION
## Summary
- Novo campo **WhatsApp Formulários** separado do Principal para receber formulários de troca, seminovos e links de compra
- Fix bug **++55** na formatação de telefone
- **MacBook Neo**: chip A18 PRO removido do nome (fica nos specs), auto-detecção e auto-preenchimento
- **iPad Pro M5**: chip adicionado à lista de chips válidos + correção automática na exibição
- **fixProdutoName**: corrige nomes antigos automaticamente na exibição, sem SQL
- **Bateria** editável inline nas tabs estoque e seminovos
- Cores **Blush, Citrus, Indigo** no mapeamento

## Test plan
- [ ] Verificar que formulários de troca/seminovos/links de compra usam o novo WhatsApp Formulários
- [ ] Verificar que telefones mostram +55 (não ++55) na página de simulações
- [ ] Cadastrar MacBook Neo e confirmar nome sem A18 PRO
- [ ] Verificar que MacBook Neo existente mostra nome corrigido automaticamente
- [ ] Verificar que iPad Pro sem M5 mostra M5 na exibição
- [ ] Editar bateria de seminovo nas tabs estoque e seminovos

🤖 Generated with [Claude Code](https://claude.com/claude-code)