### PR TITLE
Fix: remover cores duplicadas que quebram o build

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -148,8 +148,6 @@ const COR_PT: Record<string, string> = {
   "JET BLACK": "Preto Brilhante",
   "CLOUD WHITE": "Branco Nuvem",
   "SKY BLUE": "Azul Céu",
-  "TEAL": "Verde-azulado",
-  "DEEP BLUE": "Azul Profundo",
 };
 
 function traduzirCor(cor: string | null | undefined): string {
@@ -214,7 +212,6 @@ const PT_TO_EN: Record<string, string> = {
   "AZUL CÉU": "Sky Blue",
   "AZUL CEU": "Sky Blue",
   "VERDE-AZULADO": "Teal",
-  "AZUL PROFUNDO": "Deep Blue",
 };
 
 const ORIGEM_CODES = ["AA","BE","BR","BZ","CH","E","HN","J","LL","LZ","N","QL","VC","ZD","ZP"];


### PR DESCRIPTION
## Summary
- Remove propriedades duplicadas TEAL e AZUL PROFUNDO nos mapas COR_PT e PT_TO_EN
- Corrige erro TS1117 que causava falha no deploy da Vercel

## Test plan
- [x] `tsc --noEmit` passa sem erros

🤖 Generated with [Claude Code](https://claude.com/claude-code)