### PR TITLE
Catálogo de cores migrado para inglês com PT ao lado

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -8,7 +8,7 @@ import { getCategoriasEstoque, addCategoriaEstoque, removeCategoriaEstoque, edit
 import type { Categoria } from "@/lib/categorias";
 
 import BarcodeScanner from "@/components/BarcodeScanner";
-import { buildProdutoName as buildProdutoNameFromSpec, CORES_POR_CATEGORIA, COR_OBRIGATORIA, IPHONE_ORIGENS, WATCH_PULSEIRAS, getIphoneCores, type ProdutoSpec } from "@/lib/produto-specs";
+import { buildProdutoName as buildProdutoNameFromSpec, CORES_POR_CATEGORIA, COR_EN_TO_PT, COR_OBRIGATORIA, IPHONE_ORIGENS, WATCH_PULSEIRAS, getIphoneCores, type ProdutoSpec } from "@/lib/produto-specs";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 import type { Banco } from "@/lib/admin-types";
 
@@ -182,6 +182,7 @@ const PT_TO_EN: Record<string, string> = {
   "AMORA": "Mulberry",
   "AZUL PROFUNDO": "Deep Blue",
   "AZUL PACÍFICO": "Pacific Blue",
+  "AZUL PACIFICO": "Pacific Blue",
   "AZUL SIERRA": "Sierra Blue",
   "AZUL TEMPESTADE": "Storm Blue",
   "AZUL PRATA": "Silver Blue",
@@ -190,16 +191,23 @@ const PT_TO_EN: Record<string, string> = {
   "VERDE MEIA-NOITE": "Midnight Green",
   "ROXO PROFUNDO": "Deep Purple",
   "LARANJA CÓSMICO": "Cosmic Orange",
+  "LARANJA COSMICO": "Cosmic Orange",
   "ROSA CLARO": "Light Pink",
   "PRETO FURTIVO": "Stealth Black",
   "PRETO ESPACIAL": "Space Black",
   "CINZA ESPACIAL": "Space Gray",
   "TITÂNIO NATURAL": "Natural Titanium",
+  "TITANIO NATURAL": "Natural Titanium",
   "TITÂNIO PRETO": "Black Titanium",
+  "TITANIO PRETO": "Black Titanium",
   "TITÂNIO BRANCO": "White Titanium",
+  "TITANIO BRANCO": "White Titanium",
   "TITÂNIO DESERTO": "Desert Titanium",
+  "TITANIO DESERTO": "Desert Titanium",
   "TITÂNIO AZUL": "Blue Titanium",
+  "TITANIO AZUL": "Blue Titanium",
   "TITÂNIO": "Titanium",
+  "TITANIO": "Titanium",
   "NATURAL": "Natural",
   "ULTRAMARINO": "Ultramarine",
   "LAVANDA": "Lavender",
@@ -2492,7 +2500,7 @@ export default function EstoquePage() {
               {coresEfetivas ? (
                 <select value={form.cor} onChange={(e) => set("cor", e.target.value)} className={`${inputCls} flex-1`} style={{ width: "auto" }}>
                   {COR_OBRIGATORIA.includes(formBaseCat) ? <option value="" disabled>— Selecionar —</option> : <option value="">— Opcional —</option>}
-                  {coresEfetivas.map((c) => <option key={c}>{c}</option>)}
+                  {coresEfetivas.map((c) => <option key={c} value={c}>{c}{COR_EN_TO_PT[c] ? ` · ${COR_EN_TO_PT[c]}` : ""}</option>)}
                 </select>
               ) : (
                 <input value={form.cor} onChange={(e) => set("cor", e.target.value)} placeholder="Ex: Silver, Azul, Preto..." className={`${inputCls} flex-1`} style={{ width: "auto" }} />
@@ -2507,7 +2515,7 @@ export default function EstoquePage() {
                 {coresEfetivas ? (
                   <select value={v.cor} onChange={(e) => { const nv = [...variacoes]; nv[i].cor = e.target.value; setVariacoes(nv); }} className={`${inputCls} flex-1`} style={{ width: "auto" }}>
                     {COR_OBRIGATORIA.includes(formBaseCat) ? <option value="" disabled>— Selecionar —</option> : <option value="">— Opcional —</option>}
-                    {coresEfetivas.map((c) => <option key={c}>{c}</option>)}
+                    {coresEfetivas.map((c) => <option key={c} value={c}>{c}{COR_EN_TO_PT[c] ? ` · ${COR_EN_TO_PT[c]}` : ""}</option>)}
                   </select>
                 ) : (
                   <input value={v.cor} onChange={(e) => { const nv = [...variacoes]; nv[i].cor = e.target.value; setVariacoes(nv); }} placeholder="Cor" className={`${inputCls} flex-1`} style={{ width: "auto" }} />
@@ -4091,8 +4099,8 @@ export default function EstoquePage() {
                           className={`w-full text-[13px] mt-0.5 px-2 py-1.5 rounded-lg border ${dm ? "bg-[#1C1C1E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"} focus:border-[#E8740E] focus:outline-none`}
                         >
                           <option value="">— Selecionar —</option>
-                          {p.cor && !coresCat.includes(p.cor) && <option key={p.cor} value={p.cor}>{(() => { const u = p.cor.toUpperCase().trim(); const en = PT_TO_EN[u]; return en ? `${en} · ${p.cor}` : p.cor; })()}</option>}
-                          {coresCat.map((c) => { const u = c.toUpperCase().trim(); const en = PT_TO_EN[u]; return <option key={c} value={c}>{en ? `${en} · ${c}` : c}</option>; })}
+                          {p.cor && !coresCat.includes(p.cor) && <option key={p.cor} value={p.cor}>{p.cor}{COR_EN_TO_PT[p.cor.toUpperCase()] ? ` · ${COR_EN_TO_PT[p.cor.toUpperCase()]}` : ""}</option>}
+                          {coresCat.map((c) => <option key={c} value={c}>{c}{COR_EN_TO_PT[c] ? ` · ${COR_EN_TO_PT[c]}` : ""}</option>)}
                         </select>
                       ) : (
                         <input

--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -20,44 +20,43 @@ export const STRUCTURED_CATS = ["IPHONES", "MACBOOK", "MAC_MINI", "IPADS", "APPL
 
 /** Cores de iPhone por linha/modelo */
 export const IPHONE_CORES_POR_MODELO: Record<string, string[]> = {
-  "11":            ["PRETO", "VERDE", "ROXO", "VERMELHO", "BRANCO", "AMARELO"],
-  "11 PRO":        ["DOURADO", "VERDE MEIA-NOITE", "PRATA", "CINZA ESPACIAL"],
-  "11 PRO MAX":    ["DOURADO", "VERDE MEIA-NOITE", "PRATA", "CINZA ESPACIAL"],
-  "12":            ["PRETO", "AZUL", "VERDE", "ROXO", "VERMELHO", "BRANCO"],
-  "12 PRO":        ["DOURADO", "GRAFITE", "AZUL PACIFICO", "PRATA"],
-  "12 PRO MAX":    ["DOURADO", "GRAFITE", "AZUL PACIFICO", "PRATA"],
-  "13":            ["AZUL", "VERDE", "MEIA-NOITE", "ROSA", "VERMELHO", "ESTELAR"],
-  "13 PRO":        ["VERDE ALPINO", "DOURADO", "GRAFITE", "AZUL SIERRA", "PRATA"],
-  "13 PRO MAX":    ["VERDE ALPINO", "DOURADO", "GRAFITE", "AZUL SIERRA", "PRATA"],
-  "14":            ["AZUL", "MEIA-NOITE", "ROXO", "VERMELHO", "ESTELAR", "AMARELO"],
-  "14 PLUS":       ["AZUL", "MEIA-NOITE", "ROXO", "VERMELHO", "ESTELAR", "AMARELO"],
-  "14 PRO":        ["ROXO PROFUNDO", "DOURADO", "PRATA", "PRETO ESPACIAL"],
-  "14 PRO MAX":    ["ROXO PROFUNDO", "DOURADO", "PRATA", "PRETO ESPACIAL"],
-  "15":            ["PRETO", "AZUL", "VERDE", "ROSA", "AMARELO"],
-  "15 PLUS":       ["PRETO", "AZUL", "VERDE", "ROSA", "AMARELO"],
-  "15 PRO":        ["TITANIO PRETO", "TITANIO AZUL", "TITANIO NATURAL", "TITANIO BRANCO"],
-  "15 PRO MAX":    ["TITANIO PRETO", "TITANIO AZUL", "TITANIO NATURAL", "TITANIO BRANCO"],
-  "16":            ["PRETO", "ROSA", "TEAL", "ULTRAMARINO", "BRANCO"],
-  "16 PLUS":       ["PRETO", "ROSA", "TEAL", "ULTRAMARINO", "BRANCO"],
-  "16 PRO":        ["TITANIO PRETO", "TITANIO DESERTO", "TITANIO NATURAL", "TITANIO BRANCO"],
-  "16 PRO MAX":    ["TITANIO PRETO", "TITANIO DESERTO", "TITANIO NATURAL", "TITANIO BRANCO"],
-  "16E":           ["PRETO", "BRANCO"],
-  "17":            ["PRETO", "LAVANDA", "AZUL NEVOA", "SAGE", "BRANCO"],
-  "17 AIR":        ["BRANCO NUVEM", "DOURADO CLARO", "AZUL CEU", "PRETO ESPACIAL"],
-  "17 PRO":        ["LARANJA COSMICO", "AZUL PROFUNDO", "PRATA"],
-  "17 PRO MAX":    ["LARANJA COSMICO", "AZUL PROFUNDO", "PRATA"],
+  "11":            ["BLACK", "GREEN", "PURPLE", "RED", "WHITE", "YELLOW"],
+  "11 PRO":        ["GOLD", "MIDNIGHT GREEN", "SILVER", "SPACE GRAY"],
+  "11 PRO MAX":    ["GOLD", "MIDNIGHT GREEN", "SILVER", "SPACE GRAY"],
+  "12":            ["BLACK", "BLUE", "GREEN", "PURPLE", "RED", "WHITE"],
+  "12 PRO":        ["GOLD", "GRAPHITE", "PACIFIC BLUE", "SILVER"],
+  "12 PRO MAX":    ["GOLD", "GRAPHITE", "PACIFIC BLUE", "SILVER"],
+  "13":            ["BLUE", "GREEN", "MIDNIGHT", "PINK", "RED", "STARLIGHT"],
+  "13 PRO":        ["ALPINE GREEN", "GOLD", "GRAPHITE", "SIERRA BLUE", "SILVER"],
+  "13 PRO MAX":    ["ALPINE GREEN", "GOLD", "GRAPHITE", "SIERRA BLUE", "SILVER"],
+  "14":            ["BLUE", "MIDNIGHT", "PURPLE", "RED", "STARLIGHT", "YELLOW"],
+  "14 PLUS":       ["BLUE", "MIDNIGHT", "PURPLE", "RED", "STARLIGHT", "YELLOW"],
+  "14 PRO":        ["DEEP PURPLE", "GOLD", "SILVER", "SPACE BLACK"],
+  "14 PRO MAX":    ["DEEP PURPLE", "GOLD", "SILVER", "SPACE BLACK"],
+  "15":            ["BLACK", "BLUE", "GREEN", "PINK", "YELLOW"],
+  "15 PLUS":       ["BLACK", "BLUE", "GREEN", "PINK", "YELLOW"],
+  "15 PRO":        ["BLACK TITANIUM", "BLUE TITANIUM", "NATURAL TITANIUM", "WHITE TITANIUM"],
+  "15 PRO MAX":    ["BLACK TITANIUM", "BLUE TITANIUM", "NATURAL TITANIUM", "WHITE TITANIUM"],
+  "16":            ["BLACK", "PINK", "TEAL", "ULTRAMARINE", "WHITE"],
+  "16 PLUS":       ["BLACK", "PINK", "TEAL", "ULTRAMARINE", "WHITE"],
+  "16 PRO":        ["BLACK TITANIUM", "DESERT TITANIUM", "NATURAL TITANIUM", "WHITE TITANIUM"],
+  "16 PRO MAX":    ["BLACK TITANIUM", "DESERT TITANIUM", "NATURAL TITANIUM", "WHITE TITANIUM"],
+  "16E":           ["BLACK", "WHITE"],
+  "17":            ["BLACK", "LAVENDER", "HAZE BLUE", "SAGE", "WHITE"],
+  "17 AIR":        ["CLOUD WHITE", "LIGHT GOLD", "SKY BLUE", "SPACE BLACK"],
+  "17 PRO":        ["COSMIC ORANGE", "DEEP BLUE", "SILVER"],
+  "17 PRO MAX":    ["COSMIC ORANGE", "DEEP BLUE", "SILVER"],
 };
 
 /** Lista completa de todas as cores de iPhone (fallback) */
 export const IPHONE_CORES = [
-  "AMARELO", "AZUL", "AZUL CEU", "AZUL NEVOA", "AZUL PACIFICO", "AZUL PROFUNDO", "AZUL SIERRA",
-  "BRANCO", "BRANCO NUVEM", "CINZA ESPACIAL",
-  "DOURADO", "DOURADO CLARO", "ESTELAR",
-  "GRAFITE", "LARANJA COSMICO", "LAVANDA",
-  "MEIA-NOITE", "PRETO", "PRETO ESPACIAL", "PRATA",
-  "ROSA", "ROXO", "ROXO PROFUNDO", "SAGE",
-  "TEAL", "TITANIO AZUL", "TITANIO BRANCO", "TITANIO DESERTO", "TITANIO NATURAL", "TITANIO PRETO",
-  "ULTRAMARINO", "VERDE", "VERDE ALPINO", "VERDE MEIA-NOITE", "VERMELHO",
+  "ALPINE GREEN", "BLACK", "BLACK TITANIUM", "BLUE", "BLUE TITANIUM",
+  "CLOUD WHITE", "COSMIC ORANGE", "DEEP BLUE", "DEEP PURPLE", "DESERT TITANIUM",
+  "GOLD", "GRAPHITE", "GREEN", "HAZE BLUE",
+  "LAVENDER", "LIGHT GOLD", "MIDNIGHT", "MIDNIGHT GREEN",
+  "NATURAL TITANIUM", "PACIFIC BLUE", "PINK", "PURPLE", "RED",
+  "SAGE", "SIERRA BLUE", "SILVER", "SKY BLUE", "SPACE BLACK", "SPACE GRAY", "STARLIGHT",
+  "TEAL", "ULTRAMARINE", "WHITE", "WHITE TITANIUM", "YELLOW",
 ];
 
 /** Retorna as cores do iPhone baseado no modelo selecionado */
@@ -65,19 +64,19 @@ export function getIphoneCores(modelo: string): string[] {
   return IPHONE_CORES_POR_MODELO[modelo] || IPHONE_CORES;
 }
 
-export const MACBOOK_CORES = ["MEIA-NOITE", "PRATA", "ESTELAR", "AZUL CEU", "PRETO ESPACIAL"];
+export const MACBOOK_CORES = ["MIDNIGHT", "SILVER", "STARLIGHT", "SKY BLUE", "SPACE BLACK"];
 
-export const IPAD_CORES = ["AZUL", "CINZA ESPACIAL", "ESTELAR", "ROXO"];
+export const IPAD_CORES = ["BLUE", "SPACE GRAY", "STARLIGHT", "PURPLE"];
 
 export const WATCH_CORES = [
-  "TITANIO PRETO", "DOURADO", "GRAFITE", "PRETO ONYX", "MEIA-NOITE",
-  "NATURAL", "TITANIO NATURAL", "ROSA", "VERMELHO", "OURO ROSA",
-  "PRATA", "ARDOSIA", "CINZA ESPACIAL", "ESTELAR",
+  "BLACK TITANIUM", "GOLD", "GRAPHITE", "ONYX BLACK", "MIDNIGHT",
+  "NATURAL", "NATURAL TITANIUM", "PINK", "RED", "ROSE GOLD",
+  "SILVER", "SLATE", "SPACE GRAY", "STARLIGHT",
 ];
 
-export const AIRPODS_CORES = ["MEIA-NOITE", "ESTELAR"];
+export const AIRPODS_CORES = ["MIDNIGHT", "STARLIGHT"];
 
-export const ACESSORIOS_CORES = ["PRETO", "BRANCO"];
+export const ACESSORIOS_CORES = ["BLACK", "WHITE"];
 
 /** Mapa de cores por categoria para lookup rápido */
 export const CORES_POR_CATEGORIA: Record<string, string[]> = {
@@ -290,6 +289,11 @@ export const COR_PT_TO_EN: Record<string, string> = {
   "ARDOSIA": "SLATE",
   "OURO ROSA": "ROSE GOLD",
 };
+
+// Mapa reverso EN → PT (gerado a partir de COR_PT_TO_EN)
+export const COR_EN_TO_PT: Record<string, string> = Object.fromEntries(
+  Object.entries(COR_PT_TO_EN).map(([pt, en]) => [en, pt.charAt(0).toUpperCase() + pt.slice(1).toLowerCase()])
+);
 
 /** Converte cor em português para inglês (nome comercial Apple) */
 export function corToEn(cor: string): string {


### PR DESCRIPTION
## Summary
- Todas as cores do catálogo (produto-specs.ts) migradas para inglês (Apple commercial names)
- Dropdown mostra "DESERT TITANIUM · Titanio Deserto" (EN + PT)
- `displayNomeProduto()` anexa cor EN ao nome quando não presente no texto
- Modal mostra nome completo: "IPHONE 16 PRO MAX 256GB DESERT TITANIUM" com "Titânio Deserto" em cinza
- Suporte a cores legadas em PT no banco (PT_TO_EN com versões sem acento)
- COR_EN_TO_PT gerado automaticamente para tradução reversa

## Test plan
- [ ] Abrir produto no estoque → dropdown de cor mostra nomes em EN com PT ao lado
- [ ] Selecionar cor → nome do produto no header atualiza com cor EN
- [ ] Verificar tradução PT em cinza ao lado do nome
- [ ] Cadastrar novo produto → cores no form em EN
- [ ] Produtos legados com cor em PT continuam funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)