### PR TITLE
fix: remove extra closing div causing parse error

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -2047,7 +2047,6 @@ export default function EstoquePage() {
           </div>
         )}
         </div>
-      </div>
       )}
 
       {/* Preços Sugeridos por tipo */}


### PR DESCRIPTION
## Summary
- Remove extra `</div>` tag that caused an "Unterminated regexp literal" parse error on the estoque page

## Test plan
- [x] Build passes successfully
- [ ] Verify estoque page loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)