### PR TITLE
Reposição, Fornecedores, fixes e melhorias

### DIFF
--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -33,6 +33,28 @@ interface Cliente {
   vendas: VendaResumo[];
 }
 
+interface FornecedorCompra {
+  produto: string;
+  cor: string | null;
+  qnt: number;
+  custo_unitario: number;
+  data: string;
+  categoria: string;
+  status: string;
+  serial_no: string | null;
+}
+
+interface Fornecedor {
+  nome: string;
+  total_produtos: number;
+  total_investido: number;
+  total_em_estoque: number;
+  primeira_compra: string;
+  ultima_compra: string;
+  categorias: string[];
+  compras: FornecedorCompra[];
+}
+
 const fmt = (v: number) => `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
 const fmtDate = (d: string) => {
   if (!d) return "—";
@@ -43,10 +65,11 @@ const fmtDate = (d: string) => {
 export default function ClientesPage() {
   const { password, darkMode: dm, apiHeaders } = useAdmin();
   const searchParams = useSearchParams();
-  const [tab, setTab] = useState<"clientes" | "lojistas" | "notas">("clientes");
+  const [tab, setTab] = useState<"clientes" | "lojistas" | "fornecedores" | "notas">("clientes");
   const [search, setSearch] = useState(() => searchParams.get("q") || "");
   const [debouncedSearch, setDebouncedSearch] = useState(() => searchParams.get("q") || "");
   const [clientes, setClientes] = useState<Cliente[]>([]);
+  const [fornecedores, setFornecedores] = useState<Fornecedor[]>([]);
   const [notas, setNotas] = useState<{ id: string; data: string; cliente: string; produto: string; preco_vendido: number; nota_fiscal_url: string }[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -54,8 +77,9 @@ export default function ClientesPage() {
   const [editing, setEditing] = useState(false);
   const [editForm, setEditForm] = useState({ nome: "", cpf: "", email: "", bairro: "", cidade: "", uf: "", cep: "", endereco: "" });
   const [savingClient, setSavingClient] = useState(false);
-  const [totals, setTotals] = useState({ total: 0, total_gasto: 0, total_compras: 0 });
+  const [totals, setTotals] = useState({ total: 0, total_gasto: 0, total_compras: 0, total_investido: 0, total_em_estoque: 0, total_produtos: 0 });
   const [sortBy, setSortBy] = useState<"gasto" | "compras" | "nome" | "recente">("gasto");
+  const [fornSort, setFornSort] = useState<"investido" | "produtos" | "nome" | "recente">("investido");
 
   // Debounce search
   useEffect(() => {
@@ -64,33 +88,32 @@ export default function ClientesPage() {
   }, [search]);
 
   const fetchClientes = useCallback(async () => {
-    if (!password) return; // aguardar autenticação
+    if (!password) return;
     setLoading(true);
     try {
       const params = new URLSearchParams({ tab });
       if (debouncedSearch) params.set("search", debouncedSearch);
-      const res = await fetch(`/api/admin/clientes?${params}`, {
-        headers: apiHeaders(),
-      });
+      const res = await fetch(`/api/admin/clientes?${params}`, { headers: apiHeaders() });
       if (res.ok) {
         const json = await res.json();
         if (tab === "notas") {
           setNotas(json.notas ?? []);
-          setTotals({ total: json.total ?? 0, total_gasto: 0, total_compras: 0 });
+          setTotals(t => ({ ...t, total: json.total ?? 0 }));
+        } else if (tab === "fornecedores") {
+          setFornecedores(json.fornecedores ?? []);
+          setTotals(t => ({ ...t, total: json.total, total_investido: json.total_investido, total_produtos: json.total_produtos, total_em_estoque: json.total_em_estoque }));
         } else {
           setClientes(json.clientes ?? []);
-          setTotals({ total: json.total, total_gasto: json.total_gasto, total_compras: json.total_compras });
+          setTotals(t => ({ ...t, total: json.total, total_gasto: json.total_gasto, total_compras: json.total_compras }));
         }
-      } else {
-        console.error("Clientes API error:", res.status, await res.text().catch(() => ""));
       }
-    } catch (err) { console.error("Clientes fetch error:", err); }
+    } catch (err) { console.error("Fetch error:", err); }
     setLoading(false);
   }, [password, tab, debouncedSearch, apiHeaders]);
 
   useEffect(() => { fetchClientes(); }, [fetchClientes]);
 
-  // Sort
+  // Sort clientes
   const sorted = [...clientes].sort((a, b) => {
     switch (sortBy) {
       case "gasto": return b.total_gasto - a.total_gasto;
@@ -101,23 +124,41 @@ export default function ClientesPage() {
     }
   });
 
+  // Sort fornecedores
+  const sortedForn = [...fornecedores].sort((a, b) => {
+    switch (fornSort) {
+      case "investido": return b.total_investido - a.total_investido;
+      case "produtos": return b.total_produtos - a.total_produtos;
+      case "nome": return a.nome.localeCompare(b.nome);
+      case "recente": return b.ultima_compra.localeCompare(a.ultima_compra);
+      default: return 0;
+    }
+  });
+
+  const mP = dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]";
+  const mS = dm ? "text-[#98989D]" : "text-[#86868B]";
+  const mM = dm ? "text-[#636366]" : "text-[#86868B]";
   const cardCls = `${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-white border-[#D2D2D7]"} border rounded-2xl p-4 shadow-sm`;
   const inputCls = `w-full px-4 py-3 rounded-xl border text-sm focus:outline-none focus:border-[#E8740E] transition-colors ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7] placeholder-[#636366]" : "bg-[#F5F5F7] border-[#D2D2D7] text-[#1D1D1F] placeholder-[#86868B]"}`;
+  const tableCls = `${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-white border-[#D2D2D7]"} border rounded-2xl overflow-hidden shadow-sm`;
+  const thCls = `px-4 py-3 text-left font-medium text-xs uppercase tracking-wider whitespace-nowrap ${mS}`;
+  const rowCls = `border-b cursor-pointer transition-colors ${dm ? "border-[#2C2C2E] hover:bg-[#2C2C2E]" : "border-[#F5F5F7] hover:bg-[#FAFAFA]"}`;
 
   return (
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className={`text-2xl font-bold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>Clientes</h1>
-        <p className={`text-sm ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Base de clientes com historico de compras</p>
+        <h1 className={`text-2xl font-bold ${mP}`}>Clientes</h1>
+        <p className={`text-sm ${mS}`}>Base de clientes com historico de compras</p>
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-2">
+      <div className="flex gap-2 flex-wrap">
         {([
-          { key: "clientes" as const, label: "👤 Clientes" },
-          { key: "lojistas" as const, label: "🏪 Lojistas" },
-          { key: "notas" as const, label: "📄 Notas Fiscais" },
+          { key: "clientes" as const, label: "Clientes" },
+          { key: "lojistas" as const, label: "Lojistas" },
+          { key: "fornecedores" as const, label: "Fornecedores" },
+          { key: "notas" as const, label: "Notas Fiscais" },
         ]).map((t) => (
           <button
             key={t.key}
@@ -133,7 +174,7 @@ export default function ClientesPage() {
       <div className="relative">
         <input
           type="text"
-          placeholder="Pesquisar por nome, CPF ou numero de serie..."
+          placeholder={tab === "fornecedores" ? "Pesquisar fornecedor..." : "Pesquisar por nome, CPF ou numero de serie..."}
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           className={inputCls}
@@ -143,31 +184,220 @@ export default function ClientesPage() {
         )}
       </div>
 
+      {/* ============= FORNECEDORES TAB ============= */}
+      {tab === "fornecedores" ? (<>
+        {/* Summary */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <div className={cardCls}>
+            <p className={`text-xs uppercase tracking-wider ${mS}`}>Fornecedores</p>
+            <p className={`text-2xl font-bold ${mP}`}>{totals.total}</p>
+          </div>
+          <div className={cardCls}>
+            <p className={`text-xs uppercase tracking-wider ${mS}`}>Produtos Comprados</p>
+            <p className="text-2xl font-bold text-[#E8740E]">{totals.total_produtos}</p>
+          </div>
+          <div className={cardCls}>
+            <p className={`text-xs uppercase tracking-wider ${mS}`}>Total Investido</p>
+            <p className="text-2xl font-bold text-red-500">{fmt(totals.total_investido)}</p>
+          </div>
+          <div className={cardCls}>
+            <p className={`text-xs uppercase tracking-wider ${mS}`}>Em Estoque</p>
+            <p className="text-2xl font-bold text-green-600">{totals.total_em_estoque} un.</p>
+          </div>
+        </div>
+
+        {/* Sort */}
+        <div className="flex items-center gap-2">
+          <span className={`text-xs ${mS}`}>Ordenar:</span>
+          {([
+            { key: "investido", label: "Maior investimento" },
+            { key: "produtos", label: "Mais produtos" },
+            { key: "recente", label: "Mais recente" },
+            { key: "nome", label: "Nome" },
+          ] as const).map((o) => (
+            <button
+              key={o.key}
+              onClick={() => setFornSort(o.key)}
+              className={`px-3 py-1 rounded-lg text-xs font-medium transition-colors ${fornSort === o.key ? "bg-[#E8740E] text-white" : `${dm ? "bg-[#2C2C2E] text-[#98989D]" : "bg-[#F5F5F7] text-[#86868B]"} hover:text-[#E8740E]`}`}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Fornecedores Table */}
+        <div className={tableCls}>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className={`border-b ${dm ? "border-[#3A3A3C] bg-[#2C2C2E]" : "border-[#D2D2D7] bg-[#F5F5F7]"}`}>
+                  {["Fornecedor", "Produtos", "Investido", "Em Estoque", "Categorias", "Primeira Compra", "Ultima Compra"].map(h => (
+                    <th key={h} className={thCls}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr><td colSpan={7} className={`px-4 py-12 text-center ${mM}`}>Carregando...</td></tr>
+                ) : sortedForn.length === 0 ? (
+                  <tr><td colSpan={7} className={`px-4 py-12 text-center ${mM}`}>{search ? `Nenhum resultado para "${search}"` : "Nenhum fornecedor encontrado"}</td></tr>
+                ) : sortedForn.map((f) => (
+                  <React.Fragment key={f.nome}>
+                    <tr
+                      onClick={() => setExpandedId(expandedId === f.nome ? null : f.nome)}
+                      className={`${rowCls} ${expandedId === f.nome ? (dm ? "bg-[#2C2C2E]" : "bg-[#FFF8F0]") : ""}`}
+                    >
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <span className="text-xs">{expandedId === f.nome ? "▼" : "▶"}</span>
+                          <p className={`font-semibold ${mP}`}>{f.nome}</p>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className="px-2 py-1 rounded-lg bg-[#E8740E]/10 text-[#E8740E] text-xs font-bold">{f.total_produtos}</span>
+                      </td>
+                      <td className="px-4 py-3 font-bold text-red-500">{fmt(f.total_investido)}</td>
+                      <td className="px-4 py-3">
+                        <span className={`font-semibold ${f.total_em_estoque > 0 ? "text-green-600" : mM}`}>{f.total_em_estoque} un.</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex flex-wrap gap-1">
+                          {f.categorias.slice(0, 3).map(c => (
+                            <span key={c} className={`px-2 py-0.5 rounded-md text-[10px] font-medium ${dm ? "bg-[#2C2C2E] text-[#98989D]" : "bg-[#F2F2F7] text-[#86868B]"}`}>{c}</span>
+                          ))}
+                          {f.categorias.length > 3 && <span className={`text-[10px] ${mM}`}>+{f.categorias.length - 3}</span>}
+                        </div>
+                      </td>
+                      <td className={`px-4 py-3 text-xs ${mS}`}>{fmtDate(f.primeira_compra)}</td>
+                      <td className={`px-4 py-3 text-xs ${mS}`}>{fmtDate(f.ultima_compra)}</td>
+                    </tr>
+
+                    {/* Expanded: historico de compras */}
+                    {expandedId === f.nome && (
+                      <tr>
+                        <td colSpan={7} className={`px-6 py-4 ${dm ? "bg-[#1A1A1C]" : "bg-[#FAFAFA]"}`}>
+                          <div className="space-y-3">
+                            {/* Resumo por categoria */}
+                            <div className="flex flex-wrap gap-3">
+                              {(() => {
+                                const byCat: Record<string, { qnt: number; custo: number }> = {};
+                                f.compras.forEach(c => {
+                                  const cat = c.categoria || "OUTROS";
+                                  if (!byCat[cat]) byCat[cat] = { qnt: 0, custo: 0 };
+                                  byCat[cat].qnt += c.qnt;
+                                  byCat[cat].custo += c.custo_unitario * c.qnt;
+                                });
+                                return Object.entries(byCat).sort(([,a],[,b]) => b.custo - a.custo).map(([cat, info]) => (
+                                  <div key={cat} className={`px-3 py-2 rounded-xl border ${dm ? "bg-[#2C2C2E] border-[#3A3A3C]" : "bg-white border-[#E8E8ED]"}`}>
+                                    <p className={`text-[10px] uppercase tracking-wider ${mS}`}>{cat}</p>
+                                    <p className={`text-[13px] font-bold ${mP}`}>{info.qnt} un. · {fmt(info.custo)}</p>
+                                  </div>
+                                ));
+                              })()}
+                            </div>
+
+                            <p className={`text-xs font-bold uppercase tracking-wider ${mS}`}>
+                              Historico de compras ({f.compras.length} itens)
+                            </p>
+                            <div className="space-y-1 max-h-[400px] overflow-y-auto">
+                              {f.compras.map((c, i) => (
+                                <div key={i} className={`flex items-center justify-between px-3 py-2 rounded-lg text-xs ${dm ? "bg-[#2C2C2E]" : "bg-white"}`}>
+                                  <div className="flex items-center gap-3 flex-1 min-w-0">
+                                    <span className={mM}>{fmtDate(c.data)}</span>
+                                    <span className={`font-medium truncate ${mP}`}>{c.produto}</span>
+                                    {c.cor && <span className={`shrink-0 ${mS}`}>{c.cor}</span>}
+                                    {c.serial_no && <span className="text-purple-500 font-mono shrink-0">SN: {c.serial_no}</span>}
+                                  </div>
+                                  <div className="flex items-center gap-3 shrink-0 ml-2">
+                                    <span className={mM}>{c.qnt}x</span>
+                                    <span className="font-bold text-red-500 w-24 text-right">{fmt(c.custo_unitario * c.qnt)}</span>
+                                    <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
+                                      c.status === "EM ESTOQUE" ? "bg-green-500/10 text-green-600" :
+                                      c.status === "ESGOTADO" ? "bg-red-500/10 text-red-500" :
+                                      c.status === "A CAMINHO" ? "bg-blue-500/10 text-blue-500" :
+                                      `${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#F2F2F7] text-[#86868B]"}`
+                                    }`}>{c.status || "—"}</span>
+                                  </div>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {!loading && sortedForn.length > 0 && (
+          <p className={`text-xs text-center ${mM}`}>Mostrando {sortedForn.length} fornecedores</p>
+        )}
+      </>) : tab === "notas" ? (
+
+      /* ============= NOTAS FISCAIS TAB ============= */
+        <div className={tableCls}>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className={`border-b ${dm ? "border-[#3A3A3C] bg-[#2C2C2E]" : "border-[#D2D2D7] bg-[#F5F5F7]"}`}>
+                  {["Data", "Cliente", "Produto", "Valor", "Nota Fiscal"].map((h) => (
+                    <th key={h} className={thCls}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <tr><td colSpan={5} className={`px-4 py-12 text-center ${mM}`}>Carregando...</td></tr>
+                ) : notas.length === 0 ? (
+                  <tr><td colSpan={5} className={`px-4 py-12 text-center ${mM}`}>Nenhuma nota fiscal registrada</td></tr>
+                ) : notas.map((n) => (
+                  <tr key={n.id} className={`border-b transition-colors ${dm ? "border-[#2C2C2E] hover:bg-[#2C2C2E]" : "border-[#F5F5F7] hover:bg-[#FAFAFA]"}`}>
+                    <td className={`px-4 py-3 ${mS}`}>{fmtDate(n.data)}</td>
+                    <td className={`px-4 py-3 font-semibold ${mP}`}>{n.cliente}</td>
+                    <td className={`px-4 py-3 ${mP}`}>{n.produto}</td>
+                    <td className="px-4 py-3 font-bold text-green-600">{fmt(n.preco_vendido)}</td>
+                    <td className="px-4 py-3">
+                      <a href={n.nota_fiscal_url} target="_blank" rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 px-3 py-1 rounded-lg bg-[#E8740E]/10 text-[#E8740E] text-xs font-semibold hover:bg-[#E8740E]/20 transition-colors">
+                        Ver PDF
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+      ) : (<>
+
+      {/* ============= CLIENTES / LOJISTAS TAB ============= */}
       {/* Summary Cards */}
-      {tab !== "notas" && <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div className={cardCls}>
-          <p className={`text-xs uppercase tracking-wider ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
-            {tab === "lojistas" ? "Total Lojistas" : "Total Clientes"}
-          </p>
-          <p className={`text-2xl font-bold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{totals.total}</p>
+          <p className={`text-xs uppercase tracking-wider ${mS}`}>{tab === "lojistas" ? "Total Lojistas" : "Total Clientes"}</p>
+          <p className={`text-2xl font-bold ${mP}`}>{totals.total}</p>
         </div>
         <div className={cardCls}>
-          <p className={`text-xs uppercase tracking-wider ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Total Compras</p>
+          <p className={`text-xs uppercase tracking-wider ${mS}`}>Total Compras</p>
           <p className="text-2xl font-bold text-[#E8740E]">{totals.total_compras}</p>
         </div>
         <div className={cardCls}>
-          <p className={`text-xs uppercase tracking-wider ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Faturamento</p>
+          <p className={`text-xs uppercase tracking-wider ${mS}`}>Faturamento</p>
           <p className="text-2xl font-bold text-green-600">{fmt(totals.total_gasto)}</p>
         </div>
         <div className={cardCls}>
-          <p className={`text-xs uppercase tracking-wider ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Ticket Medio</p>
+          <p className={`text-xs uppercase tracking-wider ${mS}`}>Ticket Medio</p>
           <p className="text-2xl font-bold text-[#E8740E]">{totals.total_compras > 0 ? fmt(totals.total_gasto / totals.total_compras) : "R$ 0"}</p>
         </div>
-      </div>}
+      </div>
 
       {/* Sort */}
-      {tab !== "notas" && <div className="flex items-center gap-2">
-        <span className={`text-xs ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Ordenar:</span>
+      <div className="flex items-center gap-2">
+        <span className={`text-xs ${mS}`}>Ordenar:</span>
         {([
           { key: "gasto", label: "Maior gasto" },
           { key: "compras", label: "Mais compras" },
@@ -182,89 +412,52 @@ export default function ClientesPage() {
             {o.label}
           </button>
         ))}
-      </div>}
-
-      {/* Notas Fiscais Tab */}
-      {tab === "notas" ? (
-        <div className={`${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-white border-[#D2D2D7]"} border rounded-2xl overflow-hidden shadow-sm`}>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className={`border-b ${dm ? "border-[#3A3A3C] bg-[#2C2C2E]" : "border-[#D2D2D7] bg-[#F5F5F7]"}`}>
-                  {["Data", "Cliente", "Produto", "Valor", "Nota Fiscal"].map((h) => (
-                    <th key={h} className={`px-4 py-3 text-left font-medium text-xs uppercase tracking-wider whitespace-nowrap ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>{h}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {loading ? (
-                  <tr><td colSpan={5} className={`px-4 py-12 text-center ${dm ? "text-[#636366]" : "text-[#86868B]"}`}>Carregando...</td></tr>
-                ) : notas.length === 0 ? (
-                  <tr><td colSpan={5} className={`px-4 py-12 text-center ${dm ? "text-[#636366]" : "text-[#86868B]"}`}>Nenhuma nota fiscal registrada</td></tr>
-                ) : notas.map((n) => (
-                  <tr key={n.id} className={`border-b transition-colors ${dm ? "border-[#2C2C2E] hover:bg-[#2C2C2E]" : "border-[#F5F5F7] hover:bg-[#FAFAFA]"}`}>
-                    <td className={`px-4 py-3 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>{fmtDate(n.data)}</td>
-                    <td className={`px-4 py-3 font-semibold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{n.cliente}</td>
-                    <td className={`px-4 py-3 ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{n.produto}</td>
-                    <td className="px-4 py-3 font-bold text-green-600">{fmt(n.preco_vendido)}</td>
-                    <td className="px-4 py-3">
-                      <a href={n.nota_fiscal_url} target="_blank" rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 px-3 py-1 rounded-lg bg-[#E8740E]/10 text-[#E8740E] text-xs font-semibold hover:bg-[#E8740E]/20 transition-colors">
-                        📄 Ver PDF
-                      </a>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      ) : (<>
+      </div>
 
       {/* Table */}
-      <div className={`${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-white border-[#D2D2D7]"} border rounded-2xl overflow-hidden shadow-sm`}>
+      <div className={tableCls}>
         <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead>
               <tr className={`border-b ${dm ? "border-[#3A3A3C] bg-[#2C2C2E]" : "border-[#D2D2D7] bg-[#F5F5F7]"}`}>
                 {["Cliente", tab === "lojistas" ? "CNPJ" : "CPF", "Compras", "Total Gasto", "Ultima Compra", "Cliente Desde", "Local"].map((h) => (
-                  <th key={h} className={`px-4 py-3 text-left font-medium text-xs uppercase tracking-wider whitespace-nowrap ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>{h}</th>
+                  <th key={h} className={thCls}>{h}</th>
                 ))}
               </tr>
             </thead>
             <tbody>
               {loading ? (
-                <tr><td colSpan={7} className={`px-4 py-12 text-center ${dm ? "text-[#636366]" : "text-[#86868B]"}`}>Carregando...</td></tr>
+                <tr><td colSpan={7} className={`px-4 py-12 text-center ${mM}`}>Carregando...</td></tr>
               ) : sorted.length === 0 ? (
-                <tr><td colSpan={7} className={`px-4 py-12 text-center ${dm ? "text-[#636366]" : "text-[#86868B]"}`}>
+                <tr><td colSpan={7} className={`px-4 py-12 text-center ${mM}`}>
                   {search ? `Nenhum resultado para "${search}"` : "Nenhum cliente encontrado"}
                 </td></tr>
               ) : sorted.map((c) => (
                 <React.Fragment key={c.nome}>
                   <tr
                     onClick={() => setDetailClient(c)}
-                    className={`border-b cursor-pointer transition-colors ${dm ? "border-[#2C2C2E] hover:bg-[#2C2C2E]" : "border-[#F5F5F7] hover:bg-[#FAFAFA]"} ${expandedId === c.nome ? (dm ? "bg-[#2C2C2E]" : "bg-[#FFF8F0]") : ""}`}
+                    className={`${rowCls} ${expandedId === c.nome ? (dm ? "bg-[#2C2C2E]" : "bg-[#FFF8F0]") : ""}`}
                   >
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-2">
                         <span className="text-xs">{expandedId === c.nome ? "▼" : "▶"}</span>
                         <div>
-                          <p className={`font-semibold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{c.nome}</p>
-                          {c.email && <p className={`text-xs ${dm ? "text-[#636366]" : "text-[#86868B]"}`}>{c.email}</p>}
+                          <p className={`font-semibold ${mP}`}>{c.nome}</p>
+                          {c.email && <p className={`text-xs ${mM}`}>{c.email}</p>}
                         </div>
                       </div>
                     </td>
-                    <td className={`px-4 py-3 text-xs font-mono ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>{(tab === "lojistas" ? c.cnpj : c.cpf) || "—"}</td>
+                    <td className={`px-4 py-3 text-xs font-mono ${mS}`}>{(tab === "lojistas" ? c.cnpj : c.cpf) || "—"}</td>
                     <td className="px-4 py-3">
                       <span className="px-2 py-1 rounded-lg bg-[#E8740E]/10 text-[#E8740E] text-xs font-bold">{c.total_compras}</span>
                     </td>
                     <td className="px-4 py-3 font-bold text-green-600">{fmt(c.total_gasto)}</td>
                     <td className="px-4 py-3">
-                      <p className={`text-xs ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{fmtDate(c.ultima_compra)}</p>
-                      <p className={`text-xs truncate max-w-[150px] ${dm ? "text-[#636366]" : "text-[#86868B]"}`}>{c.ultimo_produto}</p>
+                      <p className={`text-xs ${mP}`}>{fmtDate(c.ultima_compra)}</p>
+                      <p className={`text-xs truncate max-w-[150px] ${mM}`}>{c.ultimo_produto}</p>
                     </td>
-                    <td className={`px-4 py-3 text-xs ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>{fmtDate(c.cliente_desde)}</td>
-                    <td className={`px-4 py-3 text-xs ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
+                    <td className={`px-4 py-3 text-xs ${mS}`}>{fmtDate(c.cliente_desde)}</td>
+                    <td className={`px-4 py-3 text-xs ${mS}`}>
                       {c.bairro ? `${c.bairro}${c.cidade ? `, ${c.cidade}` : ""}` : c.cidade || "—"}
                     </td>
                   </tr>
@@ -274,29 +467,27 @@ export default function ClientesPage() {
                     <tr>
                       <td colSpan={7} className={`px-6 py-4 ${dm ? "bg-[#1A1A1C]" : "bg-[#FAFAFA]"}`}>
                         <div className="space-y-3">
-                          {/* Info do cliente */}
                           <div className="flex flex-wrap gap-4 text-xs">
-                            {c.cpf && <span className={dm ? "text-[#98989D]" : "text-[#86868B]"}>CPF: <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{c.cpf}</strong></span>}
-                            {c.cnpj && <span className={dm ? "text-[#98989D]" : "text-[#86868B]"}>CNPJ: <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{c.cnpj}</strong></span>}
-                            {c.email && <span className={dm ? "text-[#98989D]" : "text-[#86868B]"}>Email: <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{c.email}</strong></span>}
-                            {c.bairro && <span className={dm ? "text-[#98989D]" : "text-[#86868B]"}>Bairro: <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{c.bairro}</strong></span>}
-                            {c.cidade && <span className={dm ? "text-[#98989D]" : "text-[#86868B]"}>Cidade: <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{c.cidade}{c.uf ? ` - ${c.uf}` : ""}</strong></span>}
+                            {c.cpf && <span className={mS}>CPF: <strong className={mP}>{c.cpf}</strong></span>}
+                            {c.cnpj && <span className={mS}>CNPJ: <strong className={mP}>{c.cnpj}</strong></span>}
+                            {c.email && <span className={mS}>Email: <strong className={mP}>{c.email}</strong></span>}
+                            {c.bairro && <span className={mS}>Bairro: <strong className={mP}>{c.bairro}</strong></span>}
+                            {c.cidade && <span className={mS}>Cidade: <strong className={mP}>{c.cidade}{c.uf ? ` - ${c.uf}` : ""}</strong></span>}
                           </div>
 
-                          {/* Historico de compras */}
-                          <p className={`text-xs font-bold uppercase tracking-wider ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
+                          <p className={`text-xs font-bold uppercase tracking-wider ${mS}`}>
                             Historico de compras ({c.vendas.length})
                           </p>
                           <div className="space-y-1">
                             {c.vendas.map((v) => (
                               <div key={v.id} className={`flex items-center justify-between px-3 py-2 rounded-lg text-xs ${dm ? "bg-[#2C2C2E]" : "bg-white"}`}>
                                 <div className="flex items-center gap-3">
-                                  <span className={dm ? "text-[#636366]" : "text-[#86868B]"}>{fmtDate(v.data)}</span>
-                                  <span className={`font-medium ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{v.produto}</span>
-                                  {v.serial_no && <span className={`font-mono ${dm ? "text-[#636366]" : "text-[#86868B]"}`}>SN: {v.serial_no}</span>}
+                                  <span className={mM}>{fmtDate(v.data)}</span>
+                                  <span className={`font-medium ${mP}`}>{v.produto}</span>
+                                  {v.serial_no && <span className={`font-mono ${mM}`}>SN: {v.serial_no}</span>}
                                 </div>
                                 <div className="flex items-center gap-3">
-                                  <span className={dm ? "text-[#636366]" : "text-[#86868B]"}>{v.forma} · {v.banco}</span>
+                                  <span className={mM}>{v.forma} · {v.banco}</span>
                                   <span className="font-bold text-green-600">{fmt(v.preco_vendido)}</span>
                                 </div>
                               </div>
@@ -313,9 +504,8 @@ export default function ClientesPage() {
         </div>
       </div>
 
-      {/* Footer count */}
       {!loading && sorted.length > 0 && (
-        <p className={`text-xs text-center ${dm ? "text-[#636366]" : "text-[#86868B]"}`}>
+        <p className={`text-xs text-center ${mM}`}>
           Mostrando {sorted.length} {tab === "lojistas" ? "lojistas" : "clientes"}
         </p>
       )}
@@ -326,8 +516,6 @@ export default function ClientesPage() {
         const c = detailClient;
         const mBg = dm ? "bg-[#1C1C1E]" : "bg-white";
         const mSec = dm ? "bg-[#2C2C2E] border-[#3A3A3C]" : "bg-[#F9F9FB] border-[#E8E8ED]";
-        const mP = dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]";
-        const mS = dm ? "text-[#98989D]" : "text-[#86868B]";
         const mInput = `w-full px-3 py-2 rounded-lg border text-sm ${dm ? "bg-[#3A3A3C] border-[#4A4A4C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"} focus:outline-none focus:border-[#E8740E]`;
 
         const openEdit = () => {
@@ -341,7 +529,6 @@ export default function ClientesPage() {
 
         const saveEdit = async () => {
           setSavingClient(true);
-          // Atualizar todas as vendas desse cliente com os novos dados
           for (const v of c.vendas) {
             const updates: Record<string, string | null> = {};
             if (editForm.nome && editForm.nome !== c.nome) updates.cliente = editForm.nome.toUpperCase();
@@ -356,7 +543,6 @@ export default function ClientesPage() {
                 headers: { ...apiHeaders(), "Content-Type": "application/json" },
                 body: JSON.stringify({ table: "vendas", id: v.id, ...updates }),
               }).catch(() => {});
-              // Fallback: patch direto
               await fetch(`https://fohhlehrqtwruzxjzrql.supabase.co/rest/v1/vendas?id=eq.${v.id}`, {
                 method: "PATCH",
                 headers: {
@@ -377,7 +563,6 @@ export default function ClientesPage() {
         return (
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => { setDetailClient(null); setEditing(false); }} onKeyDown={(e) => { if (e.key === "Escape") { setDetailClient(null); setEditing(false); } }} tabIndex={-1} ref={(el) => el?.focus()}>
             <div className={`w-full max-w-2xl mx-4 ${mBg} rounded-2xl shadow-2xl overflow-hidden max-h-[90vh] overflow-y-auto`} onClick={(e) => e.stopPropagation()}>
-              {/* Header */}
               <div className={`flex items-center justify-between px-6 py-4 border-b ${dm ? "border-[#3A3A3C]" : "border-[#E8E8ED]"}`}>
                 <div>
                   <p className={`text-[10px] uppercase tracking-wider ${mS}`}>Editar Contato</p>
@@ -385,15 +570,12 @@ export default function ClientesPage() {
                 </div>
                 <div className="flex items-center gap-2">
                   {!editing && (
-                    <button onClick={openEdit} className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-[#E8740E]/10 text-[#E8740E] hover:bg-[#E8740E]/20">
-                      Editar
-                    </button>
+                    <button onClick={openEdit} className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-[#E8740E]/10 text-[#E8740E] hover:bg-[#E8740E]/20">Editar</button>
                   )}
                   <button onClick={() => { setDetailClient(null); setEditing(false); }} className={`w-8 h-8 flex items-center justify-center rounded-full ${dm ? "hover:bg-[#3A3A3C]" : "hover:bg-[#F0F0F5]"} ${mS} hover:text-[#E8740E] text-lg`}>✕</button>
                 </div>
               </div>
 
-              {/* Info Card */}
               <div className={`mx-5 mt-4 p-4 rounded-xl border ${mSec}`}>
                 <div className="flex items-start justify-between mb-3">
                   <div>
@@ -410,7 +592,6 @@ export default function ClientesPage() {
                 </div>
               </div>
 
-              {/* Informações de Contato */}
               <div className={`mx-5 mt-3 p-4 rounded-xl border ${mSec}`}>
                 <p className={`text-xs font-bold ${mP} mb-3`}>Informacoes de Contato</p>
                 <div className="grid grid-cols-2 gap-4">
@@ -427,7 +608,6 @@ export default function ClientesPage() {
                 </div>
               </div>
 
-              {/* Endereço */}
               <div className={`mx-5 mt-3 p-4 rounded-xl border ${mSec}`}>
                 <p className={`text-xs font-bold ${mP} mb-3`}>Endereco</p>
                 <div className="grid grid-cols-3 gap-3">
@@ -449,7 +629,6 @@ export default function ClientesPage() {
                 </div>
               </div>
 
-              {/* Resumo Financeiro */}
               <div className={`mx-5 mt-3 p-4 rounded-xl border ${mSec}`}>
                 <p className={`text-xs font-bold ${mP} mb-3`}>Resumo Financeiro</p>
                 <div className="grid grid-cols-3 gap-3">
@@ -468,19 +647,15 @@ export default function ClientesPage() {
                 </div>
               </div>
 
-              {/* Botões de edição */}
               {editing && (
                 <div className="mx-5 mt-3 flex gap-2">
                   <button onClick={saveEdit} disabled={savingClient} className="flex-1 py-3 rounded-xl bg-[#E8740E] text-white text-sm font-semibold hover:bg-[#D06A0D] disabled:opacity-50">
                     {savingClient ? "Salvando..." : "Salvar Alteracoes"}
                   </button>
-                  <button onClick={() => setEditing(false)} className={`px-4 py-3 rounded-xl border text-sm font-semibold ${dm ? "border-[#3A3A3C] text-[#98989D]" : "border-[#D2D2D7] text-[#86868B]"}`}>
-                    Cancelar
-                  </button>
+                  <button onClick={() => setEditing(false)} className={`px-4 py-3 rounded-xl border text-sm font-semibold ${dm ? "border-[#3A3A3C] text-[#98989D]" : "border-[#D2D2D7] text-[#86868B]"}`}>Cancelar</button>
                 </div>
               )}
 
-              {/* Últimas Operações */}
               <div className={`mx-5 mt-3 p-4 rounded-xl border ${mSec}`}>
                 <p className={`text-xs font-bold ${mP} mb-3`}>Ultimas Operacoes ({c.vendas.length})</p>
                 {c.vendas.length === 0 ? (
@@ -504,7 +679,6 @@ export default function ClientesPage() {
                 )}
               </div>
 
-              {/* Fechar */}
               <div className="mx-5 mt-4 mb-5">
                 <button onClick={() => { setDetailClient(null); setEditing(false); }} className={`w-full py-3 rounded-xl text-sm font-semibold ${dm ? "bg-[#3A3A3C] text-[#F5F5F7] hover:bg-[#4A4A4C]" : "bg-[#F5F5F7] text-[#1D1D1F] hover:bg-[#E8E8ED]"} transition-colors`}>
                   Fechar

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -3066,7 +3066,7 @@ export default function EstoquePage() {
                   return modeloEntries.map(([modelo, items], cardIdx) => {
                   // Sub-agrupar por nome do produto (sem origem VC/LL/J/BE/BR/HN/IN/ZA)
                   const stripOrigem = (nome: string) => nome
-                    .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ)\s*(\([^)]*\))?/gi, "")
+                    .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ)(?=\s|$|\()(\s*\([^)]*\))?/gi, "")
                     .replace(/[-–]\s*(CHIP\s+(F[ÍI]SICO\s*\+\s*)?)?E-?SIM/gi, "")
                     .replace(/[-–]\s*CHIP\s+VIRTUAL/gi, "")
                     .replace(/\s*\(\d+C\s*CPU\/\d+C\s*GPU\)\s*/gi, " ")  // (10C CPU/10C GPU)

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -2047,7 +2047,6 @@ export default function EstoquePage() {
           </div>
         )}
         </div>
-      </div>
       )}
 
       {/* Preços Sugeridos por tipo */}

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -3150,9 +3150,9 @@ export default function EstoquePage() {
                             colorSummary[c] = (colorSummary[c] || 0) + p.qnt;
                           });
                           return (
-                            <span className={`text-[11px] ${textSecondary} flex items-center gap-1 flex-wrap cursor-pointer`}>
+                            <span className={`text-[11px] ${textSecondary} hidden sm:flex items-center gap-1 flex-wrap cursor-pointer max-w-[300px] overflow-hidden max-h-[1.4em]`}>
                               {Object.entries(colorSummary).sort(([a],[b]) => a.localeCompare(b)).map(([c, n], i) => (
-                                <span key={c}>{i > 0 && <span className="mx-0.5">·</span>}{n}x {c}</span>
+                                <span key={c} className="whitespace-nowrap">{i > 0 && <span className="mx-0.5">·</span>}{n}x {c}</span>
                               ))}
                             </span>
                           );

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -2163,7 +2163,7 @@ export default function EstoquePage() {
         const catOrder = ["IPHONES", "IPADS", "MACBOOK", "MAC_MINI", "APPLE_WATCH", "AIRPODS", "ACESSORIOS"];
 
         // Agrupar novos por modelo_base+cor → {totalQnt, min, jaCaminho, corDisplay}
-        type RepoGroup = { totalQnt: number; min: number; corDisplay: string; jaCaminho: boolean; falta: number };
+        type RepoGroup = { totalQnt: number; min: number; corEN: string; corPT: string; corDisplay: string; jaCaminho: boolean; falta: number };
         const byCatModel: Record<string, Record<string, RepoGroup[]>> = {};
 
         for (const p of novos) {
@@ -2172,12 +2172,22 @@ export default function EstoquePage() {
           const base = extractBase(nome);
           const cor = extractCor(nome, p.cor);
           const corKey = (cor || "—").toUpperCase();
-          const corDisplay = cor ? (traduzirCor(cor) || cor) : "—";
+          // Bilíngue: EN (PT) — mesmo padrão do resto do sistema
+          const corUpper = (cor || "").toUpperCase().trim();
+          const ptFromEN = COR_PT[corUpper]; // se cor é EN → pega PT
+          const enFromPT = PT_TO_EN[corUpper]; // se cor é PT → pega EN
+          let corEN = cor || "—";
+          let corPT = "";
+          if (ptFromEN) { corEN = cor!; corPT = ptFromEN; }
+          else if (enFromPT) { corEN = enFromPT; corPT = cor!; }
+          const corDisplay = corPT && corPT.toLowerCase() !== corEN.toLowerCase()
+            ? `${corEN.toUpperCase()} (${corPT.charAt(0).toUpperCase() + corPT.slice(1).toLowerCase()})`
+            : (cor || "—");
 
           if (!byCatModel[cat]) byCatModel[cat] = {};
           if (!byCatModel[cat][base]) byCatModel[cat][base] = [];
 
-          const existing = byCatModel[cat][base].find(c => (c.corDisplay || "—").toUpperCase() === corKey || traduzirCor(c.corDisplay).toUpperCase() === corKey);
+          const existing = byCatModel[cat][base].find(c => c.corEN.toUpperCase() === corEN.toUpperCase() || (c.corDisplay || "—").toUpperCase() === corKey);
           if (existing) {
             existing.totalQnt += p.qnt;
             if (typeof p.estoque_minimo === "number" && p.estoque_minimo > 0) existing.min = p.estoque_minimo;
@@ -2185,7 +2195,7 @@ export default function EstoquePage() {
             byCatModel[cat][base].push({
               totalQnt: p.qnt,
               min: (typeof p.estoque_minimo === "number" && p.estoque_minimo > 0) ? p.estoque_minimo : 0,
-              corDisplay,
+              corEN, corPT, corDisplay,
               jaCaminho: produtosACaminho.has(p.produto.toUpperCase()),
               falta: 0,
             });
@@ -2282,7 +2292,7 @@ export default function EstoquePage() {
                               }`}>
                                 <div className="flex items-center gap-2">
                                   <span className="text-[14px]">{c.totalQnt === 0 ? "🔴" : "🟡"}</span>
-                                  <span className={`text-[13px] font-semibold ${textPrimary}`}>{c.corDisplay}</span>
+                                  <span className={`text-[13px] font-semibold ${textPrimary}`}>{c.corEN.toUpperCase()}{c.corPT && c.corPT.toLowerCase() !== c.corEN.toLowerCase() && <span className={`ml-1 font-normal opacity-60 text-[11px]`}>({c.corPT.charAt(0).toUpperCase() + c.corPT.slice(1).toLowerCase()})</span>}</span>
                                   {c.jaCaminho && (
                                     <span className="text-[10px] font-bold text-blue-500 px-1.5 py-0.5 rounded-full bg-blue-500/10">✈️ A CAMINHO</span>
                                   )}

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -281,18 +281,23 @@ function displayNomeProduto(nome: string, cor: string | null | undefined, catego
   const upper = corClean.toUpperCase().trim();
   const en = PT_TO_EN[upper];
   const corEN = en ? en.toUpperCase() : upper; // cor em inglês (ou original se não tem tradução)
+  // Verifica se o nome já contém alguma cor comercial conhecida (EN)
+  const displayUpper = display.toUpperCase();
+  const nomeJaTemCorEN = Object.keys(COR_PT).sort((a, b) => b.length - a.length)
+    .some(enKey => enKey.length >= 3 && displayUpper.includes(enKey));
+
   if (en) {
     // Substitui a cor em PT pelo equivalente EN no nome (case-insensitive)
     const pattern = upper.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+");
     const before = display;
     try { display = display.replace(new RegExp(pattern, "gi"), corEN); } catch { /* ignore */ }
-    // Se não substituiu (cor não estava no nome), anexar a cor EN ao final
-    if (display === before && !display.toUpperCase().includes(corEN)) {
+    // Se não substituiu e nome NÃO tem cor EN conhecida, anexar
+    if (display === before && !display.toUpperCase().includes(corEN) && !nomeJaTemCorEN) {
       display = `${display} ${corEN}`;
     }
   } else {
-    // Cor sem tradução — se não está no nome, anexar
-    if (!display.toUpperCase().includes(upper)) {
+    // Cor sem tradução — se não está no nome e nome não tem cor conhecida, anexar
+    if (!display.toUpperCase().includes(upper) && !nomeJaTemCorEN) {
       display = `${display} ${cor}`;
     }
   }

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -1516,6 +1516,25 @@ export default function EstoquePage() {
   const produtosACaminho = new Set(aCaminho.map((p) => p.produto.toUpperCase()));
   const esgotados = novos.filter((p) => p.qnt === 0);
 
+  // Reposição: agrupar por modelo+cor e verificar se está abaixo do mínimo
+  const reposicaoCount = (() => {
+    // Agrupar novos por produto+cor → somar qnt e pegar estoque_minimo
+    const groups: Record<string, { totalQnt: number; min: number | null }> = {};
+    for (const p of novos) {
+      const key = `${p.produto}|||${p.cor || ""}`;
+      if (!groups[key]) groups[key] = { totalQnt: 0, min: null };
+      groups[key].totalQnt += p.qnt;
+      if (typeof p.estoque_minimo === "number" && p.estoque_minimo > 0) {
+        groups[key].min = p.estoque_minimo;
+      }
+    }
+    let count = 0;
+    for (const g of Object.values(groups)) {
+      if (g.min && g.totalQnt < g.min) count++;
+    }
+    return count;
+  })();
+
   const currentList =
     tab === "naoativados" ? naoAtivados :
     tab === "seminovos" ? seminovos :
@@ -1916,7 +1935,7 @@ export default function EstoquePage() {
             { key: "atacado", label: "Atacado", count: atacado.length },
             { key: "acaminho", label: "Produtos a Caminho", count: aCaminho.length },
             { key: "pendencias", label: "Pendências", count: pendencias.length },
-            { key: "reposicao", label: "Reposição", count: esgotados.length + acabando.length },
+            { key: "reposicao", label: "Reposição", count: reposicaoCount },
           ] as const).map((t) => (
             <button key={t.key} onClick={() => setTab(t.key as typeof tab)}
               className={`px-3.5 py-2 rounded-lg text-[12px] font-semibold transition-all ${
@@ -2123,7 +2142,7 @@ export default function EstoquePage() {
       {/* ===== ABA REPOSIÇÃO ===== */}
       {tab === "reposicao" ? (() => {
         const stripOrigemRepo = (nome: string) => nome
-          .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ)\s*(\([^)]*\))?/gi, "")
+          .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ)(?=\s|$|\()(\s*\([^)]*\))?/gi, "")
           .replace(/[-–]\s*(CHIP\s+(F[ÍI]SICO\s*\+\s*)?)?E-?SIM/gi, "")
           .replace(/[-–]\s*CHIP\s+VIRTUAL/gi, "")
           .replace(/\s*\(\d+C\s*CPU\/\d+C\s*GPU\)\s*/gi, " ")
@@ -2132,66 +2151,80 @@ export default function EstoquePage() {
         // Extrair modelo base (sem cor): "IPHONE 17 PRO MAX 256GB SILVER" → "IPHONE 17 PRO MAX 256GB"
         const extractBase = (nome: string) => {
           const m = nome.match(/^(.+?\d+\s*(?:GB|TB))/i);
-          return m ? m[1].trim() : nome;
+          return m ? m[1].trim().toUpperCase() : nome.toUpperCase();
         };
         // Extrair cor do nome
-        const extractCor = (nome: string) => {
+        const extractCor = (nome: string, corField: string | null | undefined) => {
           const base = extractBase(nome);
           const rest = nome.slice(base.length).trim();
-          return rest || null;
-        };
-        // Extrair linha: "IPHONE 17 PRO MAX 256GB" → "LINHA 17", "MACBOOK AIR M4 13"" → "CHIP M4"
-        const extractLinha = (nome: string, cat: string) => {
-          if (cat === "IPHONE") { const m = nome.match(/IPHONE\s+(\d+)/i); return m ? `LINHA ${m[1]}` : "OUTROS"; }
-          if (cat === "IPAD") { const m = nome.match(/IPAD\s+(PRO|AIR|MINI)?/i); return m?.[1] ? `iPad ${m[1]}` : "iPad"; }
-          if (cat === "MACBOOK" || cat === "MAC_MINI") { const m = nome.match(/M(\d+)/i); return m ? `CHIP M${m[1]}` : "OUTROS"; }
-          if (cat === "APPLE_WATCH") { const m = nome.match(/SERIES\s+(\d+)|ULTRA\s*(\d*)|SE\s*(\d*)/i); return m ? (m[1] ? `SERIES ${m[1]}` : m[2] !== undefined ? "ULTRA" : "SE") : "OUTROS"; }
-          return "OUTROS";
+          return rest || corField || null;
         };
 
-        // Filtrar itens para reposição: qnt < estoque_minimo (só itens com mínimo definido)
-        const reposicaoItems = novos.filter(p => {
-          const min = p.estoque_minimo;
-          if (typeof min === "number" && min > 0) return p.qnt < min;
-          return false; // sem mínimo definido = não aparece na reposição
-        });
+        const catOrder = ["IPHONES", "IPADS", "MACBOOK", "MAC_MINI", "APPLE_WATCH", "AIRPODS", "ACESSORIOS"];
 
-        // Estrutura: cat → linha → modelo_base → [{cor, qnt, esgotado}]
-        type CorInfo = { cor: string | null; qnt: number; jaCaminho: boolean };
-        type ModeloInfo = { base: string; cores: CorInfo[]; totalQnt: number };
-        const catOrder = ["IPHONE", "IPAD", "MACBOOK", "MAC_MINI", "APPLE_WATCH", "AIRPODS", "ACESSORIOS"];
-        const catLabels: Record<string, string> = { IPHONE: "IPHONES", IPAD: "IPADS", MACBOOK: "MACBOOKS", MAC_MINI: "MAC MINI", APPLE_WATCH: "APPLE WATCH", AIRPODS: "AIRPODS", ACESSORIOS: "ACESSÓRIOS" };
+        // Agrupar novos por modelo_base+cor → {totalQnt, min, jaCaminho, corDisplay}
+        type RepoGroup = { totalQnt: number; min: number; corDisplay: string; jaCaminho: boolean; falta: number };
+        const byCatModel: Record<string, Record<string, RepoGroup[]>> = {};
 
-        // Agrupar: cat → modelo_base → [{cor, qnt}]
-        const byCatModel: Record<string, Record<string, CorInfo[]>> = {};
-        for (const p of reposicaoItems) {
+        for (const p of novos) {
           const cat = p.categoria || "OUTROS";
           const nome = stripOrigemRepo(p.produto);
           const base = extractBase(nome);
-          const cor = extractCor(nome) || p.cor || null;
+          const cor = extractCor(nome, p.cor);
+          const corKey = (cor || "—").toUpperCase();
+          const corDisplay = cor ? (traduzirCor(cor) || cor) : "—";
+
           if (!byCatModel[cat]) byCatModel[cat] = {};
           if (!byCatModel[cat][base]) byCatModel[cat][base] = [];
-          const existing = byCatModel[cat][base].find(c => c.cor === cor);
-          if (existing) { existing.qnt += p.qnt; }
-          else { byCatModel[cat][base].push({ cor, qnt: p.qnt, jaCaminho: produtosACaminho.has(nome.toUpperCase()) }); }
+
+          const existing = byCatModel[cat][base].find(c => (c.corDisplay || "—").toUpperCase() === corKey || traduzirCor(c.corDisplay).toUpperCase() === corKey);
+          if (existing) {
+            existing.totalQnt += p.qnt;
+            if (typeof p.estoque_minimo === "number" && p.estoque_minimo > 0) existing.min = p.estoque_minimo;
+          } else {
+            byCatModel[cat][base].push({
+              totalQnt: p.qnt,
+              min: (typeof p.estoque_minimo === "number" && p.estoque_minimo > 0) ? p.estoque_minimo : 0,
+              corDisplay,
+              jaCaminho: produtosACaminho.has(p.produto.toUpperCase()),
+              falta: 0,
+            });
+          }
         }
 
-        const sortedCats = Object.keys(byCatModel).sort((a, b) => {
+        // Calcular falta e filtrar apenas quem está abaixo do mínimo
+        const byCatModelFiltered: Record<string, Record<string, RepoGroup[]>> = {};
+        for (const [cat, models] of Object.entries(byCatModel)) {
+          for (const [base, cores] of Object.entries(models)) {
+            const abaixo = cores.filter(c => {
+              c.falta = c.min > 0 ? Math.max(0, c.min - c.totalQnt) : 0;
+              return c.min > 0 && c.totalQnt < c.min;
+            });
+            if (abaixo.length > 0) {
+              if (!byCatModelFiltered[cat]) byCatModelFiltered[cat] = {};
+              byCatModelFiltered[cat][base] = abaixo;
+            }
+          }
+        }
+
+        const sortedCats = Object.keys(byCatModelFiltered).sort((a, b) => {
           const ia = catOrder.indexOf(a); const ib = catOrder.indexOf(b);
           return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
         });
+
+        const totalFalta = Object.values(byCatModelFiltered).reduce((s, models) =>
+          s + Object.values(models).reduce((s2, cores) => s2 + cores.reduce((s3, c) => s3 + c.falta, 0), 0), 0);
 
         // Build copy text
         const buildCopyText = () => {
           const lines: string[] = ["*COMPRAR PRODUTOS*", ""];
           for (const cat of sortedCats) {
-            lines.push(`*${catLabels[cat] || cat}*`);
-            const modelos = Object.entries(byCatModel[cat]).sort(([a], [b]) => a.localeCompare(b));
+            lines.push(`*${dynamicCatLabels[cat] || cat}*`);
+            const modelos = Object.entries(byCatModelFiltered[cat]).sort(([a], [b]) => a.localeCompare(b));
             for (const [base, cores] of modelos) {
               lines.push(`\n${base}`);
-              for (const c of cores) {
-                const label = c.qnt === 0 ? `COMPRAR ${c.cor || "—"}` : `${c.qnt}x ${c.cor || "—"}`;
-                lines.push(`${c.qnt === 0 ? "🔴" : "🟡"} ${label}${c.jaCaminho ? " ✈️" : ""}`);
+              for (const c of cores.sort((a, b) => b.falta - a.falta)) {
+                lines.push(`${c.totalQnt === 0 ? "🔴" : "🟡"} ${c.corDisplay}: ${c.totalQnt}/${c.min} (falta ${c.falta})${c.jaCaminho ? " ✈️ A CAMINHO" : ""}`);
               }
             }
             lines.push("");
@@ -2200,58 +2233,85 @@ export default function EstoquePage() {
         };
 
         return (
-          <div className={`${bgCard} border ${borderCard} rounded-2xl p-6 shadow-sm space-y-4`}>
-            <div className="flex items-center justify-between">
-              <div>
-                <h2 className={`text-[18px] font-bold ${textPrimary}`}>Comprar Produtos</h2>
-                <p className={`text-[13px] mt-1 ${textSecondary}`}>Produtos abaixo do estoque mínimo — clique na categoria</p>
+          <div className="space-y-4">
+            {/* Header */}
+            <div className={`${bgCard} border ${borderCard} rounded-2xl p-6 shadow-sm`}>
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 className={`text-[18px] font-bold ${textPrimary}`}>Reposição de Estoque</h2>
+                  <p className={`text-[13px] mt-1 ${textSecondary}`}>
+                    {totalFalta > 0 ? `${totalFalta} unidades precisam ser compradas` : "Estoque OK!"}
+                  </p>
+                </div>
+                {totalFalta > 0 && (
+                  <button onClick={() => { navigator.clipboard.writeText(buildCopyText()); setMsg("Lista copiada!"); }}
+                    className="px-4 py-2 rounded-xl text-xs font-semibold bg-[#E8740E] text-white hover:bg-[#F5A623] transition-colors">
+                    📋 Copiar Lista
+                  </button>
+                )}
               </div>
-              <button onClick={() => { navigator.clipboard.writeText(buildCopyText()); setMsg("Lista copiada!"); }}
-                className="px-4 py-2 rounded-xl text-xs font-semibold bg-[#E8740E] text-white hover:bg-[#F5A623] transition-colors">
-                📋 Copiar Lista
-              </button>
             </div>
+
             {sortedCats.length === 0 ? (
-              <p className={`text-sm ${textSecondary} text-center py-8`}>Estoque OK! Nenhum produto abaixo do mínimo.</p>
+              <div className={`${bgCard} border ${borderCard} rounded-2xl p-8 text-center`}>
+                <p className={`text-[40px] mb-2`}>✅</p>
+                <p className={`text-[15px] font-bold ${textPrimary}`}>Estoque completo!</p>
+                <p className={`text-[13px] ${textSecondary} mt-1`}>Todos os produtos estão acima do mínimo configurado.</p>
+                <p className={`text-[11px] ${textMuted} mt-3`}>Configure o estoque mínimo abrindo um produto lacrado e definindo o campo "Estoque Mínimo".</p>
+              </div>
             ) : (
               sortedCats.map(cat => {
-                const modelos = Object.entries(byCatModel[cat]).sort(([a], [b]) => a.localeCompare(b));
-                const totalItems = modelos.reduce((s, [, cores]) => s + cores.length, 0);
-                const isOpen = expandedProducts.has(`repo_${cat}`);
+                const modelos = Object.entries(byCatModelFiltered[cat]).sort(([a], [b]) => a.localeCompare(b));
+                const totalFaltaCat = modelos.reduce((s, [, cores]) => s + cores.reduce((s2, c) => s2 + c.falta, 0), 0);
                 return (
-                  <div key={cat} className={`border rounded-xl overflow-hidden ${dm ? "border-[#3A3A3C]" : "border-[#E8E8ED]"}`}>
-                    <button
-                      onClick={() => setExpandedProducts(prev => { const s = new Set(prev); s.has(`repo_${cat}`) ? s.delete(`repo_${cat}`) : s.add(`repo_${cat}`); return s; })}
-                      className={`w-full flex items-center justify-between px-5 py-4 font-bold text-[15px] transition-colors ${isOpen ? (dm ? "bg-[#2C2C2E]" : "bg-[#F5F5F7]") : (dm ? "hover:bg-[#1C1C1E]" : "hover:bg-[#FAFAFA]")}`}
-                      style={{ color: isOpen ? "var(--at-accent, #E8740E)" : undefined }}
-                    >
-                      <span className={`flex items-center gap-2 ${!isOpen ? textPrimary : ""}`}>
-                        <span className="text-[12px]">{isOpen ? "▼" : "▶"}</span>
-                        {catLabels[cat] || cat}
-                      </span>
-                      <span className={`text-[12px] font-normal ${textSecondary}`}>{totalItems} itens</span>
-                    </button>
-                    {isOpen && (
-                      <div className={`px-5 pb-4 pt-2 space-y-4 ${dm ? "bg-[#1C1C1E]" : "bg-white"}`}>
-                        {modelos.map(([base, cores]) => (
-                          <div key={base}>
-                            <p className={`text-[13px] font-bold ${textPrimary} mb-1`}>{base}</p>
-                            <div className="pl-3 space-y-0.5">
-                              {cores.sort((a, b) => (b.qnt - a.qnt) || (a.cor || "").localeCompare(b.cor || "")).map((c, i) => (
-                                <p key={i} className={`text-[13px] ${textPrimary}`}>
-                                  {c.qnt === 0 ? "🔴" : "🟡"} {c.qnt === 0 ? "COMPRAR" : `${c.qnt}x`} {c.cor || "—"}
-                                  {c.jaCaminho && <span className="text-[10px] font-bold text-blue-500 ml-2">A CAMINHO</span>}
-                                </p>
-                              ))}
-                            </div>
+                  <div key={cat} className={`${bgCard} border ${borderCard} rounded-2xl overflow-hidden shadow-sm`}>
+                    <div className={`px-5 py-3 border-b ${borderCard} flex items-center justify-between`}>
+                      <h3 className={`text-[14px] font-bold ${textPrimary}`}>{dynamicCatLabels[cat] || cat}</h3>
+                      <span className="text-[11px] font-bold text-red-500">{totalFaltaCat} un. faltando</span>
+                    </div>
+                    <div className="divide-y" style={{ borderColor: dm ? "#2C2C2E" : "#F2F2F7" }}>
+                      {modelos.map(([base, cores]) => (
+                        <div key={base} className="px-5 py-3">
+                          <p className={`text-[13px] font-bold ${textPrimary} mb-2`}>{base}</p>
+                          <div className="grid gap-1.5">
+                            {cores.sort((a, b) => b.falta - a.falta).map((c, i) => (
+                              <div key={i} className={`flex items-center justify-between px-3 py-2 rounded-xl ${
+                                c.totalQnt === 0
+                                  ? (dm ? "bg-red-500/10 border border-red-500/20" : "bg-red-50 border border-red-100")
+                                  : (dm ? "bg-yellow-500/10 border border-yellow-500/20" : "bg-yellow-50 border border-yellow-100")
+                              }`}>
+                                <div className="flex items-center gap-2">
+                                  <span className="text-[14px]">{c.totalQnt === 0 ? "🔴" : "🟡"}</span>
+                                  <span className={`text-[13px] font-semibold ${textPrimary}`}>{c.corDisplay}</span>
+                                  {c.jaCaminho && (
+                                    <span className="text-[10px] font-bold text-blue-500 px-1.5 py-0.5 rounded-full bg-blue-500/10">✈️ A CAMINHO</span>
+                                  )}
+                                </div>
+                                <div className="flex items-center gap-3">
+                                  <span className={`text-[12px] ${textSecondary}`}>
+                                    {c.totalQnt}/{c.min}
+                                  </span>
+                                  <span className={`text-[12px] font-bold ${c.totalQnt === 0 ? "text-red-500" : "text-yellow-600"}`}>
+                                    comprar {c.falta}
+                                  </span>
+                                </div>
+                              </div>
+                            ))}
                           </div>
-                        ))}
-                      </div>
-                    )}
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 );
               })
             )}
+
+            {/* Dica */}
+            <div className={`px-5 py-3 rounded-xl border border-dashed ${dm ? "border-[#3A3A3C]" : "border-[#D2D2D7]"}`}>
+              <p className={`text-[11px] ${textMuted}`}>
+                💡 Para definir o estoque mínimo de um produto, abra um produto lacrado → campo "Estoque Mínimo". O mínimo é por cor: todos os itens da mesma cor compartilham o mesmo mínimo.
+              </p>
+            </div>
           </div>
         );
       })()

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -3074,8 +3074,8 @@ export default function EstoquePage() {
                     .trim();
                   const byProduto: Record<string, ProdutoEstoque[]> = {};
                   items.forEach((p) => {
-                    // No estoque (lacrados): ocultar itens com qnt=0
-                    if (tab === "estoque" && p.qnt === 0) return;
+                    // Ocultar itens esgotados (qnt=0) em lacrados e seminovos
+                    if ((tab === "estoque" || tab === "seminovos") && p.qnt === 0) return;
                     const groupKey = stripOrigem(p.produto).toUpperCase();
                     if (!byProduto[groupKey]) byProduto[groupKey] = [];
                     byProduto[groupKey].push(p);

--- a/app/api/admin/clientes/route.ts
+++ b/app/api/admin/clientes/route.ts
@@ -11,29 +11,117 @@ export async function GET(req: NextRequest) {
 
   const { searchParams } = new URL(req.url);
   const search = searchParams.get("search")?.trim() || "";
-  const tab = searchParams.get("tab") || "clientes"; // "clientes" or "lojistas"
+  const tab = searchParams.get("tab") || "clientes";
 
-  // Buscar todas vendas com dados do cliente
+  // =========== TAB: FORNECEDORES ===========
+  if (tab === "fornecedores") {
+    // Buscar do estoque: agrupar por fornecedor
+    const { data: estoqueData, error: estoqueErr } = await supabase
+      .from("estoque")
+      .select("fornecedor, produto, cor, qnt, custo_unitario, data_compra, data_entrada, categoria, tipo, status, serial_no")
+      .not("fornecedor", "is", null)
+      .neq("fornecedor", "");
+
+    if (estoqueErr) return NextResponse.json({ error: estoqueErr.message }, { status: 500 });
+
+    // Agrupar por fornecedor
+    const fornMap = new Map<string, {
+      nome: string;
+      total_produtos: number;
+      total_investido: number;
+      total_em_estoque: number;
+      primeira_compra: string;
+      ultima_compra: string;
+      categorias: Set<string>;
+      compras: {
+        produto: string;
+        cor: string | null;
+        qnt: number;
+        custo_unitario: number;
+        data: string;
+        categoria: string;
+        status: string;
+        serial_no: string | null;
+      }[];
+    }>();
+
+    for (const item of (estoqueData || [])) {
+      const forn = (item.fornecedor || "").trim().toUpperCase();
+      if (!forn) continue;
+      if (search && !forn.includes(search.toUpperCase())) continue;
+
+      if (!fornMap.has(forn)) {
+        fornMap.set(forn, {
+          nome: forn,
+          total_produtos: 0,
+          total_investido: 0,
+          total_em_estoque: 0,
+          primeira_compra: item.data_compra || item.data_entrada || "9999-12-31",
+          ultima_compra: item.data_compra || item.data_entrada || "0000-01-01",
+          categorias: new Set(),
+          compras: [],
+        });
+      }
+
+      const f = fornMap.get(forn)!;
+      const custo = (item.custo_unitario || 0) * (item.qnt || 1);
+      f.total_produtos += item.qnt || 1;
+      f.total_investido += custo;
+      if (item.status === "EM ESTOQUE") f.total_em_estoque += item.qnt || 0;
+      if (item.categoria) f.categorias.add(item.categoria);
+
+      const data = item.data_compra || item.data_entrada || "";
+      if (data && data < f.primeira_compra) f.primeira_compra = data;
+      if (data && data > f.ultima_compra) f.ultima_compra = data;
+
+      f.compras.push({
+        produto: item.produto,
+        cor: item.cor,
+        qnt: item.qnt || 1,
+        custo_unitario: item.custo_unitario || 0,
+        data: data,
+        categoria: item.categoria || "",
+        status: item.status || "",
+        serial_no: item.serial_no || null,
+      });
+    }
+
+    const fornecedores = Array.from(fornMap.values())
+      .map(f => ({
+        ...f,
+        categorias: Array.from(f.categorias),
+        compras: f.compras.sort((a, b) => (b.data || "").localeCompare(a.data || "")),
+      }))
+      .sort((a, b) => b.total_investido - a.total_investido);
+
+    return NextResponse.json({
+      fornecedores,
+      total: fornecedores.length,
+      total_investido: fornecedores.reduce((s, f) => s + f.total_investido, 0),
+      total_produtos: fornecedores.reduce((s, f) => s + f.total_produtos, 0),
+      total_em_estoque: fornecedores.reduce((s, f) => s + f.total_em_estoque, 0),
+    });
+  }
+
+  // =========== TABS: clientes / lojistas / notas ===========
   let query = supabase
     .from("vendas")
-    .select("*")
+    .select("id,data,cliente,cpf,cnpj,email,pessoa,bairro,cidade,uf,origem,tipo,produto,fornecedor,preco_vendido,forma,banco,serial_no,imei,nota_fiscal_url,status_pagamento")
+    .neq("status_pagamento", "CANCELADO")
     .order("data", { ascending: false });
 
-  // Filtrar por serial ou imei se parece código de produto
   if (search) {
     const clean = search.replace(/[\.\-\/\s]/g, "");
-    // Se parece serial/imei (alfanumérico 8+ chars)
     if (/^[A-Z0-9]{8,}$/i.test(clean)) {
       query = query.or(`serial_no.ilike.%${clean}%,imei.ilike.%${clean}%,cpf.ilike.%${clean}%,cliente.ilike.%${search}%`);
     } else if (/^\d{3,}$/.test(clean)) {
-      // Parece CPF
       query = query.ilike("cpf", `%${clean}%`);
     } else {
       query = query.ilike("cliente", `%${search}%`);
     }
   }
 
-  // Buscar todas as vendas sem limite fixo (paginação automática)
+  // Paginação em batches
   const rawVendas: Record<string, unknown>[] = [];
   let from = 0;
   const PAGE = 1000;
@@ -46,98 +134,57 @@ export async function GET(req: NextRequest) {
     from += PAGE;
   }
 
-  // Filtrar canceladas no JS (evita problema com neq e NULL no Supabase)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const vendas = (rawVendas ?? []).filter(
-    (v: any) => v.status_pagamento !== "CANCELADO"
-  );
+  // Tab "notas"
+  if (tab === "notas") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const notas = rawVendas.filter((v: any) => v.nota_fiscal_url).map((v: any) => ({
+      id: v.id, data: v.data, cliente: v.cliente, produto: v.produto,
+      preco_vendido: Number(v.preco_vendido || 0), nota_fiscal_url: v.nota_fiscal_url,
+    }));
+    return NextResponse.json({ notas, total: notas.length });
+  }
 
-  // Agrupar por cliente
+  // Agrupar por cliente (sem enviar vendas[] no response — fica mais leve)
   const clienteMap = new Map<string, {
-    nome: string;
-    cpf: string | null;
-    cnpj: string | null;
-    email: string | null;
-    pessoa: string | null;
-    bairro: string | null;
-    cidade: string | null;
-    uf: string | null;
-    total_compras: number;
-    total_gasto: number;
-    ultima_compra: string;
-    ultimo_produto: string;
-    cliente_desde: string;
-    is_lojista: boolean;
-    vendas: {
-      id: string;
-      data: string;
-      produto: string;
-      preco_vendido: number;
-      forma: string;
-      banco: string;
-      serial_no: string | null;
-      imei: string | null;
-    }[];
+    nome: string; cpf: string | null; cnpj: string | null; email: string | null;
+    pessoa: string | null; bairro: string | null; cidade: string | null; uf: string | null;
+    total_compras: number; total_gasto: number; ultima_compra: string; ultimo_produto: string;
+    cliente_desde: string; is_lojista: boolean;
+    vendas: { id: string; data: string; produto: string; preco_vendido: number; forma: string; banco: string; serial_no: string | null; imei: string | null }[];
   }>();
-
-  // Mapa de CPF → chave do clienteMap (para unificar mesma pessoa com nomes diferentes)
   const cpfToKey = new Map<string, string>();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  for (const v of vendas as any[]) {
+  for (const v of rawVendas as any[]) {
     const nome = (v.cliente || "").trim();
     if (!nome) continue;
-
     const isAtacado = v.tipo === "ATACADO" || v.origem === "ATACADO";
     const cpf = (v.cpf || "").trim();
 
-    // Determinar a chave de agrupamento:
-    // - Com CPF: agrupa por CPF (mesma pessoa mesmo com nomes diferentes)
-    // - Sem CPF: agrupa só pelo nome exato (não mistura com outros)
     let key: string;
     if (cpf) {
-      if (cpfToKey.has(cpf)) {
-        key = cpfToKey.get(cpf)!;
-      } else {
-        key = `cpf:${cpf}`;
-        cpfToKey.set(cpf, key);
-      }
+      if (cpfToKey.has(cpf)) { key = cpfToKey.get(cpf)!; }
+      else { key = `cpf:${cpf}`; cpfToKey.set(cpf, key); }
     } else {
       key = `nome:${nome.toUpperCase()}`;
     }
 
     if (!clienteMap.has(key)) {
       clienteMap.set(key, {
-        nome,
-        cpf: v.cpf,
-        cnpj: v.cnpj,
-        email: v.email,
-        pessoa: v.pessoa,
-        bairro: v.bairro,
-        cidade: v.cidade,
-        uf: v.uf,
-        total_compras: 0,
-        total_gasto: 0,
-        ultima_compra: v.data,
-        ultimo_produto: v.produto,
-        cliente_desde: v.data,
-        is_lojista: isAtacado,
-        vendas: [],
+        nome, cpf: v.cpf, cnpj: v.cnpj, email: v.email, pessoa: v.pessoa,
+        bairro: v.bairro, cidade: v.cidade, uf: v.uf,
+        total_compras: 0, total_gasto: 0, ultima_compra: v.data, ultimo_produto: v.produto,
+        cliente_desde: v.data, is_lojista: isAtacado, vendas: [],
       });
     }
 
     const c = clienteMap.get(key)!;
     c.total_compras++;
     c.total_gasto += Number(v.preco_vendido || 0);
-    if (v.data > c.ultima_compra) {
-      c.ultima_compra = v.data;
-      c.ultimo_produto = v.produto;
-    }
+    if (v.data > c.ultima_compra) { c.ultima_compra = v.data; c.ultimo_produto = v.produto; }
     if (v.data < c.cliente_desde) c.cliente_desde = v.data;
     if (isAtacado) c.is_lojista = true;
-    // Sempre usar o nome mais completo
     if (nome.length > c.nome.length) c.nome = nome;
-    // Preencher dados pessoais mais recentes
     if (v.cpf && !c.cpf) c.cpf = v.cpf;
     if (v.cnpj && !c.cnpj) c.cnpj = v.cnpj;
     if (v.email && !c.email) c.email = v.email;
@@ -147,34 +194,11 @@ export async function GET(req: NextRequest) {
     if (v.pessoa && !c.pessoa) c.pessoa = v.pessoa;
 
     c.vendas.push({
-      id: v.id,
-      data: v.data,
-      produto: v.produto,
-      preco_vendido: Number(v.preco_vendido || 0),
-      forma: v.forma,
-      banco: v.banco,
-      serial_no: v.serial_no,
-      imei: v.imei,
+      id: v.id, data: v.data, produto: v.produto, preco_vendido: Number(v.preco_vendido || 0),
+      forma: v.forma, banco: v.banco, serial_no: v.serial_no, imei: v.imei,
     });
   }
 
-  // Tab "notas" — vendas com nota fiscal
-  if (tab === "notas") {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const notasRaw = (rawVendas ?? []).filter((v: any) => v.nota_fiscal_url && v.status_pagamento !== "CANCELADO");
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const notas = notasRaw.map((v: any) => ({
-      id: v.id,
-      data: v.data,
-      cliente: v.cliente,
-      produto: v.produto,
-      preco_vendido: Number(v.preco_vendido || 0),
-      nota_fiscal_url: v.nota_fiscal_url,
-    }));
-    return NextResponse.json({ notas, total: notas.length });
-  }
-
-  // Filtrar por tab
   let clientes = Array.from(clienteMap.values());
   if (tab === "lojistas") {
     clientes = clientes.filter((c) => c.is_lojista);
@@ -182,7 +206,6 @@ export async function GET(req: NextRequest) {
     clientes = clientes.filter((c) => !c.is_lojista);
   }
 
-  // Ordenar por total gasto desc
   clientes.sort((a, b) => b.total_gasto - a.total_gasto);
 
   return NextResponse.json({

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -143,13 +143,17 @@ export async function POST(req: NextRequest) {
   let estoqueId = body._estoque_id;
   delete body._estoque_id;
 
-  // Se tem estoque_id, copiar IMEI e Serial do estoque para a venda (se existirem)
+  // Se tem estoque_id, verificar se produto ainda está disponível e copiar IMEI/Serial
   let imeiFromEstoque: string | null = null;
   let serialFromEstoque: string | null = null;
-  if (estoqueId && (!body.imei || !body.serial_no)) {
-    const { data: estoqueItem } = await supabase.from("estoque").select("imei, serial_no").eq("id", estoqueId).single();
-    if (estoqueItem?.imei && !body.imei) imeiFromEstoque = estoqueItem.imei;
-    if (estoqueItem?.serial_no && !body.serial_no) serialFromEstoque = estoqueItem.serial_no;
+  if (estoqueId) {
+    const { data: estoqueItem } = await supabase.from("estoque").select("imei, serial_no, qnt, status").eq("id", estoqueId).single();
+    if (!estoqueItem) return NextResponse.json({ error: "Produto não encontrado no estoque" }, { status: 404 });
+    if (estoqueItem.status === "ESGOTADO" || estoqueItem.qnt <= 0) {
+      return NextResponse.json({ error: "Produto já foi vendido (ESGOTADO). Não é possível registrar outra venda." }, { status: 409 });
+    }
+    if (estoqueItem.imei && !body.imei) imeiFromEstoque = estoqueItem.imei;
+    if (estoqueItem.serial_no && !body.serial_no) serialFromEstoque = estoqueItem.serial_no;
   }
 
   // Garantir nome do cliente em caixa alta


### PR DESCRIPTION
## Summary
- **Reposição redesenhada**: estoque mínimo por cor, agrupado por categoria/modelo, indicadores visuais, botão copiar lista
- **Cores bilíngues na Reposição**: EN + PT (ex: SILVER (Prata))
- **Aba Fornecedores** na página de Clientes com histórico de compras e total investido
- **Performance otimizada** na página de Clientes (queries específicas, filtro server-side)
- **Bloqueio de venda duplicada**: backend rejeita venda em produto ESGOTADO (409)
- **Fixes**: regex INDIGO, TEAL/ULTRAMARINE, seminovos qnt=0, layout mobile, parse error

## Test plan
- [ ] Verificar aba Reposição com cores EN (PT)
- [ ] Verificar aba Fornecedores nos Clientes
- [ ] Tentar vender produto já ESGOTADO (deve bloquear)
- [ ] Seminovos vendidos não aparecem na lista

🤖 Generated with [Claude Code](https://claude.com/claude-code)