### PR TITLE
Fix: cores MacBook Neo + traduções PT

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -148,6 +148,9 @@ const COR_PT: Record<string, string> = {
   "JET BLACK": "Preto Brilhante",
   "CLOUD WHITE": "Branco Nuvem",
   "SKY BLUE": "Azul Céu",
+  "INDIGO": "Indigo",
+  "BLUSH": "Rosa Blush",
+  "CITRUS": "Cítrico",
 };
 
 function traduzirCor(cor: string | null | undefined): string {

--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -64,7 +64,7 @@ export function getIphoneCores(modelo: string): string[] {
   return IPHONE_CORES_POR_MODELO[modelo] || IPHONE_CORES;
 }
 
-export const MACBOOK_CORES = ["MIDNIGHT", "SILVER", "STARLIGHT", "SKY BLUE", "SPACE BLACK"];
+export const MACBOOK_CORES = ["BLUSH", "CITRUS", "INDIGO", "MIDNIGHT", "SILVER", "SKY BLUE", "SPACE BLACK", "STARLIGHT"];
 
 export const IPAD_CORES = ["BLUE", "SPACE GRAY", "STARLIGHT", "PURPLE"];
 


### PR DESCRIPTION
## Summary
- Cores corretas do MacBook Neo: Silver, Blush, Citrus, Indigo
- Adicionadas traduções PT para INDIGO, BLUSH, CITRUS

🤖 Generated with [Claude Code](https://claude.com/claude-code)