### PR TITLE
feat: seed automático do catálogo + edição de atribuições

### DIFF
--- a/app/admin/catalogo/page.tsx
+++ b/app/admin/catalogo/page.tsx
@@ -659,12 +659,42 @@ function ModelosTab({ data, headers, reload }: TabProps) {
       <div className="w-80 shrink-0 bg-white rounded-xl shadow-sm overflow-hidden flex flex-col">
         <div className="p-4 border-b border-[#F5F5F7] flex items-center justify-between">
           <h2 className="font-semibold text-[#1D1D1F]">Modelos</h2>
-          <button
-            onClick={() => setShowNewForm(!showNewForm)}
-            className="px-3 py-1.5 rounded-lg text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D] transition-colors"
-          >
-            + Novo Modelo
-          </button>
+          <div className="flex gap-2">
+            <button
+              onClick={async () => {
+                if (!confirm("Preencher automaticamente as configurações de todos os modelos com dados padrão?")) return;
+                setSaving("seed");
+                try {
+                  const res = await fetch("/api/admin/catalogo", {
+                    method: "POST",
+                    headers: headers(),
+                    body: JSON.stringify({ resource: "seed_modelo_configs" }),
+                  });
+                  const json = await res.json();
+                  if (json.ok) {
+                    alert(`Configurações preenchidas para ${json.seeded} de ${json.total} modelos!`);
+                    reload();
+                  } else {
+                    alert("Erro: " + json.error);
+                  }
+                } catch (e) {
+                  alert("Erro: " + String(e));
+                } finally {
+                  setSaving(null);
+                }
+              }}
+              disabled={saving === "seed"}
+              className="px-3 py-1.5 rounded-lg text-sm font-semibold bg-blue-500 text-white hover:bg-blue-600 transition-colors disabled:opacity-50"
+            >
+              {saving === "seed" ? "Preenchendo..." : "Preencher Dados"}
+            </button>
+            <button
+              onClick={() => setShowNewForm(!showNewForm)}
+              className="px-3 py-1.5 rounded-lg text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D] transition-colors"
+            >
+              + Novo Modelo
+            </button>
+          </div>
         </div>
 
         {showNewForm && (

--- a/app/api/admin/catalogo/route.ts
+++ b/app/api/admin/catalogo/route.ts
@@ -1,5 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getSupabase } from "@/lib/supabase";
+import {
+  IPHONE_CORES_POR_MODELO, IPHONE_STORAGES_POR_MODELO, IPHONE_ORIGENS,
+  MACBOOK_CHIPS, MACBOOK_RAMS, MACBOOK_STORAGES, MACBOOK_TELAS_AIR, MACBOOK_TELAS_PRO, MACBOOK_TELAS_NEO, MACBOOK_CORES,
+  MAC_MINI_CHIPS, MAC_MINI_RAMS, MAC_MINI_STORAGES,
+  IPAD_CHIPS, IPAD_TELAS, IPAD_STORAGES, IPAD_CORES,
+  WATCH_TAMANHOS, WATCH_PULSEIRAS, WATCH_BAND_MODELS, WATCH_CORES,
+  AIRPODS_MODELOS,
+} from "@/lib/produto-specs";
 
 function checkAuth(req: NextRequest): boolean {
   const pw = req.headers.get("x-admin-password");
@@ -76,8 +84,8 @@ export async function GET(req: NextRequest) {
 // DELETE /api/admin/catalogo — delete record
 // Body: { resource, ...fields }  (PATCH/DELETE also need `id`)
 
-type Resource = "categorias" | "modelos" | "spec_tipos" | "spec_valores" | "modelo_configs" | "categoria_specs_config";
-type SimpleResource = Exclude<Resource, "modelo_configs" | "categoria_specs_config">;
+type Resource = "categorias" | "modelos" | "spec_tipos" | "spec_valores" | "modelo_configs" | "categoria_specs_config" | "seed_modelo_configs";
+type SimpleResource = Exclude<Resource, "modelo_configs" | "categoria_specs_config" | "seed_modelo_configs">;
 
 const TABLE_MAP: Record<SimpleResource, string> = {
   categorias: "catalogo_categorias",
@@ -142,6 +150,129 @@ export async function POST(req: NextRequest) {
       }
 
       return NextResponse.json({ ok: true });
+    }
+
+    // Special handler: seed all modelo configs from produto-specs.ts data
+    if (resource === "seed_modelo_configs") {
+      // Get all models from DB
+      const { data: modelos } = await supabase.from("catalogo_modelos").select("id, nome, categoria_key");
+      if (!modelos) return NextResponse.json({ error: "No models found" }, { status: 400 });
+
+      let seeded = 0;
+      for (const modelo of modelos) {
+        const configs: { tipo_chave: string; valor: string }[] = [];
+        const catKey = modelo.categoria_key;
+        const nome = modelo.nome;
+
+        // iPhone configs
+        if (catKey === "IPHONES") {
+          // Match model name to IPHONE_CORES_POR_MODELO key
+          const modelKey = nome.replace(/^iPhone\s*/i, "").toUpperCase();
+          const cores = IPHONE_CORES_POR_MODELO[modelKey];
+          if (cores) cores.forEach(c => configs.push({ tipo_chave: "cores", valor: c }));
+          const storages = IPHONE_STORAGES_POR_MODELO[modelKey];
+          if (storages) storages.forEach(s => configs.push({ tipo_chave: "capacidade", valor: s }));
+          // All iPhones get all origins
+          IPHONE_ORIGENS.forEach(o => configs.push({ tipo_chave: "origem", valor: o }));
+        }
+
+        // MacBook Air configs
+        if (catKey === "MACBOOK_AIR") {
+          const airChips = MACBOOK_CHIPS.filter(c => !c.includes("PRO") && !c.includes("MAX"));
+          airChips.forEach(c => configs.push({ tipo_chave: "chips_air", valor: c }));
+          MACBOOK_TELAS_AIR.forEach(t => configs.push({ tipo_chave: "telas", valor: t }));
+          MACBOOK_CORES.forEach(c => configs.push({ tipo_chave: "cores", valor: c }));
+          MACBOOK_RAMS.filter(r => ["8GB", "16GB", "24GB"].includes(r)).forEach(r => configs.push({ tipo_chave: "ram", valor: r }));
+          MACBOOK_STORAGES.filter(s => ["256GB", "512GB", "1TB", "2TB"].includes(s)).forEach(s => configs.push({ tipo_chave: "ssd", valor: s }));
+        }
+
+        // MacBook Pro configs
+        if (catKey === "MACBOOK_PRO") {
+          const proChips = MACBOOK_CHIPS.filter(c => c.includes("PRO") || c.includes("MAX"));
+          proChips.forEach(c => configs.push({ tipo_chave: "chips_pro_max", valor: c }));
+          MACBOOK_TELAS_PRO.forEach(t => configs.push({ tipo_chave: "telas", valor: t }));
+          MACBOOK_CORES.forEach(c => configs.push({ tipo_chave: "cores", valor: c }));
+          MACBOOK_RAMS.forEach(r => configs.push({ tipo_chave: "ram", valor: r }));
+          MACBOOK_STORAGES.forEach(s => configs.push({ tipo_chave: "ssd", valor: s }));
+        }
+
+        // MacBook Neo configs
+        if (catKey === "MACBOOK_NEO") {
+          const neoChips = MACBOOK_CHIPS.filter(c => c.startsWith("A18") || c === "M4");
+          neoChips.forEach(c => configs.push({ tipo_chave: "chips_air", valor: c }));
+          MACBOOK_TELAS_NEO.forEach(t => configs.push({ tipo_chave: "telas", valor: t }));
+          MACBOOK_CORES.forEach(c => configs.push({ tipo_chave: "cores", valor: c }));
+          MACBOOK_RAMS.filter(r => ["8GB", "16GB", "24GB"].includes(r)).forEach(r => configs.push({ tipo_chave: "ram", valor: r }));
+          MACBOOK_STORAGES.filter(s => ["256GB", "512GB", "1TB"].includes(s)).forEach(s => configs.push({ tipo_chave: "ssd", valor: s }));
+        }
+
+        // Mac Mini configs
+        if (catKey === "MAC_MINI") {
+          const airChips = MAC_MINI_CHIPS.filter(c => !c.includes("PRO"));
+          airChips.forEach(c => configs.push({ tipo_chave: "chips_air", valor: c }));
+          const proChips = MAC_MINI_CHIPS.filter(c => c.includes("PRO"));
+          proChips.forEach(c => configs.push({ tipo_chave: "chips_pro_max", valor: c }));
+          MAC_MINI_RAMS.forEach(r => configs.push({ tipo_chave: "ram", valor: r }));
+          MAC_MINI_STORAGES.forEach(s => configs.push({ tipo_chave: "ssd", valor: s }));
+        }
+
+        // Mac Studio configs
+        if (catKey === "MAC_STUDIO") {
+          const maxChips = MACBOOK_CHIPS.filter(c => c.includes("MAX") || c.includes("ULTRA"));
+          if (maxChips.length === 0) {
+            ["M4 MAX", "M4 ULTRA", "M5 MAX", "M5 ULTRA"].forEach(c => configs.push({ tipo_chave: "chips_max", valor: c }));
+          } else {
+            maxChips.forEach(c => configs.push({ tipo_chave: "chips_max", valor: c }));
+          }
+          MACBOOK_RAMS.filter(r => parseInt(r) >= 32).forEach(r => configs.push({ tipo_chave: "ram", valor: r }));
+          MACBOOK_STORAGES.forEach(s => configs.push({ tipo_chave: "ssd", valor: s }));
+        }
+
+        // iMac configs
+        if (catKey === "IMAC") {
+          const imacChips = MACBOOK_CHIPS.filter(c => !c.includes("PRO") && !c.includes("MAX") && c.startsWith("M"));
+          imacChips.forEach(c => configs.push({ tipo_chave: "chips_air", valor: c }));
+          MACBOOK_RAMS.filter(r => ["8GB", "16GB", "24GB", "32GB"].includes(r)).forEach(r => configs.push({ tipo_chave: "ram", valor: r }));
+          MACBOOK_STORAGES.filter(s => ["256GB", "512GB", "1TB", "2TB"].includes(s)).forEach(s => configs.push({ tipo_chave: "ssd", valor: s }));
+          // iMac cores (same as MacBook)
+          MACBOOK_CORES.forEach(c => configs.push({ tipo_chave: "cores", valor: c }));
+        }
+
+        // iPad configs
+        if (catKey === "IPADS") {
+          IPAD_CHIPS.forEach(c => configs.push({ tipo_chave: "chips_air", valor: c }));
+          IPAD_TELAS.forEach(t => configs.push({ tipo_chave: "telas", valor: t }));
+          IPAD_STORAGES.forEach(s => configs.push({ tipo_chave: "capacidade", valor: s }));
+          IPAD_CORES.forEach(c => configs.push({ tipo_chave: "cores", valor: c }));
+          ["WIFI", "WIFI+CELL"].forEach(c => configs.push({ tipo_chave: "conectividade", valor: c }));
+        }
+
+        // Apple Watch configs
+        if (catKey === "APPLE_WATCH") {
+          WATCH_TAMANHOS.forEach(t => configs.push({ tipo_chave: "tamanho_aw", valor: t }));
+          WATCH_CORES.forEach(c => configs.push({ tipo_chave: "cores_aw", valor: c }));
+          WATCH_PULSEIRAS.forEach(p => configs.push({ tipo_chave: "tamanho_pulseira", valor: p }));
+          WATCH_BAND_MODELS.forEach(b => configs.push({ tipo_chave: "pulseiras", valor: b }));
+          ["GPS", "GPS + CEL"].forEach(c => configs.push({ tipo_chave: "conectividade_aw", valor: c }));
+        }
+
+        // AirPods configs
+        if (catKey === "AIRPODS") {
+          AIRPODS_MODELOS.forEach(m => configs.push({ tipo_chave: "descricao_airpods", valor: m }));
+        }
+
+        if (configs.length > 0) {
+          // Delete existing configs
+          await supabase.from("catalogo_modelo_configs").delete().eq("modelo_id", modelo.id);
+          // Insert new configs
+          const rows = configs.map(c => ({ modelo_id: modelo.id, tipo_chave: c.tipo_chave, valor: c.valor }));
+          const { error: insError } = await supabase.from("catalogo_modelo_configs").insert(rows);
+          if (insError) console.error(`Seed error for ${nome}:`, insError.message);
+          else seeded++;
+        }
+      }
+
+      return NextResponse.json({ ok: true, seeded, total: modelos.length });
     }
 
     const table = TABLE_MAP[resource as SimpleResource];


### PR DESCRIPTION
## Summary
- Endpoint seed_modelo_configs popula configs de todos os modelos com dados de produto-specs.ts
- Botão "Preencher Dados" na aba Modelos do catálogo
- toggleCatSpec funciona via API (ciclo: off → opcional → obrigatório → off)

## Test plan
- [ ] Ir em Catálogo > Modelos > clicar "Preencher Dados"
- [ ] Verificar que configs aparecem nos modelos

🤖 Generated with [Claude Code](https://claude.com/claude-code)