### PR TITLE
fix: múltiplos bugs em estoque, vendas e cancelamento

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -1671,7 +1671,7 @@ export default function EstoquePage() {
   // Filtrar por tipo
   const novos = estoque.filter((p) => (p.tipo || "NOVO") === "NOVO");
   const naoAtivados = estoque.filter((p) => p.tipo === "NAO_ATIVADO");
-  const seminovos = estoque.filter((p) => p.tipo === "SEMINOVO");
+  const seminovos = estoque.filter((p) => p.tipo === "SEMINOVO" && p.status !== "ESGOTADO");
   const atacado = estoque.filter((p) => p.tipo === "ATACADO");
   const emEstoque = novos; // Aba Estoque = só lacrados (NOVO)
   const pendencias = estoque.filter((p) => p.tipo === "PENDENCIA");
@@ -2978,7 +2978,12 @@ export default function EstoquePage() {
               const grandTotal = filtered.reduce((s, p) => s + p.qnt * (p.custo_unitario || 0), 0);
               return (
                 <div className="space-y-4">
-                  {sortedDates.map(date => {
+                  {sortedDates.filter(date => {
+                    // Ocultar pedidos onde todos os itens já foram recebidos (exceto se filtrando por recebidos)
+                    if (acaminhoFilter === "recebidos") return true;
+                    const items = byDate[date];
+                    return acaminhoFilter === "todos" ? true : items.some(p => p.tipo === "A_CAMINHO");
+                  }).map(date => {
                     const items = byDate[date];
                     const pendentes = items.filter(p => p.tipo === "A_CAMINHO");
                     const recebidos = items.filter(p => p.tipo !== "A_CAMINHO");
@@ -3335,11 +3340,13 @@ export default function EstoquePage() {
                   return modeloEntries.map(([modelo, items], cardIdx) => {
                   // Sub-agrupar por nome do produto (sem origem VC/LL/J/BE/BR/HN/IN/ZA)
                   const stripOrigem = (nome: string) => nome
-                    .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ)(?=\s|$|\()(\s*\([^)]*\))?/gi, "")
+                    .replace(/\s+(VC|LL|BE|BR|HN|IN|ZA|BZ)(?=\s|$|\()(\s*\([^)]*\))?/gi, "")
+                    .replace(/\s+J(?=\s*\(|\s*$)(\s*\([^)]*\))?/gi, "")
                     .replace(/[-–]\s*(CHIP\s+(F[ÍI]SICO\s*\+\s*)?)?E-?SIM/gi, "")
                     .replace(/[-–]\s*CHIP\s+VIRTUAL/gi, "")
                     .replace(/\s*\(\d+C\s*CPU\/\d+C\s*GPU\)\s*/gi, " ")  // (10C CPU/10C GPU)
                     .replace(/\s{2,}/g, " ")
+                    .replace(/\s*[-–]\s*$/, "")
                     .trim();
                   const byProduto: Record<string, ProdutoEstoque[]> = {};
                   items.forEach((p) => {
@@ -3504,7 +3511,7 @@ export default function EstoquePage() {
                                           <button onClick={() => handleSaveNome(prodItems.map((x) => x.id), editingNome[prodItems[0].id])} className="text-[10px] text-[#E8740E] font-bold shrink-0">OK</button>
                                         </div>
                                       ) : (
-                                        <span className={`flex items-center gap-1.5 ${canEditNome ? "cursor-pointer hover:text-[#E8740E]" : ""}`} onClick={(e) => { if (canEditNome) { e.stopPropagation(); setEditingNome({ ...editingNome, [prodItems[0].id]: prodNome }); } }}>
+                                        <span className={`flex items-center gap-1.5 ${canEditNome ? "cursor-pointer hover:text-[#E8740E]" : ""}`} onClick={(e) => { if (canEditNome) { e.stopPropagation(); setEditingNome({ ...editingNome, [prodItems[0].id]: prodItems[0].produto }); } }}>
                                           {displayNomeProduto(prodNome, prodItems[0]?.cor, prodItems[0]?.categoria)}
                                           {/* Badge de núcleos para MacBooks */}
                                           {getBaseCat(prodItems[0]?.categoria) === "MACBOOK" && (() => {

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -444,7 +444,7 @@ export default function VendasPage() {
 
   const produtosFiltrados = catSel ? (() => {
     const [cat, tipo] = catSel.split("__");
-    return estoque.filter(p => p.categoria === cat && ((p.tipo ?? "NOVO") === "SEMINOVO" ? "SEMINOVO" : "NOVO") === tipo);
+    return estoque.filter(p => p.categoria === cat && ((p.tipo ?? "NOVO") === "SEMINOVO" ? "SEMINOVO" : "NOVO") === tipo && p.qnt > 0 && p.status === "EM ESTOQUE");
   })() : [];
 
   const fetchVendas = useCallback(async () => {
@@ -2114,11 +2114,13 @@ export default function VendasPage() {
                     : baseList;
                   // Limpar nome do produto: remover origem e chip
                   const stripOrigemVendas = (nome: string) => nome
-                    .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ)\s*(\([^)]*\))?/gi, "")
+                    .replace(/\s+(VC|LL|BE|BR|HN|IN|ZA|BZ)(?=\s|$|\()(\s*\([^)]*\))?/gi, "")
+                    .replace(/\s+J(?=\s*\(|\s*$)(\s*\([^)]*\))?/gi, "")
                     .replace(/[-–]\s*(CHIP\s+(F[ÍI]SICO\s*\+\s*)?)?E-?SIM/gi, "")
                     .replace(/[-–]\s*CHIP\s+VIRTUAL/gi, "")
                     .replace(/\s*\(\d+C\s*CPU\/\d+C\s*GPU\)\s*/gi, " ")
                     .replace(/\s{2,}/g, " ")
+                    .replace(/\s*[-–]\s*$/, "")
                     .trim();
                   const grupos: Record<string, EstoqueItem[]> = {};
                   for (const p of filtrados) {
@@ -2141,9 +2143,12 @@ export default function VendasPage() {
 
                   // Extrair modelo base (sem cor) pra agrupar cores num card só
                   const extractModeloBase = (nome: string) => {
-                    // Pega tudo até a memória (ex: "IPHONE 16 PLUS 128GB")
-                    const m = nome.match(/^(.+?\d+\s*(?:GB|TB))/i);
-                    return m ? m[1].trim() : nome;
+                    // Apple Watch: "WATCH ULTRA 3 49MM" ou "WATCH S10 42MM"
+                    const watchMatch = nome.match(/^(.*?(?:WATCH|APPLE\s*WATCH)\s*(?:ULTRA\s*\d*|SE\s*\d*|S\d+|SERIES\s*\d+)(?:\s*\d+MM)?)/i);
+                    if (watchMatch) return watchMatch[1].trim();
+                    // Acessórios sem memória: retorna o nome todo (já stripped)
+                    const memMatch = nome.match(/^(.+?\d+\s*(?:GB|TB))/i);
+                    return memMatch ? memMatch[1].trim() : nome;
                   };
 
                   // Reagrupar: modelo base → cores → itens

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -657,28 +657,43 @@ export async function DELETE(req: NextRequest) {
   }
 
   // Se tinha produto na troca, remover a pendência específica do estoque
-  // (apenas a pendência correspondente ao produto da troca, não todas do cliente)
   if (venda && venda.produto_na_troca && venda.cliente) {
     const clienteUpper = (venda.cliente || "").toUpperCase();
-    // 1ª troca
-    if (venda.troca_produto) {
-      await supabase.from("estoque")
-        .delete()
-        .eq("produto", venda.troca_produto)
+    // Helper: busca pendência por produto exato, fallback por cliente+data
+    async function removerPendencia(trocaProduto: string | null, label: string) {
+      // 1. Tentar por nome exato do produto
+      if (trocaProduto) {
+        const { data: found } = await supabase.from("estoque")
+          .select("id, produto")
+          .eq("produto", trocaProduto)
+          .eq("cliente", clienteUpper)
+          .in("tipo", ["PENDENCIA", "SEMINOVO"])
+          .order("created_at", { ascending: false })
+          .limit(1);
+        if (found && found.length > 0) {
+          await supabase.from("estoque").delete().eq("id", found[0].id);
+          await logActivity(usuario, `Removeu pendência ${label} (cancelamento)`, `${found[0].produto} — ${venda.cliente}`, "estoque");
+          return;
+        }
+      }
+      // 2. Fallback: buscar por cliente + tipo + data da venda
+      const { data: fallback } = await supabase.from("estoque")
+        .select("id, produto")
         .eq("cliente", clienteUpper)
         .in("tipo", ["PENDENCIA", "SEMINOVO"])
+        .eq("data_compra", venda.data)
+        .order("created_at", { ascending: false })
         .limit(1);
-      await logActivity(usuario, "Removeu pendência troca (cancelamento)", `${venda.troca_produto} — ${venda.cliente}`, "estoque");
+      if (fallback && fallback.length > 0) {
+        await supabase.from("estoque").delete().eq("id", fallback[0].id);
+        await logActivity(usuario, `Removeu pendência ${label} (cancelamento, fallback)`, `${fallback[0].produto} — ${venda.cliente}`, "estoque");
+      }
     }
+    // 1ª troca
+    await removerPendencia(venda.troca_produto, "troca");
     // 2ª troca
-    if (venda.troca_produto2 && venda.produto_na_troca2) {
-      await supabase.from("estoque")
-        .delete()
-        .eq("produto", venda.troca_produto2)
-        .eq("cliente", clienteUpper)
-        .in("tipo", ["PENDENCIA", "SEMINOVO"])
-        .limit(1);
-      await logActivity(usuario, "Removeu pendência troca 2 (cancelamento)", `${venda.troca_produto2} — ${venda.cliente}`, "estoque");
+    if (venda.produto_na_troca2) {
+      await removerPendencia(venda.troca_produto2, "troca 2");
     }
   }
 


### PR DESCRIPTION
## Summary
- Seminovos esgotados não aparecem mais na aba de seminovos
- Filtro "Recebidos" em Produtos a Caminho carrega corretamente
- Fontes duplicadas (ex: "FONTE APPLE 20W" e "FONTE APPLE 20W -") agrupadas
- Edição de nome em pendências usa valor do banco, não o display traduzido
- Cancelamento de venda remove pendências com fallback por cliente+data
- Watch Ultra agrupado corretamente na seleção de vendas (extractModeloBase)
- Regex de origem não remove mais "J" de "JET BLACK", "JADE" etc
- Produtos esgotados não aparecem na busca de vendas

## Test plan
- [ ] Verificar que seminovos esgotados sumiram da aba seminovos
- [ ] Filtrar "Recebidos" em Produtos a Caminho
- [ ] Verificar fontes agrupadas corretamente
- [ ] Buscar "Watch Ultra" na venda e ver agrupamento correto
- [ ] Cancelar venda com troca e verificar que pendência some

🤖 Generated with [Claude Code](https://claude.com/claude-code)