### PR TITLE
fix: Watch GPS+CEL abreviado e nomes padronizados

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -1013,8 +1013,8 @@ export default function EstoquePage() {
         return `${modelo}${chip} ${spec.ipad_tela} ${spec.ipad_storage}${conn}${c}`.toUpperCase();
       }
       case "APPLE_WATCH": {
-        const conn = spec.aw_conn === "GPS+CELL" ? " GPS+CELLULAR" : " GPS";
-        const pulseira = spec.aw_pulseira ? ` ${spec.aw_pulseira}` : "";
+        const conn = spec.aw_conn === "GPS+CELL" ? " GPS+CEL" : " GPS";
+        const pulseira = spec.aw_pulseira ? ` PULSEIRA ${spec.aw_pulseira}` : "";
         return `APPLE WATCH ${spec.aw_modelo} ${spec.aw_tamanho}${conn}${c}${pulseira}`.toUpperCase();
       }
       case "AIRPODS":
@@ -1062,14 +1062,14 @@ export default function EstoquePage() {
             }
             continue;
           }
-          // Caso 2: normalizar GPS+CEL → GPS+CELLULAR
+          // Caso 2: normalizar GPS+CELLULAR → GPS+CEL
           let fixed = nome;
-          if (fixed.includes("GPS+CEL ") || fixed.endsWith("GPS+CEL")) {
-            fixed = fixed.replace(/GPS\+CEL\b/g, "GPS+CELLULAR");
+          if (fixed.includes("GPS+CELLULAR")) {
+            fixed = fixed.replace(/GPS\+CELLULAR/g, "GPS+CEL");
           }
-          // Caso 3: CELL → CELLULAR
-          if (fixed.includes(" CELL ") || fixed.endsWith(" CELL")) {
-            fixed = fixed.replace(/\bCELL\b/g, "CELLULAR");
+          // Caso 3: CELLULAR → CEL (standalone)
+          if (fixed.includes(" CELLULAR ") || fixed.endsWith(" CELLULAR")) {
+            fixed = fixed.replace(/\bCELLULAR\b/g, "CEL");
           }
           // Caso 4: remover "APPLE WATCH " duplicado
           fixed = fixed.replace(/^APPLE WATCH APPLE WATCH/i, "APPLE WATCH");
@@ -1442,9 +1442,9 @@ export default function EstoquePage() {
       if (sizeIdx !== -1) {
         // Pega até o tamanho (ex: "APPLE WATCH ULTRA 3 49MM"), remove cores
         const baseParts = words.slice(0, sizeIdx + 1).filter(w => !COLOR_WORDS.has(w.toUpperCase()));
-        // Incluir GPS/CELLULAR após tamanho
-        const connectWords = new Set(["GPS","CELLULAR","WI-FI","5G","4G","LTE"]);
-        if (sizeIdx + 1 < words.length && connectWords.has(words[sizeIdx + 1].toUpperCase())) {
+        // Incluir GPS/GPS+CEL/CELLULAR após tamanho
+        const nextWord = sizeIdx + 1 < words.length ? words[sizeIdx + 1].toUpperCase() : "";
+        if (/^(GPS(\+CEL)?|CELLULAR|WI-FI|5G|4G|LTE)$/i.test(nextWord)) {
           baseParts.push(words[sizeIdx + 1]);
         }
         return baseParts.join(" ");

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -519,7 +519,8 @@ function getModeloBase(produto: string, categoria: string): string {
     if (genMatch) return `AirPods ${genMatch[1]}`;
     return "AirPods";
   }
-  return produto;
+  // Fallback: normalizar trailing dashes/espaços
+  return produto.replace(/\s*[-–]\s*$/, "").trim();
 }
 
 export default function EstoquePage() {
@@ -1431,10 +1432,26 @@ export default function EstoquePage() {
       "NATURAL","TITANIUM","COSMIC","LAVENDER","SAGE","TEAL","ULTRAMARINE","MIDNIGHT",
       "STARLIGHT","ROSE","DESERT","DEEP","DARK","ORANGE","GRAY","GREY","PRETO","BRANCO",
       "AZUL","ROSA","PRATA","VERDE","VERMELHO","AMARELO","ROXO","CINZA","DOURADO",
+      "JET","SLATE","OCEAN","PRETA","MILANES","MILANESE","LAKE",
     ]);
     const words = produto.split(/\s+/);
     const storageIdx = words.findIndex(w => /^\d+(GB|TB)$/i.test(w));
-    if (storageIdx === -1) return produto;
+    // Watches/AirPods: sem storage, agrupar por modelo+tamanho
+    if (storageIdx === -1) {
+      const sizeIdx = words.findIndex(w => /^\d+MM$/i.test(w));
+      if (sizeIdx !== -1) {
+        // Pega até o tamanho (ex: "APPLE WATCH ULTRA 3 49MM"), remove cores
+        const baseParts = words.slice(0, sizeIdx + 1).filter(w => !COLOR_WORDS.has(w.toUpperCase()));
+        // Incluir GPS/CELLULAR após tamanho
+        const connectWords = new Set(["GPS","CELLULAR","WI-FI","5G","4G","LTE"]);
+        if (sizeIdx + 1 < words.length && connectWords.has(words[sizeIdx + 1].toUpperCase())) {
+          baseParts.push(words[sizeIdx + 1]);
+        }
+        return baseParts.join(" ");
+      }
+      // Sem storage nem tamanho: remover cores do nome
+      return words.filter(w => !COLOR_WORDS.has(w.toUpperCase()) && !/^PULSEIRA$/i.test(w)).join(" ");
+    }
     const baseParts = words.slice(0, storageIdx + 1).filter(w => !COLOR_WORDS.has(w.toUpperCase()));
     // Incluir sufixo de conectividade (WI-FI, CELLULAR) que aparece logo após o storage
     const connectWords = new Set(["WI-FI","CELLULAR","5G","4G","LTE"]);
@@ -3032,8 +3049,10 @@ export default function EstoquePage() {
                           </thead>
                           <tbody>
                             {(() => {
-                              // Agrupar pendentes por modelo base
-                              const pendentesDate = items.filter(p => p.tipo === "A_CAMINHO");
+                              // Agrupar itens por modelo base (pendentes ou recebidos conforme filtro)
+                              const pendentesDate = acaminhoFilter === "recebidos"
+                                ? items.filter(p => p.tipo !== "A_CAMINHO")
+                                : items.filter(p => p.tipo === "A_CAMINHO");
                               const groupMap = new Map<string, typeof pendentesDate>();
                               pendentesDate.forEach(p => {
                                 const base = getBaseModelACaminho(p.produto);

--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -337,8 +337,8 @@ export function buildProdutoName(cat: string, spec: ProdutoSpec, cor?: string): 
     }
     case "APPLE_WATCH": {
       const tamanho = spec.aw_tamanho ? ` ${spec.aw_tamanho}` : "";
-      const conn = spec.aw_conn === "GPS+CELL" ? " GPS+CELLULAR" : spec.aw_conn === "GPS" ? " GPS" : "";
-      const pulseira = spec.aw_pulseira ? ` ${spec.aw_pulseira}` : "";
+      const conn = spec.aw_conn === "GPS+CELL" ? " GPS+CEL" : spec.aw_conn === "GPS" ? " GPS" : "";
+      const pulseira = spec.aw_pulseira ? ` PULSEIRA ${spec.aw_pulseira}` : "";
       const band = spec.aw_band ? ` ${spec.aw_band}` : "";
       return `APPLE WATCH ${spec.aw_modelo}${tamanho}${conn}${c}${pulseira}${band}`.toUpperCase();
     }


### PR DESCRIPTION
## Summary
- GPS+CELLULAR abreviado para GPS+CEL em todos os nomes de Watch
- Pulseira prefixada com "PULSEIRA" no nome gerado (ex: "PULSEIRA OCEAN PRETA")
- Normalização existente invertida: GPS+CELLULAR → GPS+CEL
- Dados corrigidos no banco: todos os Watches com nomes consistentes e prefixo "APPLE"

## Test plan
- [ ] Verificar nome do Watch na venda do JMS
- [ ] Novo Watch registrado usa GPS+CEL
- [ ] Watches no estoque mostram nome padronizado

🤖 Generated with [Claude Code](https://claude.com/claude-code)