### PR TITLE
fix: cores em a caminho EN primeiro, PT ao lado

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -1013,8 +1013,8 @@ export default function EstoquePage() {
         return `${modelo}${chip} ${spec.ipad_tela} ${spec.ipad_storage}${conn}${c}`.toUpperCase();
       }
       case "APPLE_WATCH": {
-        const conn = spec.aw_conn === "GPS+CELL" ? " GPS+CELLULAR" : " GPS";
-        const pulseira = spec.aw_pulseira ? ` ${spec.aw_pulseira}` : "";
+        const conn = spec.aw_conn === "GPS+CELL" ? " GPS+CEL" : " GPS";
+        const pulseira = spec.aw_pulseira ? ` PULSEIRA ${spec.aw_pulseira}` : "";
         return `APPLE WATCH ${spec.aw_modelo} ${spec.aw_tamanho}${conn}${c}${pulseira}`.toUpperCase();
       }
       case "AIRPODS":
@@ -1062,14 +1062,14 @@ export default function EstoquePage() {
             }
             continue;
           }
-          // Caso 2: normalizar GPS+CEL → GPS+CELLULAR
+          // Caso 2: normalizar GPS+CELLULAR → GPS+CEL
           let fixed = nome;
-          if (fixed.includes("GPS+CEL ") || fixed.endsWith("GPS+CEL")) {
-            fixed = fixed.replace(/GPS\+CEL\b/g, "GPS+CELLULAR");
+          if (fixed.includes("GPS+CELLULAR")) {
+            fixed = fixed.replace(/GPS\+CELLULAR/g, "GPS+CEL");
           }
-          // Caso 3: CELL → CELLULAR
-          if (fixed.includes(" CELL ") || fixed.endsWith(" CELL")) {
-            fixed = fixed.replace(/\bCELL\b/g, "CELLULAR");
+          // Caso 3: CELLULAR → CEL (standalone)
+          if (fixed.includes(" CELLULAR ") || fixed.endsWith(" CELLULAR")) {
+            fixed = fixed.replace(/\bCELLULAR\b/g, "CEL");
           }
           // Caso 4: remover "APPLE WATCH " duplicado
           fixed = fixed.replace(/^APPLE WATCH APPLE WATCH/i, "APPLE WATCH");
@@ -1442,9 +1442,9 @@ export default function EstoquePage() {
       if (sizeIdx !== -1) {
         // Pega até o tamanho (ex: "APPLE WATCH ULTRA 3 49MM"), remove cores
         const baseParts = words.slice(0, sizeIdx + 1).filter(w => !COLOR_WORDS.has(w.toUpperCase()));
-        // Incluir GPS/CELLULAR após tamanho
-        const connectWords = new Set(["GPS","CELLULAR","WI-FI","5G","4G","LTE"]);
-        if (sizeIdx + 1 < words.length && connectWords.has(words[sizeIdx + 1].toUpperCase())) {
+        // Incluir GPS/GPS+CEL/CELLULAR após tamanho
+        const nextWord = sizeIdx + 1 < words.length ? words[sizeIdx + 1].toUpperCase() : "";
+        if (/^(GPS(\+CEL)?|CELLULAR|WI-FI|5G|4G|LTE)$/i.test(nextWord)) {
           baseParts.push(words[sizeIdx + 1]);
         }
         return baseParts.join(" ");

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -3122,8 +3122,21 @@ export default function EstoquePage() {
                                         </td>
                                         <td className={`px-4 py-2 text-[13px] font-medium ${textPrimary} pl-8`} onClick={() => setDetailProduct(p)}>
                                           <span className={`mr-1 ${dm ? "text-[#6E6E73]" : "text-[#C0C0C5]"}`}>└</span>
-                                          {p.cor || p.produto}
-                                          {ptLabel && p.cor && ptLabel.toUpperCase() !== p.cor.toUpperCase() && <span className={`ml-1.5 text-[11px] font-normal ${textSecondary}`}>{ptLabel}</span>}
+                                          {(() => {
+                                            if (!p.cor) return p.produto;
+                                            const upper = p.cor.toUpperCase().trim();
+                                            const ptFromEN = COR_PT[upper];
+                                            if (ptFromEN && ptFromEN.toLowerCase() !== p.cor.toLowerCase()) {
+                                              // Cor em EN → mostrar EN + PT ao lado
+                                              return <>{p.cor} <span className={`text-[11px] font-normal ${textSecondary}`}>{ptFromEN}</span></>;
+                                            }
+                                            const enFromPT = PT_TO_EN[upper];
+                                            if (enFromPT) {
+                                              // Cor em PT → mostrar EN + PT ao lado
+                                              return <>{enFromPT} <span className={`text-[11px] font-normal ${textSecondary}`}>{p.cor.charAt(0).toUpperCase() + p.cor.slice(1).toLowerCase()}</span></>;
+                                            }
+                                            return p.cor;
+                                          })()}
                                           {(p.serial_no || p.imei) && (
                                             <span className={`ml-2 text-[10px] font-mono ${dm ? "text-green-400" : "text-green-600"}`}>
                                               ✅ {p.serial_no || p.imei}

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -519,7 +519,8 @@ function getModeloBase(produto: string, categoria: string): string {
     if (genMatch) return `AirPods ${genMatch[1]}`;
     return "AirPods";
   }
-  return produto;
+  // Fallback: normalizar trailing dashes/espaços
+  return produto.replace(/\s*[-–]\s*$/, "").trim();
 }
 
 export default function EstoquePage() {
@@ -1431,10 +1432,26 @@ export default function EstoquePage() {
       "NATURAL","TITANIUM","COSMIC","LAVENDER","SAGE","TEAL","ULTRAMARINE","MIDNIGHT",
       "STARLIGHT","ROSE","DESERT","DEEP","DARK","ORANGE","GRAY","GREY","PRETO","BRANCO",
       "AZUL","ROSA","PRATA","VERDE","VERMELHO","AMARELO","ROXO","CINZA","DOURADO",
+      "JET","SLATE","OCEAN","PRETA","MILANES","MILANESE","LAKE",
     ]);
     const words = produto.split(/\s+/);
     const storageIdx = words.findIndex(w => /^\d+(GB|TB)$/i.test(w));
-    if (storageIdx === -1) return produto;
+    // Watches/AirPods: sem storage, agrupar por modelo+tamanho
+    if (storageIdx === -1) {
+      const sizeIdx = words.findIndex(w => /^\d+MM$/i.test(w));
+      if (sizeIdx !== -1) {
+        // Pega até o tamanho (ex: "APPLE WATCH ULTRA 3 49MM"), remove cores
+        const baseParts = words.slice(0, sizeIdx + 1).filter(w => !COLOR_WORDS.has(w.toUpperCase()));
+        // Incluir GPS/CELLULAR após tamanho
+        const connectWords = new Set(["GPS","CELLULAR","WI-FI","5G","4G","LTE"]);
+        if (sizeIdx + 1 < words.length && connectWords.has(words[sizeIdx + 1].toUpperCase())) {
+          baseParts.push(words[sizeIdx + 1]);
+        }
+        return baseParts.join(" ");
+      }
+      // Sem storage nem tamanho: remover cores do nome
+      return words.filter(w => !COLOR_WORDS.has(w.toUpperCase()) && !/^PULSEIRA$/i.test(w)).join(" ");
+    }
     const baseParts = words.slice(0, storageIdx + 1).filter(w => !COLOR_WORDS.has(w.toUpperCase()));
     // Incluir sufixo de conectividade (WI-FI, CELLULAR) que aparece logo após o storage
     const connectWords = new Set(["WI-FI","CELLULAR","5G","4G","LTE"]);
@@ -3032,8 +3049,10 @@ export default function EstoquePage() {
                           </thead>
                           <tbody>
                             {(() => {
-                              // Agrupar pendentes por modelo base
-                              const pendentesDate = items.filter(p => p.tipo === "A_CAMINHO");
+                              // Agrupar itens por modelo base (pendentes ou recebidos conforme filtro)
+                              const pendentesDate = acaminhoFilter === "recebidos"
+                                ? items.filter(p => p.tipo !== "A_CAMINHO")
+                                : items.filter(p => p.tipo === "A_CAMINHO");
                               const groupMap = new Map<string, typeof pendentesDate>();
                               pendentesDate.forEach(p => {
                                 const base = getBaseModelACaminho(p.produto);

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -120,6 +120,7 @@ const COR_PT: Record<string, string> = {
   "LARANJA": "Laranja",
   "COSMIC ORANGE": "Laranja Cósmico",
   "ORANGE": "Laranja",
+  "DEEP BLUE": "Azul Profundo",
   "DEEP PURPLE": "Roxo Profundo",
   "ALPINE GREEN": "Verde Alpino",
   "SIERRA BLUE": "Azul Serra",
@@ -1695,7 +1696,7 @@ export default function EstoquePage() {
   const aCaminho = estoque.filter((p) => p.tipo === "A_CAMINHO" && p.status === "A CAMINHO");
   // Produtos que tinham pedido (A_CAMINHO) mas já foram movidos para estoque
   // Produtos que tinham pedido (A_CAMINHO) mas já foram movidos para estoque — identificados por terem data_compra
-  const pedidosRecebidos = estoque.filter((p) => p.tipo !== "A_CAMINHO" && !!p.data_compra);
+  const pedidosRecebidos = estoque.filter((p) => p.tipo !== "A_CAMINHO" && !!p.pedido_fornecedor_id && !["PENDENCIA", "SEMINOVO"].includes(p.tipo));
   const acabando = novos.filter((p) => p.qnt === 1);
 
   // Esgotados: qnt=0 em NOVO. Marcar se já está a caminho
@@ -3121,7 +3122,7 @@ export default function EstoquePage() {
                                         </td>
                                         <td className={`px-4 py-2 text-[13px] font-medium ${textPrimary} pl-8`} onClick={() => setDetailProduct(p)}>
                                           <span className={`mr-1 ${dm ? "text-[#6E6E73]" : "text-[#C0C0C5]"}`}>└</span>
-                                          {p.cor || p.produto}
+                                          {ptLabel || p.cor || p.produto}
                                           {ptLabel && p.cor !== ptLabel && <span className={`ml-1.5 text-[11px] font-normal ${textSecondary}`}>{ptLabel}</span>}
                                           {(p.serial_no || p.imei) && (
                                             <span className={`ml-2 text-[10px] font-mono ${dm ? "text-green-400" : "text-green-600"}`}>

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -3122,8 +3122,8 @@ export default function EstoquePage() {
                                         </td>
                                         <td className={`px-4 py-2 text-[13px] font-medium ${textPrimary} pl-8`} onClick={() => setDetailProduct(p)}>
                                           <span className={`mr-1 ${dm ? "text-[#6E6E73]" : "text-[#C0C0C5]"}`}>└</span>
-                                          {ptLabel || p.cor || p.produto}
-                                          {ptLabel && p.cor !== ptLabel && <span className={`ml-1.5 text-[11px] font-normal ${textSecondary}`}>{ptLabel}</span>}
+                                          {p.cor || p.produto}
+                                          {ptLabel && p.cor && ptLabel.toUpperCase() !== p.cor.toUpperCase() && <span className={`ml-1.5 text-[11px] font-normal ${textSecondary}`}>{ptLabel}</span>}
                                           {(p.serial_no || p.imei) && (
                                             <span className={`ml-2 text-[10px] font-mono ${dm ? "text-green-400" : "text-green-600"}`}>
                                               ✅ {p.serial_no || p.imei}

--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -337,8 +337,8 @@ export function buildProdutoName(cat: string, spec: ProdutoSpec, cor?: string): 
     }
     case "APPLE_WATCH": {
       const tamanho = spec.aw_tamanho ? ` ${spec.aw_tamanho}` : "";
-      const conn = spec.aw_conn === "GPS+CELL" ? " GPS+CELLULAR" : spec.aw_conn === "GPS" ? " GPS" : "";
-      const pulseira = spec.aw_pulseira ? ` ${spec.aw_pulseira}` : "";
+      const conn = spec.aw_conn === "GPS+CELL" ? " GPS+CEL" : spec.aw_conn === "GPS" ? " GPS" : "";
+      const pulseira = spec.aw_pulseira ? ` PULSEIRA ${spec.aw_pulseira}` : "";
       const band = spec.aw_band ? ` ${spec.aw_band}` : "";
       return `APPLE WATCH ${spec.aw_modelo}${tamanho}${conn}${c}${pulseira}${band}`.toUpperCase();
     }


### PR DESCRIPTION
## Summary
- Cores expandidas em a caminho: EN como texto principal, PT em texto menor ao lado
- Ex: **Lavender** *Lavanda*, **Deep Blue** *Azul Profundo*

🤖 Generated with [Claude Code](https://claude.com/claude-code)