### PR TITLE
feat: Chip e Núcleos no formulário Mac Mini e MacBook

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -910,8 +910,9 @@ export default function EstoquePage() {
     }
     if (baseCat === "MAC_MINI") {
       const chipMatch = n.match(/(M\d+(?:\s*PRO)?)/i);
+      const nucleosMatch = n.match(/\((\d+C?\s*CPU\/\d+C?\s*GPU)\)/i);
       const ramMatch = n.match(/(\d+GB)\s/);
-      return { mm_chip: chipMatch ? chipMatch[1] : "M4", mm_ram: ramMatch ? ramMatch[1] : "16GB", mm_storage: storage || "256GB" };
+      return { mm_chip: chipMatch ? chipMatch[1] : "M4", mm_nucleos: nucleosMatch ? nucleosMatch[1] : "10C CPU/10C GPU", mm_ram: ramMatch ? ramMatch[1] : "16GB", mm_storage: storage || "256GB" };
     }
     if (baseCat === "APPLE_WATCH") {
       const modeloMatch = n.match(/(SERIES\s*\d+|SE|ULTRA\s*\d*)/i);
@@ -1037,7 +1038,7 @@ export default function EstoquePage() {
     // MACBOOK
     mb_modelo: "AIR", mb_tela: "13\"", mb_chip: "M4", mb_nucleos: "", mb_ram: "16GB", mb_storage: "256GB",
     // MAC_MINI
-    mm_chip: "M4", mm_ram: "16GB", mm_storage: "256GB",
+    mm_chip: "M4", mm_nucleos: "10C CPU/10C GPU", mm_ram: "16GB", mm_storage: "256GB",
     // IPADS
     ipad_modelo: "AIR", ipad_chip: "", ipad_tela: "11\"", ipad_storage: "128GB", ipad_conn: "WIFI",
     // APPLE_WATCH
@@ -1069,7 +1070,8 @@ export default function EstoquePage() {
         return `IPHONE ${spec.ip_modelo}${linha} ${spec.ip_storage}${c}${origem}`.toUpperCase();
       }
       case "MAC_MINI":
-        return `MAC MINI ${spec.mm_chip} ${spec.mm_ram} ${spec.mm_storage}`.toUpperCase();
+        const mmNucleos = spec.mm_nucleos ? ` (${spec.mm_nucleos})` : "";
+        return `MAC MINI ${spec.mm_chip}${mmNucleos} ${spec.mm_ram} ${spec.mm_storage}`.toUpperCase();
       case "MACBOOK": {
         const tipo = spec.mb_modelo === "AIR" ? "MACBOOK AIR" : spec.mb_modelo === "NEO" ? "MACBOOK NEO" : "MACBOOK PRO";
         const tela = spec.mb_modelo === "NEO" ? spec.mb_tela || '13"' : spec.mb_tela;
@@ -1789,7 +1791,7 @@ export default function EstoquePage() {
         setSpec({
           ip_modelo: "16", ip_linha: "", ip_storage: "128GB", ip_origem: "",
           mb_modelo: "AIR", mb_tela: "13\"", mb_chip: "M4", mb_nucleos: "", mb_ram: "16GB", mb_storage: "256GB",
-          mm_chip: "M4", mm_ram: "16GB", mm_storage: "256GB",
+          mm_chip: "M4", mm_nucleos: "10C CPU/10C GPU", mm_ram: "16GB", mm_storage: "256GB",
           ipad_modelo: "AIR", ipad_chip: "", ipad_tela: "11\"", ipad_storage: "128GB", ipad_conn: "WIFI",
           aw_modelo: "SERIES 11", aw_tamanho: "42mm", aw_conn: "GPS", aw_pulseira: "", aw_band: "",
           air_modelo: "AIRPODS 4",

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -11,6 +11,9 @@ import {
   WATCH_BAND_MODELS,
   MACBOOK_RAMS,
   MACBOOK_STORAGES,
+  MACBOOK_NUCLEOS,
+  MAC_MINI_CHIPS,
+  MAC_MINI_NUCLEOS,
   MAC_MINI_RAMS,
   MAC_MINI_STORAGES,
   CORES_POR_CATEGORIA,
@@ -98,6 +101,7 @@ function inferSpecFromCatalogModel(nome: string, categoria: string): Partial<Pro
   } else if (categoria === "MAC_MINI") {
     const chip = nome.match(/\b(M\d+(\s+(PRO|MAX))?)\b/i);
     s.mm_chip = chip ? chip[1].toUpperCase() : "";
+    s.mm_nucleos = ""; // user selects nucleos manually
   } else if (categoria === "APPLE_WATCH") {
     const part = nome.replace(/^Apple Watch\s+/i, "");
     if (/SE.*2|2.*SE/i.test(part)) { s.aw_modelo = "SE 2"; s.aw_tamanho = "40mm"; }
@@ -590,6 +594,13 @@ export default function ProdutoSpecFields({
             </>
           )}
           <div>
+            <p className={labelCls}>Núcleos</p>
+            <select value={row.spec.mb_nucleos} onChange={(e) => setSpec("mb_nucleos", e.target.value)} className={inputCls}>
+              <option value="">— Selecionar —</option>
+              {MACBOOK_NUCLEOS.map((n) => <option key={n}>{n}</option>)}
+            </select>
+          </div>
+          <div>
             <p className={labelCls}>Tela</p>
             <select value={row.spec.mb_tela} onChange={(e) => setSpec("mb_tela", e.target.value)} className={inputCls}>
               <option value="">— Não informar —</option>
@@ -615,7 +626,22 @@ export default function ProdutoSpecFields({
 
       {/* Mac Mini specs */}
       {row.categoria === "MAC_MINI" && (
-        <div className={`grid grid-cols-3 gap-3 p-3 ${bgSection} rounded-lg`}>
+        <div className={`grid grid-cols-2 md:grid-cols-4 gap-3 p-3 ${bgSection} rounded-lg`}>
+          {!categoryModelos.length && (
+            <div>
+              <p className={labelCls}>Chip</p>
+              <select value={row.spec.mm_chip} onChange={(e) => setSpec("mm_chip", e.target.value)} className={inputCls}>
+                {MAC_MINI_CHIPS.map((c) => <option key={c}>{c}</option>)}
+              </select>
+            </div>
+          )}
+          <div>
+            <p className={labelCls}>Núcleos</p>
+            <select value={row.spec.mm_nucleos} onChange={(e) => setSpec("mm_nucleos", e.target.value)} className={inputCls}>
+              <option value="">— Selecionar —</option>
+              {MAC_MINI_NUCLEOS.map((n) => <option key={n}>{n}</option>)}
+            </select>
+          </div>
           <div>
             <p className={labelCls}>RAM</p>
             <select value={row.spec.mm_ram} onChange={(e) => setSpec("mm_ram", e.target.value)} className={inputCls}>

--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -198,6 +198,13 @@ export const MACBOOK_NUCLEOS = [
 ];
 
 export const MAC_MINI_CHIPS = ["M1", "M2", "M2 PRO", "M4", "M4 PRO"];
+export const MAC_MINI_NUCLEOS = [
+  "8C CPU/8C GPU",
+  "8C CPU/10C GPU",
+  "10C CPU/10C GPU",
+  "12C CPU/16C GPU",
+  "14C CPU/20C GPU",
+];
 export const MAC_MINI_RAMS = ["8GB", "16GB", "24GB", "32GB", "48GB", "64GB"];
 export const MAC_MINI_STORAGES = ["256GB", "512GB", "1TB", "2TB"];
 
@@ -229,7 +236,7 @@ export const AIRPODS_MODELOS = ["AIRPODS 4", "AIRPODS 4 ANC", "AIRPODS PRO 2", "
 export interface ProdutoSpec {
   ip_modelo: string; ip_linha: string; ip_storage: string; ip_origem: string;
   mb_modelo: string; mb_tela: string; mb_chip: string; mb_nucleos: string; mb_ram: string; mb_storage: string;
-  mm_chip: string; mm_ram: string; mm_storage: string;
+  mm_chip: string; mm_nucleos: string; mm_ram: string; mm_storage: string;
   ipad_modelo: string; ipad_chip: string; ipad_tela: string; ipad_storage: string; ipad_conn: string;
   aw_modelo: string; aw_tamanho: string; aw_conn: string; aw_pulseira: string; aw_band: string;
   air_modelo: string;
@@ -238,7 +245,7 @@ export interface ProdutoSpec {
 export const DEFAULT_SPEC: ProdutoSpec = {
   ip_modelo: "16", ip_linha: "", ip_storage: "128GB", ip_origem: "",
   mb_modelo: "AIR", mb_tela: '13"', mb_chip: "M4", mb_nucleos: "", mb_ram: "16GB", mb_storage: "256GB",
-  mm_chip: "M4", mm_ram: "16GB", mm_storage: "256GB",
+  mm_chip: "M4", mm_nucleos: "10C CPU/10C GPU", mm_ram: "16GB", mm_storage: "256GB",
   ipad_modelo: "AIR", ipad_chip: "", ipad_tela: '11"', ipad_storage: "128GB", ipad_conn: "WIFI",
   aw_modelo: "SERIES 10", aw_tamanho: "42mm", aw_conn: "GPS", aw_pulseira: "", aw_band: "",
   air_modelo: "AIRPODS 4",
@@ -314,9 +321,10 @@ export function buildProdutoName(cat: string, spec: ProdutoSpec, cor?: string): 
       return `IPHONE ${spec.ip_modelo}${linha}${storage}${c}${origem}`.toUpperCase();
     }
     case "MAC_MINI": {
+      const nucleos = spec.mm_nucleos ? ` (${spec.mm_nucleos})` : "";
       const ram = spec.mm_ram ? ` ${spec.mm_ram}` : "";
       const storage = spec.mm_storage ? ` ${spec.mm_storage}` : "";
-      return `MAC MINI ${spec.mm_chip}${ram}${storage}`.toUpperCase();
+      return `MAC MINI ${spec.mm_chip}${nucleos}${ram}${storage}`.toUpperCase();
     }
     case "MACBOOK": {
       const tipo = spec.mb_modelo === "AIR" ? "MACBOOK AIR" : spec.mb_modelo === "NEO" ? "MACBOOK NEO" : "MACBOOK PRO";


### PR DESCRIPTION
## Summary
- Adiciona campo **Núcleos** (CPU/GPU) ao formulário de cadastro de **Mac Mini** e **MacBook**
- Adiciona campo **Chip** ao Mac Mini (visível quando não há modelos do catálogo)
- Adiciona `MAC_MINI_NUCLEOS` array e `mm_nucleos` ao `ProdutoSpec`
- Atualiza `buildProdutoName` e `parseProductSpecs` para incluir núcleos no nome do Mac Mini
- O Chip é inferido automaticamente do modelo do catálogo; Núcleos é selecionado manualmente

## Test plan
- [ ] Acessar cadastro de produto Mac Mini e verificar campos Chip + Núcleos
- [ ] Acessar cadastro de produto MacBook e verificar campo Núcleos
- [ ] Verificar que nome gerado inclui núcleos (ex: MAC MINI M4 (10C CPU/10C GPU) 16GB 256GB)
- [ ] Verificar badges de núcleos no estoque para Mac Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)