### PR TITLE
fix: Núcleos apenas do catálogo do modelo

### DIFF
--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -293,12 +293,17 @@ export default function ProdutoSpecFields({
   const macMiniRamOptions = cfgOr("ram", MAC_MINI_RAMS);
   const macMiniSsdOptions = cfgOr("ssd", MAC_MINI_STORAGES);
   // Núcleos: usa chip_air ou chip_pro_max do catálogo (configurado por modelo)
-  const nucleosChipAir = cfgOr("chip_air");
-  const nucleosChipProMax = cfgOr("chip_pro_max");
-  // Combina ambos se existirem, senão fallback hardcoded
-  const macNucleosCatalog = [...(nucleosChipAir || []), ...(nucleosChipProMax || [])];
-  const mbNucleosOptions = macNucleosCatalog.length ? macNucleosCatalog : MACBOOK_NUCLEOS.map(n => `(${n})`);
-  const mmNucleosOptions = macNucleosCatalog.length ? macNucleosCatalog : MAC_MINI_NUCLEOS.map(n => `(${n})`);
+  // Se tem modelo do catálogo selecionado, mostra APENAS o que está configurado
+  // Se não tem modelo do catálogo, usa fallback hardcoded
+  const nucleosChipAir = modeloConfigs["chip_air"] || [];
+  const nucleosChipProMax = modeloConfigs["chip_pro_max"] || [];
+  const macNucleosCatalog = [...nucleosChipAir, ...nucleosChipProMax];
+  const mbNucleosOptions = hasCatalogModel
+    ? macNucleosCatalog  // só o que está no catálogo (pode ser vazio = sem dropdown)
+    : MACBOOK_NUCLEOS.map(n => `(${n})`);
+  const mmNucleosOptions = hasCatalogModel
+    ? macNucleosCatalog
+    : MAC_MINI_NUCLEOS.map(n => `(${n})`);
   const awTamanhoOptions = cfgOr("tamanho_aw", WATCH_TAMANHOS_FULL);
   const awConnOptions = cfgOr("conectividade_aw", ["GPS", "GPS + CEL"]);
   const awBandOptions = cfgOr("pulseiras", WATCH_BAND_MODELS);
@@ -600,16 +605,18 @@ export default function ProdutoSpecFields({
               </div>
             </>
           )}
-          <div>
-            <p className={labelCls}>Núcleos</p>
-            <select value={row.spec.mb_nucleos} onChange={(e) => setSpec("mb_nucleos", e.target.value)} className={inputCls}>
-              <option value="">— Selecionar —</option>
-              {mbNucleosOptions.map((n) => {
-                const clean = n.replace(/^\(|\)$/g, "").trim();
-                return <option key={clean} value={clean}>{clean}</option>;
-              })}
-            </select>
-          </div>
+          {mbNucleosOptions.length > 0 && (
+            <div>
+              <p className={labelCls}>Núcleos</p>
+              <select value={row.spec.mb_nucleos} onChange={(e) => setSpec("mb_nucleos", e.target.value)} className={inputCls}>
+                <option value="">— Selecionar —</option>
+                {mbNucleosOptions.map((n) => {
+                  const clean = n.replace(/^\(|\)$/g, "").trim();
+                  return <option key={clean} value={clean}>{clean}</option>;
+                })}
+              </select>
+            </div>
+          )}
           <div>
             <p className={labelCls}>Tela</p>
             <select value={row.spec.mb_tela} onChange={(e) => setSpec("mb_tela", e.target.value)} className={inputCls}>
@@ -645,16 +652,18 @@ export default function ProdutoSpecFields({
               </select>
             </div>
           )}
-          <div>
-            <p className={labelCls}>Núcleos</p>
-            <select value={row.spec.mm_nucleos} onChange={(e) => setSpec("mm_nucleos", e.target.value)} className={inputCls}>
-              <option value="">— Selecionar —</option>
-              {mmNucleosOptions.map((n) => {
-                const clean = n.replace(/^\(|\)$/g, "").trim();
-                return <option key={clean} value={clean}>{clean}</option>;
-              })}
-            </select>
-          </div>
+          {mmNucleosOptions.length > 0 && (
+            <div>
+              <p className={labelCls}>Núcleos</p>
+              <select value={row.spec.mm_nucleos} onChange={(e) => setSpec("mm_nucleos", e.target.value)} className={inputCls}>
+                <option value="">— Selecionar —</option>
+                {mmNucleosOptions.map((n) => {
+                  const clean = n.replace(/^\(|\)$/g, "").trim();
+                  return <option key={clean} value={clean}>{clean}</option>;
+                })}
+              </select>
+            </div>
+          )}
           <div>
             <p className={labelCls}>RAM</p>
             <select value={row.spec.mm_ram} onChange={(e) => setSpec("mm_ram", e.target.value)} className={inputCls}>


### PR DESCRIPTION
## Summary
- Dropdown de Núcleos mostra **apenas** valores configurados no catálogo para o modelo selecionado
- Se o modelo não tem chip_air/chip_pro_max configurado (ex: MacBook Neo), o dropdown fica **oculto**
- Fallback hardcoded só é usado quando nenhum modelo do catálogo está selecionado

## Test plan
- [ ] MacBook Neo → dropdown de Núcleos não aparece ✅
- [ ] MacBook Air M4 → mostra apenas `10C CPU/8C GPU` e `10C CPU/10C GPU`
- [ ] Mac Mini M4 Pro → mostra apenas `12C CPU/16C GPU` e `14C CPU/20C GPU`
- [ ] Sem modelo do catálogo → fallback com todos os valores

🤖 Generated with [Claude Code](https://claude.com/claude-code)