### PR TITLE
fix: Cadastros + dados de clientes/lojistas/fornecedores sumidos

### DIFF
--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -198,8 +198,8 @@ export default function ClientesPage() {
     <div className="space-y-6">
       {/* Header */}
       <div>
-        <h1 className={`text-2xl font-bold ${mP}`}>Clientes</h1>
-        <p className={`text-sm ${mS}`}>Base de clientes com historico de compras</p>
+        <h1 className={`text-2xl font-bold ${mP}`}>Cadastros</h1>
+        <p className={`text-sm ${mS}`}>Base de cadastros com historico de compras</p>
       </div>
 
       {/* Tabs */}

--- a/app/api/admin/clientes/route.ts
+++ b/app/api/admin/clientes/route.ts
@@ -103,10 +103,10 @@ export async function GET(req: NextRequest) {
   }
 
   // =========== TABS: clientes / lojistas / notas ===========
+  // Não usar .neq("status_pagamento", "CANCELADO") — bug do Supabase exclui registros com NULL
   let query = supabase
     .from("vendas")
     .select("id,data,cliente,cpf,cnpj,email,pessoa,bairro,cidade,uf,origem,tipo,produto,fornecedor,preco_vendido,forma,banco,serial_no,imei,nota_fiscal_url,status_pagamento")
-    .neq("status_pagamento", "CANCELADO")
     .order("data", { ascending: false });
 
   if (search) {
@@ -133,10 +133,15 @@ export async function GET(req: NextRequest) {
     from += PAGE;
   }
 
+  // Filtrar cancelados em JS (evita bug do .neq() com NULL no Supabase)
+  const vendas = rawVendas.filter((v: Record<string, unknown>) =>
+    v.status_pagamento !== "CANCELADO"
+  );
+
   // Tab "notas"
   if (tab === "notas") {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const notas = rawVendas.filter((v: any) => v.nota_fiscal_url).map((v: any) => ({
+    const notas = vendas.filter((v: any) => v.nota_fiscal_url).map((v: any) => ({
       id: v.id, data: v.data, cliente: v.cliente, produto: v.produto,
       preco_vendido: Number(v.preco_vendido || 0), nota_fiscal_url: v.nota_fiscal_url,
     }));
@@ -154,7 +159,7 @@ export async function GET(req: NextRequest) {
   const cpfToKey = new Map<string, string>();
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  for (const v of rawVendas as any[]) {
+  for (const v of vendas as any[]) {
     const nome = (v.cliente || "").trim();
     if (!nome) continue;
     const isAtacado = v.tipo === "ATACADO" || v.origem === "ATACADO";

--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -33,7 +33,7 @@ const NAV: NavEntry[] = [
     label: "Financeiro", icon: "\u{1F4B0}",
     items: [
       { href: "/admin/vendas", label: "Vendas", icon: "\u{1F4B0}", pageKey: "vendas_ver" },
-      { href: "/admin/clientes", label: "Clientes", icon: "\u{1F465}", pageKey: "clientes" },
+      { href: "/admin/clientes", label: "Cadastros", icon: "\u{1F465}", pageKey: "clientes" },
       { href: "/admin/gastos", label: "Gastos", icon: "\u{1F4E4}", pageKey: "gastos" },
       { href: "/admin/saldos", label: "Saldos", icon: "\u{1F3E6}", pageKey: "saldos" },
       { href: "/admin/recebiveis", label: "Recebiveis", icon: "\u{1F4B3}", pageKey: "recebiveis" },

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -295,8 +295,8 @@ export default function ProdutoSpecFields({
   // Núcleos: usa chip_air ou chip_pro_max do catálogo (configurado por modelo)
   // Se tem modelo do catálogo selecionado, mostra APENAS o que está configurado
   // Se não tem modelo do catálogo, usa fallback hardcoded
-  const nucleosChipAir = modeloConfigs["chip_air"] || [];
-  const nucleosChipProMax = modeloConfigs["chip_pro_max"] || [];
+  const nucleosChipAir = modeloConfigs["chips_air"] || modeloConfigs["chip_air"] || [];
+  const nucleosChipProMax = modeloConfigs["chips_pro_max"] || modeloConfigs["chip_pro_max"] || [];
   const macNucleosCatalog = [...nucleosChipAir, ...nucleosChipProMax];
   const mbNucleosOptions = hasCatalogModel
     ? macNucleosCatalog  // só o que está no catálogo (pode ser vazio = sem dropdown)


### PR DESCRIPTION
## Summary
- Renomeia aba **Clientes → Cadastros** no nav e header
- **Corrige dados sumidos**: o `.neq("status_pagamento", "CANCELADO")` do Supabase excluía silenciosamente todas as vendas com `status_pagamento = NULL`, perdendo dados desde Outubro/2025
- Filtra cancelados em JavaScript (mesmo padrão já usado no mapa-vendas)

## Test plan
- [ ] Nav mostra "Cadastros" ao invés de "Clientes"
- [ ] Verificar que dados de clientes, lojistas e compras de fornecedores voltaram
- [ ] Verificar que vendas canceladas continuam excluídas

🤖 Generated with [Claude Code](https://claude.com/claude-code)