### PR TITLE
fix: paginação na query de fornecedores (dados cortados)

### DIFF
--- a/app/api/admin/clientes/route.ts
+++ b/app/api/admin/clientes/route.ts
@@ -26,13 +26,23 @@ export async function GET(req: NextRequest) {
     const cadastrados = new Set((fornCadastro || []).map(f => f.nome.trim().toUpperCase()));
     const cadastroMap = new Map((fornCadastro || []).map(f => [f.nome.trim().toUpperCase(), f]));
 
-    // 2) Buscar compras do estoque filtrando só fornecedores cadastrados
-    const { data: estoqueData, error: estoqueErr } = await supabase
+    // 2) Buscar compras do estoque (com paginação — Supabase limita a 1000 por query)
+    const estoqueQuery = supabase
       .from("estoque")
       .select("fornecedor, produto, cor, qnt, custo_unitario, data_compra, data_entrada, categoria, tipo, status, serial_no")
-      .not("fornecedor", "is", null)
-      .neq("fornecedor", "");
-    if (estoqueErr) return NextResponse.json({ error: estoqueErr.message }, { status: 500 });
+      .not("fornecedor", "is", null);
+    const estoqueData: Record<string, unknown>[] = [];
+    let estFrom = 0;
+    const EST_PAGE = 1000;
+    while (true) {
+      const { data: batch, error: batchErr } = await estoqueQuery.range(estFrom, estFrom + EST_PAGE - 1);
+      if (batchErr) return NextResponse.json({ error: batchErr.message }, { status: 500 });
+      if (!batch || batch.length === 0) break;
+      // Filtrar fornecedor vazio em JS (evita bug .neq() com NULL)
+      estoqueData.push(...batch.filter((b: Record<string, unknown>) => b.fornecedor && (b.fornecedor as string).trim() !== ""));
+      if (batch.length < EST_PAGE) break;
+      estFrom += EST_PAGE;
+    }
 
     // Agrupar por fornecedor (só cadastrados)
     const fornMap = new Map<string, {
@@ -62,7 +72,8 @@ export async function GET(req: NextRequest) {
       });
     }
 
-    for (const item of (estoqueData || [])) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    for (const item of estoqueData as any[]) {
       const forn = (item.fornecedor || "").trim().toUpperCase();
       if (!forn || !cadastrados.has(forn)) continue; // Ignora não-cadastrados (clientes de upgrade)
       if (!fornMap.has(forn)) continue; // filtrado por search


### PR DESCRIPTION
## Summary
- A query de estoque na aba Fornecedores não tinha paginação
- Supabase limita a 1000 registros por query por padrão
- Com mais de 1000 itens no estoque, dados de compras ficavam cortados
- Agora busca todos os registros em batches de 1000
- Remove `.neq("fornecedor", "")` para evitar bug do NULL e filtra em JS

## Test plan
- [ ] Verificar que aba Fornecedores mostra todos os dados de compras
- [ ] Verificar totais de investido/produtos

🤖 Generated with [Claude Code](https://claude.com/claude-code)