### PR TITLE
fix: aliases de fornecedores corrigidos conforme sistema antigo

### DIFF
--- a/app/api/admin/clientes/route.ts
+++ b/app/api/admin/clientes/route.ts
@@ -25,19 +25,16 @@ export async function GET(req: NextRequest) {
     const cadastrados = new Set((fornCadastro || []).map(f => f.nome.trim().toUpperCase()));
     const cadastroMap = new Map((fornCadastro || []).map(f => [f.nome.trim().toUpperCase(), f]));
 
-    // Mapeamento de aliases → nome canônico (consolida fornecedores duplicados)
+    // Mapeamento de aliases → nome canônico (baseado no sistema antigo todos_contatos_tigrao.csv)
     const FORN_ALIASES: Record<string, string> = {
       "ECO": "ECO CELL", "ECO CEL": "ECO CELL", "ECOCEL": "ECO CELL",
       "EMILIO SHOP": "EMILIO",
-      "FABIO BANGU": "FÁBIO BANGU", "FÁBIO": "FÁBIO BANGU", "FÁBIO RODRIGO VAZ DA SILVA": "FÁBIO BANGU",
-      "MADE": "MADE IN",
+      "FABIO BANGU": "FÁBIO BANGU",
       "MIAMI ZONE": "MIAMI",
-      "PLANETA": "PLANETA CEL",
+      "PLANETA CEL": "PLANETA",
       "TM": "TM CEL",
-      "TARTARUGA-F/A": "TARTARUGA",
-      "XFB": "XFB IMPORT",
+      "XFB IMPORT": "XFB",
       "ZN": "ZN CELL", "ZN CEL": "ZN CELL",
-      "DANIELLA": "DANIELLA ARRUDA GONÇALVES BANDEIRA",
     };
     function normForn(nome: string): string {
       const up = nome.trim().toUpperCase();


### PR DESCRIPTION
## Summary
- Corrige aliases baseado no `todos_contatos_tigrao.csv` do sistema antigo
- MADE e MADE IN são fornecedores separados
- TARTARUGA e TARTARUGA-F/A são separados  
- FÁBIO BANGU, FÁBIO e FÁBIO RODRIGO são pessoas diferentes
- DANIELLA é cliente, removido alias
- PLANETA é o canônico (não PLANETA CEL), XFB é o canônico (não XFB IMPORT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)