### PR TITLE
fix: corrigir aliases de fornecedores

### DIFF
--- a/app/api/admin/clientes/route.ts
+++ b/app/api/admin/clientes/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
     const FORN_ALIASES: Record<string, string> = {
       "ECO": "ECO CELL", "ECO CEL": "ECO CELL", "ECOCEL": "ECO CELL",
       "EMILIO SHOP": "EMILIO",
-      "FABIO BANGU": "FÁBIO BANGU",
+      "FABIO BANGU": "FÁBIO BANGU", "FABIO F/A": "FÁBIO BANGU",
       "MIAMI ZONE": "MIAMI",
       "PLANETA CEL": "PLANETA",
       "TM": "TM CEL",

--- a/app/api/admin/clientes/route.ts
+++ b/app/api/admin/clientes/route.ts
@@ -25,19 +25,16 @@ export async function GET(req: NextRequest) {
     const cadastrados = new Set((fornCadastro || []).map(f => f.nome.trim().toUpperCase()));
     const cadastroMap = new Map((fornCadastro || []).map(f => [f.nome.trim().toUpperCase(), f]));
 
-    // Mapeamento de aliases → nome canônico (consolida fornecedores duplicados)
+    // Mapeamento de aliases → nome canônico (baseado no sistema antigo todos_contatos_tigrao.csv)
     const FORN_ALIASES: Record<string, string> = {
       "ECO": "ECO CELL", "ECO CEL": "ECO CELL", "ECOCEL": "ECO CELL",
       "EMILIO SHOP": "EMILIO",
-      "FABIO BANGU": "FÁBIO BANGU", "FÁBIO": "FÁBIO BANGU", "FÁBIO RODRIGO VAZ DA SILVA": "FÁBIO BANGU",
-      "MADE": "MADE IN",
+      "FABIO BANGU": "FÁBIO BANGU",
       "MIAMI ZONE": "MIAMI",
-      "PLANETA": "PLANETA CEL",
+      "PLANETA CEL": "PLANETA",
       "TM": "TM CEL",
-      "TARTARUGA-F/A": "TARTARUGA",
-      "XFB": "XFB IMPORT",
+      "XFB IMPORT": "XFB",
       "ZN": "ZN CELL", "ZN CEL": "ZN CELL",
-      "DANIELLA": "DANIELLA ARRUDA GONÇALVES BANDEIRA",
     };
     function normForn(nome: string): string {
       const up = nome.trim().toUpperCase();


### PR DESCRIPTION
## Summary
- Remove incorrect fornecedor alias mappings (FÁBIO variants are different people, DANIELLA is a client not supplier)
- Keep only verified aliases based on original system spreadsheet (`todos_contatos_tigrao.csv`)
- Corrected aliases: ECO→ECO CELL, EMILIO SHOP→EMILIO, FABIO BANGU→FÁBIO BANGU, MIAMI ZONE→MIAMI, PLANETA CEL→PLANETA, TM→TM CEL, XFB IMPORT→XFB, ZN/ZN CEL→ZN CELL

## Test plan
- [ ] Verify /admin/cadastros fornecedores tab loads correctly
- [ ] Confirm no duplicate fornecedores with similar names
- [ ] Check that FÁBIO, FÁBIO BANGU and FÁBIO RODRIGO appear as separate entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)