### PR TITLE
feat: agrupar compras por data e sinalizar itens sem SN

### DIFF
--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -80,6 +80,12 @@ export default function ClientesPage() {
   const [notas, setNotas] = useState<{ id: string; data: string; cliente: string; produto: string; preco_vendido: number; nota_fiscal_url: string }[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [expandedDates, setExpandedDates] = useState<Set<string>>(new Set());
+  const toggleDate = (key: string) => setExpandedDates(prev => {
+    const n = new Set(prev);
+    if (n.has(key)) n.delete(key); else n.add(key);
+    return n;
+  });
   const [detailClient, setDetailClient] = useState<Cliente | null>(null);
   const [editing, setEditing] = useState(false);
   const [editForm, setEditForm] = useState({ nome: "", cpf: "", email: "", bairro: "", cidade: "", uf: "", cep: "", endereco: "" });
@@ -436,37 +442,92 @@ export default function ClientesPage() {
                     </div>
                   )}
 
-                  {/* Historico de compras */}
+                  {/* Historico de compras agrupado por data */}
                   <div>
                     <p className={`text-xs font-bold uppercase tracking-wider ${mS} mb-2`}>
                       Historico de compras ({f.compras.length} itens)
                     </p>
                     {f.compras.length === 0 ? (
                       <p className={`text-sm ${mM} py-4 text-center`}>Nenhuma compra registrada ainda</p>
-                    ) : (
-                      <div className="space-y-1 max-h-[400px] overflow-y-auto">
-                        {f.compras.map((c, i) => (
-                          <div key={i} className={`flex items-center justify-between px-3 py-2 rounded-lg text-xs ${dm ? "bg-[#2C2C2E]" : "bg-[#F9F9FB]"}`}>
-                            <div className="flex items-center gap-3 flex-1 min-w-0">
-                              <span className={mM}>{fmtDate(c.data)}</span>
-                              <span className={`font-medium truncate ${mP}`}>{c.produto}</span>
-                              {c.cor && <span className={`shrink-0 ${mS}`}>{c.cor}</span>}
-                              {c.serial_no && <span className="text-purple-500 font-mono shrink-0">SN: {c.serial_no}</span>}
-                            </div>
-                            <div className="flex items-center gap-3 shrink-0 ml-2">
-                              <span className={mM}>{c.qnt}x</span>
-                              <span className="font-bold text-red-500 w-24 text-right">{fmt(c.custo_unitario * c.qnt)}</span>
-                              <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
-                                c.status === "EM ESTOQUE" ? "bg-green-500/10 text-green-600" :
-                                c.status === "ESGOTADO" ? "bg-red-500/10 text-red-500" :
-                                c.status === "A CAMINHO" ? "bg-blue-500/10 text-blue-500" :
-                                `${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#F2F2F7] text-[#86868B]"}`
-                              }`}>{c.status || "—"}</span>
-                            </div>
+                    ) : (() => {
+                      // Agrupa por data
+                      const groups = new Map<string, typeof f.compras>();
+                      for (const c of f.compras) {
+                        const k = c.data || "—";
+                        if (!groups.has(k)) groups.set(k, []);
+                        groups.get(k)!.push(c);
+                      }
+                      const sorted = Array.from(groups.entries()).sort((a, b) => (b[0] || "").localeCompare(a[0] || ""));
+                      const semSerialTotal = f.compras.filter(c => !c.serial_no).length;
+                      return (
+                        <>
+                          {semSerialTotal > 0 && (
+                            <p className="text-[11px] text-amber-600 mb-2">
+                              ⚠️ {semSerialTotal} {semSerialTotal === 1 ? "item está" : "itens estão"} sem número de série
+                            </p>
+                          )}
+                          <div className="space-y-1 max-h-[500px] overflow-y-auto">
+                            {sorted.map(([data, itens]) => {
+                              const key = `${f.id || f.nome}:${data}`;
+                              const isOpen = expandedDates.has(key);
+                              const totalQnt = itens.reduce((s, c) => s + (c.qnt || 1), 0);
+                              const totalValor = itens.reduce((s, c) => s + (c.custo_unitario || 0) * (c.qnt || 1), 0);
+                              const semSerial = itens.filter(c => !c.serial_no).length;
+                              const statusCount: Record<string, number> = {};
+                              itens.forEach(c => { const s = c.status || "—"; statusCount[s] = (statusCount[s] || 0) + (c.qnt || 1); });
+                              return (
+                                <div key={key} className={`rounded-lg ${dm ? "bg-[#2C2C2E]" : "bg-[#F9F9FB]"}`}>
+                                  <button
+                                    onClick={() => toggleDate(key)}
+                                    className={`w-full flex items-center justify-between px-3 py-2 text-xs hover:opacity-80 transition-opacity`}
+                                  >
+                                    <div className="flex items-center gap-3 flex-1 min-w-0">
+                                      <span className={`shrink-0 ${mM}`}>{isOpen ? "▼" : "▶"}</span>
+                                      <span className={`font-semibold ${mP}`}>{fmtDate(data)}</span>
+                                      <span className={mS}>{totalQnt} {totalQnt === 1 ? "item" : "itens"}</span>
+                                      {semSerial > 0 && (
+                                        <span className="text-amber-600 text-[10px]">⚠ {semSerial} sem SN</span>
+                                      )}
+                                      <div className="flex items-center gap-1">
+                                        {Object.entries(statusCount).map(([st, qt]) => (
+                                          <span key={st} className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
+                                            st === "EM ESTOQUE" ? "bg-green-500/10 text-green-600" :
+                                            st === "ESGOTADO" ? "bg-red-500/10 text-red-500" :
+                                            st === "VENDIDO" ? "bg-blue-500/10 text-blue-500" :
+                                            st === "A CAMINHO" ? "bg-purple-500/10 text-purple-500" :
+                                            `${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#F2F2F7] text-[#86868B]"}`
+                                          }`}>{qt} {st}</span>
+                                        ))}
+                                      </div>
+                                    </div>
+                                    <span className="font-bold text-red-500 w-28 text-right shrink-0">{fmt(totalValor)}</span>
+                                  </button>
+                                  {isOpen && (
+                                    <div className={`border-t ${dm ? "border-[#3A3A3C]" : "border-[#E5E5EA]"} px-3 py-2 space-y-1`}>
+                                      {itens.map((c, i) => (
+                                        <div key={i} className="flex items-center justify-between text-[11px] py-1">
+                                          <div className="flex items-center gap-2 flex-1 min-w-0">
+                                            <span className={`font-medium truncate ${mP}`}>{c.produto}</span>
+                                            {c.cor && <span className={`shrink-0 ${mS}`}>{c.cor}</span>}
+                                            {c.serial_no
+                                              ? <span className="text-purple-500 font-mono shrink-0">SN: {c.serial_no}</span>
+                                              : <span className="text-amber-600 shrink-0">⚠ sem SN</span>}
+                                          </div>
+                                          <div className="flex items-center gap-2 shrink-0 ml-2">
+                                            <span className={mM}>{c.qnt}x</span>
+                                            <span className="font-bold text-red-500 w-20 text-right">{fmt(c.custo_unitario * c.qnt)}</span>
+                                          </div>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })}
                           </div>
-                        ))}
-                      </div>
-                    )}
+                        </>
+                      );
+                    })()}
                   </div>
                 </div>
               </div>

--- a/scripts/backfill-fornecedores.mjs
+++ b/scripts/backfill-fornecedores.mjs
@@ -1,0 +1,97 @@
+import { createClient } from "@supabase/supabase-js";
+import fs from "fs";
+const env = fs.readFileSync("/Users/Nicolas/Projetos/tigrao-tradein/.env.local", "utf8");
+for (const line of env.split("\n")) {
+  const m = line.match(/^([A-Z_]+)=["']?(.+?)["']?$/);
+  if (m) process.env[m[1]] = m[2];
+}
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const DRY_RUN = process.argv.includes("--dry");
+const map = JSON.parse(fs.readFileSync("scripts/fornecedores-map.json", "utf8"));
+const serialMap = map.serial_to_forn;
+const imeiMap = map.imei_to_forn;
+
+console.log(`Carregado: ${Object.keys(serialMap).length} seriais, ${Object.keys(imeiMap).length} IMEIs`);
+console.log(`Modo: ${DRY_RUN ? "DRY-RUN" : "APLICANDO"}`);
+
+async function fetchAll(table, sel, filter) {
+  const out = [];
+  let from = 0;
+  while (true) {
+    let q = sb.from(table).select(sel).range(from, from + 999);
+    if (filter) q = filter(q);
+    const { data, error } = await q;
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+    out.push(...data);
+    if (data.length < 1000) break;
+    from += 1000;
+  }
+  return out;
+}
+
+// === VENDAS ===
+const vendas = await fetchAll("vendas", "id,serial_no,imei,fornecedor", q => q.is("fornecedor", null));
+console.log(`\nVendas com fornecedor NULL: ${vendas.length}`);
+
+let matchSerial = 0, matchImei = 0, noMatch = 0;
+const updates = [];
+for (const v of vendas) {
+  let forn = null;
+  if (v.serial_no && serialMap[v.serial_no.toUpperCase()]) {
+    forn = serialMap[v.serial_no.toUpperCase()];
+    matchSerial++;
+  } else if (v.imei && imeiMap[v.imei]) {
+    forn = imeiMap[v.imei];
+    matchImei++;
+  } else {
+    noMatch++;
+    continue;
+  }
+  updates.push({ id: v.id, fornecedor: forn });
+}
+console.log(`  Match por serial: ${matchSerial}`);
+console.log(`  Match por IMEI: ${matchImei}`);
+console.log(`  Sem match: ${noMatch}`);
+
+if (!DRY_RUN && updates.length > 0) {
+  console.log(`\nAplicando ${updates.length} updates em vendas...`);
+  let done = 0;
+  for (const u of updates) {
+    const { error } = await sb.from("vendas").update({ fornecedor: u.fornecedor }).eq("id", u.id);
+    if (error) { console.error("ERR", u.id, error.message); break; }
+    done++;
+    if (done % 100 === 0) console.log(`  ${done}/${updates.length}`);
+  }
+  console.log(`✅ Vendas atualizadas: ${done}`);
+}
+
+// === ESTOQUE ===
+const estoque = await fetchAll("estoque", "id,serial_no,fornecedor", q => q.is("fornecedor", null));
+console.log(`\nEstoque com fornecedor NULL: ${estoque.length}`);
+
+let estMatch = 0, estNoMatch = 0;
+const estUpdates = [];
+for (const e of estoque) {
+  if (e.serial_no && serialMap[e.serial_no.toUpperCase()]) {
+    estUpdates.push({ id: e.id, fornecedor: serialMap[e.serial_no.toUpperCase()] });
+    estMatch++;
+  } else {
+    estNoMatch++;
+  }
+}
+console.log(`  Match: ${estMatch}, sem match: ${estNoMatch}`);
+
+if (!DRY_RUN && estUpdates.length > 0) {
+  console.log(`\nAplicando ${estUpdates.length} updates em estoque...`);
+  let done = 0;
+  for (const u of estUpdates) {
+    const { error } = await sb.from("estoque").update({ fornecedor: u.fornecedor }).eq("id", u.id);
+    if (error) { console.error("ERR", u.id, error.message); break; }
+    done++;
+  }
+  console.log(`✅ Estoque atualizado: ${done}`);
+}
+
+console.log("\n=== FIM ===");

--- a/scripts/extract-fornecedores-map.py
+++ b/scripts/extract-fornecedores-map.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Extrai mapa serial/imei → fornecedor das Entradas da planilha de exportação."""
+import numbers_parser
+import json
+import warnings
+warnings.filterwarnings("ignore")
+
+PATH = "/Users/Nicolas/Library/Mobile Documents/com~apple~CloudDocs/Downloads/EXPORTAÇÃO-OUTUBRO_25 ATÉ 27_03_26.numbers"
+
+doc = numbers_parser.Document(PATH)
+t = doc.sheets[0].tables[0]
+
+# Header indices
+headers = {}
+for c in range(t.num_cols):
+    v = t.cell(0, c).value
+    if v is not None:
+        headers[str(v).strip()] = c
+
+idx_tipo_op = headers["Tipo de Operação"]
+idx_contato = headers["Contato"]
+idx_serial = headers["Número de Série"]
+idx_imei = headers["IMEI"]
+idx_data = headers["Data"]
+idx_produto = headers["Produto"]
+idx_preco_compra = headers["Preço de Compra"]
+idx_preco_unit = headers["Preço Unitário"]
+
+def s(v):
+    if v is None: return ""
+    return str(v).strip()
+
+def parse_data(d):
+    """26/03/2026 → 2026-03-26"""
+    if not d: return ""
+    parts = d.split("/")
+    if len(parts) == 3:
+        return f"{parts[2]}-{parts[1].zfill(2)}-{parts[0].zfill(2)}"
+    return ""
+
+# Mapa: serial → fornecedor, imei → fornecedor
+# Também guarda lista detalhada por fornecedor pra debug
+serial_map = {}
+imei_map = {}
+entries = []
+sem_serial_sem_imei = 0
+
+for r in range(1, t.num_rows):
+    tipo_op = s(t.cell(r, idx_tipo_op).value)
+    if tipo_op != "Entrada":
+        continue
+    contato = s(t.cell(r, idx_contato).value)
+    if not contato:
+        continue
+    serial = s(t.cell(r, idx_serial).value)
+    imei = s(t.cell(r, idx_imei).value)
+    data = parse_data(s(t.cell(r, idx_data).value))
+    produto = s(t.cell(r, idx_produto).value)
+
+    if serial:
+        serial_map[serial.upper()] = contato
+    if imei:
+        imei_map[imei] = contato
+    if not serial and not imei:
+        sem_serial_sem_imei += 1
+
+    entries.append({
+        "fornecedor": contato,
+        "serial": serial,
+        "imei": imei,
+        "data": data,
+        "produto": produto,
+    })
+
+print(f"Total entradas: {len(entries)}")
+print(f"Sem serial/imei: {sem_serial_sem_imei}")
+print(f"Map por serial: {len(serial_map)}")
+print(f"Map por imei: {len(imei_map)}")
+
+# Distribuição por fornecedor
+from collections import Counter
+fc = Counter(e["fornecedor"] for e in entries)
+print(f"\nTop 20 fornecedores:")
+for f, c in fc.most_common(20):
+    print(f"  {f}: {c}")
+
+# Cristiano específico
+cristiano = [e for e in entries if "CRISTIANO" in e["fornecedor"].upper()]
+print(f"\nCristiano: {len(cristiano)} entradas")
+
+out = {
+    "serial_to_forn": serial_map,
+    "imei_to_forn": imei_map,
+    "entries": entries,
+}
+with open("scripts/fornecedores-map.json", "w", encoding="utf-8") as f:
+    json.dump(out, f, ensure_ascii=False, indent=2)
+print("\n✅ Salvo em scripts/fornecedores-map.json")


### PR DESCRIPTION
## Summary
- Histórico de compras do fornecedor agrupado por data (clique para expandir)
- Linha agregada mostra qnt total, valor total e contagem por status
- Itens sem número de série destacados em amber para facilitar correção
- Scripts de backfill incluídos (extract + apply)

## Test plan
- [ ] Abrir Cadastros → Fornecedores → clicar em CRISTIANO
- [ ] Conferir que histórico aparece agrupado por data, com setinha ▶
- [ ] Clicar em uma data e ver os itens individuais
- [ ] Verificar aviso de itens sem SN

🤖 Generated with [Claude Code](https://claude.com/claude-code)