### PR TITLE
fix(ProdutoSpecFields): auto-preenche nome para categorias não estrut…

### DIFF
--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -344,7 +344,9 @@ export default function ProdutoSpecFields({
       catalogo_modelo_nome: modelo.nome,
       spec: newSpec,
       cor: "",
-      produto: buildProdutoName(row.categoria, newSpec, ""),
+      produto: STRUCTURED_CATS.includes(row.categoria)
+        ? buildProdutoName(row.categoria, newSpec, "")
+        : (modelo.nome || "").toUpperCase(),
     };
     onChange(updated);
   };


### PR DESCRIPTION
…uradas

Quando usuário seleciona um modelo do catálogo em categorias como ACESSORIOS/OUTROS (não estruturadas), usa o nome do modelo como produto em vez de deixar vazio.