### PR TITLE
feat(estoque): cores em PT simplificado + lacrados mostram cores esgo…

### DIFF
--- a/app/admin/busca/page.tsx
+++ b/app/admin/busca/page.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useCallback, useRef, useEffect } from "react";
 import Link from "next/link";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { corParaPT } from "@/lib/cor-pt";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -209,7 +210,7 @@ export default function BuscaSerialPage() {
                           </span>
                         )}
                         {mainItem.cor && (
-                          <span className={`text-xs ${textSecondary}`}>{mainItem.cor}</span>
+                          <span className={`text-xs ${textSecondary}`}>{corParaPT(mainItem.cor)}</span>
                         )}
                       </div>
                     </div>

--- a/app/admin/catalogo/page.tsx
+++ b/app/admin/catalogo/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState, useCallback } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { corParaPT } from "@/lib/cor-pt";
 
 // Traduz valores de specs em inglês pra português no display (não altera o banco).
 // A chave continua sendo a string original, então selecionar/comparar funciona igual.
@@ -48,8 +49,12 @@ const COR_PT: Record<string, string> = {
 };
 
 function traduzirValor(valor: string, tipoChave?: string): string {
-  // Para cores, manter o valor original em inglês (sem tradução PT).
-  if (tipoChave === "cores") return valor;
+  // Para cores: mostra EN + PT simplificado lado a lado, ex: "Sky Blue  Azul"
+  if (tipoChave === "cores") {
+    const pt = corParaPT(valor);
+    if (pt && pt !== valor && pt !== "—") return `${valor}  ${pt}`;
+    return valor;
+  }
   const pt = COR_PT[valor.toLowerCase().trim()];
   return pt || valor;
 }

--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { useAutoRefetch } from "@/lib/useAutoRefetch";
 import { useSearchParams } from "next/navigation";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { corParaPT } from "@/lib/cor-pt";
 
 interface VendaResumo {
   id: string;
@@ -574,7 +575,7 @@ export default function ClientesPage() {
                                         <div key={i} className="flex items-center justify-between text-[11px] py-1">
                                           <div className="flex items-center gap-2 flex-1 min-w-0">
                                             <span className={`font-medium truncate ${mP}`}>{c.produto}</span>
-                                            {c.cor && <span className={`shrink-0 ${mS}`}>{c.cor}</span>}
+                                            {c.cor && <span className={`shrink-0 ${mS}`}>{corParaPT(c.cor)}</span>}
                                             {c.serial_no
                                               ? <span className="text-purple-500 font-mono shrink-0">SN: {c.serial_no}</span>
                                               : <span className="text-amber-600 shrink-0">⚠ sem SN</span>}

--- a/app/admin/encomendas/page.tsx
+++ b/app/admin/encomendas/page.tsx
@@ -4,6 +4,7 @@ import { hojeBR } from "@/lib/date-utils";
 import { useEffect, useState, useCallback } from "react";
 import { useAutoRefetch } from "@/lib/useAutoRefetch";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { corParaPT } from "@/lib/cor-pt";
 
 interface Encomenda {
   id: string;
@@ -195,7 +196,7 @@ export default function EncomendasPage() {
                         <a href={`https://wa.me/${enc.whatsapp.replace(/\D/g, "")}`} target="_blank" rel="noopener noreferrer" className="ml-1 text-green-500 text-xs">WA</a>
                       )}
                     </td>
-                    <td className="px-4 py-3 whitespace-nowrap">{enc.produto}{enc.cor ? ` (${enc.cor})` : ""}</td>
+                    <td className="px-4 py-3 whitespace-nowrap">{enc.produto}{enc.cor ? ` (${corParaPT(enc.cor)})` : ""}</td>
                     <td className="px-4 py-3 font-medium">{fmt(enc.valor_venda)}</td>
                     <td className="px-4 py-3 text-green-600">{enc.sinal_recebido ? fmt(enc.sinal_recebido) : "—"}</td>
                     <td className="px-4 py-3 text-[#E8740E] font-bold">{fmt(enc.valor_venda - (enc.sinal_recebido || 0))}</td>

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -35,7 +35,8 @@ function formatProdutoDisplay(p: {
   const src = `${nomeRaw} ${obs}`;
   const up = src.toUpperCase();
   const baseCat = getBaseCat(p.categoria || "IPHONES");
-  const cor = (p.cor || "").trim();
+  const corRaw = (p.cor || "").trim();
+  const cor = corRaw ? corParaPT(corRaw) : "";
 
   // Maior valor GB/TB = armazenamento (storage)
   const memMatches = [...up.matchAll(/(\d+)\s*(GB|TB)/g)];
@@ -94,21 +95,19 @@ function formatProdutoDisplay(p: {
     if (hasCell) parts.push("Wi-Fi + Cellular");
     else if (hasWifi) parts.push("Wi-Fi");
   } else if (baseCat === "MACBOOK") {
-    const chipM = up.match(/M(\d+)(\s*PRO|\s*MAX)?/);
-    const chip = chipM ? ` M${chipM[1]}${chipM[2] ? " " + chipM[2].trim().replace(/^PRO$/i, "Pro").replace(/^MAX$/i, "Max") : ""}` : "";
+    // Chip NÃO entra no nome de preview — só no modal de detalhes.
     let modelo = "MacBook";
     if (/NEO/.test(up)) modelo = "MacBook Neo";
     else if (/AIR/.test(up)) modelo = "MacBook Air";
     else if (/PRO/.test(up)) modelo = "MacBook Pro";
-    parts.push(modelo + chip);
+    parts.push(modelo);
     if (tela) parts.push(tela);
     if (ram) parts.push(ram);
     if (ssd) parts.push(ssd);
     if (cor) parts.push(cor);
   } else if (baseCat === "MAC_MINI") {
-    const chipM = up.match(/M(\d+)(\s*PRO|\s*MAX)?/);
-    const chip = chipM ? ` M${chipM[1]}${chipM[2] ? " " + chipM[2].trim().replace(/^PRO$/i, "Pro").replace(/^MAX$/i, "Max") : ""}` : "";
-    parts.push("Mac Mini" + chip);
+    // Chip NÃO entra no nome de preview — só no modal de detalhes.
+    parts.push("Mac Mini");
     if (ram) parts.push(ram);
     if (ssd) parts.push(ssd);
   } else if (baseCat === "APPLE_WATCH") {
@@ -131,7 +130,7 @@ function formatProdutoDisplay(p: {
     return cleanProdutoDisplay(nomeRaw);
   }
 
-  return parts.filter(Boolean).join(" - ");
+  return parts.filter(Boolean).join(" ");
 }
 
 /** Limpa o nome do produto para exibição: remove código de origem, info de chip e tags. */
@@ -1185,13 +1184,49 @@ export default function EstoquePage() {
 
   // ── Catálogo dinâmico de modelos ──────────────────────────────────────────
   const [catalogoModelos, setCatalogoModelos] = useState<{id: string; categoria_key: string; nome: string; ordem: number; ativo: boolean}[]>([]);
+  // Mapa modelo_id -> array de cores válidas (em inglês canônico)
+  const [coresPorModelo, setCoresPorModelo] = useState<Record<string, string[]>>({});
   useEffect(() => {
     if (!password) return;
     fetch("/api/admin/catalogo", { headers: { "x-admin-password": password } })
       .then(r => r.json())
       .then(json => { if (Array.isArray(json.modelos)) setCatalogoModelos(json.modelos); })
       .catch(() => {});
+    fetch("/api/admin/catalogo?all_configs=1", { headers: { "x-admin-password": password } })
+      .then(r => r.json())
+      .then(json => {
+        if (!Array.isArray(json.configs)) return;
+        const byModel: Record<string, string[]> = {};
+        for (const c of json.configs as { modelo_id: string; tipo_chave: string; valor: string }[]) {
+          if (c.tipo_chave !== "cores") continue;
+          if (!byModel[c.modelo_id]) byModel[c.modelo_id] = [];
+          byModel[c.modelo_id].push(c.valor);
+        }
+        setCoresPorModelo(byModel);
+      })
+      .catch(() => {});
   }, [password]);
+
+  // Dado um nome de produto, devolve as cores válidas do catálogo (em EN canônico)
+  const getCoresValidasParaProduto = useCallback((produtoNome: string, categoriaEstoque: string): string[] => {
+    if (!produtoNome || !catalogoModelos.length) return [];
+    const CAT_CATALOG: Record<string, string[]> = {
+      IPHONES: ["IPHONES"], MACBOOK: ["MACBOOK_AIR", "MACBOOK_PRO", "MACBOOK_NEO"],
+      MAC_MINI: ["MAC_MINI"], IPADS: ["IPADS"], APPLE_WATCH: ["APPLE_WATCH"],
+      AIRPODS: ["AIRPODS"], ACESSORIOS: ["ACESSORIOS"],
+    };
+    const keys = CAT_CATALOG[categoriaEstoque] || [];
+    if (!keys.length) return [];
+    const catModelos = catalogoModelos.filter(m => keys.includes(m.categoria_key) && m.ativo !== false);
+    const prodNorm = normalizeModelName(produtoNome);
+    const match = catModelos
+      .map(m => ({ m, norm: normalizeModelName(m.nome) }))
+      .filter(({ norm }) => modelMatchesProduct(norm, prodNorm))
+      .sort((a, b) => b.norm.length - a.norm.length)[0];
+    if (!match) return [];
+    return coresPorModelo[match.m.id] || [];
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogoModelos, coresPorModelo]);
   function getCatModelos(catKey: string, fallback: string[]): string[] {
     const db = catalogoModelos.filter(m => m.categoria_key === catKey && m.ativo !== false).sort((a, b) => a.ordem - b.ordem).map(m => m.nome);
     return db.length > 0 ? db : fallback;
@@ -3949,6 +3984,17 @@ export default function EstoquePage() {
                             if (!colorSummary[key]) colorSummary[key] = { label, qnt: 0 };
                             colorSummary[key].qnt += p.qnt;
                           });
+                          // Apenas para LACRADOS (tipo NOVO) — injeta cores do catálogo que zeraram como 0x
+                          const isLacrado = (items[0]?.tipo || "NOVO") === "NOVO" && items[0]?.categoria !== "SEMINOVOS";
+                          if (isLacrado) {
+                            const coresValidas = getCoresValidasParaProduto(items[0]?.produto || "", items[0]?.categoria || "");
+                            coresValidas.forEach(corEN => {
+                              const label = corParaPT(corEN);
+                              if (!label || label === "—") return;
+                              const key = label.toUpperCase().trim();
+                              if (!colorSummary[key]) colorSummary[key] = { label, qnt: 0 };
+                            });
+                          }
                           return (
                             <span className={`text-[11px] ${textSecondary} hidden sm:flex items-center gap-1 flex-wrap cursor-pointer`}>
                               {Object.values(colorSummary).sort((a,b) => a.label.localeCompare(b.label)).map((c, i) => (
@@ -5576,7 +5622,7 @@ export default function EstoquePage() {
 
                 if (baseCat === "IPHONES") {
                   push("Armazenamento", armazenamento);
-                  push("Cor", p.cor);
+                  push("Cor", p.cor ? corParaPT(p.cor) : null);
                   push("Origem", origem);
                   push("Bateria", bateria);
                   if (isSeminovo) {
@@ -5592,7 +5638,7 @@ export default function EstoquePage() {
                 } else if (baseCat === "IPADS") {
                   push("Tamanho", telaFinal);
                   push("Armazenamento", armazenamento);
-                  push("Cor", p.cor);
+                  push("Cor", p.cor ? corParaPT(p.cor) : null);
                   push("Conectividade", isCellular ? "Wi-Fi + Cellular" : (isWifi ? "Wi-Fi" : null));
                   push("Bateria", bateria);
                   push("Caixa", comCaixa ? "Sim" : null);
@@ -5604,18 +5650,18 @@ export default function EstoquePage() {
                   push("RAM", ram);
                   push("SSD", ssd);
                   push("Chip", cpu && gpu ? `${cpu}C CPU / ${gpu}C GPU` : (cpu || gpu));
-                  push("Cor", p.cor);
+                  push("Cor", p.cor ? corParaPT(p.cor) : null);
                   push("Ciclos de bateria", ciclos);
                   push("Grade", grade);
                 } else if (baseCat === "MAC_MINI") {
                   push("RAM", ram);
                   push("SSD", ssd);
                   push("Chip", cpu && gpu ? `${cpu}C CPU / ${gpu}C GPU` : (cpu || gpu));
-                  push("Cor", p.cor);
+                  push("Cor", p.cor ? corParaPT(p.cor) : null);
                 } else if (baseCat === "APPLE_WATCH") {
                   push("Tamanho", tamMm ? tamMm[1] + "mm" : null);
                   push("Conectividade", isCellular ? "GPS + Cellular" : (isGps ? "GPS" : null));
-                  push("Cor", p.cor);
+                  push("Cor", p.cor ? corParaPT(p.cor) : null);
                   push("Modelo da pulseira", band);
                   push("Tamanho da pulseira", pulseiraTam);
                   push("Caixa", comCaixa ? "Sim" : null);

--- a/app/admin/etiquetas-preco/page.tsx
+++ b/app/admin/etiquetas-preco/page.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useAdmin } from "@/components/admin/AdminShell";
 import { CATEGORIAS, CAT_LABELS } from "@/lib/produto-specs";
+import { corParaPT } from "@/lib/cor-pt";
 import { QRCodeCanvas } from "qrcode.react";
 
 interface ProdutoEstoque {
@@ -98,7 +99,7 @@ function EtiquetaPreco({
         </p>
         {produto.cor && tamanho !== "pequena" && (
           <p className="text-gray-500" style={{ fontSize: config.fontSize.serial, marginTop: "0.5mm" }}>
-            {produto.cor}
+            {corParaPT(produto.cor)}
           </p>
         )}
       </div>
@@ -340,7 +341,7 @@ export default function EtiquetasPrecoPage() {
       <div class="wrap" ${idx < produtosSelecionados.length - 1 ? 'style="page-break-after:always"' : ''}>
         <div class="marca">TIGRAO IMPORTS</div>
         <div class="produto">${p.produto}</div>
-        ${p.cor ? `<div class="cor">${p.cor}</div>` : ""}
+        ${p.cor ? `<div class="cor">${corParaPT(p.cor)}</div>` : ""}
         <div class="preco">${formatPrice(precoVal)}</div>
         <div class="pix">a vista no PIX</div>
         <div class="qr"><canvas id="qr-${idx}" data-qr="${qrData.replace(/"/g, "&quot;")}"></canvas></div>
@@ -556,7 +557,7 @@ export default function EtiquetasPrecoPage() {
                           <p className="font-semibold text-gray-900">{p.produto}</p>
                           <p className="text-xs text-gray-400">{CAT_LABELS[p.categoria] || p.categoria} {p.tipo === "SEMINOVO" && <span className="text-amber-500 font-semibold">SEMINOVO</span>}</p>
                         </td>
-                        <td className="px-4 py-3 text-gray-600">{p.cor || "—"}</td>
+                        <td className="px-4 py-3 text-gray-600">{corParaPT(p.cor)}</td>
                         <td className="px-4 py-3 text-gray-500 font-mono text-xs">
                           {p.serial_no || p.imei || "—"}
                         </td>

--- a/app/admin/etiquetas/page.tsx
+++ b/app/admin/etiquetas/page.tsx
@@ -20,6 +20,7 @@ import {
   DEFAULT_SPEC, buildProdutoName,
   type ProdutoSpec,
 } from "@/lib/produto-specs";
+import { corParaPT } from "@/lib/cor-pt";
 
 interface Etiqueta {
   id: string;
@@ -265,7 +266,7 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
       </style></head><body>
       <div class="wrap">
         <div class="produto">${etiqueta.produto}</div>
-        ${etiqueta.cor ? `<div class="cor">${etiqueta.cor}</div>` : ""}
+        ${etiqueta.cor ? `<div class="cor">${corParaPT(etiqueta.cor)}</div>` : ""}
         ${serial ? `<div class="extra">SN: ${serial}</div>` : ""}
         ${imei ? `<div class="extra">IMEI: ${imei}</div>` : ""}
         <div class="qr"><canvas id="qr"></canvas></div>
@@ -495,7 +496,7 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
       return `
       <div class="wrap" ${idx < lista.length - 1 ? 'style="page-break-after:always"' : ''}>
         <div class="produto">${et.produto}</div>
-        ${et.cor ? `<div class="cor">${et.cor}</div>` : ""}
+        ${et.cor ? `<div class="cor">${corParaPT(et.cor)}</div>` : ""}
         ${serial ? `<div class="extra">SN: ${serial}</div>` : ""}
         ${imei ? `<div class="extra">IMEI: ${imei}</div>` : ""}
         <div class="qr"><canvas id="qr-${idx}"></canvas></div>
@@ -670,7 +671,7 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
                     <p className={labelCls}>Cor</p>
                     <select value={cor} onChange={(e) => setCor(e.target.value)} className={inputCls}>
                       <option value="">Selecione a cor...</option>
-                      {coresUnicas.map((c) => <option key={c} value={c}>{c}</option>)}
+                      {coresUnicas.map((c) => <option key={c} value={c}>{corParaPT(c)}</option>)}
                     </select>
                   </div>
                 )}
@@ -679,7 +680,7 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
                 {produtoEstoque && (
                   <div className="px-4 py-3 bg-gray-900 rounded-xl">
                     <p className="text-xs text-gray-400">Produto na etiqueta:</p>
-                    <p className="text-white font-bold">{produtoEstoque}{cor ? ` — ${cor}` : ""}</p>
+                    <p className="text-white font-bold">{produtoEstoque}{cor ? ` — ${corParaPT(cor)}` : ""}</p>
                   </div>
                 )}
               </>
@@ -943,7 +944,7 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
             <div className="border-2 border-dashed border-gray-300 rounded-xl p-4 bg-gray-50 flex justify-center">
               <div className="bg-white border border-gray-400 rounded p-3 shadow-sm" style={{ minWidth: 200, maxWidth: 280 }}>
                 <p className="text-sm font-bold text-gray-900 leading-tight text-center">{etiquetaGerada.produto}</p>
-                {etiquetaGerada.cor && <p className="text-xs text-gray-500 text-center">{etiquetaGerada.cor}</p>}
+                {etiquetaGerada.cor && <p className="text-xs text-gray-500 text-center">{corParaPT(etiquetaGerada.cor)}</p>}
                 {(etiquetaGerada.serial_no || etiquetaGerada.imei) && (
                   <p className="text-[10px] text-gray-400 text-center mt-1">
                     {etiquetaGerada.serial_no && `SN: ${etiquetaGerada.serial_no}`}
@@ -1119,7 +1120,7 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
                           <td className="px-4 py-3 font-mono text-xs text-gray-600">{et.codigo_barras}</td>
                           <td className="px-4 py-3">
                             <p className="font-medium text-gray-900">{et.produto}</p>
-                            {et.cor && <p className="text-xs text-gray-400">{et.cor}</p>}
+                            {et.cor && <p className="text-xs text-gray-400">{corParaPT(et.cor)}</p>}
                           </td>
                           <td className="px-4 py-3 text-gray-600">{et.fornecedor || "—"}</td>
                           <td className="px-4 py-3">
@@ -1177,7 +1178,7 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
             <div className="p-6 space-y-4">
               <div className="bg-gray-50 rounded-xl p-4 space-y-2">
                 <p className="font-bold text-gray-900 text-lg">{modalScan.produto}</p>
-                {modalScan.cor && <p className="text-sm text-gray-600">Cor: {modalScan.cor}</p>}
+                {modalScan.cor && <p className="text-sm text-gray-600">Cor: {corParaPT(modalScan.cor)}</p>}
                 {modalScan.armazenamento && <p className="text-sm text-gray-600">Armazenamento: {modalScan.armazenamento}</p>}
                 {modalScan.fornecedor && <p className="text-sm text-gray-600">Fornecedor: {modalScan.fornecedor}</p>}
                 {/* Custo salvo internamente, não exibido na tela */}

--- a/app/admin/gastos/page.tsx
+++ b/app/admin/gastos/page.tsx
@@ -9,6 +9,7 @@ import { useTabParam } from "@/lib/useTabParam";
 import type { Gasto, Banco } from "@/lib/admin-types";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 import { STRUCTURED_CATS, buildProdutoName, IPHONE_ORIGENS, DEFAULT_SPEC, type ProdutoSpec } from "@/lib/produto-specs";
+import { corParaPT } from "@/lib/cor-pt";
 
 /** Converte string BR (ex: "12.250,89" ou "128,89") para número */
 const parseBR = (v: string): number => {
@@ -489,7 +490,7 @@ function ProdutosVinculados({ pedidoFornecedorId, password, dm, fornecedores }: 
                         const corUp = corLimpa.toUpperCase();
                         const aliases = COLOR_ALIASES[corUp] || [corUp];
                         const corJaNoNome = corUp && aliases.some(a => new RegExp(`\\b${a}\\b`).test(nomeUp));
-                        return `${nomeLimpo}${corLimpa && !corJaNoNome ? ` — ${corLimpa}` : ""}`;
+                        return `${nomeLimpo}${corLimpa && !corJaNoNome ? ` — ${corParaPT(corLimpa)}` : ""}`;
                       })()}{(() => {
                         const origem = getOrigemFromObs(p.observacao);
                         if (!origem) return "";

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
 import { getWhatsAppByVendedor, VENDEDORES } from "@/lib/whatsapp-config";
+import { corParaPT } from "@/lib/cor-pt";
 
 export default function GerarLinkPage() {
   const { user, password: adminPw, apiHeaders: adminHeaders, darkMode: dm } = useAdmin();
@@ -549,7 +550,7 @@ export default function GerarLinkPage() {
                               {coresDisponiveis.map(cor => (
                                 <button key={cor} onClick={() => setCorSel(corSel === cor ? "" : cor)}
                                   className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${corSel === cor ? "bg-[#E8740E] text-white border-[#E8740E]" : (dm ? "bg-[#2C2C2E] text-[#F5F5F7] border-[#3A3A3C] hover:border-[#E8740E]" : "bg-white text-[#1D1D1F] border-[#D2D2D7] hover:border-[#E8740E]")}`}
-                                >{cor}</button>
+                                >{corParaPT(cor)}</button>
                               ))}
                             </div>
                           </div>

--- a/app/admin/operacoes/page.tsx
+++ b/app/admin/operacoes/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState, useCallback } from "react";
 import { useAutoRefetch } from "@/lib/useAutoRefetch";
+import { corParaPT } from "@/lib/cor-pt";
 import { useAdmin } from "@/components/admin/AdminShell";
 
 interface Operacao {
@@ -206,7 +207,7 @@ export default function OperacoesPage() {
                           <p className={`text-sm font-semibold ${txtP}`}>{item.produto}</p>
                           <div className="flex items-center gap-2 mt-1.5 flex-wrap">
                             {item.tipo_venda && <span className={`text-[10px] px-2 py-0.5 rounded-full font-semibold ${item.tipo_venda === "NOVO" || item.tipo_venda === "VENDA" ? "bg-green-100 text-green-700" : item.tipo_venda === "UPGRADE" ? "bg-purple-100 text-purple-700" : item.tipo_venda === "ATACADO" ? "bg-blue-100 text-blue-700" : item.tipo_venda === "SEMINOVO" ? "bg-yellow-100 text-yellow-700" : "bg-gray-100 text-gray-700"}`}>{item.tipo_venda}</span>}
-                            {item.cor && <span className={`text-[11px] ${txtS}`}>{item.cor}</span>}
+                            {item.cor && <span className={`text-[11px] ${txtS}`}>{corParaPT(item.cor)}</span>}
                           </div>
                           {(item.serial_no || item.imei) && (
                             <div className={`flex items-center gap-4 mt-2 px-3 py-2 rounded-lg ${dm ? "bg-[#2C2C2E]" : "bg-[#F9F9FB]"}`}>
@@ -228,7 +229,7 @@ export default function OperacoesPage() {
                                   const win = window.open("", "_blank", "width=300,height=300");
                                   if (!win) return;
                                   const produtoNome = item.produto || "";
-                                  const cor = item.cor || "";
+                                  const cor = item.cor ? corParaPT(item.cor) : "";
                                   const serial = item.serial_no || "";
                                   const imei = item.imei || "";
                                   win.document.write(`<!DOCTYPE html><html><head>

--- a/app/admin/orcamento/page.tsx
+++ b/app/admin/orcamento/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState, useMemo } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { corParaPT } from "@/lib/cor-pt";
 
 // Taxas para orçamento cliente (embutir no preço parcelado)
 const TAXAS_PARCELA: Record<number, number> = {
@@ -181,7 +182,7 @@ export default function OrcamentoPage() {
   // Extrair info relevante do obs: garantia apple
   const cleanSemiDetails = (item: SeminovoEstoque): string => {
     const parts: string[] = [];
-    if (item.cor) parts.push(item.cor);
+    if (item.cor) parts.push(corParaPT(item.cor));
     if (item.bateria) parts.push(`🔋${item.bateria}%`);
     // Extrair garantia do obs
     if (item.observacao) {
@@ -460,7 +461,7 @@ export default function OrcamentoPage() {
                   <p className={`text-xs ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Selecionado</p>
                   <p className={`text-sm font-bold mt-0.5 ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{cleanSemiNome(semiSel.produto)}</p>
                   <div className="flex flex-wrap gap-3 mt-1 text-xs">
-                    {semiSel.cor && <span className={dm ? "text-[#98989D]" : "text-[#86868B]"}>Cor: {semiSel.cor}</span>}
+                    {semiSel.cor && <span className={dm ? "text-[#98989D]" : "text-[#86868B]"}>Cor: {corParaPT(semiSel.cor)}</span>}
                     {semiSel.bateria && <span className="text-green-500">🔋 {semiSel.bateria}%</span>}
                     {cleanSemiDetails(semiSel) && <span className={dm ? "text-[#98989D]" : "text-[#86868B]"}>{cleanSemiDetails(semiSel)}</span>}
                     <span className="text-[#E8740E] font-semibold">Custo: R$ {semiSel.custo_unitario?.toLocaleString("pt-BR")}</span>

--- a/app/admin/precos/page.tsx
+++ b/app/admin/precos/page.tsx
@@ -5,6 +5,7 @@ import { useAdmin } from "@/components/admin/AdminShell";
 import { useTabParam } from "@/lib/useTabParam";
 import { getCategoriasPrecos, addCategoriaPrecos, removeCategoriaPrecos, EMOJI_OPTIONS } from "@/lib/categorias";
 import type { Categoria } from "@/lib/categorias";
+import { corParaPT } from "@/lib/cor-pt";
 
 const UsadosContent = lazy(() => import("@/app/admin/usados/page").then(m => ({ default: m.UsadosContent })));
 
@@ -1184,7 +1185,7 @@ function HistoricoPrecos() {
                       <tr key={i} className="border-b border-[#F5F5F7] last:border-0 hover:bg-[#F5F5F7] transition-colors">
                         <td className="px-4 py-2.5 text-[#86868B]">{d.data}</td>
                         <td className="px-4 py-2.5 font-medium">{d.fornecedor}</td>
-                        <td className="px-4 py-2.5">{d.produto}{d.cor ? ` ${d.cor}` : ""}</td>
+                        <td className="px-4 py-2.5">{d.produto}{d.cor ? ` ${corParaPT(d.cor)}` : ""}</td>
                         <td className="px-4 py-2.5 text-right font-semibold">{fmt(d.custo)}</td>
                         <td className="px-4 py-2.5 text-right text-[#86868B]">{d.qnt}</td>
                       </tr>

--- a/app/admin/rastreio/page.tsx
+++ b/app/admin/rastreio/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { corParaPT } from "@/lib/cor-pt";
 
 const fmt = (v: number) => `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
 
@@ -70,7 +71,7 @@ export default function RastreioPage() {
           date: e.data_entrada || "—",
           type: e.tipo === "SEMINOVO" ? "troca" : "entrada",
           title: `Entrada no estoque`,
-          detail: e.produto + (e.cor ? ` ${e.cor}` : ""),
+          detail: e.produto + (e.cor ? ` ${corParaPT(e.cor)}` : ""),
           extra: {
             "Fornecedor": e.fornecedor || "—",
             "Custo": fmt(e.custo_unitario || 0),

--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, useMemo } from "react";
 import dynamic from "next/dynamic";
 import { useAdmin } from "@/components/admin/AdminShell";
 import TradeInQuestionsAdmin from "@/components/admin/TradeInQuestionsAdmin";
+import { corParaPT } from "@/lib/cor-pt";
 
 const FunnelPanel = dynamic(() => import("@/app/admin/analytics/page"), { ssr: false });
 
@@ -775,7 +776,7 @@ export default function AdminPage() {
               {/* Used device */}
               <div className="bg-[#F5F5F7] rounded-xl p-4 space-y-2">
                 <h3 className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">Aparelho na Troca</h3>
-                <p className="text-[#1D1D1F] font-medium text-sm">{modalRow.modelo_usado} {modalRow.storage_usado}{modalRow.cor_usado ? ` — ${modalRow.cor_usado}` : ""}</p>
+                <p className="text-[#1D1D1F] font-medium text-sm">{modalRow.modelo_usado} {modalRow.storage_usado}{modalRow.cor_usado ? ` — ${corParaPT(modalRow.cor_usado)}` : ""}</p>
                 {modalRow.condicao_linhas && modalRow.condicao_linhas.length > 0 && (
                   <div className="text-xs text-[#6E6E73] space-y-0.5">
                     {modalRow.condicao_linhas.map((linha, i) => (

--- a/app/admin/trocas/page.tsx
+++ b/app/admin/trocas/page.tsx
@@ -13,6 +13,7 @@ import {
   type ProdutoSpec,
   DEFAULT_SPEC,
 } from "@/lib/produto-specs";
+import { corParaPT } from "@/lib/cor-pt";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -326,7 +327,7 @@ export default function TrocasPage() {
                       >
                         <div className={`font-medium ${txtP}`}>{item.produto}</div>
                         <div className={`text-xs ${txtS}`}>
-                          {item.cor && <span>{item.cor} · </span>}
+                          {item.cor && <span>{corParaPT(item.cor)} · </span>}
                           {item.serial_no && <span>SN: {item.serial_no} · </span>}
                           {item.imei && <span>IMEI: {item.imei} · </span>}
                           <span>{fmt(item.custo_unitario)}</span>
@@ -343,7 +344,7 @@ export default function TrocasPage() {
                   <div>
                     <p className={`font-semibold text-sm ${txtP}`}>{produtoSaida.produto}</p>
                     <p className={`text-xs ${txtS} mt-1`}>
-                      {produtoSaida.cor && <span>{produtoSaida.cor} · </span>}
+                      {produtoSaida.cor && <span>{corParaPT(produtoSaida.cor)} · </span>}
                       {produtoSaida.serial_no && <span>SN: {produtoSaida.serial_no} · </span>}
                       {produtoSaida.imei && <span>IMEI: {produtoSaida.imei} · </span>}
                       <span>{fmt(produtoSaida.custo_unitario)}</span>
@@ -512,7 +513,7 @@ export default function TrocasPage() {
                           <div className="flex items-center gap-2 flex-wrap">
                             <span className="text-red-500 text-xs font-medium">SAIU</span>
                             <span className={`text-sm ${txtP}`}>{t.produto_saida_nome}</span>
-                            {t.produto_saida_cor && <span className={`text-xs ${txtS}`}>{t.produto_saida_cor}</span>}
+                            {t.produto_saida_cor && <span className={`text-xs ${txtS}`}>{corParaPT(t.produto_saida_cor)}</span>}
                             <span className={`text-xs ${txtS}`}>{fmt(t.produto_saida_custo)}</span>
                           </div>
                           {(t.produto_saida_serial || t.produto_saida_imei) && (
@@ -526,7 +527,7 @@ export default function TrocasPage() {
                           <div className="flex items-center gap-2 flex-wrap">
                             <span className="text-green-500 text-xs font-medium">ENTROU</span>
                             <span className={`text-sm ${txtP}`}>{t.produto_entrada_nome}</span>
-                            {t.produto_entrada_cor && <span className={`text-xs ${txtS}`}>{t.produto_entrada_cor}</span>}
+                            {t.produto_entrada_cor && <span className={`text-xs ${txtS}`}>{corParaPT(t.produto_entrada_cor)}</span>}
                             <span className={`text-xs ${txtS}`}>{fmt(t.produto_entrada_custo)}</span>
                           </div>
                           {(t.produto_entrada_serial || t.produto_entrada_imei) && (

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -8,6 +8,7 @@ import { useTabParam } from "@/lib/useTabParam";
 import { useOnlineStatus } from "@/lib/useOnlineStatus";
 import { addToQueue, getQueue, removeFromQueue, getQueueCount } from "@/lib/offline-queue";
 import type { Venda } from "@/lib/admin-types";
+import { corParaPT } from "@/lib/cor-pt";
 import BarcodeScanner from "@/components/BarcodeScanner";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 
@@ -2351,7 +2352,7 @@ export default function VendasPage() {
                                     >
                                       <span className="flex items-center gap-2">
                                         <span className="text-[10px] text-[#86868B]">{isCorExpanded ? "▼" : "▶"}</span>
-                                        <span className="font-semibold">{cor}</span>
+                                        <span className="font-semibold">{corParaPT(cor)}</span>
                                       </span>
                                       <span className={`text-[10px] ${dm ? "text-[#636366]" : "text-[#C7C7CC]"}`}>{corQnt} un.</span>
                                     </button>
@@ -4442,7 +4443,7 @@ export default function VendasPage() {
                                           <h4 className="text-xs font-bold text-[#86868B] uppercase">🔄 Produto na Troca</h4>
                                           <div className="text-xs space-y-1 bg-amber-50 border border-amber-200 rounded-lg p-3">
                                             {tProd && <p><strong>Modelo:</strong> {tProd}</p>}
-                                            {tCor && <p><strong>Cor:</strong> {tCor}</p>}
+                                            {tCor && <p><strong>Cor:</strong> {corParaPT(tCor)}</p>}
                                             {tBat && <p><strong>Bateria:</strong> {tBat}%</p>}
                                             {tSerial && <p><strong>Serial:</strong> {tSerial}</p>}
                                             {tImei && <p><strong>IMEI:</strong> {tImei}</p>}
@@ -4469,7 +4470,7 @@ export default function VendasPage() {
                                           <h4 className="text-xs font-bold text-[#86868B] uppercase">🔄 2º Produto na Troca</h4>
                                           <div className="text-xs space-y-1 bg-amber-50 border border-amber-200 rounded-lg p-3">
                                             {t2Prod && <p><strong>Modelo:</strong> {t2Prod}</p>}
-                                            {t2Cor && <p><strong>Cor:</strong> {t2Cor}</p>}
+                                            {t2Cor && <p><strong>Cor:</strong> {corParaPT(t2Cor)}</p>}
                                             {t2Bat && <p><strong>Bateria:</strong> {t2Bat}%</p>}
                                             {t2Serial && <p><strong>Serial:</strong> {t2Serial}</p>}
                                             {t2Imei && <p><strong>IMEI:</strong> {t2Imei}</p>}

--- a/app/api/admin/catalogo/route.ts
+++ b/app/api/admin/catalogo/route.ts
@@ -16,6 +16,7 @@ export async function GET(req: NextRequest) {
   try {
     const supabase = getSupabase();
     const modeloId = req.nextUrl.searchParams.get("modelo_id");
+    const allConfigs = req.nextUrl.searchParams.get("all_configs");
 
     // Return configs for a specific model
     if (modeloId) {
@@ -23,6 +24,15 @@ export async function GET(req: NextRequest) {
         .from("catalogo_modelo_configs")
         .select("*")
         .eq("modelo_id", modeloId);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+      return NextResponse.json({ configs: data ?? [] });
+    }
+
+    // Return ALL model configs (used by estoque page to know all valid colors per model)
+    if (allConfigs) {
+      const { data, error } = await supabase
+        .from("catalogo_modelo_configs")
+        .select("modelo_id,tipo_chave,valor");
       if (error) return NextResponse.json({ error: error.message }, { status: 500 });
       return NextResponse.json({ configs: data ?? [] });
     }

--- a/components/admin/SuperSearch.tsx
+++ b/components/admin/SuperSearch.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { corParaPT } from "@/lib/cor-pt";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type SearchResult = Record<string, any>;
@@ -302,7 +303,7 @@ function DetailModal({ item, onClose, onSave, dm }: { item: SearchResult; onClos
                   const win = window.open("", "_blank", "width=300,height=300");
                   if (!win) return;
                   const produtoNome = item.produto || "";
-                  const cor = item.cor || "";
+                  const cor = item.cor ? corParaPT(item.cor) : "";
                   const serial = item.serial_no || "";
                   const imei = item.imei || "";
                   win.document.write(`<!DOCTYPE html><html><head>
@@ -395,7 +396,7 @@ window.onload=function(){window.print();window.close();};
               <div>
                 <p className={`text-[10px] uppercase tracking-wider ${textSecondary}`}>Cor</p>
                 {editing ? <input value={editFields.cor} onChange={(e) => setEditFields(f => ({ ...f, cor: e.target.value }))} className={inputCls} />
-                  : <p className={`text-sm ${textPrimary}`}>{item.cor}</p>}
+                  : <p className={`text-sm ${textPrimary}`}>{corParaPT(item.cor)}</p>}
               </div>
             )}
             {item.categoria && (
@@ -476,7 +477,7 @@ window.onload=function(){window.print();window.close();};
               )}
               <div className="col-span-2">
                 <p className={`text-[10px] uppercase tracking-wider ${textSecondary}`}>Produto que saiu</p>
-                <p className={`text-sm ${textPrimary}`}>{item.troca_info.produto_saida_nome}{item.troca_info.produto_saida_cor ? ` · ${item.troca_info.produto_saida_cor}` : ""}</p>
+                <p className={`text-sm ${textPrimary}`}>{item.troca_info.produto_saida_nome}{item.troca_info.produto_saida_cor ? ` · ${corParaPT(item.troca_info.produto_saida_cor)}` : ""}</p>
                 {(item.troca_info.produto_saida_serial || item.troca_info.produto_saida_imei) && (
                   <p className={`text-xs font-mono ${textSecondary}`}>{item.troca_info.produto_saida_serial ? `SN ${item.troca_info.produto_saida_serial}` : ""}{item.troca_info.produto_saida_imei ? `  ·  IMEI ${item.troca_info.produto_saida_imei}` : ""}</p>
                 )}

--- a/lib/cor-pt.ts
+++ b/lib/cor-pt.ts
@@ -3,35 +3,63 @@ import { COR_PT_TO_EN } from "./produto-specs";
 // Tradução simplificada: cores em inglês do catálogo → PT base.
 // Várias variantes em inglês colapsam pra mesma cor genérica em PT.
 export const COR_EN_TO_PT_SIMPLES: Record<string, string> = {
+  // Pretos
   "Black": "Preto",
-  "Black Titanium": "Titânio Preto",
-  "Blue": "Azul",
-  "Blue Titanium": "Titânio Azul",
-  "Cloud White": "Branco",
-  "Deep Purple": "Roxo",
-  "Desert Titanium": "Titânio Deserto",
-  "Gold": "Dourado",
-  "Graphite": "Cinza",
-  "Green": "Verde",
-  "Indigo": "Azul",
   "Jet Black": "Preto",
-  "Lavender": "Lavanda",
   "Midnight": "Preto",
-  "Natural": "Natural",
-  "Natural Titanium": "Titânio Natural",
-  "Orange": "Laranja",
-  "Pink": "Rosa",
-  "Purple": "Roxo",
-  "Red": "Vermelho",
-  "Rose Gold": "Dourado",
-  "Silver": "Prata",
-  "Slate": "Cinza",
   "Space Black": "Preto",
-  "Space Gray": "Cinza",
-  "Starlight": "Estelar",
+  // Brancos
   "White": "Branco",
-  "White Titanium": "Titânio Branco",
+  "Cloud White": "Branco",
+  // Azuis (todos colapsam)
+  "Blue": "Azul",
+  "Sky Blue": "Azul",
+  "Mist Blue": "Azul",
+  "Sierra Blue": "Azul",
+  "Pacific Blue": "Azul",
+  "Deep Blue": "Azul",
+  "Indigo": "Azul",
+  "Ultramarine": "Azul",
+  // Verdes
+  "Green": "Verde",
+  "Alpine Green": "Verde",
+  "Midnight Green": "Verde",
+  "Sage": "Verde",
+  "Teal": "Verde",
+  // Cinzas / Prata
+  "Silver": "Prata",
+  "Graphite": "Cinza",
+  "Slate": "Cinza",
+  "Space Gray": "Cinza",
+  // Dourados
+  "Gold": "Dourado",
+  "Light Gold": "Dourado",
+  "Rose Gold": "Dourado",
+  // Roxos
+  "Purple": "Roxo",
+  "Deep Purple": "Roxo",
+  "Lavender": "Roxo",
+  // Rosas
+  "Pink": "Rosa",
+  "Blush": "Rosa",
+  // Laranjas
+  "Orange": "Laranja",
+  "Cosmic Orange": "Laranja",
+  // Amarelos
   "Yellow": "Amarelo",
+  "Citrus": "Amarelo",
+  // Vermelhos
+  "Red": "Vermelho",
+  "(PRODUCT)RED": "Vermelho",
+  // Estelar
+  "Starlight": "Estelar",
+  // Titânios
+  "Black Titanium": "Titânio Preto",
+  "Blue Titanium": "Titânio Azul",
+  "Desert Titanium": "Titânio Deserto",
+  "Natural Titanium": "Titânio Natural",
+  "White Titanium": "Titânio Branco",
+  "Natural": "Titânio Natural",
 };
 
 export function corParaPT(corEN: string | null | undefined): string {


### PR DESCRIPTION
…tadas

- lib/cor-pt.ts: mapa EN→PT simplificado (Sky Blue/Mist Blue→Azul, etc)
- estoque: remove traços do nome, chip sai do preview, cor traduzida no modal
- estoque: cards de lacrados mostram cores do catálogo com 0x quando esgotadas
- catalogo: UI mostra EN + PT lado a lado para cores
- api/catalogo: novo param all_configs=1 para buscar todas cores por modelo
- 15+ páginas admin: wrap de display com corParaPT()