### PR TITLE
Cores PT/EN, modal editável e filtro por Linha iPhones

### DIFF
--- a/app/admin/catalogo/page.tsx
+++ b/app/admin/catalogo/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState, useCallback } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
-import { corParaPT } from "@/lib/cor-pt";
+import { corParaPT, corParaEN } from "@/lib/cor-pt";
 
 // Traduz valores de specs em inglês pra português no display (não altera o banco).
 // A chave continua sendo a string original, então selecionar/comparar funciona igual.
@@ -49,14 +49,20 @@ const COR_PT: Record<string, string> = {
 };
 
 function traduzirValor(valor: string, tipoChave?: string): string {
-  // Para cores: mostra EN + PT simplificado lado a lado, ex: "Sky Blue  Azul"
-  if (tipoChave === "cores") {
-    const pt = corParaPT(valor);
-    if (pt && pt !== valor && pt !== "—") return `${valor}  ${pt}`;
-    return valor;
-  }
   const pt = COR_PT[valor.toLowerCase().trim()];
   return pt || valor;
+}
+
+/** Para tipos de cor: retorna { en, pt } para renderizar EN principal + PT cinza */
+function corEnPt(valor: string): { en: string; pt: string | null } {
+  const en = corParaEN(valor) || valor;
+  const pt = corParaPT(valor);
+  if (!pt || pt === "—" || pt.toLowerCase() === en.toLowerCase()) return { en, pt: null };
+  return { en, pt };
+}
+
+function isCorTipo(chave?: string): boolean {
+  return chave === "cores" || chave === "cores_aw";
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -918,7 +924,9 @@ function ModelosTab({ data, headers, reload }: TabProps) {
                               >
                                 {checked && <div className="w-2 h-2 rounded-full bg-white" />}
                               </div>
-                              <span className="text-sm text-[#1D1D1F]">{traduzirValor(v.valor, cs.tipo_chave)}</span>
+                              <span className="text-sm text-[#1D1D1F]">
+                                {isCorTipo(cs.tipo_chave) ? (() => { const { en, pt } = corEnPt(v.valor); return <>{en}{pt && <span className="ml-1 text-xs text-[#86868B]">{pt}</span>}</>; })() : traduzirValor(v.valor, cs.tipo_chave)}
+                              </span>
                             </label>
                           );
                         })}
@@ -1169,7 +1177,9 @@ function EspecificacoesTab({ data, headers, reload }: TabProps) {
                     key={v.id}
                     className="flex items-center gap-1 px-3 py-1 rounded-full bg-[#F5F5F7] text-sm text-[#1D1D1F] border border-[#E8E8ED]"
                   >
-                    <span>{traduzirValor(v.valor, selectedTipo.chave)}</span>
+                    <span>
+                      {isCorTipo(selectedTipo.chave) ? (() => { const { en, pt } = corEnPt(v.valor); return <>{en}{pt && <span className="ml-1 text-xs text-[#86868B]">{pt}</span>}</>; })() : traduzirValor(v.valor, selectedTipo.chave)}
+                    </span>
                     <button
                       onClick={() => handleDeleteValor(v.id)}
                       disabled={saving === v.id}

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -5635,18 +5635,61 @@ export default function EstoquePage() {
                   const limpo = obs.replace(/\[[^\]]*\]/g, "").trim();
                   if (limpo) push("Observação", limpo);
                 }
-                if (rows.length === 0) return null;
+                if (rows.length === 0 && !(canEdit && isAdmin)) return null;
+                // Helper para reescrever tag no observacao
+                const setTag = async (tagName: string, value: string | null) => {
+                  let newObs = (p.observacao || "").replace(new RegExp(`\\[${tagName}:[^\\]]*\\]`, "g"), "").trim();
+                  if (value && value.trim()) newObs = `${newObs} [${tagName}:${value.trim()}]`.trim();
+                  await apiPatch(p.id, { observacao: newObs });
+                  setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, observacao: newObs } : x));
+                  setDetailProduct({ ...p, observacao: newObs });
+                  showSaved("spec");
+                };
+                const editableTags: { label: string; tag: string; current: string }[] = [];
+                if (baseCat === "MACBOOK" || baseCat === "IPADS") editableTags.push({ label: "Tamanho (tela)", tag: "TELA", current: tela || "" });
+                if (baseCat === "MACBOOK" || baseCat === "MAC_MINI") {
+                  editableTags.push({ label: "RAM", tag: "RAM", current: ram || "" });
+                  editableTags.push({ label: "SSD", tag: "SSD", current: ssd || "" });
+                  editableTags.push({ label: "CPU (núcleos)", tag: "CPU", current: cpu || "" });
+                  editableTags.push({ label: "GPU (núcleos)", tag: "GPU", current: gpu || "" });
+                  editableTags.push({ label: "Ciclos de bateria", tag: "CICLOS", current: ciclos || "" });
+                }
+                if (baseCat === "APPLE_WATCH") {
+                  editableTags.push({ label: "Modelo da pulseira", tag: "BAND", current: band || "" });
+                  editableTags.push({ label: "Tamanho da pulseira", tag: "PULSEIRA_TAM", current: pulseiraTam || "" });
+                }
                 return (
                   <div className={`mx-4 mt-3 p-4 rounded-xl border ${mSec}`}>
                     <p className={`text-xs font-bold ${mP} mb-3`}>Especificações</p>
-                    <div className="grid grid-cols-2 gap-3">
-                      {rows.map(([label, value]) => (
-                        <div key={label}>
-                          <p className={`text-[10px] uppercase tracking-wider ${mS}`}>{label}</p>
-                          <p className={`text-[13px] font-bold mt-0.5 ${mP}`}>{value}</p>
+                    {rows.length > 0 && (
+                      <div className="grid grid-cols-2 gap-3">
+                        {rows.map(([label, value]) => (
+                          <div key={label}>
+                            <p className={`text-[10px] uppercase tracking-wider ${mS}`}>{label}</p>
+                            <p className={`text-[13px] font-bold mt-0.5 ${mP}`}>{value}</p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                    {canEdit && isAdmin && editableTags.length > 0 && (
+                      <>
+                        <p className={`text-[10px] uppercase tracking-wider mt-4 mb-2 ${mS}`}>Editar (admin)</p>
+                        <div className="grid grid-cols-2 gap-3">
+                          {editableTags.map(({ label, tag, current }) => (
+                            <div key={tag}>
+                              <p className={`text-[10px] uppercase tracking-wider ${mS}`}>{label}</p>
+                              <input
+                                defaultValue={current}
+                                placeholder="—"
+                                onBlur={(e) => { const v = e.target.value.trim(); if (v !== current) setTag(tag, v || null); }}
+                                onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+                                className={`w-full text-[13px] font-bold mt-0.5 px-2 py-1 rounded-lg border ${dm ? "bg-[#1C1C1E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"} focus:border-[#E8740E] focus:outline-none`}
+                              />
+                            </div>
+                          ))}
                         </div>
-                      ))}
-                    </div>
+                      </>
+                    )}
                   </div>
                 );
               })()}

--- a/app/admin/gastos/page.tsx
+++ b/app/admin/gastos/page.tsx
@@ -9,7 +9,7 @@ import { useTabParam } from "@/lib/useTabParam";
 import type { Gasto, Banco } from "@/lib/admin-types";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 import { STRUCTURED_CATS, buildProdutoName, IPHONE_ORIGENS, DEFAULT_SPEC, type ProdutoSpec } from "@/lib/produto-specs";
-import { corParaPT } from "@/lib/cor-pt";
+import { corParaPT, corParaEN } from "@/lib/cor-pt";
 
 /** Converte string BR (ex: "12.250,89" ou "128,89") para número */
 const parseBR = (v: string): number => {
@@ -490,7 +490,17 @@ function ProdutosVinculados({ pedidoFornecedorId, password, dm, fornecedores }: 
                         const corUp = corLimpa.toUpperCase();
                         const aliases = COLOR_ALIASES[corUp] || [corUp];
                         const corJaNoNome = corUp && aliases.some(a => new RegExp(`\\b${a}\\b`).test(nomeUp));
-                        return `${nomeLimpo}${corLimpa && !corJaNoNome ? ` — ${corParaPT(corLimpa)}` : ""}`;
+                        const ptSimples = corLimpa ? corParaPT(corLimpa) : "";
+                        const enOrig = corLimpa ? corParaEN(corLimpa) : null;
+                        return (
+                          <>
+                            {nomeLimpo}
+                            {corLimpa && !corJaNoNome && ptSimples && <> — {ptSimples}</>}
+                            {enOrig && ptSimples && enOrig.toLowerCase() !== ptSimples.toLowerCase() && (
+                              <span className={`ml-1 text-[11px] font-normal ${dm ? "text-[#8E8E93]" : "text-[#86868B]"}`}>{enOrig}</span>
+                            )}
+                          </>
+                        );
                       })()}{(() => {
                         const origem = getOrigemFromObs(p.observacao);
                         if (!origem) return "";

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -215,6 +215,7 @@ export default function ProdutoSpecFields({
   const [clienteSuggestions, setClienteSuggestions] = useState<string[]>([]);
   const [clienteLoading, setClienteLoading] = useState(false);
   const [showClienteSugg, setShowClienteSugg] = useState(false);
+  const [linhaFiltro, setLinhaFiltro] = useState<string>("");
   const clienteDebounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Fetch all catalog models once
@@ -407,8 +408,36 @@ export default function ProdutoSpecFields({
             {CATEGORIAS.map((c) => <option key={c} value={c}>{CAT_LABELS[c] || c}</option>)}
           </select>
         </div>
+        {/* Linha (só iPhones) — filtro para reduzir lista de modelos */}
+        {row.categoria === "IPHONES" && categoryModelos.length > 0 && (() => {
+          const linhas = Array.from(new Set(
+            categoryModelos
+              .map((m) => { const mm = m.nome.match(/iPhone\s*(\d+\s*e?|SE)/i); return mm ? mm[1].replace(/\s+/g, "").toUpperCase() : null; })
+              .filter((x): x is string => !!x)
+          )).sort((a, b) => {
+            if (a === "SE") return 1; if (b === "SE") return -1;
+            return parseInt(a) - parseInt(b);
+          });
+          return (
+            <div>
+              <p className={labelCls}>Linha</p>
+              <select value={linhaFiltro} onChange={(e) => setLinhaFiltro(e.target.value)} className={inputCls}>
+                <option value="">— Todas —</option>
+                {linhas.map((l) => <option key={l} value={l}>{l === "SE" ? "iPhone SE" : `iPhone ${l}`}</option>)}
+              </select>
+            </div>
+          );
+        })()}
         {/* Modelo — vem logo após categoria */}
-        {categoryModelos.length > 0 && (
+        {categoryModelos.length > 0 && (() => {
+          const modelosFiltrados = row.categoria === "IPHONES" && linhaFiltro
+            ? categoryModelos.filter((m) => {
+                const mm = m.nome.match(/iPhone\s*(\d+\s*e?|SE)/i);
+                const l = mm ? mm[1].replace(/\s+/g, "").toUpperCase() : "";
+                return l === linhaFiltro;
+              })
+            : categoryModelos;
+          return (
           <div>
             <p className={labelCls}>
               Modelo
@@ -423,10 +452,11 @@ export default function ProdutoSpecFields({
               className={inputCls}
             >
               <option value="">— Selecionar modelo —</option>
-              {categoryModelos.map((m) => <option key={m.id} value={m.id}>{m.nome}</option>)}
+              {modelosFiltrados.map((m) => <option key={m.id} value={m.id}>{m.nome}</option>)}
             </select>
           </div>
-        )}
+          );
+        })()}
         {!compactMode && <div>
           <p className={labelCls}>Condição</p>
           <select value={row.condicao || "NOVO"} onChange={(e) => set("condicao", e.target.value)} className={inputCls}>

--- a/lib/cor-pt.ts
+++ b/lib/cor-pt.ts
@@ -81,3 +81,23 @@ export function corParaPT(corEN: string | null | undefined): string {
   // Fallback: retorna o original
   return trimmed;
 }
+
+/** Retorna a cor em inglês canônico (ex: "Sky Blue", "Teal", "Lavender"). */
+export function corParaEN(cor: string | null | undefined): string | null {
+  if (!cor) return null;
+  const trimmed = cor.trim();
+  if (!trimmed || trimmed === "—") return null;
+  // Já em EN canônico?
+  for (const en of Object.keys(COR_EN_TO_PT_SIMPLES)) {
+    if (en.toLowerCase() === trimmed.toLowerCase()) return en;
+  }
+  // PT → EN canônico
+  const en = COR_PT_TO_EN[trimmed.toUpperCase()];
+  if (en) {
+    for (const k of Object.keys(COR_EN_TO_PT_SIMPLES)) {
+      if (k.toLowerCase() === en.toLowerCase()) return k;
+    }
+    return en;
+  }
+  return trimmed.charAt(0).toUpperCase() + trimmed.slice(1).toLowerCase();
+}


### PR DESCRIPTION
## Summary
- Cores: PT simplificado como principal, EN canônico em cinza (estoque, gastos, catálogo)
- Lacrados mostram cores esgotadas como 0x no resumo do card
- Chip de MacBook/Mac Mini sai do preview e vai para o modal
- Modal do estoque: nova seção "Editar (admin)" para RAM, SSD, CPU, GPU, tela, ciclos, pulseira (MacBook/iPad/Mac Mini/Apple Watch)
- ProdutoSpecFields: novo filtro "Linha" para iPhones (reduz lista de modelos)

## Test plan
- [ ] Abrir /admin/estoque: cards de lacrados mostram cores com 0x
- [ ] Modal do MacBook mostra chip em Especificações
- [ ] Seção "Editar (admin)" salva RAM/SSD/CPU/GPU corretamente
- [ ] /admin/gastos nome de produto tem PT + EN cinza
- [ ] /admin/catalogo tab Cores e Cores AW mostram EN principal + PT cinza
- [ ] Form de entrada de iPhone: seleciona Linha → lista de modelos filtra