### PR TITLE
fix: 16e em linha 16 + PT principal no catálogo + edição de cores

### DIFF
--- a/app/admin/catalogo/page.tsx
+++ b/app/admin/catalogo/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState, useCallback } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
-import { corParaPT, corParaEN } from "@/lib/cor-pt";
+import { corParaPT, corParaEN, setCorPTOverride } from "@/lib/cor-pt";
 
 // Traduz valores de specs em inglês pra português no display (não altera o banco).
 // A chave continua sendo a string original, então selecionar/comparar funciona igual.
@@ -53,12 +53,11 @@ function traduzirValor(valor: string, tipoChave?: string): string {
   return pt || valor;
 }
 
-/** Para tipos de cor: retorna { en, pt } para renderizar EN principal + PT cinza */
-function corEnPt(valor: string): { en: string; pt: string | null } {
+/** Para tipos de cor: retorna { en, pt } — PT é principal, EN canônico secundário */
+function corEnPt(valor: string): { en: string; pt: string } {
   const en = corParaEN(valor) || valor;
   const pt = corParaPT(valor);
-  if (!pt || pt === "—" || pt.toLowerCase() === en.toLowerCase()) return { en, pt: null };
-  return { en, pt };
+  return { en, pt: pt === "—" ? valor : pt };
 }
 
 function isCorTipo(chave?: string): boolean {
@@ -925,7 +924,7 @@ function ModelosTab({ data, headers, reload }: TabProps) {
                                 {checked && <div className="w-2 h-2 rounded-full bg-white" />}
                               </div>
                               <span className="text-sm text-[#1D1D1F]">
-                                {isCorTipo(cs.tipo_chave) ? (() => { const { en, pt } = corEnPt(v.valor); return <>{en}{pt && <span className="ml-1 text-xs text-[#86868B]">{pt}</span>}</>; })() : traduzirValor(v.valor, cs.tipo_chave)}
+                                {isCorTipo(cs.tipo_chave) ? (() => { const { en, pt } = corEnPt(v.valor); return <>{pt}<span className="ml-1 text-xs text-[#86868B]">{en}</span></>; })() : traduzirValor(v.valor, cs.tipo_chave)}
                               </span>
                             </label>
                           );
@@ -1178,7 +1177,22 @@ function EspecificacoesTab({ data, headers, reload }: TabProps) {
                     className="flex items-center gap-1 px-3 py-1 rounded-full bg-[#F5F5F7] text-sm text-[#1D1D1F] border border-[#E8E8ED]"
                   >
                     <span>
-                      {isCorTipo(selectedTipo.chave) ? (() => { const { en, pt } = corEnPt(v.valor); return <>{en}{pt && <span className="ml-1 text-xs text-[#86868B]">{pt}</span>}</>; })() : traduzirValor(v.valor, selectedTipo.chave)}
+                      {isCorTipo(selectedTipo.chave) ? (() => {
+                        const { en, pt } = corEnPt(v.valor);
+                        return (
+                          <>
+                            <span
+                              className="cursor-pointer hover:text-[#E8740E]"
+                              title="Clique para editar o nome em português"
+                              onClick={() => {
+                                const novoPT = prompt(`Nome em português para "${en}":`, pt);
+                                if (novoPT !== null) { setCorPTOverride(en, novoPT.trim()); reload(); }
+                              }}
+                            >{pt}</span>
+                            <span className="ml-1 text-xs text-[#86868B]">{en}</span>
+                          </>
+                        );
+                      })() : traduzirValor(v.valor, selectedTipo.chave)}
                     </span>
                     <button
                       onClick={() => handleDeleteValor(v.id)}

--- a/app/admin/gastos/page.tsx
+++ b/app/admin/gastos/page.tsx
@@ -9,7 +9,7 @@ import { useTabParam } from "@/lib/useTabParam";
 import type { Gasto, Banco } from "@/lib/admin-types";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 import { STRUCTURED_CATS, buildProdutoName, IPHONE_ORIGENS, DEFAULT_SPEC, type ProdutoSpec } from "@/lib/produto-specs";
-import { corParaPT, corParaEN } from "@/lib/cor-pt";
+import { corParaPT, corParaEN, normalizarCoresNoTexto } from "@/lib/cor-pt";
 
 /** Converte string BR (ex: "12.250,89" ou "128,89") para número */
 const parseBR = (v: string): number => {
@@ -484,7 +484,7 @@ function ProdutosVinculados({ pedidoFornecedorId, password, dm, fornecedores }: 
                           YELLOW: ["YELLOW", "AMARELO"], AMARELO: ["YELLOW", "AMARELO"],
                           ORANGE: ["ORANGE", "LARANJA"], LARANJA: ["ORANGE", "LARANJA"],
                         };
-                        const nomeLimpo = (p.produto || "").replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim();
+                        const nomeLimpo = normalizarCoresNoTexto((p.produto || "").replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim());
                         const corLimpa = (p.cor || "").replace(/\[[^\]]*\]/g, "").trim();
                         const nomeUp = nomeLimpo.toUpperCase();
                         const corUp = corLimpa.toUpperCase();

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -408,12 +408,16 @@ export default function ProdutoSpecFields({
             {CATEGORIAS.map((c) => <option key={c} value={c}>{CAT_LABELS[c] || c}</option>)}
           </select>
         </div>
-        {/* Linha (só iPhones) — filtro para reduzir lista de modelos */}
+        {/* Linha (só iPhones) — filtro para reduzir lista de modelos.
+            Base é o número (ou SE), variantes "e"/"Plus"/"Pro"/"Pro Max" pertencem à mesma linha. */}
         {row.categoria === "IPHONES" && categoryModelos.length > 0 && (() => {
+          const linhaOf = (nome: string): string | null => {
+            const m = nome.match(/iPhone\s*(SE|\d+)/i);
+            if (!m) return null;
+            return m[1].toUpperCase();
+          };
           const linhas = Array.from(new Set(
-            categoryModelos
-              .map((m) => { const mm = m.nome.match(/iPhone\s*(\d+\s*e?|SE)/i); return mm ? mm[1].replace(/\s+/g, "").toUpperCase() : null; })
-              .filter((x): x is string => !!x)
+            categoryModelos.map((m) => linhaOf(m.nome)).filter((x): x is string => !!x)
           )).sort((a, b) => {
             if (a === "SE") return 1; if (b === "SE") return -1;
             return parseInt(a) - parseInt(b);
@@ -430,12 +434,12 @@ export default function ProdutoSpecFields({
         })()}
         {/* Modelo — vem logo após categoria */}
         {categoryModelos.length > 0 && (() => {
+          const linhaOf = (nome: string): string | null => {
+            const m = nome.match(/iPhone\s*(SE|\d+)/i);
+            return m ? m[1].toUpperCase() : null;
+          };
           const modelosFiltrados = row.categoria === "IPHONES" && linhaFiltro
-            ? categoryModelos.filter((m) => {
-                const mm = m.nome.match(/iPhone\s*(\d+\s*e?|SE)/i);
-                const l = mm ? mm[1].replace(/\s+/g, "").toUpperCase() : "";
-                return l === linhaFiltro;
-              })
+            ? categoryModelos.filter((m) => linhaOf(m.nome) === linhaFiltro)
             : categoryModelos;
           return (
           <div>

--- a/lib/cor-pt.ts
+++ b/lib/cor-pt.ts
@@ -62,10 +62,28 @@ export const COR_EN_TO_PT_SIMPLES: Record<string, string> = {
   "Natural": "Titânio Natural",
 };
 
+const CUSTOM_KEY = "custom_cor_pt_v1";
+function getCustomOverrides(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  try { return JSON.parse(localStorage.getItem(CUSTOM_KEY) || "{}"); } catch { return {}; }
+}
+export function setCorPTOverride(enCanonico: string, pt: string) {
+  if (typeof window === "undefined") return;
+  const map = getCustomOverrides();
+  if (pt && pt.trim()) map[enCanonico.toLowerCase()] = pt.trim();
+  else delete map[enCanonico.toLowerCase()];
+  localStorage.setItem(CUSTOM_KEY, JSON.stringify(map));
+  try { window.dispatchEvent(new Event("cor-pt-updated")); } catch {}
+}
+
 export function corParaPT(corEN: string | null | undefined): string {
   if (!corEN) return "—";
   const trimmed = corEN.trim();
   if (!trimmed || trimmed === "—") return "—";
+  // Override customizado (localStorage)
+  const overrides = getCustomOverrides();
+  const ovr = overrides[trimmed.toLowerCase()];
+  if (ovr) return ovr;
   // Tenta match exato (case-insensitive) EN → PT simples
   for (const [en, pt] of Object.entries(COR_EN_TO_PT_SIMPLES)) {
     if (en.toLowerCase() === trimmed.toLowerCase()) return pt;
@@ -80,6 +98,19 @@ export function corParaPT(corEN: string | null | undefined): string {
   }
   // Fallback: retorna o original
   return trimmed;
+}
+
+/** Substitui qualquer cor em inglês conhecida dentro de um texto pela versão PT simplificada. */
+export function normalizarCoresNoTexto(texto: string): string {
+  if (!texto) return texto;
+  let out = texto;
+  // Ordena por tamanho desc para evitar match parcial (ex: "Rose Gold" antes de "Gold")
+  const entries = Object.entries(COR_EN_TO_PT_SIMPLES).sort((a, b) => b[0].length - a[0].length);
+  for (const [en, pt] of entries) {
+    const re = new RegExp(`\\b${en.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "gi");
+    out = out.replace(re, pt);
+  }
+  return out;
 }
 
 /** Retorna a cor em inglês canônico (ex: "Sky Blue", "Teal", "Lavender"). */


### PR DESCRIPTION
Ajustes pedidos: iPhone 16e agrupa com linha 16; cores no catálogo mostram PT primeiro e EN cinza; PT clicável para editar (localStorage, sincroniza sistema); gastos normaliza cores embutidas no nome.