### PR TITLE
feat(catalogo): aba global Cores com edit inline EN+PT

### DIFF
--- a/app/admin/catalogo/page.tsx
+++ b/app/admin/catalogo/page.tsx
@@ -118,7 +118,7 @@ interface CatalogoData {
   categoriaSpecs: CategoriaSpec[];
 }
 
-type TabKey = "categorias" | "modelos" | "especificacoes";
+type TabKey = "categorias" | "modelos" | "especificacoes" | "cores";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -214,6 +214,9 @@ export default function CatalogoPage() {
           <button className={tabCls("especificacoes")} onClick={() => setTab("especificacoes")}>
             Especificações
           </button>
+          <button className={tabCls("cores")} onClick={() => setTab("cores")}>
+            🎨 Cores
+          </button>
         </div>
 
         {/* Tab content */}
@@ -225,6 +228,9 @@ export default function CatalogoPage() {
         )}
         {tab === "especificacoes" && (
           <EspecificacoesTab data={data} setData={setData} headers={headers} reload={load} />
+        )}
+        {tab === "cores" && (
+          <CoresGlobalTab data={data} headers={headers} reload={load} />
         )}
       </div>
     </div>
@@ -944,6 +950,296 @@ function ModelosTab({ data, headers, reload }: TabProps) {
 
 // ─── Especificacoes Tab ───────────────────────────────────────────────────────
 
+// ─── Cores Global Tab ─────────────────────────────────────────────────────────
+// UI dedicada para gerenciar Cores e Cores AW.
+// Permite editar tanto o nome em INGLÊS (canônico, salvo no banco em
+// catalogo_spec_valores) quanto o nome em PORTUGUÊS (override via
+// setCorPTOverride → localStorage). Add / Edit / Remove inline.
+function CoresGlobalTab({
+  data,
+  headers,
+  reload,
+}: {
+  data: CatalogoData;
+  headers: () => Record<string, string>;
+  reload: () => void;
+}) {
+  type Grupo = { chave: "cores" | "cores_aw"; titulo: string; subtitulo: string };
+  const grupos: Grupo[] = [
+    { chave: "cores", titulo: "Cores (geral)", subtitulo: "iPhone, iPad, MacBook, Mac Mini, AirPods…" },
+    { chave: "cores_aw", titulo: "Cores AW", subtitulo: "Apple Watch (cores específicas)" },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-[#FFF5EB] border border-[#E8740E]/20 rounded-xl p-4 text-sm text-[#1D1D1F]">
+        <strong className="text-[#E8740E]">Como funciona:</strong> O nome em <em>inglês</em> é o
+        canônico salvo no banco — usado em todo o sistema para identificar a cor. O nome em{" "}
+        <em>português</em> é apenas o rótulo de exibição (override local). Edite os dois lados livremente;
+        a sincronização acontece automaticamente em todas as telas (estoque, gastos, vendas, etc.).
+      </div>
+
+      {grupos.map((g) => (
+        <CoresGrupo key={g.chave} grupo={g} data={data} headers={headers} reload={reload} />
+      ))}
+    </div>
+  );
+}
+
+function CoresGrupo({
+  grupo,
+  data,
+  headers,
+  reload,
+}: {
+  grupo: { chave: "cores" | "cores_aw"; titulo: string; subtitulo: string };
+  data: CatalogoData;
+  headers: () => Record<string, string>;
+  reload: () => void;
+}) {
+  const valores = data.specValores
+    .filter((v) => v.tipo_chave === grupo.chave)
+    .sort((a, b) => a.ordem - b.ordem);
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editEN, setEditEN] = useState("");
+  const [editPT, setEditPT] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [newEN, setNewEN] = useState("");
+  const [newPT, setNewPT] = useState("");
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const inputCls =
+    "border border-[#E8E8ED] rounded-lg px-2.5 py-1.5 text-sm text-[#1D1D1F] bg-white focus:outline-none focus:ring-2 focus:ring-[#E8740E]/40";
+
+  function startEdit(v: SpecValor) {
+    const en = corParaEN(v.valor) || v.valor;
+    const pt = corParaPT(v.valor);
+    setEditingId(v.id);
+    setEditEN(en);
+    setEditPT(pt === "—" ? "" : pt);
+  }
+  function cancelEdit() {
+    setEditingId(null);
+    setEditEN("");
+    setEditPT("");
+  }
+
+  async function saveEdit(v: SpecValor) {
+    const en = editEN.trim();
+    const pt = editPT.trim();
+    if (!en) return alert("O nome em inglês é obrigatório.");
+    setBusy(v.id);
+    try {
+      // 1) Renomeia EN canônico no banco se mudou
+      if (en !== v.valor) {
+        const res = await fetch(BASE, {
+          method: "PATCH",
+          headers: headers(),
+          body: JSON.stringify({ resource: "spec_valores", id: v.id, valor: en }),
+        });
+        const json = await res.json();
+        if (json.error) throw new Error(json.error);
+      }
+      // 2) Atualiza override em PT
+      setCorPTOverride(en, pt);
+      cancelEdit();
+      reload();
+    } catch (e) {
+      alert(String(e));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function addCor(e: React.FormEvent) {
+    e.preventDefault();
+    const en = newEN.trim();
+    const pt = newPT.trim();
+    if (!en) return;
+    setBusy("__add__");
+    try {
+      const ordem = valores.length > 0 ? Math.max(...valores.map((v) => v.ordem)) + 1 : 1;
+      const res = await fetch(BASE, {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({
+          resource: "spec_valores",
+          tipo_chave: grupo.chave,
+          valor: en,
+          ordem,
+        }),
+      });
+      const json = await res.json();
+      if (json.error) throw new Error(json.error);
+      if (pt) setCorPTOverride(en, pt);
+      setNewEN("");
+      setNewPT("");
+      setAdding(false);
+      reload();
+    } catch (err) {
+      alert(String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function removeCor(v: SpecValor) {
+    if (!confirm(`Remover a cor "${corParaPT(v.valor)} (${v.valor})"?`)) return;
+    setBusy(v.id);
+    try {
+      const res = await fetch(BASE, {
+        method: "DELETE",
+        headers: headers(),
+        body: JSON.stringify({ resource: "spec_valores", id: v.id }),
+      });
+      const json = await res.json();
+      if (json.error) throw new Error(json.error);
+      reload();
+    } catch (err) {
+      alert(String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+      <div className="p-4 border-b border-[#F5F5F7] flex items-center justify-between">
+        <div>
+          <h2 className="font-semibold text-[#1D1D1F]">{grupo.titulo}</h2>
+          <p className="text-xs text-[#86868B] mt-0.5">{grupo.subtitulo} · {valores.length} cores</p>
+        </div>
+        <button
+          onClick={() => setAdding((a) => !a)}
+          className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D] transition-colors"
+        >
+          {adding ? "Cancelar" : "+ Nova cor"}
+        </button>
+      </div>
+
+      {adding && (
+        <form
+          onSubmit={addCor}
+          className="p-4 bg-[#FFF5EB] border-b border-[#E8740E]/20 grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-2 items-end"
+        >
+          <div>
+            <label className="block text-[11px] font-semibold text-[#6E6E73] mb-1">
+              Nome em INGLÊS (canônico)
+            </label>
+            <input
+              value={newEN}
+              onChange={(e) => setNewEN(e.target.value)}
+              placeholder="ex: Sky Blue"
+              className={`${inputCls} w-full`}
+              required
+              autoFocus
+            />
+          </div>
+          <div>
+            <label className="block text-[11px] font-semibold text-[#6E6E73] mb-1">
+              Nome em PORTUGUÊS (exibição)
+            </label>
+            <input
+              value={newPT}
+              onChange={(e) => setNewPT(e.target.value)}
+              placeholder="ex: Azul"
+              className={`${inputCls} w-full`}
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={busy === "__add__" || !newEN.trim()}
+            className="px-4 py-2 rounded-lg text-sm font-semibold bg-[#E8740E] text-white disabled:opacity-50"
+          >
+            Salvar
+          </button>
+        </form>
+      )}
+
+      {valores.length === 0 ? (
+        <div className="p-6 text-center text-[#86868B] text-sm">
+          Nenhuma cor cadastrada ainda. Clique em <strong>+ Nova cor</strong>.
+        </div>
+      ) : (
+        <div className="divide-y divide-[#F5F5F7]">
+          {valores.map((v) => {
+            const isEditing = editingId === v.id;
+            const en = corParaEN(v.valor) || v.valor;
+            const pt = corParaPT(v.valor);
+            const ptDisp = pt === "—" ? "" : pt;
+            return (
+              <div key={v.id} className="px-4 py-3">
+                {isEditing ? (
+                  <div className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto_auto] gap-2 items-end">
+                    <div>
+                      <label className="block text-[11px] font-semibold text-[#6E6E73] mb-1">
+                        Inglês (canônico)
+                      </label>
+                      <input
+                        value={editEN}
+                        onChange={(e) => setEditEN(e.target.value)}
+                        className={`${inputCls} w-full`}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-[11px] font-semibold text-[#6E6E73] mb-1">
+                        Português (exibição)
+                      </label>
+                      <input
+                        value={editPT}
+                        onChange={(e) => setEditPT(e.target.value)}
+                        className={`${inputCls} w-full`}
+                      />
+                    </div>
+                    <button
+                      onClick={() => saveEdit(v)}
+                      disabled={busy === v.id}
+                      className="px-3 py-2 rounded-lg text-xs font-semibold bg-[#E8740E] text-white disabled:opacity-50"
+                    >
+                      Salvar
+                    </button>
+                    <button
+                      onClick={cancelEdit}
+                      className="px-3 py-2 rounded-lg text-xs font-semibold bg-[#F5F5F7] text-[#1D1D1F]"
+                    >
+                      Cancelar
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="text-sm font-semibold text-[#1D1D1F] truncate">
+                        {ptDisp || <span className="text-[#86868B] italic">sem PT</span>}
+                      </div>
+                      <div className="text-xs text-[#86868B] truncate font-mono">{en}</div>
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      <button
+                        onClick={() => startEdit(v)}
+                        className="px-2.5 py-1 rounded-lg text-xs font-semibold text-[#E8740E] hover:bg-[#FFF5EB] transition-colors"
+                      >
+                        ✎ Editar
+                      </button>
+                      <button
+                        onClick={() => removeCor(v)}
+                        disabled={busy === v.id}
+                        className="px-2.5 py-1 rounded-lg text-xs font-semibold text-red-500 hover:bg-red-50 transition-colors disabled:opacity-50"
+                      >
+                        🗑️ Remover
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function EspecificacoesTab({ data, headers, reload }: TabProps) {
   const [selectedTipo, setSelectedTipo] = useState<SpecTipo | null>(null);
   const [newTipoForm, setNewTipoForm] = useState(false);
@@ -1108,7 +1404,7 @@ function EspecificacoesTab({ data, headers, reload }: TabProps) {
           )}
 
           <div className="divide-y divide-[#F5F5F7]">
-            {data.specTipos.map((tipo) => (
+            {data.specTipos.filter((t) => !isCorTipo(t.chave)).map((tipo) => (
               <div
                 key={tipo.id}
                 className={`flex items-center justify-between px-4 py-3 transition-colors ${

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -4224,14 +4224,9 @@ export default function EstoquePage() {
                                         <td className={`px-3 py-2.5 text-[14px] font-medium ${textPrimary}`}>
                                           {(() => {
                                             if (!p.cor) return "—";
-                                            const upper = p.cor.toUpperCase().trim();
-                                            const en = PT_TO_EN[upper];
-                                            const ptFromMap = COR_PT[upper];
-                                            const ptCustom = CUSTOM_COR_PT[upper];
-                                            if (ptCustom) return <>{p.cor}<span className={`ml-1 text-[12px] ${textSecondary}`}>{ptCustom}</span></>;
-                                            if (en) return <>{en.charAt(0).toUpperCase() + en.slice(1).toLowerCase()}<span className={`ml-1 text-[12px] ${textSecondary}`}>{p.cor.charAt(0).toUpperCase() + p.cor.slice(1).toLowerCase()}</span></>;
-                                            if (ptFromMap && ptFromMap.toLowerCase() !== p.cor.toLowerCase()) return <>{p.cor}<span className={`ml-1 text-[12px] ${textSecondary}`}>{ptFromMap}</span></>;
-                                            return p.cor;
+                                            const pt = corParaPT(p.cor);
+                                            const en = corEnOriginal(p.cor);
+                                            return <>{pt}{en && en.toLowerCase() !== pt.toLowerCase() && <span className={`ml-1 text-[12px] ${textSecondary}`}>{en}</span>}</>;
                                           })()}
                                         </td>
                                         <td className={`px-3 py-2.5 text-right`}>

--- a/app/admin/gastos/page.tsx
+++ b/app/admin/gastos/page.tsx
@@ -10,6 +10,7 @@ import type { Gasto, Banco } from "@/lib/admin-types";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 import { STRUCTURED_CATS, buildProdutoName, IPHONE_ORIGENS, DEFAULT_SPEC, type ProdutoSpec } from "@/lib/produto-specs";
 import { corParaPT, corParaEN, normalizarCoresNoTexto } from "@/lib/cor-pt";
+import { formatProdutoDisplay } from "@/lib/produto-display";
 
 /** Converte string BR (ex: "12.250,89" ou "128,89") para número */
 const parseBR = (v: string): number => {
@@ -470,38 +471,14 @@ function ProdutosVinculados({ pedidoFornecedorId, password, dm, fornecedores }: 
                       return null;
                     })()}
                     <span className={`font-medium truncate ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>
+                      {formatProdutoDisplay({ produto: p.produto, categoria: p.categoria, cor: p.cor, observacao: p.observacao })}
                       {(() => {
-                        const COLOR_ALIASES: Record<string, string[]> = {
-                          BLACK: ["BLACK", "PRETO"], PRETO: ["BLACK", "PRETO"],
-                          BLUE: ["BLUE", "AZUL"], AZUL: ["BLUE", "AZUL"],
-                          WHITE: ["WHITE", "BRANCO"], BRANCO: ["WHITE", "BRANCO"],
-                          GOLD: ["GOLD", "DOURADO"], DOURADO: ["GOLD", "DOURADO"],
-                          SILVER: ["SILVER", "PRATA"], PRATA: ["SILVER", "PRATA"],
-                          GREEN: ["GREEN", "VERDE"], VERDE: ["GREEN", "VERDE"],
-                          PURPLE: ["PURPLE", "ROXO"], ROXO: ["PURPLE", "ROXO"],
-                          PINK: ["PINK", "ROSA"], ROSA: ["PINK", "ROSA"],
-                          RED: ["RED", "VERMELHO"], VERMELHO: ["RED", "VERMELHO"],
-                          YELLOW: ["YELLOW", "AMARELO"], AMARELO: ["YELLOW", "AMARELO"],
-                          ORANGE: ["ORANGE", "LARANJA"], LARANJA: ["ORANGE", "LARANJA"],
-                        };
-                        const nomeLimpo = normalizarCoresNoTexto((p.produto || "").replace(/\[[^\]]*\]/g, "").replace(/\s+/g, " ").trim());
-                        const corLimpa = (p.cor || "").replace(/\[[^\]]*\]/g, "").trim();
-                        const nomeUp = nomeLimpo.toUpperCase();
-                        const corUp = corLimpa.toUpperCase();
-                        const aliases = COLOR_ALIASES[corUp] || [corUp];
-                        const corJaNoNome = corUp && aliases.some(a => new RegExp(`\\b${a}\\b`).test(nomeUp));
-                        const ptSimples = corLimpa ? corParaPT(corLimpa) : "";
-                        const enOrig = corLimpa ? corParaEN(corLimpa) : null;
-                        return (
-                          <>
-                            {nomeLimpo}
-                            {corLimpa && !corJaNoNome && ptSimples && <> — {ptSimples}</>}
-                            {enOrig && ptSimples && enOrig.toLowerCase() !== ptSimples.toLowerCase() && (
-                              <span className={`ml-1 text-[11px] font-normal ${dm ? "text-[#8E8E93]" : "text-[#86868B]"}`}>{enOrig}</span>
-                            )}
-                          </>
-                        );
-                      })()}{(() => {
+                        const en = p.cor ? corParaEN(p.cor) : null;
+                        const pt = p.cor ? corParaPT(p.cor) : "";
+                        if (!en || !pt || en.toLowerCase() === pt.toLowerCase()) return null;
+                        return <span className={`ml-1 text-[11px] font-normal ${dm ? "text-[#8E8E93]" : "text-[#86868B]"}`}>{en}</span>;
+                      })()}
+                      {(() => {
                         const origem = getOrigemFromObs(p.observacao);
                         if (!origem) return "";
                         const code = origem.split(" ")[0];

--- a/lib/produto-display.ts
+++ b/lib/produto-display.ts
@@ -1,0 +1,117 @@
+import { corParaPT } from "./cor-pt";
+
+const STRUCTURED = ["IPHONES", "MACBOOK", "MAC_MINI", "IPADS", "APPLE_WATCH", "AIRPODS", "SEMINOVOS"];
+
+function getBaseCat(cat: string): string {
+  if (cat === "SEMINOVOS") return "IPHONES";
+  if (STRUCTURED.includes(cat)) return cat;
+  const sorted = [...STRUCTURED].sort((a, b) => b.length - a.length);
+  for (const base of sorted) {
+    if (cat.startsWith(base + "_") || cat.startsWith(base)) return base;
+  }
+  return cat;
+}
+
+export function cleanProdutoDisplay(nome: string | null | undefined): string {
+  if (!nome) return "";
+  let s = String(nome);
+  s = s.replace(/\s*\((LL|JPA|HN|IN|BR|BZ|CH|ZA|KH|TH|SG)\)\s*/gi, " ");
+  s = s.replace(/\s*[-–]\s*CHIP\s*F[IÍ]SICO[^[]*$/i, "");
+  s = s.replace(/\s*\+?\s*E[-\s]?SIM\b.*$/i, "");
+  s = s.replace(/\s*CHIP\s*F[IÍ]SICO\b.*$/i, "");
+  s = s.replace(/\s+(LL|JPA|HN|IN|BR|BZ|CH|ZA|KH|TH|SG)\b.*$/i, "");
+  s = s.replace(/\[[^\]]*\]/g, "");
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/** Formata o nome do produto para exibição (PT simplificado). Compartilhado entre estoque, gastos e etc. */
+export function formatProdutoDisplay(p: {
+  produto?: string | null;
+  categoria?: string | null;
+  cor?: string | null;
+  observacao?: string | null;
+}): string {
+  const nomeRaw = String(p.produto || "");
+  const obs = String(p.observacao || "");
+  const src = `${nomeRaw} ${obs}`;
+  const up = src.toUpperCase();
+  const baseCat = getBaseCat(p.categoria || "IPHONES");
+  const corRaw = (p.cor || "").trim();
+  const cor = corRaw ? corParaPT(corRaw) : "";
+
+  const memMatches = [...up.matchAll(/(\d+)\s*(GB|TB)/g)];
+  const mems = memMatches.map(m => ({ raw: `${m[1]}${m[2]}`, gb: m[2] === "TB" ? parseInt(m[1]) * 1024 : parseInt(m[1]) }));
+  const sorted = [...mems].sort((a, b) => b.gb - a.gb);
+  const storage = sorted[0]?.raw || "";
+  const ramTag = obs.match(/\[RAM:([^\]]+)\]/);
+  let ram = ramTag ? ramTag[1].trim().toUpperCase() : "";
+  if (!ram && sorted.length >= 2) ram = sorted[sorted.length - 1].raw;
+  const ssdTag = obs.match(/\[SSD:([^\]]+)\]/);
+  const ssd = ssdTag ? ssdTag[1].trim().toUpperCase() : storage;
+  const telaTag = obs.match(/\[TELA:([^\]]+)\]/);
+  const telaNome = up.match(/\b(11|13|14|15|16)["”]/);
+  const tela = telaTag ? telaTag[1].trim().replace(/"?$/, '"') : (telaNome ? `${telaNome[1]}"` : "");
+  const mmMatch = up.match(/(\d{2})\s*MM/);
+  const tamMm = mmMatch ? `${mmMatch[1]}mm` : "";
+  const hasCell = /\+\s*CEL|CELLULAR|\+CELL|GPS\s*\+\s*CEL|\bCEL\b/.test(up);
+  const hasGps = /\bGPS\b/.test(up);
+  const hasWifi = /WI-?FI|WIFI/.test(up);
+
+  const parts: string[] = [];
+
+  if (baseCat === "IPHONES") {
+    const m = up.match(/IPHONE\s*(\d+E?)\s*(PRO\s*MAX|PRO|PLUS|AIR)?/);
+    const modelo = m
+      ? `iPhone ${m[1].replace(/E$/, "e")}${m[2] ? " " + m[2].replace(/\s+/g, " ").replace(/\bPRO MAX\b/, "Pro Max").replace(/\bPRO\b/, "Pro").replace(/\bPLUS\b/, "Plus").replace(/\bAIR\b/, "Air") : ""}`
+      : cleanProdutoDisplay(nomeRaw);
+    parts.push(modelo);
+    if (storage) parts.push(storage);
+    if (cor) parts.push(cor);
+  } else if (baseCat === "IPADS") {
+    const chipM = up.match(/(M\d+(?:\s*(?:PRO|MAX))?|A\d+(?:\s*PRO)?)/);
+    const chip = chipM ? " " + chipM[1].replace(/\s+/g, " ").toUpperCase() : "";
+    let modelo = "iPad";
+    if (/MINI/.test(up)) modelo = "iPad Mini";
+    else if (/AIR/.test(up)) modelo = "iPad Air";
+    else if (/PRO/.test(up)) modelo = "iPad Pro";
+    parts.push(modelo + chip);
+    if (tela) parts.push(tela);
+    if (storage) parts.push(storage);
+    if (cor) parts.push(cor);
+    if (hasCell) parts.push("Wi-Fi + Cellular");
+    else if (hasWifi) parts.push("Wi-Fi");
+  } else if (baseCat === "MACBOOK") {
+    let modelo = "MacBook";
+    if (/NEO/.test(up)) modelo = "MacBook Neo";
+    else if (/AIR/.test(up)) modelo = "MacBook Air";
+    else if (/PRO/.test(up)) modelo = "MacBook Pro";
+    parts.push(modelo);
+    if (tela) parts.push(tela);
+    if (ram) parts.push(ram);
+    if (ssd) parts.push(ssd);
+    if (cor) parts.push(cor);
+  } else if (baseCat === "MAC_MINI") {
+    parts.push("Mac Mini");
+    if (ram) parts.push(ram);
+    if (ssd) parts.push(ssd);
+    if (cor) parts.push(cor);
+  } else if (baseCat === "APPLE_WATCH") {
+    let modelo = "Apple Watch";
+    const ultra = up.match(/ULTRA\s*(\d+)?/);
+    const se = up.match(/\bSE\s*(\d+)?/);
+    const series = up.match(/(?:SERIES\s*|\bS)(\d+)/);
+    if (ultra) modelo = `Apple Watch Ultra${ultra[1] ? " " + ultra[1] : ""}`;
+    else if (se) modelo = `Apple Watch SE${se[1] ? " " + se[1] : ""}`;
+    else if (series) modelo = `Apple Watch Series ${series[1]}`;
+    parts.push(modelo);
+    if (tamMm) parts.push(tamMm);
+    if (ultra) parts.push("GPS + Cellular");
+    else if (hasCell) parts.push("GPS + Cellular");
+    else if (hasGps) parts.push("GPS");
+    if (cor) parts.push(cor);
+  } else {
+    return cleanProdutoDisplay(nomeRaw);
+  }
+
+  return parts.filter(Boolean).join(" ");
+}


### PR DESCRIPTION
## Summary
- Nova aba **🎨 Cores** em `/admin/catalogo` agrupa Cores e Cores AW
- Adicionar/editar/remover cor editando **EN canônico** (banco) e **PT de exibição** (override) — sincroniza em todo o sistema
- Removidos os tipos de cor da aba Especificações pra evitar duplicação

🤖 Generated with [Claude Code](https://claude.com/claude-code)