### PR TITLE
fix: estoque 16e, contrato PDF, autocomplete clientes e mais

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -437,11 +437,34 @@ export default function EntregasPage() {
             <div className="flex items-center gap-3">
               <h2 className="text-sm font-bold text-[#1D1D1F]">{editingEntregaId ? "✏️ Editar Entrega" : modoSimples ? "📮 Nova Entrega Simplificada (Correios / externa)" : "Agendar Nova Entrega"}</h2>
               {editingEntregaId && <button onClick={() => { setEditingEntregaId(null); setForm({ ...emptyForm, data_entrega: hojeBR() }); setProdutos([""]); setTrocaAtiva(false); setTrocaValor(""); setTrocaProduto(""); setDesconto(""); }} className="text-xs text-red-500 hover:underline">Cancelar edição</button>}
+              <button
+                type="button"
+                onClick={() => {
+                  if (!confirm("Limpar todos os dados do formulário?")) return;
+                  setEditingEntregaId(null);
+                  setForm({ ...emptyForm, data_entrega: hojeBR() });
+                  setProdutos([""]);
+                  setTrocaAtiva(false);
+                  setTrocaValor("");
+                  setTrocaProduto("");
+                  setDesconto("");
+                  setMsg("");
+                }}
+                className="text-xs px-3 py-1.5 rounded-lg border border-red-300 text-red-600 hover:bg-red-50"
+              >
+                🗑️ Limpar formulário
+              </button>
             </div>
             <button
               onClick={async () => {
                 try {
-                  const text = await navigator.clipboard.readText();
+                  let text = "";
+                  try {
+                    text = await navigator.clipboard.readText();
+                  } catch {
+                    const manual = window.prompt("Cole aqui os dados do cliente (Ctrl+V / Cmd+V):", "");
+                    text = manual || "";
+                  }
                   if (!text || text.length < 10) { setMsg("Nada no clipboard. Copie a mensagem do WhatsApp primeiro."); return; }
                   const lines = text.split("\n").map(l => l.trim());
                   const extract = (line: string) => line.replace(/^[✅⚠️📌🤔🔄💰📋🏷️🎯]*\s*/g, "").replace(/^[^:：]+[:：]\s*/, "").trim();

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -659,8 +659,13 @@ function getModeloBase(produto: string, categoria: string): string {
   const getSize = () => { const m = p.match(/(\d{2})[""]/); return m ? ` ${m[1]}"` : ""; };
 
   if (baseCat === "IPHONES") {
-    const match = p.match(/IPHONE\s*(\d+)\s*(PRO\s*MAX|PRO|PLUS|AIR)?/i);
-    if (match) return `iPhone ${match[1]}${match[2] ? " " + match[2].trim() : ""}${getMem()}`;
+    // Captura "16", "16e", "16 Pro", "16 Pro Max", "16 Plus", "16 Air"
+    const match = p.match(/IPHONE\s*(\d+)(E)?\s*(PRO\s*MAX|PRO|PLUS|AIR)?/i);
+    if (match) {
+      const num = match[1] + (match[2] ? "e" : "");
+      const variant = match[3] ? " " + match[3].trim() : "";
+      return `iPhone ${num}${variant}${getMem()}`;
+    }
     return produto;
   }
   if (baseCat === "IPADS") {

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -138,6 +138,34 @@ export default function GerarLinkPage() {
   const [parseMsg, setParseMsg] = useState("");
   const [simulacaoId, setSimulacaoId] = useState<string | null>(null);
 
+  // Autocomplete de clientes cadastrados
+  type CliSug = { nome: string; telefone: string | null; cpf: string | null; email: string | null; endereco: string | null; bairro: string | null; cidade: string | null; uf: string | null };
+  const [cliSugs, setCliSugs] = useState<CliSug[]>([]);
+  const [showCliSugs, setShowCliSugs] = useState(false);
+  useEffect(() => {
+    const q = cliNome.trim();
+    if (q.length < 2) { setCliSugs([]); return; }
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/admin/link-compras?autocomplete=1&q=${encodeURIComponent(q)}`, { headers: adminHeaders() });
+        const j = await res.json();
+        if (Array.isArray(j?.clientes)) setCliSugs(j.clientes);
+      } catch {}
+    }, 250);
+    return () => clearTimeout(t);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cliNome]);
+  const aplicarCliente = (c: CliSug) => {
+    setCliNome(c.nome || "");
+    if (c.telefone) setCliTelefone(c.telefone);
+    if (c.cpf) setCliCpf(c.cpf);
+    if (c.email) setCliEmail(c.email);
+    if (c.endereco) setCliEndereco(c.endereco);
+    if (c.bairro) setCliBairro(c.bairro);
+    setIncluirDadosCliente(true);
+    setShowCliSugs(false);
+  };
+
   // Prefill via query string (vindo de /admin/simulacoes)
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -980,9 +1008,36 @@ export default function GerarLinkPage() {
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div className="sm:col-span-2">
+                <div className="sm:col-span-2 relative">
                   <label className={labelCls}>Nome completo</label>
-                  <input type="text" value={cliNome} onChange={(e) => setCliNome(e.target.value)} placeholder="João da Silva" className={inputCls} />
+                  <input
+                    type="text"
+                    value={cliNome}
+                    onChange={(e) => { setCliNome(e.target.value); setShowCliSugs(true); }}
+                    onFocus={() => setShowCliSugs(true)}
+                    onBlur={() => setTimeout(() => setShowCliSugs(false), 200)}
+                    placeholder="Digite 2+ letras para buscar cliente cadastrado…"
+                    className={inputCls}
+                  />
+                  {showCliSugs && cliSugs.length > 0 && (
+                    <div className={`absolute z-20 mt-1 w-full max-h-64 overflow-y-auto rounded-xl border shadow-lg ${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-white border-[#D2D2D7]"}`}>
+                      {cliSugs.map((c, i) => (
+                        <button
+                          key={i}
+                          type="button"
+                          onMouseDown={(e) => { e.preventDefault(); aplicarCliente(c); }}
+                          className={`w-full text-left px-3 py-2 text-sm ${dm ? "hover:bg-[#2C2C2E] text-[#F5F5F7]" : "hover:bg-[#F5F5F7] text-[#1D1D1F]"} border-b ${dm ? "border-[#3A3A3C]" : "border-[#E5E5EA]"} last:border-0`}
+                        >
+                          <div className="font-semibold">{c.nome}</div>
+                          <div className="text-[11px] text-[#8E8E93] flex gap-2 flex-wrap">
+                            {c.telefone && <span>📞 {c.telefone}</span>}
+                            {c.cpf && <span>CPF {c.cpf}</span>}
+                            {c.email && <span>✉️ {c.email}</span>}
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </div>
                 <div>
                   <label className={labelCls}>CPF</label>

--- a/app/admin/saldos/page.tsx
+++ b/app/admin/saldos/page.tsx
@@ -137,7 +137,11 @@ export default function SaldosPage() {
       "3": { key: "MERCADO_PAGO", label: "Mercado Pago" },
     };
     const bancoSel = bancoMap[bancoRaw.trim()] || bancoMap["1"];
-    if (!confirm(`Depositar R$ ${toDisplayBR(String(valorDep))} de Espécie no ${bancoSel.label}?`)) return;
+    // Pergunta a data do depósito (default = dataAtual)
+    const dataRaw = window.prompt(`Data do depósito (YYYY-MM-DD):`, dataAtual);
+    if (dataRaw === null) return;
+    const dataDep = dataRaw.trim().match(/^\d{4}-\d{2}-\d{2}$/) ? dataRaw.trim() : dataAtual;
+    if (!confirm(`Depositar R$ ${toDisplayBR(String(valorDep))} de Espécie no ${bancoSel.label} em ${dataDep}?`)) return;
 
     setDepositando(true);
     setMsg("");
@@ -151,7 +155,7 @@ export default function SaldosPage() {
           "x-admin-user": encodeURIComponent(user?.nome || "sistema"),
         },
         body: JSON.stringify({
-          data: dataAtual,
+          data: dataDep,
           tipo: "SAIDA",
           categoria: "TRANSFERENCIA",
           descricao: `Depósito espécie → ${bancoSel.label}`,

--- a/app/api/admin/link-compras/route.ts
+++ b/app/api/admin/link-compras/route.ts
@@ -19,7 +19,67 @@ export async function GET(request: Request) {
 
   const url = new URL(request.url);
   const q = (url.searchParams.get("q") || "").trim();
+  const autocomplete = url.searchParams.get("autocomplete") === "1";
   const tipo = url.searchParams.get("tipo") || "";
+
+  // Autocomplete de clientes cadastrados (vendas + link_compras + entregas)
+  if (autocomplete) {
+    if (!q || q.length < 2) return NextResponse.json({ clientes: [] });
+    const like = `%${q}%`;
+
+    // 1) vendas: nome, cpf, email, endereço
+    const [vRes, lRes, eRes] = await Promise.all([
+      supabase.from("vendas")
+        .select("cliente, cpf, cnpj, email, endereco, bairro, cidade, uf, data")
+        .or(`cliente.ilike.${like},cpf.ilike.${like},email.ilike.${like}`)
+        .order("data", { ascending: false })
+        .limit(100),
+      supabase.from("link_compras")
+        .select("cliente_nome, cliente_telefone, cliente_cpf, cliente_email, created_at")
+        .or(`cliente_nome.ilike.${like},cliente_telefone.ilike.${like},cliente_cpf.ilike.${like}`)
+        .order("created_at", { ascending: false })
+        .limit(100),
+      supabase.from("entregas")
+        .select("cliente, telefone, endereco, bairro, created_at")
+        .or(`cliente.ilike.${like},telefone.ilike.${like}`)
+        .order("created_at", { ascending: false })
+        .limit(100),
+    ]);
+
+    type Cli = { nome: string; telefone: string | null; cpf: string | null; email: string | null; endereco: string | null; bairro: string | null; cidade: string | null; uf: string | null };
+    const map = new Map<string, Cli>();
+    const keyOf = (nome: string, cpf: string | null, tel: string | null) =>
+      `${(nome || "").toLowerCase().trim()}|${(cpf || "").replace(/\D/g, "")}|${(tel || "").replace(/\D/g, "")}`;
+    const mergeInto = (c: Cli) => {
+      const k = keyOf(c.nome, c.cpf, c.telefone);
+      const ex = map.get(k);
+      if (!ex) { map.set(k, c); return; }
+      ex.telefone = ex.telefone || c.telefone;
+      ex.cpf = ex.cpf || c.cpf;
+      ex.email = ex.email || c.email;
+      ex.endereco = ex.endereco || c.endereco;
+      ex.bairro = ex.bairro || c.bairro;
+      ex.cidade = ex.cidade || c.cidade;
+      ex.uf = ex.uf || c.uf;
+    };
+
+    for (const v of vRes.data || []) {
+      if (!v.cliente) continue;
+      mergeInto({ nome: v.cliente, telefone: null, cpf: v.cpf || null, email: v.email || null, endereco: v.endereco || null, bairro: v.bairro || null, cidade: v.cidade || null, uf: v.uf || null });
+    }
+    for (const l of lRes.data || []) {
+      if (!l.cliente_nome) continue;
+      mergeInto({ nome: l.cliente_nome, telefone: l.cliente_telefone || null, cpf: l.cliente_cpf || null, email: l.cliente_email || null, endereco: null, bairro: null, cidade: null, uf: null });
+    }
+    for (const e of eRes.data || []) {
+      if (!e.cliente) continue;
+      mergeInto({ nome: e.cliente, telefone: e.telefone || null, cpf: null, email: null, endereco: e.endereco || null, bairro: e.bairro || null, cidade: null, uf: null });
+    }
+
+    const clientes = Array.from(map.values()).slice(0, 20);
+    return NextResponse.json({ clientes });
+  }
+
   const arquivado = url.searchParams.get("arquivado") || "0";
   const from = url.searchParams.get("from") || "";
   const to = url.searchParams.get("to") || "";

--- a/components/StepUsedDevice.tsx
+++ b/components/StepUsedDevice.tsx
@@ -82,8 +82,9 @@ export default function StepUsedDevice({ usedValues, excludedModels, modelDiscou
     if (!model) return [];
     const norm = (s: string) => s.toUpperCase().replace(/\s+/g, " ").trim();
     const nm = norm(model);
+    // Somente match EXATO — evita "iPhone 15" casar com "iPhone 15 Pro"
     for (const [k, v] of Object.entries(catalogCores)) {
-      if (norm(k) === nm || nm.includes(norm(k)) || norm(k).includes(nm)) return v;
+      if (norm(k) === nm) return v;
     }
     return [];
   }, [model, catalogCores]);

--- a/lib/pdf-encomenda.ts
+++ b/lib/pdf-encomenda.ts
@@ -126,9 +126,10 @@ export async function gerarContratoEncomendaPDF(dados: ContratoEncomendaData): P
     }
 
     function campo(label: string, valor: string) {
+      if (!valor || !String(valor).trim()) return; // não renderiza label sem valor
       doc.fontSize(10).fillColor("#222222");
       doc.font("Helvetica-Bold").text(`${label}: `, { continued: true });
-      doc.font("Helvetica").text(valor, { lineGap: 2 });
+      doc.font("Helvetica").text(String(valor), { lineGap: 2 });
       doc.moveDown(0.2);
     }
 
@@ -137,7 +138,7 @@ export async function gerarContratoEncomendaPDF(dados: ContratoEncomendaData): P
     doc.text("CONTRATO PARTICULAR DE PRESTAÇÃO", { align: "center" });
     doc.text("DE SERVIÇO DE", { align: "center" });
     doc.fontSize(12).font("Helvetica").fillColor("#444444");
-    doc.text("INTERMEDIAÇÃO DE NEGÓCIOS (ENCOMENDA COM TROCA)", { align: "center" });
+    doc.text(`INTERMEDIAÇÃO DE NEGÓCIOS (ENCOMENDA${dados.temTroca ? " COM TROCA" : ""})`, { align: "center" });
     doc.moveDown(0.5);
     linha();
 

--- a/supabase/migrations/20260407_link_compras.sql
+++ b/supabase/migrations/20260407_link_compras.sql
@@ -41,3 +41,8 @@ CREATE INDEX IF NOT EXISTS idx_link_compras_cliente_cpf ON link_compras(cliente_
 CREATE INDEX IF NOT EXISTS idx_link_compras_short_code ON link_compras(short_code);
 CREATE INDEX IF NOT EXISTS idx_link_compras_tipo ON link_compras(tipo);
 CREATE INDEX IF NOT EXISTS idx_link_compras_arquivado ON link_compras(arquivado) WHERE arquivado = FALSE;
+
+-- RLS: libera acesso (API valida via x-admin-password antes)
+ALTER TABLE link_compras ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS link_compras_all ON link_compras;
+CREATE POLICY link_compras_all ON link_compras FOR ALL USING (true) WITH CHECK (true);


### PR DESCRIPTION
## Summary
- estoque/getModeloBase: regex suporta iPhone 16e
- StepUsedDevice: cores case-insensitive + match exato de modelo
- pdf-encomenda: labels vazios + título condicional
- saldos: prompt data depósito
- link-compras: autocomplete clientes (API + UI)
- entregas: fallback clipboard + limpar formulário
- link_compras RLS policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)