### PR TITLE
feat(admin): reposição fonte única, edição de link, fluxo de entrega …

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -798,12 +798,29 @@ export default function EstoquePage() {
   const [detailModelConfigs, setDetailModelConfigs] = useState<Record<string, string[]>>({});
   // Mapa completo modelo → [cores EN] do catálogo (usado na reposição)
   const [catalogoCoresMap, setCatalogoCoresMap] = useState<Record<string, string[]>>({});
+  const [catalogoCatByModel, setCatalogoCatByModel] = useState<Record<string, string>>({});
   useEffect(() => {
     fetch("/api/catalogo-cores")
       .then(r => r.json())
-      .then(j => { if (j?.modelos) setCatalogoCoresMap(j.modelos); })
+      .then(j => {
+        if (j?.modelos) setCatalogoCoresMap(j.modelos);
+        if (j?.categorias) setCatalogoCatByModel(j.categorias);
+      })
       .catch(() => {});
   }, []);
+  // Modelos ocultos da reposição (controle do usuário, localStorage)
+  const [reposicaoOcultos, setReposicaoOcultos] = useState<Set<string>>(() => {
+    try { return new Set(JSON.parse(localStorage.getItem("tigrao_reposicao_ocultos") || "[]")); } catch { return new Set(); }
+  });
+  const toggleReposicaoOculto = (nomeModelo: string) => {
+    setReposicaoOcultos(prev => {
+      const next = new Set(prev);
+      if (next.has(nomeModelo)) next.delete(nomeModelo); else next.add(nomeModelo);
+      localStorage.setItem("tigrao_reposicao_ocultos", JSON.stringify([...next]));
+      return next;
+    });
+  };
+  const [showReposicaoConfig, setShowReposicaoConfig] = useState(false);
   const [savedField, setSavedField] = useState<string | null>(null);
   const showSaved = (field: string) => { setSavedField(field); setTimeout(() => setSavedField(null), 1800); };
   const [editingDetailSerial, setEditingDetailSerial] = useState(false);
@@ -2875,75 +2892,90 @@ export default function EstoquePage() {
 
         const catOrder = ["IPHONES", "IPADS", "MACBOOK", "MAC_MINI", "APPLE_WATCH", "AIRPODS", "ACESSORIOS"];
 
-        // Agrupar novos por modelo_base+cor → {totalQnt, min, jaCaminho, corDisplay}
+        // === FONTE ÚNICA: catalogo_modelo_configs ===
+        // Lógica invertida: iterar catálogo como base, contar estoque por cor.
+        // Cores que não estão no catálogo NÃO aparecem (mesmo se existirem no estoque com lixo histórico).
         type RepoGroup = { totalQnt: number; min: number; corEN: string; corPT: string; corDisplay: string; jaCaminho: boolean; falta: number };
         const byCatModel: Record<string, Record<string, RepoGroup[]>> = {};
 
-        for (const p of novos) {
-          const cat = p.categoria || "OUTROS";
-          // Usar getModeloBase (mesma função do Lacrados) para consistência de agrupamento
-          const base = getModeloBase(p.produto, p.categoria).toUpperCase();
-          // Usar p.cor como chave primária (mesma cor para BLUE e BLUE WI-FI)
-          const cor = p.cor || extractCor(stripOrigemRepo(p.produto), null);
-          const corKey = (cor || "—").toUpperCase();
-          // Bilíngue: EN (PT) — mesmo padrão do resto do sistema
-          const corUpper = (cor || "").toUpperCase().trim();
-          const ptFromEN = COR_PT[corUpper]; // se cor é EN → pega PT
-          const enFromPT = PT_TO_EN[corUpper]; // se cor é PT → pega EN
-          let corEN = cor || "—";
-          let corPT = "";
-          if (ptFromEN) { corEN = cor!; corPT = ptFromEN; }
-          else if (enFromPT) { corEN = enFromPT; corPT = cor!; }
-          const corPTCap = corPT ? corPT.charAt(0).toUpperCase() + corPT.slice(1).toLowerCase() : "";
-          const corDisplay = corPTCap && corPT.toLowerCase() !== corEN.toLowerCase()
-            ? `${corPTCap} · ${corEN.toUpperCase()}`
-            : (corPTCap || cor || "—");
-
-          if (!byCatModel[cat]) byCatModel[cat] = {};
-          if (!byCatModel[cat][base]) byCatModel[cat][base] = [];
-
-          const existing = byCatModel[cat][base].find(c => c.corEN.toUpperCase() === corEN.toUpperCase() || (c.corDisplay || "—").toUpperCase() === corKey);
-          if (existing) {
-            existing.totalQnt += p.qnt;
-            if (typeof p.estoque_minimo === "number" && p.estoque_minimo > 0) existing.min = p.estoque_minimo;
-          } else {
-            byCatModel[cat][base].push({
-              totalQnt: p.qnt,
-              min: (typeof p.estoque_minimo === "number" && p.estoque_minimo > 0) ? p.estoque_minimo : 0,
-              corEN, corPT, corDisplay,
-              jaCaminho: produtosACaminho.has(p.produto.toUpperCase()),
-              falta: 0,
-            });
-          }
-        }
-
-        // Enriquecer com cores do catálogo que ainda não estão no estoque.
-        // Match: strip storage do base → procura no catalogoCoresMap por match exato (case-insensitive).
         const stripStorageBase = (b: string) => b.replace(/\b\d+\s*(GB|TB)\b/gi, "").replace(/\s+/g, " ").trim();
         const normCmp = (s: string) => s.toLowerCase().replace(/\s+/g, " ").trim();
-        for (const [, models] of Object.entries(byCatModel)) {
-          for (const [base, cores] of Object.entries(models)) {
-            const baseSemStorage = normCmp(stripStorageBase(base));
-            let catCores: string[] | null = null;
-            for (const [nomeCat, lista] of Object.entries(catalogoCoresMap)) {
-              if (normCmp(nomeCat) === baseSemStorage) { catCores = lista; break; }
-            }
-            if (!catCores || catCores.length === 0) continue;
-            // Precisa de um estoque_minimo representativo pra esse modelo
-            const minGrupo = Math.max(0, ...cores.map(c => c.min || 0));
-            for (const corEN of catCores) {
-              const corPTnew = COR_PT[corEN.toUpperCase()] || "";
-              const jaExiste = cores.some(c =>
-                c.corEN.toUpperCase() === corEN.toUpperCase() ||
-                (corPTnew && c.corPT && c.corPT.toLowerCase() === corPTnew.toLowerCase())
-              );
-              if (jaExiste) continue;
-              cores.push({
-                totalQnt: 0,
-                min: minGrupo,
+
+        // Index por estoque: modelo_base_sem_storage → Map<corNormalizada, {qnt, min, storage}>
+        // Acumula estoque por storage tb pra podermos expandir uma linha por storage.
+        type EstIdx = { totalQnt: number; min: number; jaCaminho: boolean; storage: string };
+        const estoqueIdx = new Map<string, Map<string, EstIdx>>(); // baseSemStorage → storage → dados
+        const storagesPorModelo = new Map<string, Set<string>>(); // baseSemStorage → storages presentes
+        const minPorModelo = new Map<string, Map<string, Map<string, number>>>(); // base → storage → corNorm → min
+        const qntPorModelo = new Map<string, Map<string, Map<string, number>>>(); // base → storage → corNorm → qnt
+        const caminhoPorProduto = produtosACaminho;
+
+        const getStorage = (s: string) => { const m = s.match(/\b(\d+)\s*(GB|TB)\b/i); return m ? `${m[1]}${m[2].toUpperCase()}` : ""; };
+
+        for (const p of novos) {
+          const baseFull = getModeloBase(p.produto, p.categoria).toUpperCase();
+          const storage = getStorage(baseFull) || getStorage(p.produto) || "";
+          const baseSemStorage = normCmp(stripStorageBase(baseFull));
+          const corRaw = (p.cor || extractCor(stripOrigemRepo(p.produto), null) || "").toString();
+          const corUpper = corRaw.toUpperCase().trim();
+          // Normaliza para EN (para comparar com catálogo)
+          const enFromPT = PT_TO_EN[corUpper];
+          const corEN = enFromPT || corUpper;
+          const corNorm = corEN.toLowerCase();
+
+          if (!storagesPorModelo.has(baseSemStorage)) storagesPorModelo.set(baseSemStorage, new Set());
+          storagesPorModelo.get(baseSemStorage)!.add(storage);
+
+          if (!qntPorModelo.has(baseSemStorage)) qntPorModelo.set(baseSemStorage, new Map());
+          const qntStor = qntPorModelo.get(baseSemStorage)!;
+          if (!qntStor.has(storage)) qntStor.set(storage, new Map());
+          const qntCor = qntStor.get(storage)!;
+          qntCor.set(corNorm, (qntCor.get(corNorm) || 0) + p.qnt);
+
+          if (typeof p.estoque_minimo === "number" && p.estoque_minimo > 0) {
+            if (!minPorModelo.has(baseSemStorage)) minPorModelo.set(baseSemStorage, new Map());
+            const minStor = minPorModelo.get(baseSemStorage)!;
+            if (!minStor.has(storage)) minStor.set(storage, new Map());
+            const minCor = minStor.get(storage)!;
+            minCor.set(corNorm, Math.max(minCor.get(corNorm) || 0, p.estoque_minimo));
+          }
+        }
+        void estoqueIdx; void caminhoPorProduto;
+
+        // Iterar catálogo e construir grupos
+        for (const [nomeCat, coresCat] of Object.entries(catalogoCoresMap)) {
+          if (reposicaoOcultos.has(nomeCat)) continue;
+          if (!coresCat || coresCat.length === 0) continue;
+          const cat = catalogoCatByModel[nomeCat] || "OUTROS";
+          const baseSemStorage = normCmp(nomeCat);
+          const storages = storagesPorModelo.get(baseSemStorage);
+          // Se o modelo ainda não tem estoque nenhum, ainda assim mostra uma linha por storage padrão do próprio nome
+          const listaStorages = storages && storages.size > 0 ? [...storages] : [""];
+
+          for (const storage of listaStorages) {
+            const baseKey = (nomeCat + (storage ? ` ${storage}` : "")).toUpperCase();
+            if (!byCatModel[cat]) byCatModel[cat] = {};
+            if (!byCatModel[cat][baseKey]) byCatModel[cat][baseKey] = [];
+            const grupoAtual = byCatModel[cat][baseKey];
+            const qntCor = qntPorModelo.get(baseSemStorage)?.get(storage);
+            const minCor = minPorModelo.get(baseSemStorage)?.get(storage);
+            const minGrupoFallback = minCor ? Math.max(0, ...minCor.values()) : 0;
+
+            for (const corEN of coresCat) {
+              const corNorm = corEN.toLowerCase();
+              const corPT = COR_PT[corEN.toUpperCase()] || "";
+              const corPTCap = corPT ? corPT.charAt(0).toUpperCase() + corPT.slice(1).toLowerCase() : "";
+              const corDisplay = corPTCap || corEN;
+              const totalQnt = qntCor?.get(corNorm) || 0;
+              const min = (minCor?.get(corNorm)) || minGrupoFallback;
+              // já existe? (dedup)
+              if (grupoAtual.some(c => c.corEN.toUpperCase() === corEN.toUpperCase())) continue;
+              grupoAtual.push({
+                totalQnt,
+                min,
                 corEN,
-                corPT: corPTnew,
-                corDisplay: corPTnew || corEN,
+                corPT,
+                corDisplay,
                 jaCaminho: false,
                 falta: 0,
               });
@@ -3002,14 +3034,49 @@ export default function EstoquePage() {
                     {totalFalta > 0 ? `${totalFalta} unidades precisam ser compradas` : "Estoque OK!"}
                   </p>
                 </div>
-                {totalFalta > 0 && (
-                  <button onClick={() => { navigator.clipboard.writeText(buildCopyText()); setMsg("Lista copiada!"); }}
-                    className="px-4 py-2 rounded-xl text-xs font-semibold bg-[#E8740E] text-white hover:bg-[#F5A623] transition-colors">
-                    📋 Copiar Lista
+                <div className="flex items-center gap-2">
+                  <button onClick={() => setShowReposicaoConfig(true)}
+                    className={`px-3 py-2 rounded-xl text-xs font-semibold border transition-colors ${dm ? "border-[#3A3A3C] text-[#F5F5F7] hover:bg-[#2C2C2E]" : "border-[#D2D2D7] text-[#1D1D1F] hover:bg-[#F2F2F7]"}`}
+                    title="Controlar quais modelos aparecem na reposição">
+                    ⚙️ Modelos
                   </button>
-                )}
+                  {totalFalta > 0 && (
+                    <button onClick={() => { navigator.clipboard.writeText(buildCopyText()); setMsg("Lista copiada!"); }}
+                      className="px-4 py-2 rounded-xl text-xs font-semibold bg-[#E8740E] text-white hover:bg-[#F5A623] transition-colors">
+                      📋 Copiar Lista
+                    </button>
+                  )}
+                </div>
               </div>
             </div>
+
+            {showReposicaoConfig && (
+              <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4" onClick={() => setShowReposicaoConfig(false)}>
+                <div className={`${bgCard} border ${borderCard} rounded-2xl max-w-lg w-full max-h-[85vh] overflow-hidden flex flex-col shadow-2xl`} onClick={(e) => e.stopPropagation()}>
+                  <div className={`px-5 py-4 border-b ${borderCard} flex items-center justify-between`}>
+                    <div>
+                      <h3 className={`text-[15px] font-bold ${textPrimary}`}>Modelos na Reposição</h3>
+                      <p className={`text-[11px] ${textMuted} mt-0.5`}>Desmarque modelos que você não quer ver na lista de reposição.</p>
+                    </div>
+                    <button onClick={() => setShowReposicaoConfig(false)} className={`text-[18px] ${textSecondary} hover:text-red-500`}>✕</button>
+                  </div>
+                  <div className="overflow-y-auto p-4 space-y-1">
+                    {Object.entries(catalogoCoresMap)
+                      .sort(([a], [b]) => a.localeCompare(b))
+                      .map(([nome]) => {
+                        const oculto = reposicaoOcultos.has(nome);
+                        return (
+                          <label key={nome} className={`flex items-center gap-3 px-3 py-2 rounded-lg cursor-pointer ${dm ? "hover:bg-[#2C2C2E]" : "hover:bg-[#F9F9FB]"}`}>
+                            <input type="checkbox" checked={!oculto} onChange={() => toggleReposicaoOculto(nome)} className="w-4 h-4 accent-[#E8740E]" />
+                            <span className={`text-[13px] ${oculto ? textMuted : textPrimary} ${oculto ? "line-through" : ""}`}>{nome}</span>
+                            <span className={`ml-auto text-[10px] ${textMuted}`}>{catalogoCatByModel[nome] || ""}</span>
+                          </label>
+                        );
+                      })}
+                  </div>
+                </div>
+              </div>
+            )}
 
             {sortedCats.length === 0 ? (
               <div className={`${bgCard} border ${borderCard} rounded-2xl p-8 text-center`}>

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -149,23 +149,39 @@ export default function GerarLinkPage() {
   const [parseMsg, setParseMsg] = useState("");
   const [simulacaoId, setSimulacaoId] = useState<string | null>(null);
 
-  // Autocomplete de clientes cadastrados
+  // Autocomplete de clientes cadastrados — dispara por nome OU CPF
   type CliSug = { nome: string; telefone: string | null; cpf: string | null; email: string | null; endereco: string | null; bairro: string | null; cidade: string | null; uf: string | null };
   const [cliSugs, setCliSugs] = useState<CliSug[]>([]);
   const [showCliSugs, setShowCliSugs] = useState(false);
+  const [cliSugSource, setCliSugSource] = useState<"nome" | "cpf">("nome");
   useEffect(() => {
     const q = cliNome.trim();
-    if (q.length < 2) { setCliSugs([]); return; }
+    if (q.length < 2) { if (cliSugSource === "nome") setCliSugs([]); return; }
     const t = setTimeout(async () => {
       try {
         const res = await fetch(`/api/admin/link-compras?autocomplete=1&q=${encodeURIComponent(q)}`, { headers: adminHeaders() });
         const j = await res.json();
-        if (Array.isArray(j?.clientes)) setCliSugs(j.clientes);
+        if (Array.isArray(j?.clientes)) { setCliSugs(j.clientes); setCliSugSource("nome"); }
       } catch {}
     }, 250);
     return () => clearTimeout(t);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cliNome]);
+  useEffect(() => {
+    const q = cliCpf.replace(/\D/g, "");
+    if (q.length < 3) return;
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/admin/link-compras?autocomplete=1&q=${encodeURIComponent(q)}`, { headers: adminHeaders() });
+        const j = await res.json();
+        if (Array.isArray(j?.clientes) && j.clientes.length > 0) {
+          setCliSugs(j.clientes); setCliSugSource("cpf"); setShowCliSugs(true);
+        }
+      } catch {}
+    }, 300);
+    return () => clearTimeout(t);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cliCpf]);
   const aplicarCliente = (c: CliSug) => {
     setCliNome(c.nome || "");
     if (c.telefone) setCliTelefone(c.telefone);
@@ -206,13 +222,23 @@ export default function GerarLinkPage() {
     cliente_nome: string | null;
     cliente_telefone: string | null;
     cliente_cpf: string | null;
+    cliente_email: string | null;
     produto: string;
     cor: string | null;
     valor: number;
     forma_pagamento: string | null;
+    parcelas: string | null;
+    entrada: number;
     troca_produto: string | null;
     troca_valor: number;
+    troca_produto2: string | null;
+    troca_valor2: number;
     vendedor: string | null;
+    operador: string | null;
+    status: string | null;
+    cliente_dados_preenchidos: Record<string, unknown> | null;
+    cliente_preencheu_em: string | null;
+    entrega_id: string | null;
     arquivado: boolean;
     created_at: string;
   };
@@ -270,6 +296,79 @@ export default function GerarLinkPage() {
     try {
       await navigator.clipboard.writeText(url);
     } catch { /* ignore */ }
+  }
+
+  // === Editar link existente ===
+  const [editingLinkId, setEditingLinkId] = useState<string | null>(null);
+  const [viewDataLink, setViewDataLink] = useState<LinkCompra | null>(null);
+  const [encaminharLink, setEncaminharLink] = useState<LinkCompra | null>(null);
+  const [encaminharData, setEncaminharData] = useState("");
+  const [encaminharHorario, setEncaminharHorario] = useState("");
+  const [encaminharObs, setEncaminharObs] = useState("");
+
+  function editarLink(l: LinkCompra) {
+    reutilizarLink(l);
+    setEditingLinkId(l.id);
+    setPasteMsg(`✏️ Editando link ${l.short_code}. Ao clicar em "Gerar Link" as alterações serão salvas.`);
+  }
+
+  async function salvarEdicaoLink() {
+    if (!editingLinkId) return false;
+    const prodsFilled = produtos.filter(Boolean);
+    const nomeProdutoFinal = corSel ? `${prodsFilled[0]} ${corSel}` : (prodsFilled[0] || "");
+    try {
+      const res = await fetch("/api/admin/link-compras", {
+        method: "PATCH",
+        headers: adminHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          id: editingLinkId,
+          produto: nomeProdutoFinal,
+          cor: corSel || null,
+          valor: Number(rawPreco) || 0,
+          forma_pagamento: forma || null,
+          parcelas: parcelas || null,
+          entrada: Number(rawEntrada) || 0,
+          troca_produto: trocaProduto || null,
+          troca_valor: Number(trocaValor.replace(/\./g, "").replace(",", ".")) || 0,
+          troca_produto2: temSegundaTroca ? (trocaProduto2 || null) : null,
+          troca_valor2: temSegundaTroca ? (Number(trocaValor2.replace(/\./g, "").replace(",", ".")) || 0) : 0,
+          vendedor: vendedorNome || null,
+          cliente_nome: cliNome.trim() || null,
+          cliente_telefone: cliTelefone.trim() || null,
+          cliente_cpf: cliCpf.trim() || null,
+          cliente_email: cliEmail.trim() || null,
+        }),
+      });
+      if (!res.ok) { const j = await res.json().catch(() => ({})); setPasteMsg(`❌ Erro ao salvar: ${j.error || res.status}`); return false; }
+      setPasteMsg(`✅ Link ${editingLinkId.slice(0, 6)} atualizado.`);
+      setEditingLinkId(null);
+      return true;
+    } catch (e) {
+      setPasteMsg(`❌ Erro: ${String(e)}`);
+      return false;
+    }
+  }
+
+  async function encaminharParaEntrega() {
+    if (!encaminharLink || !encaminharData) return;
+    try {
+      const res = await fetch("/api/admin/link-compras/encaminhar-entrega", {
+        method: "POST",
+        headers: adminHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          link_id: encaminharLink.id,
+          data_entrega: encaminharData,
+          horario: encaminharHorario || null,
+          observacao: encaminharObs || null,
+        }),
+      });
+      const j = await res.json();
+      if (!res.ok) { alert("Erro: " + (j.error || res.status)); return; }
+      setEncaminharLink(null);
+      setEncaminharData(""); setEncaminharHorario(""); setEncaminharObs("");
+      fetchHistorico();
+      alert("✅ Entrega criada com sucesso!");
+    } catch (e) { alert("Erro: " + String(e)); }
   }
 
   function reutilizarLink(l: LinkCompra) {
@@ -386,8 +485,24 @@ export default function GerarLinkPage() {
   // WhatsApp por vendedor (centralizado em lib/whatsapp-config.ts)
 
   async function gerarLink() {
+    // Snapshot local — evita race com re-renders/setState que possam limpar produtos[0]
     const prodsFilled = produtos.filter(Boolean);
-    if (prodsFilled.length === 0) return;
+    if (prodsFilled.length === 0) {
+      setPasteMsg("⚠️ Selecione ao menos um produto antes de gerar o link.");
+      return;
+    }
+    const nomeProdutoFinal = corSel ? `${prodsFilled[0]} ${corSel}` : prodsFilled[0];
+    if (!nomeProdutoFinal || !nomeProdutoFinal.trim()) {
+      setPasteMsg("⚠️ Nome do produto vazio — selecione novamente.");
+      return;
+    }
+
+    // Modo edição: salva por cima e não cria short_code novo
+    if (editingLinkId) {
+      const ok = await salvarEdicaoLink();
+      if (ok) { setAba("historico"); fetchHistorico(); }
+      return;
+    }
 
     const whatsappDestino = getWhatsAppByVendedor(vendedorNome);
     const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
@@ -395,7 +510,7 @@ export default function GerarLinkPage() {
     // Montar dados com keys curtas
     const shortData: Record<string, string> = {};
     // Incluir cor no nome do produto se selecionada
-    shortData.p = corSel ? `${prodsFilled[0]} ${corSel}` : prodsFilled[0];
+    shortData.p = nomeProdutoFinal;
     for (let i = 1; i < prodsFilled.length; i++) {
       shortData[`p${i + 1}`] = prodsFilled[i];
     }
@@ -457,7 +572,7 @@ export default function GerarLinkPage() {
               cliente_telefone: cliTelefone.trim() || null,
               cliente_cpf: cliCpf.trim() || null,
               cliente_email: cliEmail.trim() || null,
-              produto: corSel ? `${prodsFilled[0]} ${corSel}` : prodsFilled[0],
+              produto: nomeProdutoFinal,
               produtos_extras: prodsFilled.length > 1 ? prodsFilled.slice(1) : null,
               cor: corSel || null,
               valor: Number(rawPreco) || 0,
@@ -621,6 +736,65 @@ export default function GerarLinkPage() {
 
   return (
     <div className="max-w-lg mx-auto space-y-4">
+      {/* Modal: Ver dados preenchidos pelo cliente */}
+      {viewDataLink && (
+        <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4" onClick={() => setViewDataLink(null)}>
+          <div className="bg-white rounded-2xl max-w-md w-full max-h-[85vh] overflow-hidden flex flex-col shadow-2xl" onClick={(e) => e.stopPropagation()}>
+            <div className="px-5 py-4 border-b border-[#E5E5EA] flex items-center justify-between">
+              <div>
+                <h3 className="text-sm font-bold text-[#1D1D1F]">Dados preenchidos pelo cliente</h3>
+                <p className="text-[11px] text-[#86868B] mt-0.5">Link {viewDataLink.short_code} · {viewDataLink.cliente_preencheu_em ? new Date(viewDataLink.cliente_preencheu_em).toLocaleString("pt-BR") : ""}</p>
+              </div>
+              <button onClick={() => setViewDataLink(null)} className="text-lg text-[#86868B] hover:text-red-500">✕</button>
+            </div>
+            <div className="overflow-y-auto p-4">
+              {viewDataLink.cliente_dados_preenchidos ? (
+                <dl className="space-y-2 text-xs">
+                  {Object.entries(viewDataLink.cliente_dados_preenchidos).map(([k, v]) => (
+                    <div key={k} className="flex gap-2 border-b border-[#F2F2F7] pb-1.5">
+                      <dt className="text-[#86868B] font-semibold min-w-[110px] capitalize">{k.replace(/_/g, " ")}:</dt>
+                      <dd className="text-[#1D1D1F] break-words">{String(v ?? "")}</dd>
+                    </div>
+                  ))}
+                </dl>
+              ) : (
+                <p className="text-xs text-[#86868B] text-center py-6">Cliente ainda não preencheu.</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Modal: Encaminhar pra entrega */}
+      {encaminharLink && (
+        <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4" onClick={() => setEncaminharLink(null)}>
+          <div className="bg-white rounded-2xl max-w-md w-full shadow-2xl" onClick={(e) => e.stopPropagation()}>
+            <div className="px-5 py-4 border-b border-[#E5E5EA] flex items-center justify-between">
+              <h3 className="text-sm font-bold text-[#1D1D1F]">Encaminhar para entrega</h3>
+              <button onClick={() => setEncaminharLink(null)} className="text-lg text-[#86868B] hover:text-red-500">✕</button>
+            </div>
+            <div className="p-4 space-y-3">
+              <p className="text-[11px] text-[#86868B]">Uma entrega será criada em /admin/entregas com os dados preenchidos pelo cliente.</p>
+              <div>
+                <label className="text-[11px] text-[#86868B] font-semibold">Data da entrega *</label>
+                <input type="date" value={encaminharData} onChange={(e) => setEncaminharData(e.target.value)} className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm mt-1" />
+              </div>
+              <div>
+                <label className="text-[11px] text-[#86868B] font-semibold">Horário (opcional)</label>
+                <input type="time" value={encaminharHorario} onChange={(e) => setEncaminharHorario(e.target.value)} className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm mt-1" />
+              </div>
+              <div>
+                <label className="text-[11px] text-[#86868B] font-semibold">Observação (opcional)</label>
+                <textarea value={encaminharObs} onChange={(e) => setEncaminharObs(e.target.value)} rows={2} className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm mt-1" />
+              </div>
+              <button onClick={encaminharParaEntrega} disabled={!encaminharData} className="w-full py-2.5 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 disabled:opacity-50">
+                Criar entrega
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <h1 className="text-xl font-bold text-[#1D1D1F]">Gerar Link de Compra</h1>
       <p className="text-sm text-[#86868B]">
         Gere um link pre-preenchido para enviar ao cliente. Ele completa os dados pessoais e envia direto pro WhatsApp da Bianca.
@@ -677,8 +851,19 @@ export default function GerarLinkPage() {
                       <span className="text-[10px] text-[#86868B]">
                         {new Date(l.created_at).toLocaleString("pt-BR", { day: "2-digit", month: "2-digit", year: "2-digit", hour: "2-digit", minute: "2-digit" })}
                       </span>
-                      {l.vendedor && <span className="text-[10px] text-[#86868B]">· {l.vendedor}</span>}
+                      {l.entrega_id ? (
+                        <span className="text-[10px] px-2 py-0.5 rounded-full font-bold bg-green-200 text-green-800">✅ Entrega criada</span>
+                      ) : l.cliente_preencheu_em ? (
+                        <span className="text-[10px] px-2 py-0.5 rounded-full font-bold bg-blue-200 text-blue-800">📝 Preenchido</span>
+                      ) : (
+                        <span className="text-[10px] px-2 py-0.5 rounded-full font-bold bg-gray-200 text-gray-700">⏳ Aguardando</span>
+                      )}
                     </div>
+                    <p className="text-[10px] text-[#86868B] mt-0.5">
+                      {l.operador ? <>Criado por <strong>{l.operador}</strong></> : null}
+                      {l.operador && l.vendedor ? " · " : null}
+                      {l.vendedor ? <>Vendedora <strong>{l.vendedor}</strong></> : null}
+                    </p>
                     <p className="text-sm font-semibold text-[#1D1D1F] mt-1">{l.produto}{l.cor ? ` — ${l.cor}` : ""}</p>
                     {l.valor > 0 && <p className="text-xs text-[#E8740E] font-bold">R$ {Number(l.valor).toLocaleString("pt-BR")}</p>}
                     {(l.cliente_nome || l.cliente_telefone) && (
@@ -705,6 +890,28 @@ export default function GerarLinkPage() {
                   >
                     ♻️ Reutilizar
                   </button>
+                  <button
+                    onClick={() => editarLink(l)}
+                    className="text-xs px-2.5 py-1 rounded-lg bg-white border border-[#D2D2D7] hover:border-blue-400 hover:text-blue-600 font-medium"
+                  >
+                    ✏️ Editar
+                  </button>
+                  {l.cliente_preencheu_em && (
+                    <button
+                      onClick={() => setViewDataLink(l)}
+                      className="text-xs px-2.5 py-1 rounded-lg bg-white border border-blue-200 text-blue-600 hover:bg-blue-50 font-medium"
+                    >
+                      👁 Dados cliente
+                    </button>
+                  )}
+                  {l.cliente_preencheu_em && !l.entrega_id && (
+                    <button
+                      onClick={() => { setEncaminharLink(l); setEncaminharData(new Date().toISOString().slice(0, 10)); }}
+                      className="text-xs px-2.5 py-1 rounded-lg bg-green-500 text-white hover:bg-green-600 font-medium"
+                    >
+                      → Encaminhar entrega
+                    </button>
+                  )}
                   <button
                     onClick={() => arquivarLink(l.id, !l.arquivado)}
                     className="text-xs px-2.5 py-1 rounded-lg bg-white border border-[#D2D2D7] hover:border-amber-400 hover:text-amber-600 font-medium"
@@ -838,16 +1045,20 @@ export default function GerarLinkPage() {
                           <p className={`text-sm font-semibold ${sel ? "text-[#E8740E]" : (dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]")}`}>{m.nome}</p>
                           <p className={`text-sm font-bold ${sel ? "text-[#E8740E]" : (dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]")}`}>{m.preco > 0 ? `R$ ${m.preco.toLocaleString("pt-BR")}` : "—"}</p>
                         </button>
-                        {sel && catSel !== "SEMINOVOS" && coresDisponiveis.length > 0 && (
+                        {sel && catSel !== "SEMINOVOS" && (
                           <div className={`px-4 py-3 ${dm ? "bg-[#1C1C1E] border-t border-[#3A3A3C]" : "bg-[#FAFAFA] border-t border-[#E5E5EA]"}`}>
                             <p className={`text-xs font-medium mb-2 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Selecione a cor:</p>
-                            <div className="flex flex-wrap gap-2">
-                              {coresDisponiveis.map(cor => (
-                                <button key={cor} onClick={() => setCorSel(corSel === cor ? "" : cor)}
-                                  className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${corSel === cor ? "bg-[#E8740E] text-white border-[#E8740E]" : (dm ? "bg-[#2C2C2E] text-[#F5F5F7] border-[#3A3A3C] hover:border-[#E8740E]" : "bg-white text-[#1D1D1F] border-[#D2D2D7] hover:border-[#E8740E]")}`}
-                                >{corParaPT(cor)}</button>
-                              ))}
-                            </div>
+                            {coresDisponiveis.length > 0 ? (
+                              <div className="flex flex-wrap gap-2">
+                                {coresDisponiveis.map(cor => (
+                                  <button key={cor} onClick={() => setCorSel(corSel === cor ? "" : cor)}
+                                    className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${corSel === cor ? "bg-[#E8740E] text-white border-[#E8740E]" : (dm ? "bg-[#2C2C2E] text-[#F5F5F7] border-[#3A3A3C] hover:border-[#E8740E]" : "bg-white text-[#1D1D1F] border-[#D2D2D7] hover:border-[#E8740E]")}`}
+                                  >{corParaPT(cor)}</button>
+                                ))}
+                              </div>
+                            ) : (
+                              <p className={`text-xs italic ${dm ? "text-[#636366]" : "text-[#86868B]"}`}>Nenhuma cor cadastrada para este modelo no catálogo.</p>
+                            )}
                           </div>
                         )}
                       </div>

--- a/app/admin/saldos/page.tsx
+++ b/app/admin/saldos/page.tsx
@@ -118,6 +118,22 @@ export default function SaldosPage() {
   const [depModal, setDepModal] = useState(false);
   const [depValor, setDepValor] = useState("");
   const [depBanco, setDepBanco] = useState<"ITAU" | "INFINITE" | "MERCADO_PAGO">("ITAU");
+  const [depData, setDepData] = useState("");
+  // Histórico de depósitos em espécie
+  type DepHist = { id: string; data: string; valor: number; banco: string; descricao: string };
+  const [depHistModal, setDepHistModal] = useState(false);
+  const [depHist, setDepHist] = useState<DepHist[]>([]);
+  const [depHistLoading, setDepHistLoading] = useState(false);
+  const fetchDepHist = async () => {
+    setDepHistLoading(true);
+    try {
+      const res = await fetch(`/api/gastos?is_dep_esp=1&limit=100`, { headers: { "x-admin-password": password } });
+      const j = await res.json();
+      const rows = (j.data || j || []).filter((g: { is_dep_esp?: boolean; categoria?: string }) => g.is_dep_esp || g.categoria === "TRANSFERENCIA");
+      setDepHist(rows);
+    } catch { /* ignore */ }
+    setDepHistLoading(false);
+  };
 
   // Valor disponível = fechamento noite da espécie (nunca a base manual)
   const especieDisponivel = Number(saldoHoje?.esp_especie ?? 0);
@@ -129,6 +145,7 @@ export default function SaldosPage() {
     }
     setDepValor(toDisplayBR(String(especieDisponivel)));
     setDepBanco("ITAU");
+    setDepData(dataAtual);
     setMsg("");
     setDepModal(true);
   };
@@ -147,7 +164,7 @@ export default function SaldosPage() {
       MERCADO_PAGO: "Mercado Pago",
     };
     const bancoSel = { key: depBanco, label: bancoLabelMap[depBanco] };
-    const dataDep = dataAtual; // depósito SEMPRE na data selecionada na página
+    const dataDep = depData || dataAtual; // usa data escolhida no modal
 
     setDepositando(true);
     setMsg("");
@@ -209,10 +226,53 @@ export default function SaldosPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-4 flex-wrap">
         <h2 className="text-lg font-bold text-[#1D1D1F]">Saldos Bancarios</h2>
         <input type="date" value={dataAtual} onChange={(e) => setDataAtual(e.target.value)} className="px-3 py-2 rounded-xl border border-[#D2D2D7] text-sm" />
+        <button onClick={() => { setDepHistModal(true); fetchDepHist(); }}
+          className="ml-auto px-3 py-2 rounded-xl border border-[#D2D2D7] text-sm font-semibold hover:bg-[#F5F5F7]">
+          📋 Histórico de depósitos
+        </button>
       </div>
+
+      {depHistModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4" onClick={() => setDepHistModal(false)}>
+          <div className={`w-full max-w-2xl max-h-[85vh] rounded-3xl shadow-2xl overflow-hidden flex flex-col ${dm ? "bg-[#1C1C1E] border border-[#3A3A3C]" : "bg-white"}`} onClick={(e) => e.stopPropagation()}>
+            <div className={`px-5 py-4 border-b flex items-center justify-between ${dm ? "border-[#3A3A3C]" : "border-[#E5E5EA]"}`}>
+              <h3 className={`text-sm font-bold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>Histórico de depósitos em espécie</h3>
+              <button onClick={() => setDepHistModal(false)} className="text-lg text-[#86868B] hover:text-red-500">✕</button>
+            </div>
+            <div className="overflow-y-auto">
+              {depHistLoading ? (
+                <p className="p-8 text-center text-sm text-[#86868B]">Carregando...</p>
+              ) : depHist.length === 0 ? (
+                <p className="p-8 text-center text-sm text-[#86868B]">Nenhum depósito encontrado.</p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead className={`${dm ? "bg-[#2C2C2E]" : "bg-[#F5F5F7]"} sticky top-0`}>
+                    <tr>
+                      <th className="px-4 py-2 text-left text-xs uppercase text-[#86868B]">Data</th>
+                      <th className="px-4 py-2 text-left text-xs uppercase text-[#86868B]">Banco</th>
+                      <th className="px-4 py-2 text-right text-xs uppercase text-[#86868B]">Valor</th>
+                      <th className="px-4 py-2 text-left text-xs uppercase text-[#86868B]">Descrição</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {depHist.map((d) => (
+                      <tr key={d.id} className={`border-t ${dm ? "border-[#3A3A3C]" : "border-[#F2F2F7]"}`}>
+                        <td className="px-4 py-2 font-medium">{d.data}</td>
+                        <td className="px-4 py-2">{d.banco}</td>
+                        <td className="px-4 py-2 text-right font-bold text-[#2ECC71]">R$ {fmt(Number(d.valor))}</td>
+                        <td className="px-4 py-2 text-xs text-[#86868B]">{d.descricao}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {msg && <div className={`px-4 py-3 rounded-xl text-sm ${msg.includes("Erro") ? "bg-red-50 text-red-700" : "bg-green-50 text-green-700"}`}>{msg}</div>}
 
@@ -320,7 +380,11 @@ export default function SaldosPage() {
                   <div>
                     <p className={`text-[11px] uppercase tracking-wider font-semibold ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Depósito de espécie</p>
                     <h3 className={`text-xl font-bold mt-1 ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>Transferir para banco</h3>
-                    <p className={`text-xs mt-1 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Data: {dataAtual}</p>
+                    <div className="mt-2 flex items-center gap-2">
+                      <label className={`text-[10px] uppercase tracking-wider font-semibold ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Data do depósito:</label>
+                      <input type="date" value={depData} onChange={(e) => setDepData(e.target.value)}
+                        className={`px-2.5 py-1 rounded-lg border text-xs ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"}`} />
+                    </div>
                   </div>
                   <button onClick={() => !depositando && setDepModal(false)} className={`w-8 h-8 rounded-full flex items-center justify-center text-lg ${dm ? "hover:bg-[#2C2C2E] text-[#98989D]" : "hover:bg-[#F5F5F7] text-[#86868B]"}`}>×</button>
                 </div>

--- a/app/api/admin/link-compras/encaminhar-entrega/route.ts
+++ b/app/api/admin/link-compras/encaminhar-entrega/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { logActivity } from "@/lib/activity-log";
+
+function auth(request: Request) {
+  const pw = request.headers.get("x-admin-password");
+  return pw === process.env.ADMIN_PASSWORD;
+}
+function getUser(request: Request) {
+  const r = request.headers.get("x-admin-user") || "Sistema";
+  try { return decodeURIComponent(r); } catch { return r; }
+}
+
+// POST { link_id, data_entrega, horario?, entregador?, observacao? }
+// Lê o link_compras, cria uma entrega usando os dados do cliente (preferindo os preenchidos pelo cliente),
+// e vincula o link à entrega via entrega_id + status=ENCAMINHADO.
+export async function POST(request: Request) {
+  if (!auth(request)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const body = await request.json();
+  const { link_id, data_entrega, horario, entregador, observacao } = body || {};
+  if (!link_id || !data_entrega) {
+    return NextResponse.json({ error: "link_id e data_entrega obrigatórios" }, { status: 400 });
+  }
+  const { supabase } = await import("@/lib/supabase");
+
+  const { data: link, error: e1 } = await supabase
+    .from("link_compras")
+    .select("*")
+    .eq("id", link_id)
+    .single();
+  if (e1 || !link) return NextResponse.json({ error: "Link não encontrado" }, { status: 404 });
+  if (link.entrega_id) return NextResponse.json({ error: "Este link já foi encaminhado para uma entrega." }, { status: 409 });
+
+  const preench = link.cliente_dados_preenchidos || {};
+  const cliente = preench.nome || link.cliente_nome || "";
+  const telefone = preench.telefone || link.cliente_telefone || null;
+  const endereco = preench.endereco_completo
+    || (preench.endereco ? `${preench.endereco}${preench.numero ? `, ${preench.numero}` : ""}${preench.complemento ? ` - ${preench.complemento}` : ""}` : null);
+  const bairro = preench.bairro || null;
+
+  if (!cliente) return NextResponse.json({ error: "Nome do cliente ausente — cliente ainda não preencheu?" }, { status: 400 });
+
+  const produtoTxt = link.cor ? `${link.produto}` : link.produto;
+
+  const { data: entrega, error: e2 } = await supabase
+    .from("entregas")
+    .insert({
+      cliente,
+      telefone,
+      endereco,
+      bairro,
+      data_entrega,
+      horario: horario || null,
+      status: "PENDENTE",
+      entregador: entregador || null,
+      observacao: observacao || `Encaminhada do link ${link.short_code}`,
+      produto: produtoTxt,
+      tipo: link.tipo === "TROCA" ? "TROCA" : null,
+      forma_pagamento: link.forma_pagamento || null,
+      valor: link.valor || null,
+      vendedor: link.vendedor || null,
+    })
+    .select()
+    .single();
+  if (e2) return NextResponse.json({ error: e2.message }, { status: 500 });
+
+  const { error: e3 } = await supabase
+    .from("link_compras")
+    .update({ entrega_id: entrega.id, status: "ENCAMINHADO", updated_at: new Date().toISOString() })
+    .eq("id", link_id);
+  if (e3) return NextResponse.json({ error: e3.message }, { status: 500 });
+
+  logActivity(getUser(request), "Encaminhou link para entrega", `${link.short_code} → entrega ${entrega.id}`, "link_compras", link_id).catch(() => {});
+  return NextResponse.json({ ok: true, entrega });
+}

--- a/app/api/admin/link-compras/route.ts
+++ b/app/api/admin/link-compras/route.ts
@@ -137,6 +137,7 @@ export async function POST(request: Request) {
     troca_produto2: body.troca_produto2 || null,
     troca_valor2: Number(body.troca_valor2) || 0,
     vendedor: body.vendedor || null,
+    operador: getUser(request),
     simulacao_id: body.simulacao_id || null,
     observacao: body.observacao || null,
   };
@@ -160,7 +161,14 @@ export async function PATCH(request: Request) {
   const { supabase } = await import("@/lib/supabase");
 
   const allowed: Record<string, unknown> = {};
-  for (const k of ["arquivado", "status", "observacao", "cliente_nome", "cliente_telefone", "cliente_cpf", "cliente_email"]) {
+  const editableFields = [
+    "arquivado", "status", "observacao",
+    "cliente_nome", "cliente_telefone", "cliente_cpf", "cliente_email",
+    "produto", "cor", "valor", "forma_pagamento", "parcelas", "entrada",
+    "troca_produto", "troca_valor", "troca_produto2", "troca_valor2",
+    "vendedor", "entrega_id", "cliente_dados_preenchidos", "cliente_preencheu_em",
+  ];
+  for (const k of editableFields) {
     if (k in patch) allowed[k] = patch[k];
   }
   allowed.updated_at = new Date().toISOString();

--- a/app/api/catalogo-cores/route.ts
+++ b/app/api/catalogo-cores/route.ts
@@ -30,16 +30,19 @@ export async function GET(req: NextRequest) {
     if (e2) return NextResponse.json({ modelos: {} });
 
     const idToNome: Record<string, string> = {};
-    for (const m of modelos) idToNome[m.id] = m.nome;
+    const idToCat: Record<string, string> = {};
+    for (const m of modelos) { idToNome[m.id] = m.nome; idToCat[m.id] = m.categoria_key || "OUTROS"; }
 
     const result: Record<string, string[]> = {};
+    const categorias: Record<string, string> = {};
     for (const c of configs ?? []) {
       const nome = idToNome[c.modelo_id];
       if (!nome) continue;
       if (!result[nome]) result[nome] = [];
       if (!result[nome].includes(c.valor)) result[nome].push(c.valor);
+      categorias[nome] = idToCat[c.modelo_id];
     }
-    return NextResponse.json({ modelos: result });
+    return NextResponse.json({ modelos: result, categorias });
   } catch (err) {
     return NextResponse.json({ modelos: {}, error: String(err) }, { status: 200 });
   }

--- a/app/api/link-compras/[code]/preenchimento/route.ts
+++ b/app/api/link-compras/[code]/preenchimento/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+
+// Endpoint PÚBLICO: cliente preenche dados na página /c/[code] e envia de volta.
+// Salva o snapshot JSONB em link_compras.cliente_dados_preenchidos + timestamp + status=PREENCHIDO
+// Sem auth (é público por design — só aceita se o short_code existe).
+export async function POST(request: Request, ctx: { params: Promise<{ code: string }> }) {
+  try {
+    const { code } = await ctx.params;
+    if (!code) return NextResponse.json({ error: "code required" }, { status: 400 });
+
+    const body = await request.json();
+    const dados = body?.dados || body; // aceita tanto {dados:{...}} quanto raw
+
+    const { supabase } = await import("@/lib/supabase");
+
+    // Busca o link
+    const { data: link, error: e1 } = await supabase
+      .from("link_compras")
+      .select("id, status, cliente_nome, cliente_telefone, cliente_cpf, cliente_email")
+      .eq("short_code", code)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (e1 || !link) return NextResponse.json({ error: "Link não encontrado" }, { status: 404 });
+
+    const patch: Record<string, unknown> = {
+      cliente_dados_preenchidos: dados,
+      cliente_preencheu_em: new Date().toISOString(),
+      status: "PREENCHIDO",
+      updated_at: new Date().toISOString(),
+    };
+    // Se os campos principais estiverem vazios, preenche com o que veio
+    if (!link.cliente_nome && dados?.nome) patch.cliente_nome = dados.nome;
+    if (!link.cliente_telefone && dados?.telefone) patch.cliente_telefone = dados.telefone;
+    if (!link.cliente_cpf && dados?.cpf) patch.cliente_cpf = dados.cpf;
+    if (!link.cliente_email && dados?.email) patch.cliente_email = dados.email;
+
+    const { error: e2 } = await supabase.from("link_compras").update(patch).eq("id", link.id);
+    if (e2) return NextResponse.json({ error: e2.message }, { status: 500 });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/app/c/[d]/page.tsx
+++ b/app/c/[d]/page.tsx
@@ -12,6 +12,7 @@ const KEY_MAP: Record<string, string> = {
   tp2: "troca_produto2", tv2: "troca_valor2", tc2: "troca_cor2",
   p2: "produto2", p3: "produto3", p4: "produto4", p5: "produto5",
   pp: "pagamento_pago",
+  short: "short",
   // Dados do cliente pré-preenchidos pelo vendedor no gerar-link
   cn: "nome", ccpf: "cpf", cem: "email", cte: "telefone",
   ccep: "cep", cen: "endereco", cnu: "numero", cco: "complemento", cba: "bairro",
@@ -93,6 +94,8 @@ export async function generateMetadata({ params }: { params: Promise<{ d: string
 export default async function ShortLinkPage({ params }: { params: Promise<{ d: string }> }) {
   const { d } = await params;
   const data = await resolveData(d);
+  // Anexa o short_code pra que /compra possa enviar o preenchimento de volta
+  if (d.length <= 8 && /^[A-Za-z0-9]+$/.test(d)) data.short = d;
   const redirectUrl = buildRedirectUrl(data);
 
   return (

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -66,6 +66,7 @@ function CompraForm() {
   const precoParam = searchParams.get("preco") || searchParams.get("v") || "";
   const vendedor = searchParams.get("vendedor") || "";
   const whatsapp = searchParams.get("whatsapp") || "";
+  const shortCode = searchParams.get("short") || "";
 
   // Trade-in params (vindos do StepQuote)
   const trocaProdutoParam = searchParams.get("troca_produto") || "";
@@ -457,6 +458,27 @@ function CompraForm() {
     if (pagEntrega) lines.push(pagEntrega);
 
     // Entrega NÃO é criada automaticamente — equipe cria manualmente na agenda
+
+    // Se veio de um short link rastreável, devolve os dados preenchidos pro admin (fire-and-forget)
+    if (shortCode) {
+      const enderecoFullTxt = `${endereco}, ${numero}${complemento ? ` - ${complemento}` : ""}`;
+      fetch(`/api/link-compras/${encodeURIComponent(shortCode)}/preenchimento`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          dados: {
+            nome, cpf: pessoa === "PJ" ? "" : cpf, cnpj: pessoa === "PJ" ? cnpj : "", pessoa,
+            email, telefone, instagram,
+            cep, endereco, numero, complemento, bairro,
+            endereco_completo: enderecoFullTxt,
+            produto: produtoFinal, cor: corSel, preco: precoFinal,
+            forma_pagamento: pagStr,
+            local: localStr, horario, data_entrega: dataEntrega,
+            vendedor, origem,
+          },
+        }),
+      }).catch(() => {});
+    }
 
     const url = `https://wa.me/${whatsappFinal}?text=${encodeURIComponent(lines.join("\n"))}`;
     window.open(url, "_blank");

--- a/supabase/migrations/20260407_link_compras_entrega.sql
+++ b/supabase/migrations/20260407_link_compras_entrega.sql
@@ -1,0 +1,8 @@
+-- Extensões para: operador, rastreio de preenchimento pelo cliente, vínculo com entrega
+ALTER TABLE link_compras ADD COLUMN IF NOT EXISTS operador TEXT;
+ALTER TABLE link_compras ADD COLUMN IF NOT EXISTS cliente_dados_preenchidos JSONB;
+ALTER TABLE link_compras ADD COLUMN IF NOT EXISTS cliente_preencheu_em TIMESTAMPTZ;
+ALTER TABLE link_compras ADD COLUMN IF NOT EXISTS entrega_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_link_compras_status ON link_compras(status);
+CREATE INDEX IF NOT EXISTS idx_link_compras_entrega_id ON link_compras(entrega_id);


### PR DESCRIPTION
…e histórico de depósitos

- /estoque reposição: catálogo_modelo_configs como fonte única (sem cores fantasma), botão ⚙️ Modelos para ocultar modelos da lista
- /gerar-link: operador+vendedora no histórico, autocomplete por CPF, botão Editar, badges de status, modais Ver dados cliente e Encaminhar entrega
- /saldos: date picker de volta no modal de depósito, botão Histórico de depósitos em espécie
- API: endpoint público /api/link-compras/[code]/preenchimento para cliente devolver dados do formulário, endpoint /api/admin/link-compras/encaminhar-entrega para criar entrega a partir do link
- /c/[d] + /compra: passam short_code via query string e disparam POST de preenchimento antes do WhatsApp
- Migration 20260407_link_compras_entrega.sql: colunas operador, cliente_dados_preenchidos, cliente_preencheu_em, entrega_id