### PR TITLE
fix: cores reposição+gerar-link, formato PT-EN, custo_compra restore

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -2911,7 +2911,17 @@ export default function EstoquePage() {
           .replace(/[""\(\)\+\-]/g, " ")
           .replace(/\s+/g, " ").trim();
         const STOP_REPO = new Set(["de","the","with","com","e","a","o","gen"]);
-        const tokenize = (s: string) => stripRepoNoise(s).toLowerCase().split(/\s+/).filter(t => t && !STOP_REPO.has(t));
+        const expandSynonymsRepo = (toks: string[]): string[] => {
+          const set = new Set(toks);
+          if (set.has("ipad")) {
+            if (set.has("a16")) set.add("11");
+            if (set.has("11")) set.add("a16");
+            if (set.has("a14")) set.add("10");
+            if (set.has("10")) set.add("a14");
+          }
+          return [...set];
+        };
+        const tokenize = (s: string) => expandSynonymsRepo(stripRepoNoise(s).toLowerCase().split(/\s+/).filter(t => t && !STOP_REPO.has(t)));
 
         // Index catálogo: nomeCat original → { tokens, cores normalizadas }
         type CatEntry = { nomeCat: string; tokens: string[]; cores: Set<string> };

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -2898,10 +2898,24 @@ export default function EstoquePage() {
         type RepoGroup = { totalQnt: number; min: number; corEN: string; corPT: string; corDisplay: string; jaCaminho: boolean; falta: number };
         const byCatModel: Record<string, Record<string, RepoGroup[]>> = {};
 
-        const normCmp = (s: string) => s.toLowerCase().replace(/\s+/g, " ").trim();
+        // Normalização em tokens (igual gerar-link): geração 2ND/2º→2, remove GB/TB/MM/GPS/etc
+        const normGen = (s: string) => s
+          .replace(/(\d+)\s*(ST|ND|RD|TH)\b/gi, "$1")
+          .replace(/(\d+)\s*[º°]/g, "$1")
+          .replace(/\bGENERATION\b/gi, "GEN")
+          .replace(/\bGERAÇÃO\b/gi, "GEN");
+        const stripRepoNoise = (s: string) => normGen(s)
+          .replace(/\b\d+\s*(GB|TB)\b/gi, "")
+          .replace(/\b\d+\s*MM\b/gi, "")
+          .replace(/\b(GPS|CELLULAR|WI[- ]?FI|CELL)\b/gi, "")
+          .replace(/[""\(\)\+\-]/g, " ")
+          .replace(/\s+/g, " ").trim();
+        const STOP_REPO = new Set(["de","the","with","com","e","a","o","gen"]);
+        const tokenize = (s: string) => stripRepoNoise(s).toLowerCase().split(/\s+/).filter(t => t && !STOP_REPO.has(t));
 
-        // Index de cores válidas por modelo do catálogo (normalizado)
-        const catalogCoresNorm = new Map<string, Set<string>>(); // nomeCatNorm → Set<corNorm>
+        // Index catálogo: nomeCat original → { tokens, cores normalizadas }
+        type CatEntry = { nomeCat: string; tokens: string[]; cores: Set<string> };
+        const catEntries: CatEntry[] = [];
         for (const [nomeCat, coresCat] of Object.entries(catalogoCoresMap)) {
           if (!coresCat) continue;
           const set = new Set<string>();
@@ -2910,19 +2924,22 @@ export default function EstoquePage() {
             const pt = COR_PT[c.toUpperCase()];
             if (pt) set.add(pt.toLowerCase());
           }
-          catalogCoresNorm.set(normCmp(nomeCat), set);
+          catEntries.push({ nomeCat, tokens: tokenize(nomeCat), cores: set });
         }
 
-        // Acha melhor entry do catálogo para um modelo do estoque (match por tokens)
-        const findCatCores = (baseModelo: string): Set<string> | null => {
-          const baseNorm = normCmp(baseModelo);
-          // exato
-          if (catalogCoresNorm.has(baseNorm)) return catalogCoresNorm.get(baseNorm)!;
-          // contains — maior match primeiro
-          const candidatos = [...catalogCoresNorm.keys()]
-            .filter(k => baseNorm.includes(k) || k.includes(baseNorm))
-            .sort((a, b) => b.length - a.length);
-          return candidatos[0] ? catalogCoresNorm.get(candidatos[0])! : null;
+        // Acha melhor entry do catálogo por tokens: todos tokens do catálogo devem estar no produto.
+        const findCatEntry = (baseModelo: string): CatEntry | null => {
+          const baseTokens = new Set(tokenize(baseModelo));
+          let best: CatEntry | null = null;
+          let bestCount = 0;
+          for (const e of catEntries) {
+            if (e.tokens.length === 0) continue;
+            if (e.tokens.every(t => baseTokens.has(t)) && e.tokens.length > bestCount) {
+              best = e;
+              bestCount = e.tokens.length;
+            }
+          }
+          return best;
         };
 
         // Agrupar estoque por categoria → modelo base (preservando variantes)
@@ -2933,7 +2950,6 @@ export default function EstoquePage() {
 
         for (const p of novos) {
           const base = getModeloBase(p.produto, p.categoria).toUpperCase();
-          if (reposicaoOcultos.has(base)) continue;
           const cat = p.categoria || "OUTROS";
           const corRaw = (p.cor || extractCor(stripOrigemRepo(p.produto), null) || "").toString().trim();
           if (!corRaw) continue;
@@ -2960,10 +2976,13 @@ export default function EstoquePage() {
           }
         }
 
-        // Converter + filtrar cores que não estão no catálogo
+        // Converter + filtrar cores que não estão no catálogo + aplicar hide via modal
         for (const [cat, catMap] of acc.entries()) {
           for (const [base, baseMap] of catMap.entries()) {
-            const catCores = findCatCores(base);
+            const catEntry = findCatEntry(base);
+            // Hide via modal: usuário oculta pelo nome do catálogo
+            if (catEntry && reposicaoOcultos.has(catEntry.nomeCat)) continue;
+            const catCores = catEntry?.cores || null;
             const grupo: RepoGroup[] = [];
             for (const [corNorm, dados] of baseMap.entries()) {
               // Se tem catálogo, filtra. Se não tem, mostra tudo.

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
 import { getWhatsAppByVendedor, VENDEDORES } from "@/lib/whatsapp-config";
-import { corParaPT } from "@/lib/cor-pt";
+import { corParaPT, corParaEN } from "@/lib/cor-pt";
 
 export default function GerarLinkPage() {
   const { user, password: adminPw, apiHeaders: adminHeaders, darkMode: dm } = useAdmin();
@@ -335,7 +335,9 @@ export default function GerarLinkPage() {
   async function salvarEdicaoLink() {
     if (!editingLinkId) return false;
     const prodsFilled = produtos.filter(Boolean);
-    const nomeProdutoFinal = corSel ? `${prodsFilled[0]} ${corSel}` : (prodsFilled[0] || "");
+    const corPTSimples = corSel ? corParaPT(corSel) : "";
+    const corENCanon = corSel ? (corParaEN(corSel) || corSel) : "";
+    const nomeProdutoFinal = corSel ? `${prodsFilled[0]} ${corPTSimples}` : (prodsFilled[0] || "");
     try {
       const res = await fetch("/api/admin/link-compras", {
         method: "PATCH",
@@ -343,7 +345,7 @@ export default function GerarLinkPage() {
         body: JSON.stringify({
           id: editingLinkId,
           produto: nomeProdutoFinal,
-          cor: corSel || null,
+          cor: corENCanon || null,
           valor: Number(rawPreco) || 0,
           forma_pagamento: forma || null,
           parcelas: parcelas || null,
@@ -511,7 +513,9 @@ export default function GerarLinkPage() {
       setPasteMsg("⚠️ Selecione ao menos um produto antes de gerar o link.");
       return;
     }
-    const nomeProdutoFinal = corSel ? `${prodsFilled[0]} ${corSel}` : prodsFilled[0];
+    const corPTSimples = corSel ? corParaPT(corSel) : "";
+    const corENCanon = corSel ? (corParaEN(corSel) || corSel) : "";
+    const nomeProdutoFinal = corSel ? `${prodsFilled[0]} ${corPTSimples}` : prodsFilled[0];
     if (!nomeProdutoFinal || !nomeProdutoFinal.trim()) {
       setPasteMsg("⚠️ Nome do produto vazio — selecione novamente.");
       return;
@@ -594,7 +598,7 @@ export default function GerarLinkPage() {
               cliente_email: cliEmail.trim() || null,
               produto: nomeProdutoFinal,
               produtos_extras: prodsFilled.length > 1 ? prodsFilled.slice(1) : null,
-              cor: corSel || null,
+              cor: corENCanon || null,
               valor: Number(rawPreco) || 0,
               forma_pagamento: forma || null,
               parcelas: parcelas || null,

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -104,7 +104,18 @@ export default function GerarLinkPage() {
       .replace(/[""\(\)\+\-]/g, " ")
       .replace(/\s+/g, " ").trim();
     const STOP = new Set(["de","the","with","com","e","a","o","gen"]);
-    const tokens = (s: string) => stripNoise(s).toLowerCase().split(/\s+/).filter(t => t && !STOP.has(t));
+    const expandSynonyms = (toks: string[]): string[] => {
+      const set = new Set(toks);
+      // iPad chip ↔ geração (iPad A16 = iPad 11, A15 = 10, A14 = 9/10)
+      if (set.has("ipad")) {
+        if (set.has("a16")) set.add("11");
+        if (set.has("11")) set.add("a16");
+        if (set.has("a14")) set.add("10");
+        if (set.has("10")) set.add("a14");
+      }
+      return [...set];
+    };
+    const tokens = (s: string) => expandSynonyms(stripNoise(s).toLowerCase().split(/\s+/).filter(t => t && !STOP.has(t)));
     const prodTokens = new Set(tokens(produtos[0]));
 
     // Match por tokens: todos os tokens do catálogo devem existir no produto.
@@ -888,7 +899,20 @@ export default function GerarLinkPage() {
                       {l.operador && l.vendedor ? " · " : null}
                       {l.vendedor ? <>Vendedora <strong>{l.vendedor}</strong></> : null}
                     </p>
-                    <p className="text-sm font-semibold text-[#1D1D1F] mt-1">{l.produto}{l.cor ? ` — ${l.cor}` : ""}</p>
+                    <p className="text-sm font-semibold text-[#1D1D1F] mt-1">{(() => {
+                      const cor = l.cor || "";
+                      if (!cor) return l.produto;
+                      const corPT = corParaPT(cor);
+                      const corEN = corParaEN(cor) || cor;
+                      // Strip qualquer sufixo de cor (EN ou PT) do produto pra não duplicar
+                      let base = l.produto;
+                      for (const s of [cor, corPT, corEN]) {
+                        if (!s) continue;
+                        const re = new RegExp(`\\s+${s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*$`, "i");
+                        base = base.replace(re, "").trim();
+                      }
+                      return `${base} ${corPT} — ${corEN}`;
+                    })()}</p>
                     {l.valor > 0 && <p className="text-xs text-[#E8740E] font-bold">R$ {Number(l.valor).toLocaleString("pt-BR")}</p>}
                     {(l.cliente_nome || l.cliente_telefone) && (
                       <p className="text-xs text-[#86868B] mt-1">

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -1068,7 +1068,7 @@ export default function GerarLinkPage() {
                           setPreco(m.preco > 0 ? m.preco.toLocaleString("pt-BR") : "");
                           setCorSel("");
                         }} className={`w-full px-4 py-3 flex items-center justify-between text-left transition-all ${sel ? (dm ? "bg-[#E8740E]/20 border-l-4 border-[#E8740E]" : "bg-[#FFF5EB] border-l-4 border-[#E8740E]") : (dm ? "hover:bg-[#2C2C2E]" : "hover:bg-[#F9F9FB]")}`}>
-                          <p className={`text-sm font-semibold ${sel ? "text-[#E8740E]" : (dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]")}`}>{m.nome}</p>
+                          <p className={`text-sm font-semibold ${sel ? "text-[#E8740E]" : (dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]")}`}>{m.nome}{sel && corSel ? ` ${corParaPT(corSel)}` : ""}</p>
                           <p className={`text-sm font-bold ${sel ? "text-[#E8740E]" : (dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]")}`}>{m.preco > 0 ? `R$ ${m.preco.toLocaleString("pt-BR")}` : "—"}</p>
                         </button>
                         {sel && catSel !== "SEMINOVOS" && (

--- a/app/api/estoque/route.ts
+++ b/app/api/estoque/route.ts
@@ -284,9 +284,13 @@ export async function POST(req: NextRequest) {
       const usuario = getUsuario(req);
       const updateData: Record<string, unknown> = { status: "EM ESTOQUE", qnt: 1, updated_at: new Date().toISOString() };
       // Atualizar apenas campos fornecidos no body (mantém dados originais para os demais)
-      const allowedFields = ["produto", "cor", "categoria", "custo_unitario", "fornecedor", "data_entrada", "data_compra", "observacao", "tipo", "bateria", "preco_sugerido", "imei"];
+      const allowedFields = ["produto", "cor", "categoria", "custo_unitario", "custo_compra", "fornecedor", "data_entrada", "data_compra", "observacao", "tipo", "bateria", "preco_sugerido", "imei"];
       for (const f of allowedFields) {
         if (body[f] !== undefined && body[f] !== null && body[f] !== "") updateData[f] = body[f];
+      }
+      // Se body veio sem custo_compra mas com custo_unitario, garante custo_compra
+      if (updateData.custo_compra == null && updateData.custo_unitario != null) {
+        updateData.custo_compra = updateData.custo_unitario;
       }
       const { error: ue } = await supabase.from("estoque").update(updateData).eq("id", existingSerial.id);
       if (ue) return NextResponse.json({ error: ue.message }, { status: 500 });


### PR DESCRIPTION
## Summary
- Reposição: filtro de cores por tokens + hide de modelos pelo nome do catálogo
- Gerar-link: nome do produto em PT simples + cor EN canônica (display "Azul — Blue"), card mostra cor selecionada
- Estoque: preserva custo_compra no restore de serial ESGOTADO

## Test plan
- [ ] /admin/estoque reposição: cores fantasmas (Azul-petróleo no iPhone 16, etc) não aparecem
- [ ] Modal "Modelos" → desmarcar um modelo faz ele sumir da reposição
- [ ] /admin/gerar-link: selecionar cor mostra no card ("iPhone 17 256GB Azul")
- [ ] Histórico do link mostra "Azul — Blue"
- [ ] Restore de serial vendido mantém custo_compra

🤖 Generated with [Claude Code](https://claude.com/claude-code)