### PR TITLE
feat(migrations): /admin/migrations + CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,81 @@
+# Tigrão Tradein — Regras de trabalho
+
+Documento curto de convenções para Nicolas, André e Claude trabalharem no mesmo repo sem pisar no pé.
+
+## 🌿 Branches
+
+- **`main`** — produção. Protegida. Só recebe código via Pull Request com aprovação.
+- **`dev-nicolas`** — branch de trabalho do Nicolas. Só o Nicolas commita aqui.
+- **`dev-andre`** — branch de trabalho do André. Só o André commita aqui.
+- **`hotfix/<nome-curto>`** — quando precisar corrigir algo urgente em produção, sai direto da `main`.
+
+### Fluxo diário
+1. De manhã, cada um atualiza a sua branch:
+   ```bash
+   git checkout dev-nicolas   # ou dev-andre
+   git pull origin main       # pega o que foi mergeado ontem
+   ```
+2. Trabalha normalmente, commitando sempre na sua branch.
+3. Fim do dia:
+   ```bash
+   git push
+   # Abre PR no GitHub: dev-nicolas → main
+   # Testa no preview do Vercel (URL gerada automaticamente)
+   # Aprova e mergeia
+   ```
+4. Depois de mergeado, pode deletar a branch e recriar limpa no dia seguinte (opcional, mas recomendado).
+
+## 🗄️ Migrations SQL
+
+**Regra de ouro: NUNCA rodar SQL manualmente no Supabase.**
+
+### Como fazer mudança de banco
+1. Criar arquivo em `supabase/migrations/AAAAMMDD_descricao.sql`
+   - Exemplo: `20260408_add_observacao_cliente.sql`
+2. Escrever o SQL normalmente (CREATE, ALTER, INSERT, etc).
+3. Commitar na sua branch.
+4. Deploy automático do preview do Vercel.
+5. Abrir `/admin/migrations` → achar a migration **Pendente** → clicar **▶ Rodar**.
+6. Confere que ficou ✅ aplicada.
+7. PR → merge.
+
+### Por que essa regra
+- Histórico completo de TODAS mudanças de banco no git.
+- Ninguém mais fica na dúvida "será que eu rodei isso?".
+- André, Nicolas e Claude veem o mesmo estado.
+- Rollback e auditoria ficam simples.
+
+## 📝 Convenção de commits
+
+Formato curto, em português, com tipo:
+- `feat: ...` — funcionalidade nova
+- `fix: ...` — correção de bug
+- `refactor: ...` — mudança de código sem mudar comportamento
+- `chore: ...` — arrumação, dependências, etc.
+- `docs: ...` — documentação
+
+Exemplos:
+- `feat(estoque): adicionar filtro por fornecedor`
+- `fix(gerar-link): cor não persistia ao adicionar produto extra`
+
+## 🚫 O que NÃO fazer
+
+- ❌ Commitar direto na `main`
+- ❌ Rodar SQL manualmente no Supabase
+- ❌ Mergear PR sem testar no preview do Vercel
+- ❌ Trabalhar na branch do outro dev
+- ❌ `git push --force` em qualquer branch compartilhada
+
+## 🆘 Emergências
+
+Se produção quebrar e precisar reverter agora:
+1. No Vercel: **Deployments** → achar o último deploy que funcionou → clicar **Promote to Production**
+2. Isso volta ao estado anterior em ~30 segundos.
+3. Depois investiga com calma o que quebrou.
+
+## 🤖 Trabalhando com Claude Code
+
+- Claude só commita na branch de quem está pedindo.
+- Se Nicolas pede, Claude trabalha em `dev-nicolas`.
+- Se André pede, Claude trabalha em `dev-andre`.
+- Claude abre PR; humano revisa e mergeia.

--- a/app/admin/migrations/page.tsx
+++ b/app/admin/migrations/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+import { useEffect, useState, useCallback } from "react";
+import { useAdmin } from "@/components/admin/AdminShell";
+
+interface MigrationItem {
+  nome: string;
+  sql: string;
+  aplicada: boolean;
+  aplicada_em: string | null;
+  aplicada_por: string | null;
+  sucesso: boolean | null;
+  erro: string | null;
+  orfa?: boolean;
+}
+
+export default function MigrationsPage() {
+  const { password, apiHeaders } = useAdmin();
+  const [items, setItems] = useState<MigrationItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [expandido, setExpandido] = useState<string | null>(null);
+  const [filtro, setFiltro] = useState<"todas" | "pendentes" | "aplicadas">("todas");
+
+  const headers = useCallback((): Record<string, string> => apiHeaders({ "Content-Type": "application/json" }), [apiHeaders]);
+
+  const fetchList = useCallback(async () => {
+    if (!password) return;
+    setLoading(true);
+    setErro(null);
+    try {
+      const res = await fetch("/api/admin/migrations", { headers: headers() });
+      const j = await res.json();
+      if (!res.ok) {
+        setErro(j.error + (j.hint ? `\n\n💡 ${j.hint}` : ""));
+        setItems([]);
+      } else {
+        setItems(j.items || []);
+      }
+    } catch (e) {
+      setErro(String(e));
+    }
+    setLoading(false);
+  }, [password, headers]);
+
+  useEffect(() => { fetchList(); }, [fetchList]);
+
+  async function rodar(nome: string) {
+    if (!confirm(`Rodar a migration "${nome}" no banco de produção?\n\nIsso vai executar o SQL do arquivo imediatamente.`)) return;
+    setBusy(nome);
+    try {
+      const res = await fetch("/api/admin/migrations", {
+        method: "POST",
+        headers: headers(),
+        body: JSON.stringify({ nome, action: "run" }),
+      });
+      const j = await res.json();
+      if (!res.ok) alert("❌ Erro ao rodar:\n\n" + j.error);
+      else alert("✅ Migration aplicada com sucesso!");
+    } catch (e) {
+      alert("❌ Erro: " + String(e));
+    }
+    setBusy(null);
+    fetchList();
+  }
+
+  async function marcarComoAplicada(nome: string) {
+    if (!confirm(`Marcar "${nome}" como aplicada SEM rodar?\n\nUse isso só quando você já rodou o SQL manualmente no Supabase e quer registrar.`)) return;
+    setBusy(nome);
+    await fetch("/api/admin/migrations", {
+      method: "POST", headers: headers(),
+      body: JSON.stringify({ nome, action: "mark" }),
+    });
+    setBusy(null);
+    fetchList();
+  }
+
+  async function desmarcar(nome: string) {
+    if (!confirm(`Desmarcar "${nome}"?\n\nIsso remove o registro de aplicada mas NÃO desfaz o SQL no banco.`)) return;
+    setBusy(nome);
+    await fetch("/api/admin/migrations", {
+      method: "POST", headers: headers(),
+      body: JSON.stringify({ nome, action: "unmark" }),
+    });
+    setBusy(null);
+    fetchList();
+  }
+
+  const filtrados = items.filter(i => {
+    if (filtro === "pendentes") return !i.aplicada;
+    if (filtro === "aplicadas") return i.aplicada;
+    return true;
+  });
+
+  const totalPendentes = items.filter(i => !i.aplicada).length;
+  const totalAplicadas = items.filter(i => i.aplicada).length;
+
+  return (
+    <div className="max-w-5xl mx-auto space-y-4 p-1">
+      <div>
+        <h1 className="text-xl font-bold text-[#1D1D1F]">🗄️ Migrations</h1>
+        <p className="text-sm text-[#86868B] mt-1">
+          Controle centralizado de migrations SQL. Chega de rodar SQL direto no Supabase — coloca o arquivo em <code className="bg-[#F2F2F7] px-1 rounded">supabase/migrations/</code> e aplica por aqui.
+        </p>
+      </div>
+
+      {erro && (
+        <div className="bg-red-50 border border-red-200 rounded-xl p-4 whitespace-pre-wrap">
+          <p className="text-sm font-semibold text-red-800">⚠️ {erro}</p>
+        </div>
+      )}
+
+      {/* Resumo */}
+      <div className="grid grid-cols-3 gap-3">
+        <div className="bg-white border border-[#D2D2D7] rounded-xl p-3 text-center">
+          <p className="text-2xl font-bold text-[#1D1D1F]">{items.length}</p>
+          <p className="text-[11px] text-[#86868B] uppercase tracking-wide">Total</p>
+        </div>
+        <div className="bg-white border border-[#D2D2D7] rounded-xl p-3 text-center">
+          <p className="text-2xl font-bold text-[#E8740E]">{totalPendentes}</p>
+          <p className="text-[11px] text-[#86868B] uppercase tracking-wide">Pendentes</p>
+        </div>
+        <div className="bg-white border border-[#D2D2D7] rounded-xl p-3 text-center">
+          <p className="text-2xl font-bold text-green-600">{totalAplicadas}</p>
+          <p className="text-[11px] text-[#86868B] uppercase tracking-wide">Aplicadas</p>
+        </div>
+      </div>
+
+      {/* Filtro */}
+      <div className="flex gap-2">
+        {(["todas", "pendentes", "aplicadas"] as const).map(f => (
+          <button
+            key={f}
+            onClick={() => setFiltro(f)}
+            className={`px-3 py-1.5 rounded-lg text-xs font-semibold capitalize ${filtro === f ? "bg-[#E8740E] text-white" : "bg-white border border-[#D2D2D7] text-[#86868B]"}`}
+          >
+            {f}
+          </button>
+        ))}
+        <button
+          onClick={fetchList}
+          className="ml-auto px-3 py-1.5 rounded-lg text-xs font-semibold bg-white border border-[#D2D2D7] text-[#86868B] hover:text-[#1D1D1F]"
+        >
+          🔄 Atualizar
+        </button>
+      </div>
+
+      {/* Lista */}
+      {loading ? (
+        <p className="text-center text-sm text-[#86868B] py-8">Carregando...</p>
+      ) : filtrados.length === 0 ? (
+        <p className="text-center text-sm text-[#86868B] py-8">Nenhuma migration nesta categoria.</p>
+      ) : (
+        <div className="space-y-2">
+          {filtrados.map(m => {
+            const isOpen = expandido === m.nome;
+            return (
+              <div key={m.nome} className="bg-white border border-[#D2D2D7] rounded-xl overflow-hidden">
+                <div className="p-3 flex items-center gap-3">
+                  <span className="text-xl">
+                    {m.orfa ? "👻" : m.aplicada ? (m.sucesso === false ? "❌" : "✅") : "⏳"}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-mono text-[#1D1D1F] truncate">{m.nome}</p>
+                    <p className="text-[11px] text-[#86868B]">
+                      {m.orfa && "Sem arquivo local (baseline/órfã) · "}
+                      {m.aplicada
+                        ? `Aplicada em ${m.aplicada_em ? new Date(m.aplicada_em).toLocaleString("pt-BR") : "—"} por ${m.aplicada_por || "—"}`
+                        : "⚠️ Pendente — ainda não foi rodada"}
+                    </p>
+                    {m.erro && <p className="text-[11px] text-red-600 mt-0.5">Erro: {m.erro}</p>}
+                  </div>
+                  <div className="flex gap-1.5 shrink-0">
+                    {!m.orfa && (
+                      <button
+                        onClick={() => setExpandido(isOpen ? null : m.nome)}
+                        className="px-2.5 py-1.5 rounded-lg text-[11px] font-semibold bg-[#F2F2F7] text-[#1D1D1F] hover:bg-[#E5E5EA]"
+                      >
+                        {isOpen ? "Fechar" : "Ver SQL"}
+                      </button>
+                    )}
+                    {!m.aplicada && !m.orfa && (
+                      <>
+                        <button
+                          onClick={() => rodar(m.nome)}
+                          disabled={busy === m.nome}
+                          className="px-2.5 py-1.5 rounded-lg text-[11px] font-semibold bg-[#E8740E] text-white hover:bg-[#D4640A] disabled:opacity-50"
+                        >
+                          {busy === m.nome ? "..." : "▶ Rodar"}
+                        </button>
+                        <button
+                          onClick={() => marcarComoAplicada(m.nome)}
+                          disabled={busy === m.nome}
+                          className="px-2.5 py-1.5 rounded-lg text-[11px] font-semibold bg-white border border-[#D2D2D7] text-[#86868B] hover:text-[#1D1D1F]"
+                          title="Marcar como já aplicada (sem rodar)"
+                        >
+                          ✓ Marcar
+                        </button>
+                      </>
+                    )}
+                    {m.aplicada && (
+                      <button
+                        onClick={() => desmarcar(m.nome)}
+                        disabled={busy === m.nome}
+                        className="px-2.5 py-1.5 rounded-lg text-[11px] font-semibold bg-white border border-red-200 text-red-500 hover:bg-red-50"
+                        title="Desmarcar (não desfaz o SQL)"
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </div>
+                </div>
+                {isOpen && m.sql && (
+                  <pre className="bg-[#1D1D1F] text-green-400 text-[11px] p-3 overflow-x-auto max-h-80 border-t border-[#D2D2D7]">
+                    {m.sql}
+                  </pre>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="bg-[#FFF8F2] border border-[#FFD4A8] rounded-xl p-4 mt-6">
+        <p className="text-xs font-bold text-[#1D1D1F] mb-1">📌 Como usar</p>
+        <ol className="text-xs text-[#86868B] space-y-0.5 list-decimal pl-4">
+          <li>Cria o arquivo em <code className="bg-white px-1 rounded">supabase/migrations/AAAAMMDD_descricao.sql</code></li>
+          <li>Commita na sua branch (dev-nicolas ou dev-andre)</li>
+          <li>Faz o deploy do preview e abre essa página aqui</li>
+          <li>Clica em <strong>▶ Rodar</strong> na migration pendente</li>
+          <li>Confere que ficou ✅ aplicada</li>
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/migrations/route.ts
+++ b/app/api/admin/migrations/route.ts
@@ -1,0 +1,128 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+import { logActivity } from "@/lib/activity-log";
+
+function auth(request: Request) {
+  const pw = request.headers.get("x-admin-password");
+  return pw === process.env.ADMIN_PASSWORD;
+}
+function getUser(request: Request) {
+  const r = request.headers.get("x-admin-user") || "Sistema";
+  try { return decodeURIComponent(r); } catch { return r; }
+}
+
+const MIGRATIONS_DIR = path.join(process.cwd(), "supabase", "migrations");
+
+type AppliedRow = { nome: string; aplicada_em: string; aplicada_por: string | null; sucesso: boolean; erro: string | null };
+
+async function listFiles(): Promise<{ nome: string; sql: string }[]> {
+  try {
+    const files = await fs.readdir(MIGRATIONS_DIR);
+    const sqls = files.filter(f => f.endsWith(".sql")).sort();
+    const out: { nome: string; sql: string }[] = [];
+    for (const f of sqls) {
+      try {
+        const sql = await fs.readFile(path.join(MIGRATIONS_DIR, f), "utf-8");
+        out.push({ nome: f, sql });
+      } catch { /* ignore */ }
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+// GET: lista todas as migrations (arquivo no disco + status de aplicada no banco)
+export async function GET(request: Request) {
+  if (!auth(request)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { supabase } = await import("@/lib/supabase");
+
+  const files = await listFiles();
+  const { data: applied, error } = await supabase
+    .from("_migrations_applied")
+    .select("*")
+    .order("aplicada_em", { ascending: false });
+  if (error) return NextResponse.json({ error: error.message, hint: "Rode a migration 20260408_migrations_applied.sql no Supabase primeiro." }, { status: 500 });
+
+  const appliedMap = new Map<string, AppliedRow>();
+  for (const a of (applied || []) as AppliedRow[]) appliedMap.set(a.nome, a);
+
+  const items = files.map(f => {
+    const a = appliedMap.get(f.nome);
+    return {
+      nome: f.nome,
+      sql: f.sql,
+      aplicada: !!a,
+      aplicada_em: a?.aplicada_em || null,
+      aplicada_por: a?.aplicada_por || null,
+      sucesso: a?.sucesso ?? null,
+      erro: a?.erro || null,
+    };
+  });
+
+  // também inclui linhas de applied que não têm arquivo (baseline / órfãs)
+  const fileNames = new Set(files.map(f => f.nome));
+  const orfas = (applied || [])
+    .filter((a: AppliedRow) => !fileNames.has(a.nome))
+    .map((a: AppliedRow) => ({
+      nome: a.nome, sql: "", aplicada: true,
+      aplicada_em: a.aplicada_em, aplicada_por: a.aplicada_por,
+      sucesso: a.sucesso, erro: a.erro, orfa: true,
+    }));
+
+  return NextResponse.json({ items: [...items, ...orfas] });
+}
+
+// POST { nome, action: "run" | "mark" | "unmark" }
+export async function POST(request: Request) {
+  if (!auth(request)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const body = await request.json();
+  const { nome, action } = body || {};
+  if (!nome || !action) return NextResponse.json({ error: "nome e action obrigatórios" }, { status: 400 });
+  const { supabase } = await import("@/lib/supabase");
+  const user = getUser(request);
+
+  if (action === "mark") {
+    const { error } = await supabase
+      .from("_migrations_applied")
+      .upsert({ nome, aplicada_por: user, aplicada_em: new Date().toISOString(), sucesso: true, erro: null });
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    logActivity(user, "Marcou migration como aplicada", nome, "migration").catch(() => {});
+    return NextResponse.json({ ok: true });
+  }
+
+  if (action === "unmark") {
+    const { error } = await supabase.from("_migrations_applied").delete().eq("nome", nome);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    logActivity(user, "Desmarcou migration", nome, "migration").catch(() => {});
+    return NextResponse.json({ ok: true });
+  }
+
+  if (action === "run") {
+    // Lê o arquivo
+    let sql = "";
+    try {
+      sql = await fs.readFile(path.join(MIGRATIONS_DIR, nome), "utf-8");
+    } catch {
+      return NextResponse.json({ error: "Arquivo não encontrado: " + nome }, { status: 404 });
+    }
+    // Executa via RPC exec_sql (criado pela bootstrap migration)
+    const { error: runErr } = await supabase.rpc("exec_sql", { sql });
+    if (runErr) {
+      await supabase.from("_migrations_applied").upsert({
+        nome, aplicada_por: user, aplicada_em: new Date().toISOString(),
+        sucesso: false, erro: runErr.message,
+      });
+      return NextResponse.json({ error: runErr.message }, { status: 500 });
+    }
+    await supabase.from("_migrations_applied").upsert({
+      nome, aplicada_por: user, aplicada_em: new Date().toISOString(),
+      sucesso: true, erro: null,
+    });
+    logActivity(user, "Rodou migration", nome, "migration").catch(() => {});
+    return NextResponse.json({ ok: true });
+  }
+
+  return NextResponse.json({ error: "action inválida" }, { status: 400 });
+}

--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -97,6 +97,7 @@ const NAV: NavEntry[] = [
     label: "Sistema", icon: "\u2699\uFE0F",
     items: [
       { href: "/admin/taxas", label: "Taxas Maquinas", icon: "\u{1F4B3}", pageKey: "taxas" },
+      { href: "/admin/migrations", label: "Migrations", icon: "\u{1F5C4}\uFE0F", pageKey: "migrations" },
       { href: "/admin/log", label: "Log de Atividades", icon: "\u{1F4CB}", pageKey: "log" },
       { href: "/admin/usuarios", label: "Usuarios", icon: "\u{1F465}", pageKey: "usuarios" },
       { href: "/admin/configuracoes", label: "Configuracoes", icon: "⚙️", pageKey: "configuracoes" },

--- a/supabase/migrations/20260408_migrations_applied.sql
+++ b/supabase/migrations/20260408_migrations_applied.sql
@@ -1,0 +1,54 @@
+-- Controle de migrations aplicadas.
+-- Cada arquivo .sql em supabase/migrations/ é listado na página /admin/migrations.
+-- Ao rodar, o nome do arquivo é inserido aqui pra nunca mais rodar de novo.
+
+create table if not exists _migrations_applied (
+  nome text primary key,
+  aplicada_em timestamptz not null default now(),
+  aplicada_por text,
+  checksum text,
+  sucesso boolean default true,
+  erro text
+);
+
+-- Helper: exec SQL dinâmico (necessário pra rodar migrations via API).
+-- Só o service role pode chamar, e a página /admin/migrations usa x-admin-password.
+create or replace function exec_sql(sql text)
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  execute sql;
+end;
+$$;
+
+revoke all on function exec_sql(text) from public;
+revoke all on function exec_sql(text) from anon;
+revoke all on function exec_sql(text) from authenticated;
+-- service_role keeps access (owner).
+
+-- Semeia as migrations antigas como já aplicadas (baseline até 07/04).
+-- Só marca, não roda de novo.
+insert into _migrations_applied (nome, aplicada_por, aplicada_em) values
+  ('20260403_garantia.sql', 'baseline', now()),
+  ('20260403_tipo_atacado.sql', 'baseline', now()),
+  ('20260403_unique_serial_ativo.sql', 'baseline', now()),
+  ('20260404_cor_pt.sql', 'baseline', now()),
+  ('20260404_scan_sessions.sql', 'baseline', now()),
+  ('20260404_trocas.sql', 'baseline', now()),
+  ('20260406_app_settings.sql', 'baseline', now()),
+  ('20260406_app_settings_grants.sql', 'baseline', now()),
+  ('20260406_cleanup_acessorios_serial.sql', 'baseline', now()),
+  ('20260406_fix_duplicate_serial.sql', 'baseline', now()),
+  ('20260406_rename_grade_aplus.sql', 'baseline', now()),
+  ('20260406_vendas_troca_serial_imei.sql', 'baseline', now()),
+  ('20260407_entregas_flags_bia.sql', 'baseline', now()),
+  ('20260407_estoque_troca_id.sql', 'baseline', now()),
+  ('20260407_gastos_estorno.sql', 'baseline', now()),
+  ('20260407_link_compras.sql', 'baseline', now()),
+  ('20260407_link_compras_entrega.sql', 'baseline', now()),
+  ('20260407_simulacoes_cor_usado.sql', 'baseline', now()),
+  ('20260407_trocas_grants.sql', 'baseline', now()),
+  ('20260407_vendas_frete_atacado.sql', 'baseline', now())
+on conflict (nome) do nothing;


### PR DESCRIPTION
## Fim da bagunça de SQL manual

- Nova página **/admin/migrations** em Sistema
- Lista todos os arquivos em \`supabase/migrations/\` com status ✅/⏳
- Botão **▶ Rodar** aplica a migration direto pelo admin
- Baseline: 20 migrations antigas já marcadas como aplicadas
- **CLAUDE.md** na raiz com regras de branches e fluxo

## Como testar no preview
1. Abre \`/admin/migrations\`
2. Confere que aparece a lista com o baseline verde
3. A migration \`20260408_migrations_applied.sql\` já deve estar marcada (você rodou manualmente)

## ⚠️ Antes de mergear
Já foi rodado no Supabase pelo Nicolas: \`20260408_migrations_applied.sql\` (cria tabela \`_migrations_applied\` + função \`exec_sql\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)