### PR TITLE
fix(estoque): Apple Watch display + SE→Series 11

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -302,6 +302,19 @@ function displayNomeProduto(nome: string, cor: string | null | undefined, catego
   if (categoria && (getBaseCat(categoria) === "MACBOOK" || getBaseCat(categoria) === "MAC_MINI")) {
     display = display.replace(/\s*\(\d+C?\s*CPU\/\d+C?\s*GPU\)/gi, "").replace(/\s+/g, " ").trim();
   }
+  // Apple Watch: remover "PULSEIRA ..." do nome (aparece como badge) e, para Ultra, remover "GPS + Cellular"
+  if (categoria && getBaseCat(categoria) === "APPLE_WATCH") {
+    // Remove sufixo "PULSEIRA XYZ..." (até fim da string, já que vem por último)
+    display = display.replace(/\s*PULSEIRA\s+.*$/i, "").trim();
+    if (/ULTRA/i.test(display)) {
+      display = display
+        .replace(/\s*GPS\s*\+\s*CELLULAR\b/gi, "")
+        .replace(/\s*GPS\s*\+\s*CEL\b/gi, "")
+        .replace(/\s+CELLULAR\b/gi, "")
+        .replace(/\s+/g, " ")
+        .trim();
+    }
+  }
   if (!cor) {
     // Sem campo cor: tenta encontrar e traduzir cor PT embutida no nome
     const upper = display.toUpperCase();

--- a/supabase/migrations/20260409_rename_apple_watch_se_to_series11.sql
+++ b/supabase/migrations/20260409_rename_apple_watch_se_to_series11.sql
@@ -1,0 +1,7 @@
+-- Renomeia Apple Watch SE 42mm/46mm para Series 11 (eram Series 11 cadastrados erradamente como SE)
+-- Só afeta os tamanhos 42mm/46mm (SE real vem em 40mm/44mm)
+
+update estoque
+set produto = regexp_replace(produto, 'Apple Watch SE', 'Apple Watch Series 11', 'i')
+where categoria = 'APPLE_WATCH'
+  and produto ~* 'Apple Watch SE\s+4[26]\s*mm';


### PR DESCRIPTION
## Summary
- displayNomeProduto: remove sufixo PULSEIRA do nome (fica só no badge) e remove GPS+Cellular para Ultra
- Nova migration renomeia Apple Watch SE 42mm/46mm para Series 11 no estoque

## Test plan
- [ ] /admin/migrations mostra 20260409 como Pendente
- [ ] Rodar migration e validar Series 11
- [ ] Ultra sem GPS+Cellular no nome
- [ ] Pulseira como badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)