### PR TITLE
feat(entregas): view diária + motoboys + autocomplete cliente

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -76,15 +76,28 @@ export default function EntregasPage() {
   const [entregas, setEntregas] = useState<Entrega[]>([]);
   const [loading, setLoading] = useState(true);
   const [weekOffset, setWeekOffset] = useState(0);
+  // Visualização: "dia" (default) mostra um único dia com divisão por motoboy;
+  // "semana" mostra o calendário semanal completo (visão geral).
+  const [viewMode, setViewMode] = useState<"dia" | "semana">("dia");
+  // Data que estamos visualizando no modo "dia" — começa em hoje.
+  const [viewDate, setViewDate] = useState<string>(() => hojeBR());
   const [filtroBia, setFiltroBia] = useState<"todas" | "finalizada" | "pendentes_final" | "comprovante" | "sem_comprovante">("todas");
   const [showForm, setShowForm] = useState(false);
   const [modoSimples, setModoSimples] = useState(false);
   const [rastreio, setRastreio] = useState("");
 
-  // Autocomplete de clientes cadastrados (baseado em entregas anteriores)
-  type ClienteSug = { cliente: string; telefone: string | null; endereco: string | null; bairro: string | null; regiao: string | null };
+  // Autocomplete de clientes — busca em entregas + vendas, retorna última compra
+  type ClienteSug = {
+    cliente: string;
+    telefone: string | null;
+    endereco: string | null;
+    bairro: string | null;
+    regiao: string | null;
+    ultima_compra: { produto: string | null; data: string | null; valor: number | null } | null;
+  };
   const [clienteSugs, setClienteSugs] = useState<ClienteSug[]>([]);
   const [showSugs, setShowSugs] = useState(false);
+  const [clienteUltimaCompra, setClienteUltimaCompra] = useState<ClienteSug["ultima_compra"]>(null);
 
   // Seleção em massa para finalizar várias entregas
   const [modoSelecao, setModoSelecao] = useState(false);
@@ -215,7 +228,10 @@ export default function EntregasPage() {
   const fetchEntregas = useCallback(async () => {
     setLoading(true);
     try {
-      const params = new URLSearchParams({ from, to });
+      // No modo "dia", busca apenas essa data; no modo "semana", busca a semana inteira.
+      const params = viewMode === "dia"
+        ? new URLSearchParams({ from: viewDate, to: viewDate })
+        : new URLSearchParams({ from, to });
       const res = await fetch(`/api/admin/entregas?${params}`, {
         headers: apiHeaders(),
       });
@@ -225,7 +241,7 @@ export default function EntregasPage() {
       }
     } catch { /* ignore */ }
     setLoading(false);
-  }, [password, from, to]);
+  }, [password, from, to, viewMode, viewDate]);
 
   useEffect(() => {
     if (password) fetchEntregas();
@@ -273,6 +289,7 @@ export default function EntregasPage() {
     if (json.ok) {
       setMsg(isEdit ? "Entrega atualizada!" : "Entrega agendada!");
       setForm({ ...emptyForm, data_entrega: hojeBR() });
+      setClienteUltimaCompra(null);
       setProdutos([""]); setTrocas([]); setShowPagAlt(false);
       setCatSel(""); setEstoqueId(""); setDesconto(""); setTrocaAtiva(false); setTrocaValor(""); setTrocaProduto(""); setTrocaCor(""); setTrocaBateria(""); setTrocaObs(""); setProdutoManual(false); setSerialBusca("");
       setEditingEntregaId(null);
@@ -675,7 +692,7 @@ export default function EntregasPage() {
                   className={inputCls}
                 />
                 {showSugs && clienteSugs.length > 0 && (
-                  <div className="absolute z-50 top-full left-0 right-0 mt-1 bg-white border border-[#D2D2D7] rounded-xl shadow-lg max-h-[280px] overflow-y-auto">
+                  <div className="absolute z-50 top-full left-0 right-0 mt-1 bg-white border border-[#D2D2D7] rounded-xl shadow-lg max-h-[320px] overflow-y-auto">
                     {clienteSugs.map((s, i) => (
                       <button
                         key={i}
@@ -686,6 +703,7 @@ export default function EntregasPage() {
                           if (s.endereco) set("endereco", s.endereco);
                           if (s.bairro) set("bairro", s.bairro);
                           if (s.regiao) set("regiao", s.regiao);
+                          setClienteUltimaCompra(s.ultima_compra);
                           setShowSugs(false);
                         }}
                         className="w-full text-left px-3 py-2 hover:bg-[#FFF5EB] border-b border-[#F5F5F7] last:border-b-0"
@@ -694,9 +712,23 @@ export default function EntregasPage() {
                         <p className="text-[10px] text-[#86868B]">
                           {s.telefone || "—"}{s.bairro ? ` · ${s.bairro}` : ""}{s.endereco ? ` · ${s.endereco.slice(0, 40)}${s.endereco.length > 40 ? "..." : ""}` : ""}
                         </p>
+                        {s.ultima_compra?.produto && (
+                          <p className="text-[10px] text-[#E8740E] font-semibold mt-0.5">
+                            🛒 {s.ultima_compra.produto.slice(0, 48)}{s.ultima_compra.produto.length > 48 ? "..." : ""}
+                            {s.ultima_compra.data ? ` · ${formatDateBR(s.ultima_compra.data)}` : ""}
+                            {s.ultima_compra.valor ? ` · R$ ${s.ultima_compra.valor.toLocaleString("pt-BR")}` : ""}
+                          </p>
+                        )}
                       </button>
                     ))}
                   </div>
+                )}
+                {clienteUltimaCompra?.produto && (
+                  <p className="text-[10px] text-[#E8740E] font-semibold mt-1">
+                    🛒 Última compra: {clienteUltimaCompra.produto}
+                    {clienteUltimaCompra.data ? ` · ${formatDateBR(clienteUltimaCompra.data)}` : ""}
+                    {clienteUltimaCompra.valor ? ` · R$ ${clienteUltimaCompra.valor.toLocaleString("pt-BR")}` : ""}
+                  </p>
                 )}
               </div>
             </div>
@@ -1014,8 +1046,41 @@ export default function EntregasPage() {
               </select>
             </div>
             <div>
-              <p className={labelCls}>Entregador</p>
-              <input value={form.entregador} onChange={(e) => set("entregador", e.target.value)} placeholder="Nome (opcional)" className={inputCls} />
+              <p className={labelCls}>Motoboy / Entregador</p>
+              <select
+                value={
+                  form.entregador === "IGOR" || form.entregador === "LEANDRO" ||
+                  form.entregador === "RETIRADA" || form.entregador === "CORREIOS" ||
+                  form.entregador === "" ? form.entregador : "OUTRO"
+                }
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === "OUTRO") {
+                    // mantém o texto livre caso já exista, senão limpa para o usuário digitar
+                    if (["IGOR","LEANDRO","RETIRADA","CORREIOS",""].includes(form.entregador)) {
+                      set("entregador", " ");
+                    }
+                  } else {
+                    set("entregador", v);
+                  }
+                }}
+                className={inputCls}
+              >
+                <option value="">-- Selecionar --</option>
+                <option value="IGOR">🛵 Igor</option>
+                <option value="LEANDRO">🛵 Leandro</option>
+                <option value="RETIRADA">🏬 Retirada em loja</option>
+                <option value="CORREIOS">📦 Correios</option>
+                <option value="OUTRO">✏️ Outro (digitar)</option>
+              </select>
+              {!["IGOR","LEANDRO","RETIRADA","CORREIOS",""].includes(form.entregador) && (
+                <input
+                  value={form.entregador}
+                  onChange={(e) => set("entregador", e.target.value)}
+                  placeholder="Nome do entregador"
+                  className={`${inputCls} mt-1`}
+                />
+              )}
             </div>
             <div className="col-span-2 md:col-span-3">
               <p className={labelCls}>Observacao</p>
@@ -1140,10 +1205,210 @@ export default function EntregasPage() {
         </div>
       )}
 
+      {/* Navegação de modo (Dia / Semana) */}
+      {!loading && (
+        <div className="bg-white border border-[#D2D2D7] rounded-xl p-3 flex flex-wrap items-center gap-2">
+          {/* Toggle modo */}
+          <div className="flex gap-1 bg-[#F5F5F7] rounded-lg p-1">
+            <button
+              onClick={() => { setViewMode("dia"); setViewDate(hojeBR()); }}
+              className={`px-3 py-1 rounded-md text-xs font-bold transition ${viewMode === "dia" ? "bg-[#E8740E] text-white" : "text-[#86868B] hover:text-[#1D1D1F]"}`}
+            >
+              📅 Dia
+            </button>
+            <button
+              onClick={() => setViewMode("semana")}
+              className={`px-3 py-1 rounded-md text-xs font-bold transition ${viewMode === "semana" ? "bg-[#E8740E] text-white" : "text-[#86868B] hover:text-[#1D1D1F]"}`}
+            >
+              🗓️ Semana
+            </button>
+          </div>
+
+          {viewMode === "dia" && (
+            <>
+              <div className="flex items-center gap-1 ml-2">
+                <button
+                  onClick={() => {
+                    const d = new Date(viewDate + "T12:00:00");
+                    d.setDate(d.getDate() - 1);
+                    setViewDate(d.toISOString().split("T")[0]);
+                  }}
+                  className="px-2 py-1 rounded-md text-xs font-bold bg-[#F5F5F7] hover:bg-[#E5E5EA] text-[#1D1D1F]"
+                >
+                  ← Ontem
+                </button>
+                <button
+                  onClick={() => setViewDate(hojeBR())}
+                  className={`px-3 py-1 rounded-md text-xs font-bold ${viewDate === hojeBR() ? "bg-[#E8740E] text-white" : "bg-[#F5F5F7] hover:bg-[#E5E5EA] text-[#1D1D1F]"}`}
+                >
+                  Hoje
+                </button>
+                <button
+                  onClick={() => {
+                    const d = new Date(viewDate + "T12:00:00");
+                    d.setDate(d.getDate() + 1);
+                    setViewDate(d.toISOString().split("T")[0]);
+                  }}
+                  className="px-2 py-1 rounded-md text-xs font-bold bg-[#F5F5F7] hover:bg-[#E5E5EA] text-[#1D1D1F]"
+                >
+                  Amanhã →
+                </button>
+              </div>
+              <input
+                type="date"
+                value={viewDate}
+                onChange={(e) => setViewDate(e.target.value)}
+                className="ml-2 px-2 py-1 rounded-md text-xs border border-[#D2D2D7] bg-white"
+              />
+              <span className="ml-auto text-xs text-[#86868B]">
+                {(() => {
+                  const d = new Date(viewDate + "T12:00:00");
+                  const weekday = ["Domingo","Segunda","Terça","Quarta","Quinta","Sexta","Sábado"][d.getDay()];
+                  return `${weekday}, ${d.getDate()}/${String(d.getMonth() + 1).padStart(2, "0")}/${d.getFullYear()}`;
+                })()}
+              </span>
+            </>
+          )}
+        </div>
+      )}
+
+      {/* VIEW: DIA (com swimlanes por motoboy) */}
+      {!loading && viewMode === "dia" && (() => {
+        const filtered = entregas.filter((e) => e.data_entrega === viewDate).filter((e) => {
+          if (filtroBia === "finalizada") return e.finalizada === true;
+          if (filtroBia === "pendentes_final") return e.finalizada !== true;
+          if (filtroBia === "comprovante") return e.comprovante_lancado === true;
+          if (filtroBia === "sem_comprovante") return e.comprovante_lancado !== true;
+          return true;
+        });
+        filtered.sort((a, b) => (a.horario || "ZZZ").localeCompare(b.horario || "ZZZ"));
+
+        const isFutureOrPast = viewDate !== hojeBR();
+
+        // Agrupa por motoboy
+        const aguardando = filtered.filter((e) => !e.entregador || e.entregador.trim() === "");
+        const igor = filtered.filter((e) => (e.entregador || "").toUpperCase() === "IGOR");
+        const leandro = filtered.filter((e) => (e.entregador || "").toUpperCase() === "LEANDRO");
+        const outras = filtered.filter((e) => {
+          const ent = (e.entregador || "").toUpperCase();
+          return ent && ent !== "IGOR" && ent !== "LEANDRO";
+        });
+
+        const renderCard = (e: Entrega) => {
+          const sc = STATUS_CONFIG[e.status];
+          const isSel = entregasSelecionadas.has(e.id);
+          return (
+            <button
+              key={e.id}
+              onClick={() => {
+                if (modoSelecao) {
+                  const next = new Set(entregasSelecionadas);
+                  if (next.has(e.id)) next.delete(e.id); else next.add(e.id);
+                  setEntregasSelecionadas(next);
+                } else {
+                  setSelectedEntrega(e);
+                }
+              }}
+              className={`w-full text-left p-3 rounded-lg border transition-all hover:shadow-sm ${isSel ? "ring-2 ring-blue-500 border-blue-500" : `${dm ? sc.borderDark : sc.border} ${dm ? sc.bgDark : sc.bg}`}`}
+            >
+              <div className="flex items-center justify-between mb-1">
+                <div className="flex items-center gap-2">
+                  <span>{sc.icon}</span>
+                  {e.horario && <span className={`text-sm font-bold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{e.horario}</span>}
+                </div>
+                <div className="flex items-center gap-1">
+                  {e.finalizada && <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-green-500/20 text-green-600">✅</span>}
+                  {e.comprovante_lancado && <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-600">🧾</span>}
+                </div>
+              </div>
+              <p className={`text-sm font-semibold truncate ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{e.cliente}</p>
+              {e.bairro && <p className={`text-[11px] truncate ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>{e.bairro}</p>}
+              {e.produto && <p className={`text-[11px] truncate ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>🍎 {e.produto}</p>}
+            </button>
+          );
+        };
+
+        const renderColumn = (titulo: string, emoji: string, lista: Entrega[], cor: string) => (
+          <div className={`bg-white border rounded-xl overflow-hidden ${cor}`}>
+            <div className={`px-3 py-2 text-center border-b ${cor}`}>
+              <p className="text-xs font-bold uppercase tracking-wide">
+                {emoji} {titulo} <span className="text-[10px] opacity-70">({lista.length})</span>
+              </p>
+            </div>
+            <div className="p-2 space-y-2 min-h-[120px]">
+              {lista.length === 0 ? (
+                <p className="text-[11px] text-[#B0B0B0] text-center py-6">Sem entregas</p>
+              ) : (
+                lista.map(renderCard)
+              )}
+            </div>
+          </div>
+        );
+
+        // Se for dia futuro/passado: lista simples (sem divisão de motoboy)
+        if (isFutureOrPast) {
+          return (
+            <div className="bg-white border border-[#D2D2D7] rounded-xl overflow-hidden">
+              <div className="px-4 py-2 bg-[#F5F5F7] border-b border-[#D2D2D7]">
+                <p className="text-xs font-bold text-[#86868B] uppercase">
+                  {filtered.length} entrega{filtered.length !== 1 ? "s" : ""} agendada{filtered.length !== 1 ? "s" : ""}
+                </p>
+              </div>
+              <div className="p-3 space-y-2">
+                {filtered.length === 0 ? (
+                  <p className="text-sm text-[#B0B0B0] text-center py-8">Nenhuma entrega nessa data</p>
+                ) : (
+                  filtered.map(renderCard)
+                )}
+              </div>
+            </div>
+          );
+        }
+
+        // Hoje: aguardando (topo) + Igor/Leandro (swimlanes) + outras (baixo)
+        return (
+          <div className="space-y-3">
+            {aguardando.length > 0 && (
+              <div className="bg-yellow-50 border-2 border-yellow-300 rounded-xl overflow-hidden">
+                <div className="px-4 py-2 bg-yellow-100 border-b-2 border-yellow-300">
+                  <p className="text-xs font-bold text-yellow-800 uppercase">
+                    ⏳ Aguardando motoboy ({aguardando.length})
+                  </p>
+                </div>
+                <div className="p-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                  {aguardando.map(renderCard)}
+                </div>
+              </div>
+            )}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {renderColumn("Motoboy Igor", "🛵", igor, "border-blue-300")}
+              {renderColumn("Motoboy Leandro", "🛵", leandro, "border-purple-300")}
+            </div>
+            {outras.length > 0 && (
+              <div className="bg-white border border-[#D2D2D7] rounded-xl overflow-hidden">
+                <div className="px-4 py-2 bg-[#F5F5F7] border-b border-[#D2D2D7]">
+                  <p className="text-xs font-bold text-[#86868B] uppercase">
+                    📦 Outras ({outras.length}) — Retirada / Correios / Externo
+                  </p>
+                </div>
+                <div className="p-3 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+                  {outras.map(renderCard)}
+                </div>
+              </div>
+            )}
+            {filtered.length === 0 && (
+              <div className="bg-white border border-[#D2D2D7] rounded-xl p-8 text-center">
+                <p className="text-sm text-[#86868B]">Nenhuma entrega agendada para hoje</p>
+              </div>
+            )}
+          </div>
+        );
+      })()}
+
       {/* Calendario semanal */}
       {loading ? (
         <div className="p-8 text-center text-[#86868B]">Carregando...</div>
-      ) : (
+      ) : viewMode === "semana" ? (
         <>
           {/* Desktop: grid de 6 colunas */}
           <div className="hidden md:grid grid-cols-6 gap-2">
@@ -1281,7 +1546,7 @@ export default function EntregasPage() {
             })}
           </div>
         </>
-      )}
+      ) : null}
 
       {/* Resumo da semana */}
       {!loading && (

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -2662,6 +2662,23 @@ export default function VendasPage() {
               )}
             </div>
 
+            {/* Destaque do valor na forma principal quando é PIX ou ESPECIE
+                 (nesses casos não existe campo próprio — o valor sai do Preço Vendido Líquido
+                 menos as entradas mistas). Deixa explícito pra vendedora não ficar perdida. */}
+            {(form.forma === "ESPECIE" || form.forma === "PIX") && preco > 0 && (
+              <div className="mt-3 rounded-xl border-2 border-[#E8740E]/40 bg-[#FFF7ED] px-4 py-3 flex items-center justify-between flex-wrap gap-2">
+                <div>
+                  <p className="text-[10px] font-bold uppercase tracking-wider text-[#E8740E]">
+                    {form.forma === "ESPECIE" ? "💵 Valor em Espécie (Dinheiro)" : "💸 Valor em PIX"}
+                  </p>
+                  <p className="text-xl font-bold text-[#1D1D1F]">R$ {fmt(Math.max(0, valorCartao))}</p>
+                </div>
+                <p className="text-[10px] text-[#86868B] max-w-[280px] text-right">
+                  Calculado do Preço Vendido Líquido menos entradas mistas e troca. Pra mudar, ajuste o &quot;Preço Vendido Líquido&quot; acima.
+                </p>
+              </div>
+            )}
+
             {/* Pagamento misto — combinações extras */}
             {form.forma && form.forma !== "FIADO" && (
             <div className="border-t border-[#E8E8ED] pt-3 space-y-3">
@@ -2926,6 +2943,21 @@ export default function VendasPage() {
                   </>
                 )}
               </div>
+
+              {/* Destaque do valor na forma principal quando é PIX ou ESPECIE — modo carrinho */}
+              {(form.forma === "ESPECIE" || form.forma === "PIX") && preco > 0 && (
+                <div className="mt-3 rounded-xl border-2 border-[#E8740E]/40 bg-[#FFF7ED] px-4 py-3 flex items-center justify-between flex-wrap gap-2">
+                  <div>
+                    <p className="text-[10px] font-bold uppercase tracking-wider text-[#E8740E]">
+                      {form.forma === "ESPECIE" ? "💵 Valor em Espécie (Dinheiro)" : "💸 Valor em PIX"}
+                    </p>
+                    <p className="text-xl font-bold text-[#1D1D1F]">R$ {fmt(Math.max(0, valorCartao))}</p>
+                  </div>
+                  <p className="text-[10px] text-[#86868B] max-w-[280px] text-right">
+                    Calculado do Preço Vendido Líquido menos entradas mistas e troca.
+                  </p>
+                </div>
+              )}
 
               {/* Pagamento misto — cart mode */}
               {form.forma && form.forma !== "FIADO" && (

--- a/app/api/admin/entregas/route.ts
+++ b/app/api/admin/entregas/route.ts
@@ -15,27 +15,91 @@ export async function GET(req: NextRequest) {
   const to = searchParams.get("to");
   const searchClientes = searchParams.get("search_clientes")?.trim() || "";
 
-  // Autocomplete de clientes cadastrados (baseado em entregas anteriores)
+  // Autocomplete de clientes — busca em entregas E vendas, retorna última compra
   if (searchClientes) {
     const like = `%${searchClientes}%`;
-    const { data, error } = await supabase
-      .from("entregas")
-      .select("cliente, telefone, endereco, bairro, regiao")
-      .or(`cliente.ilike.${like},telefone.ilike.${like}`)
-      .order("created_at", { ascending: false })
-      .limit(200);
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-    // Dedup por cliente+telefone (pega o mais recente de cada)
-    const seen = new Set<string>();
-    const unique: Array<{ cliente: string; telefone: string | null; endereco: string | null; bairro: string | null; regiao: string | null }> = [];
-    for (const r of data || []) {
-      const key = `${(r.cliente || "").toLowerCase().trim()}|${(r.telefone || "").replace(/\D/g, "")}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      unique.push(r);
-      if (unique.length >= 20) break;
+    // Busca em entregas (por nome/telefone)
+    const { data: entregasMatch, error: errEntregas } = await supabase
+      .from("entregas")
+      .select("cliente, telefone, endereco, bairro, regiao, data_entrega, produto")
+      .or(`cliente.ilike.${like},telefone.ilike.${like}`)
+      .order("data_entrega", { ascending: false })
+      .limit(200);
+    if (errEntregas) return NextResponse.json({ error: errEntregas.message }, { status: 500 });
+
+    // Busca em vendas (por nome/telefone — vendas tem 'cliente' e recebimento no formato string)
+    const { data: vendasMatch, error: errVendas } = await supabase
+      .from("vendas")
+      .select("cliente, recebimento, endereco, bairro, produto, data, preco_vendido")
+      .or(`cliente.ilike.${like},recebimento.ilike.${like}`)
+      .order("data", { ascending: false })
+      .limit(200);
+    if (errVendas) return NextResponse.json({ error: errVendas.message }, { status: 500 });
+
+    type ClienteSug = {
+      cliente: string;
+      telefone: string | null;
+      endereco: string | null;
+      bairro: string | null;
+      regiao: string | null;
+      ultima_compra: { produto: string | null; data: string | null; valor: number | null } | null;
+    };
+
+    // Normaliza chave por nome+telefone (só dígitos)
+    const keyFor = (nome: string | null, tel: string | null) =>
+      `${(nome || "").toLowerCase().trim()}|${(tel || "").replace(/\D/g, "")}`;
+
+    // Mescla as duas fontes, priorizando a ordenação mais recente de cada
+    const acc = new Map<string, ClienteSug>();
+
+    // Primeiro entregas (tem endereco/bairro/regiao bons)
+    for (const r of entregasMatch || []) {
+      const key = keyFor(r.cliente, r.telefone);
+      if (!key || key === "|") continue;
+      if (!acc.has(key)) {
+        acc.set(key, {
+          cliente: r.cliente,
+          telefone: r.telefone,
+          endereco: r.endereco,
+          bairro: r.bairro,
+          regiao: r.regiao,
+          ultima_compra: null,
+        });
+      }
     }
+
+    // Depois vendas — preenche dados faltantes e popula ultima_compra
+    for (const v of vendasMatch || []) {
+      const key = keyFor(v.cliente, v.recebimento);
+      if (!key || key === "|") continue;
+      let sug = acc.get(key);
+      if (!sug) {
+        sug = {
+          cliente: v.cliente,
+          telefone: v.recebimento,
+          endereco: v.endereco,
+          bairro: v.bairro,
+          regiao: null,
+          ultima_compra: null,
+        };
+        acc.set(key, sug);
+      } else {
+        // completa dados que estavam faltando
+        if (!sug.endereco && v.endereco) sug.endereco = v.endereco;
+        if (!sug.bairro && v.bairro) sug.bairro = v.bairro;
+      }
+      // Última compra = primeira venda retornada (já ordenada desc por data)
+      if (!sug.ultima_compra && v.produto) {
+        sug.ultima_compra = {
+          produto: v.produto,
+          data: v.data || null,
+          valor: v.preco_vendido != null ? Number(v.preco_vendido) : null,
+        };
+      }
+    }
+
+    const unique = Array.from(acc.values()).slice(0, 20);
     return NextResponse.json({ clientes: unique });
   }
 


### PR DESCRIPTION
## Resumo

Primeira leva de melhorias na aba de Entregas, pedidas pelo André.

### 1. View diária com swimlanes de motoboy (padrão)
- A view padrão agora é **Dia** (não mais a semana toda)
- Toggle no topo: **📅 Dia** / **🗓️ Semana**
- No **dia de hoje**: layout dividido em:
  - ⏳ **Aguardando motoboy** (topo, destacado em amarelo se tiver algum)
  - 🛵 **Igor** (coluna esquerda)
  - 🛵 **Leandro** (coluna direita)
  - 📦 **Outras** (Retirada / Correios / Externo)
- Em **dias passados/futuros**: lista simples cronológica, sem divisão por motoboy — motoboy só é atribuído no próprio dia

### 2. Navegação de data
- Botões **← Ontem · Hoje · Amanhã →**
- Date picker pra pular pra qualquer dia
- Indicador do dia da semana ("Terça, 08/04/2026")

### 3. Select de motoboy padronizado
- Campo "Entregador" virou select com: **Igor**, **Leandro**, **Retirada**, **Correios**, **Outro (digitar)**
- Se escolher "Outro", aparece um input de texto livre

### 4. Autocomplete de cliente expandido
- Busca agora procura em **entregas E vendas** (antes só entregas)
- Retorna também a **última compra** do cliente: produto, data e valor
- Dropdown mostra compacto: nome · telefone · bairro + linha da última compra destacada em laranja
- Após selecionar, aparece "🛒 Última compra: ..." logo abaixo do campo cliente

## Test plan
- [ ] Abrir /admin/entregas → deve mostrar só o dia de hoje por padrão
- [ ] Clicar "Amanhã →" → deve mostrar lista simples do dia seguinte
- [ ] Clicar em "🗓️ Semana" → deve mostrar o calendário semanal antigo (visão geral)
- [ ] Abrir "+ Nova Entrega", digitar 2+ letras no nome → deve listar clientes de entregas+vendas
- [ ] Se o cliente tem compras passadas → deve mostrar última compra no dropdown
- [ ] Selecionar um cliente → preenche todos os campos + mostra "Última compra"
- [ ] No campo Motoboy → selecionar Igor/Leandro e salvar → aparecer na coluna certa do dia
- [ ] Criar entrega sem motoboy → aparecer em "Aguardando motoboy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)