### PR TITLE
fix(estoque): cleanup Apple Watch Series 11 corruption + iPad modelo …

### DIFF
--- a/app/admin/debug-watch/page.tsx
+++ b/app/admin/debug-watch/page.tsx
@@ -23,8 +23,8 @@ export default function DebugWatchPage() {
     try {
       const r = await fetch("/api/admin/debug-watch", {
         method: "POST",
-        headers: { ...apiHeaders, "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "rename" }),
+        headers: { ...apiHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "cleanup" }),
       });
       const j = await r.json();
       alert(JSON.stringify(j, null, 2));

--- a/app/api/admin/debug-watch/route.ts
+++ b/app/api/admin/debug-watch/route.ts
@@ -35,16 +35,15 @@ export async function GET(request: Request) {
 export async function POST(request: Request) {
   if (!auth(request)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const body = await request.json().catch(() => ({}));
-  if (body?.action !== "rename") return NextResponse.json({ error: "action inválida" }, { status: 400 });
+  if (body?.action !== "rename" && body?.action !== "cleanup") return NextResponse.json({ error: "action inválida" }, { status: 400 });
 
   const { supabase } = await import("@/lib/supabase");
 
-  // Busca todas as linhas de APPLE_WATCH com SE 42/46mm
   const { data, error } = await supabase
     .from("estoque")
     .select("id, produto")
     .eq("categoria", "APPLE_WATCH")
-    .or("produto.ilike.%apple watch se%42%mm%,produto.ilike.%apple watch se%46%mm%");
+    .limit(1000);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
@@ -52,7 +51,16 @@ export async function POST(request: Request) {
   const updates: { id: string; produto_antigo: string; produto_novo: string }[] = [];
 
   for (const r of rows) {
-    const novo = (r.produto || "").replace(/apple\s*watch\s*se/gi, "Apple Watch Series 11");
+    let novo = (r.produto || "")
+      // Limpa corrupção: "Series 11RIES 11" → "Series 11" (repete até sumir)
+      .replace(/series\s*11ries\s*11/gi, "Series 11")
+      .replace(/series\s*11ries\s*11/gi, "Series 11")
+      .replace(/series\s*11ries\s*11/gi, "Series 11");
+    // Renomeia SE 42/46mm → Series 11 usando word boundary pra não pegar "SE" dentro de "SERIES"
+    if (/\bse\b\s*4[26]\s*mm/i.test(novo)) {
+      novo = novo.replace(/\bapple\s*watch\s+se\b/gi, "Apple Watch Series 11");
+    }
+    novo = novo.replace(/\s+/g, " ").trim();
     if (novo !== r.produto) {
       const { error: upErr } = await supabase.from("estoque").update({ produto: novo }).eq("id", r.id);
       if (!upErr) updates.push({ id: r.id, produto_antigo: r.produto, produto_novo: novo });

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -686,6 +686,22 @@ export default function ProdutoSpecFields({
       {row.categoria === "IPADS" && (
         <div className={`grid grid-cols-2 md:grid-cols-3 gap-3 p-3 ${bgSection} rounded-lg`}>
           <div>
+            <p className={labelCls}>Modelo</p>
+            <select value={row.spec.ipad_modelo} onChange={(e) => setSpec("ipad_modelo", e.target.value)} className={inputCls}>
+              <option value="IPAD">iPad</option>
+              <option value="MINI 6">iPad Mini 6</option>
+              <option value="MINI 7">iPad Mini 7</option>
+              <option value="AIR 4">iPad Air 4</option>
+              <option value="AIR 5">iPad Air 5</option>
+              <option value="AIR 6">iPad Air 6</option>
+              <option value="AIR 7">iPad Air 7</option>
+              <option value="PRO 11">iPad Pro 11"</option>
+              <option value="PRO 12.9">iPad Pro 12.9"</option>
+              <option value="PRO M4 11">iPad Pro M4 11"</option>
+              <option value="PRO M4 13">iPad Pro M4 13"</option>
+            </select>
+          </div>
+          <div>
             <p className={labelCls}>Tela</p>
             <select value={row.spec.ipad_tela} onChange={(e) => setSpec("ipad_tela", e.target.value)} className={inputCls}>
               <option value="">— Não informar —</option>

--- a/supabase/migrations/20260409c_fix_apple_watch_series_corruption.sql
+++ b/supabase/migrations/20260409c_fix_apple_watch_series_corruption.sql
@@ -1,0 +1,23 @@
+-- 1) Limpa corrupção causada por renames anteriores: "SERIES 11RIES 11" → "SERIES 11"
+update estoque
+set produto = replace(replace(produto, 'SERIES 11RIES 11', 'SERIES 11'), 'Series 11RIES 11', 'Series 11')
+where categoria = 'APPLE_WATCH'
+  and produto ilike '%11RIES 11%';
+
+-- Repete pra cobrir múltiplas iterações de corrupção
+update estoque
+set produto = replace(replace(produto, 'SERIES 11RIES 11', 'SERIES 11'), 'Series 11RIES 11', 'Series 11')
+where categoria = 'APPLE_WATCH'
+  and produto ilike '%11RIES 11%';
+
+update estoque
+set produto = replace(replace(produto, 'SERIES 11RIES 11', 'SERIES 11'), 'Series 11RIES 11', 'Series 11')
+where categoria = 'APPLE_WATCH'
+  and produto ilike '%11RIES 11%';
+
+-- 2) Renomeia Apple Watch SE 42/46mm → Series 11 usando word boundary (\y)
+-- pra NÃO casar o "SE" dentro de "SERIES"
+update estoque
+set produto = regexp_replace(produto, '\yApple Watch SE\y', 'Apple Watch Series 11', 'gi')
+where categoria = 'APPLE_WATCH'
+  and produto ~* '\yApple Watch SE\y\s*4[26]\s*mm';


### PR DESCRIPTION
…field

- Migration limpa nomes corrompidos (SERIES 11RIES 11 → SERIES 11)
- Rename SE 42/46mm → Series 11 com word boundary (não casa SE dentro de SERIES)
- Adiciona dropdown Modelo no formulário do iPad (Air 4/5/6/7, Mini, Pro)
- debug-watch: action cleanup + apiHeaders() corrigido