### PR TITLE
feat(entregas): atribuir motoboy direto no modal

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -1692,6 +1692,53 @@ export default function EntregasPage() {
                   </div>
                 )}
 
+                {/* Atribuir Motoboy */}
+                <div className="pt-2">
+                  <p className="text-xs font-bold text-[#86868B] uppercase mb-2">🛵 Atribuir Motoboy</p>
+                  <div className="flex flex-wrap gap-2">
+                    {([
+                      { value: "IGOR", label: "Igor", emoji: "🛵", color: "blue" },
+                      { value: "LEANDRO", label: "Leandro", emoji: "🛵", color: "purple" },
+                      { value: "RETIRADA", label: "Retirada", emoji: "🏬", color: "gray" },
+                      { value: "CORREIOS", label: "Correios", emoji: "📦", color: "gray" },
+                    ] as const).map((opt) => {
+                      const isActive = (e.entregador || "").toUpperCase() === opt.value;
+                      const activeStyle = opt.color === "blue"
+                        ? "bg-blue-100 text-blue-700 border-2 border-blue-400"
+                        : opt.color === "purple"
+                          ? "bg-purple-100 text-purple-700 border-2 border-purple-400"
+                          : "bg-gray-100 text-gray-700 border-2 border-gray-400";
+                      return (
+                        <button
+                          key={opt.value}
+                          onClick={() => quickPatchEntrega(e.id, { entregador: opt.value })}
+                          className={`px-3 py-2 rounded-lg text-xs font-semibold transition-colors ${
+                            isActive
+                              ? activeStyle
+                              : "bg-white border border-[#D2D2D7] text-[#86868B] hover:bg-[#F5F5F7]"
+                          }`}
+                        >
+                          {opt.emoji} {opt.label}
+                        </button>
+                      );
+                    })}
+                    {e.entregador && !["IGOR","LEANDRO","RETIRADA","CORREIOS"].includes((e.entregador || "").toUpperCase()) && (
+                      <span className="px-3 py-2 rounded-lg text-xs font-semibold bg-gray-100 text-gray-700 border border-gray-300">
+                        ✏️ {e.entregador}
+                      </span>
+                    )}
+                    {e.entregador && (
+                      <button
+                        onClick={() => quickPatchEntrega(e.id, { entregador: null })}
+                        className="px-3 py-2 rounded-lg text-xs font-semibold bg-white border border-red-200 text-red-500 hover:bg-red-50"
+                        title="Remover motoboy"
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </div>
+                </div>
+
                 {/* Status badge */}
                 <div className="pt-2">
                   <p className="text-xs font-bold text-[#86868B] uppercase mb-2">Alterar Status</p>


### PR DESCRIPTION
## Resumo

Ajuste rápido pedido pelo André depois do teste em produção.

Ao clicar numa entrega (especialmente no grupo "Aguardando motoboy"), o modal de detalhes agora tem uma seção **🛵 Atribuir Motoboy** com botões de 1 clique para:

- 🛵 **Igor**
- 🛵 **Leandro**
- 🏬 **Retirada**
- 📦 **Correios**
- ✕ (remover motoboy)

Usa o \`quickPatchEntrega\` existente, então salva sem recarregar a tela. O card se move da seção "Aguardando motoboy" para a coluna certa instantaneamente.

Motoboys customizados (texto livre, ex: "João") aparecem como chip, mas ainda dá pra reatribuir pros padrões clicando em qualquer um deles.

## Test plan
- [ ] Criar entrega sem motoboy → deve aparecer em "Aguardando motoboy"
- [ ] Clicar na entrega → modal com botões Igor/Leandro/Retirada/Correios
- [ ] Clicar em "Igor" → card vai pra coluna Igor automaticamente
- [ ] Clicar em "Leandro" → card vai pra coluna Leandro
- [ ] Clicar no X → volta pra "Aguardando motoboy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)