### PR TITLE
fix(estoque/entregas): regex SE/iPad geração + cores PT

### DIFF
--- a/app/admin/entregas/ProdutoPicker.tsx
+++ b/app/admin/entregas/ProdutoPicker.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useMemo } from "react";
+import { corParaPT } from "@/lib/cor-pt";
 
 export interface EstoquePickerItem {
   id: string;
@@ -91,15 +92,20 @@ export default function ProdutoPicker({
 
   const modelEntries = Object.entries(byModel).sort(([a], [b]) => a.localeCompare(b));
 
-  // Cores disponíveis para o modelo selecionado (únicas, não vazias)
+  // Cores disponíveis para o modelo selecionado (únicas, não vazias).
+  // Agrupa por label PT simplificado (ex "Mist Blue" e "Blue" viram "Azul").
+  // Retorna [{ ptLabel, qnt }] — usa ptLabel como value no select.
   const coresDoModelo = useMemo(() => {
-    if (!modeloSel || !byModel[modeloSel]) return [];
-    const cores = new Set<string>();
+    if (!modeloSel || !byModel[modeloSel]) return [] as { ptLabel: string; qnt: number }[];
+    const map = new Map<string, number>();
     byModel[modeloSel].items.forEach((p) => {
       const c = (p.cor || "").trim();
-      if (c) cores.add(c);
+      if (!c) return;
+      const pt = corParaPT(c) || c;
+      if (!pt || pt === "—") return;
+      map.set(pt, (map.get(pt) || 0) + (p.qnt || 0));
     });
-    return Array.from(cores).sort();
+    return Array.from(map.entries()).map(([ptLabel, qnt]) => ({ ptLabel, qnt })).sort((a, b) => a.ptLabel.localeCompare(b.ptLabel));
   }, [modeloSel, byModel]);
 
   return (
@@ -172,17 +178,11 @@ export default function ProdutoPicker({
           <p className={labelCls}>Cor</p>
           <select value={corSel} onChange={(e) => setCorSel(e.target.value)} className={inputCls}>
             <option value="">-- Selecionar cor --</option>
-            {coresDoModelo.map((cor) => {
-              // Conta quantas unidades dessa cor existem no modelo
-              const qnt = byModel[modeloSel].items
-                .filter((p) => (p.cor || "").trim() === cor)
-                .reduce((s, p) => s + p.qnt, 0);
-              return (
-                <option key={cor} value={cor}>
-                  {cor} ({qnt} un.)
-                </option>
-              );
-            })}
+            {coresDoModelo.map(({ ptLabel, qnt }) => (
+              <option key={ptLabel} value={ptLabel}>
+                {ptLabel} ({qnt} un.)
+              </option>
+            ))}
           </select>
         </div>
       )}

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -85,8 +85,15 @@ function formatProdutoDisplay(p: {
     const chipM = up.match(/(M\d+(?:\s*(?:PRO|MAX))?|A\d+(?:\s*PRO)?)/);
     const chip = chipM ? " " + chipM[1].replace(/\s+/g, " ").toUpperCase() : "";
     let modelo = "iPad";
-    if (/MINI/.test(up)) modelo = "iPad Mini";
+    // Captura geração depois de MINI/AIR/PRO (ex: "IPAD AIR 5", "IPAD MINI 7", "IPAD PRO 6")
+    const mMini = up.match(/IPAD\s+MINI\s+(\d+)\b/);
+    const mAir = up.match(/IPAD\s+AIR\s+(\d+)\b/);
+    const mPro = up.match(/IPAD\s+PRO\s+(\d+)\b/);
+    if (mMini) modelo = `iPad Mini ${mMini[1]}`;
+    else if (/MINI/.test(up)) modelo = "iPad Mini";
+    else if (mAir) modelo = `iPad Air ${mAir[1]}`;
     else if (/AIR/.test(up)) modelo = "iPad Air";
+    else if (mPro) modelo = `iPad Pro ${mPro[1]}`;
     else if (/PRO/.test(up)) modelo = "iPad Pro";
     parts.push(modelo + chip);
     if (tela) parts.push(tela);
@@ -113,7 +120,8 @@ function formatProdutoDisplay(p: {
   } else if (baseCat === "APPLE_WATCH") {
     let modelo = "Apple Watch";
     const ultra = up.match(/ULTRA\s*(\d+)?/);
-    const se = up.match(/\bSE\s*(\d+)?/);
+    // \bSE\b com lookahead — NÃO pode casar dentro de "SERIES". Aceita "SE", "SE 2", "SE3".
+    const se = up.match(/\bSE(?!R)\s*(\d+)?\b/);
     const series = up.match(/(?:SERIES\s*|\bS)(\d+)/);
     if (ultra) modelo = `Apple Watch Ultra${ultra[1] ? " " + ultra[1] : ""}`;
     else if (se) modelo = `Apple Watch SE${se[1] ? " " + se[1] : ""}`;


### PR DESCRIPTION
Itens 11, 14, 15 - corrige regex que casava SE dentro de SERIES, captura geração iPad, cores em PT no seletor de entregas