### PR TITLE
fix(entregas): simplifica endereço e label do shopping

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -894,21 +894,14 @@ export default function EntregasPage() {
               <p className={labelCls}>Bairro</p>
               <input value={form.bairro} onChange={(e) => set("bairro", e.target.value)} placeholder="Ex: Barra da Tijuca" className={inputCls} />
             </div>
-            <div className="col-span-2 md:col-span-3 p-3 rounded-xl border border-[#E5E5EA] bg-[#FAFAFA] space-y-3">
-              <p className="text-xs font-bold text-[#86868B] uppercase tracking-wider">Endereços</p>
-              <div>
-                <p className={labelCls}>Endereço do cliente (cadastro)</p>
-                <input value={form.endereco} onChange={(e) => {
-                  const v = e.target.value;
-                  set("endereco", v);
-                  // se o campo de entrega ainda não foi editado, espelha
-                  if (!form.endereco_entrega || form.endereco_entrega === form.endereco) set("endereco_entrega", v);
-                }} placeholder="Endereço cadastrado do cliente" className={inputCls} />
-              </div>
-              <div>
-                <p className={labelCls}>Endereço de entrega</p>
-                <input value={form.endereco_entrega} onChange={(e) => set("endereco_entrega", e.target.value)} placeholder="Onde será entregue (default = cadastro)" className={inputCls} />
-              </div>
+            <div className="col-span-2 md:col-span-3">
+              <p className={labelCls}>Endereço de Entrega</p>
+              <input
+                value={form.endereco_entrega}
+                onChange={(e) => set("endereco_entrega", e.target.value)}
+                placeholder="Onde será entregue (pode ser diferente do residencial)"
+                className={inputCls}
+              />
             </div>
             <div>
               <p className={labelCls}>Local de Entrega</p>
@@ -927,8 +920,23 @@ export default function EntregasPage() {
             </div>
             {(form.local_entrega === "SHOPPING" || form.local_entrega === "RESIDÊNCIA" || form.local_entrega === "OUTRO") && (
               <div className="col-span-2">
-                <p className={labelCls}>{form.local_entrega === "SHOPPING" ? "Shopping (nome + loja)" : form.local_entrega === "RESIDÊNCIA" ? "Detalhes residência" : "Detalhes"}</p>
-                <input value={form.local_detalhes} onChange={(e) => set("local_detalhes", e.target.value)} placeholder={form.local_entrega === "SHOPPING" ? "Ex: Carioca Shopping - Loja 234" : "Ex: Bloco A, Apto 301, Portaria 24h"} className={inputCls} />
+                <p className={labelCls}>
+                  {form.local_entrega === "SHOPPING"
+                    ? "🏬 Shopping (ponto de encontro)"
+                    : form.local_entrega === "RESIDÊNCIA"
+                    ? "Detalhes residência"
+                    : "Detalhes"}
+                </p>
+                <input
+                  value={form.local_detalhes}
+                  onChange={(e) => set("local_detalhes", e.target.value)}
+                  placeholder={
+                    form.local_entrega === "SHOPPING"
+                      ? "Ex: Barra Shopping - praça de alimentação"
+                      : "Ex: Bloco A, Apto 301, Portaria 24h"
+                  }
+                  className={inputCls}
+                />
               </div>
             )}
             {modoSimples && (


### PR DESCRIPTION
## Resumo

Dois ajustes pedidos pelo André depois do teste em produção:

### 1. Remove campo "Endereço do cliente (cadastro)"
Antes o form tinha dois campos: endereço cadastrado + endereço de entrega. Mas o endereço do cadastro nem sempre é útil (nem todo cliente tem endereço salvo, e quando tem, não é sempre pra onde a entrega vai). Agora só tem **"Endereço de Entrega"** — o único que importa pro motoboy.

### 2. Label do Shopping vira "ponto de encontro"
Antes estava "Shopping (nome + loja)" com placeholder "Carioca Shopping - Loja 234". Mas a Tigrão não entrega em loja específica do shopping — marca um ponto de encontro aleatório com o cliente.

Agora:
- Label: **"🏬 Shopping (ponto de encontro)"**
- Placeholder: **"Ex: Barra Shopping - praça de alimentação"**

## Test plan
- [ ] Abrir Nova Entrega → só aparece um campo "Endereço de Entrega" (não dois)
- [ ] Selecionar Local = Shopping → aparece campo com label "Shopping (ponto de encontro)"
- [ ] Placeholder sugere "praça de alimentação" em vez de "loja 234"

🤖 Generated with [Claude Code](https://claude.com/claude-code)