### PR TITLE
feat(estoque): select editável de condição no modal

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -5377,7 +5377,33 @@ export default function EstoquePage() {
                           )}
                         </div>
                       )}
-                      <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Condicao</p><span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${p.tipo === "NAO_ATIVADO" ? "bg-purple-100 text-purple-700" : isLac ? "bg-blue-100 text-blue-700" : "bg-yellow-100 text-yellow-700"}`}>{p.tipo === "NAO_ATIVADO" ? "Não Ativado" : isLac ? "Lacrado" : "Usado"}</span></div>
+                      <div>
+                        <p className={`text-[10px] uppercase tracking-wider ${mS}`}>Condicao</p>
+                        {canEdit ? (
+                          <select
+                            value={p.tipo === "NAO_ATIVADO" ? "NAO_ATIVADO" : isLac ? "NOVO" : "SEMINOVO"}
+                            onChange={async (e) => {
+                              const novo = e.target.value as "NOVO" | "SEMINOVO" | "NAO_ATIVADO";
+                              try {
+                                await apiPatch(p.id, { tipo: novo });
+                                setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, tipo: novo } : x));
+                                setDetailProduct({ ...p, tipo: novo });
+                                showSaved("tipo");
+                                setMsg(`Condição alterada para ${novo === "NOVO" ? "Lacrado" : novo === "NAO_ATIVADO" ? "Não Ativado" : "Usado"}`);
+                              } catch (err) {
+                                setMsg("❌ " + String(err instanceof Error ? err.message : err));
+                              }
+                            }}
+                            className={`mt-0.5 text-[11px] font-semibold px-2 py-1 rounded-lg border ${dm ? "bg-[#1C1C1E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"} focus:border-[#E8740E] focus:outline-none`}
+                          >
+                            <option value="NOVO">🔵 Lacrado</option>
+                            <option value="NAO_ATIVADO">🟣 Não Ativado</option>
+                            <option value="SEMINOVO">🟡 Usado</option>
+                          </select>
+                        ) : (
+                          <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${p.tipo === "NAO_ATIVADO" ? "bg-purple-100 text-purple-700" : isLac ? "bg-blue-100 text-blue-700" : "bg-yellow-100 text-yellow-700"}`}>{p.tipo === "NAO_ATIVADO" ? "Não Ativado" : isLac ? "Lacrado" : "Usado"}</span>
+                        )}
+                      </div>
                       {/* Caixa badge */}
                       {(p.observacao?.includes("[COM_CAIXA]") || /com\s+caixa/i.test(p.observacao || "")) && (
                         <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Caixa</p>


### PR DESCRIPTION
## Resumo

Quando um cliente dá um produto na troca, o sistema marca automaticamente como "Usado" e joga na aba **Seminovos**. Mas às vezes o cliente recebeu o aparelho e entregou **lacrado sem abrir** — nesse caso deveria entrar como "Lacrado" na aba de estoque normal.

Agora no modal de **Editar Item**, o badge "Condição" virou um **select editável**:

- 🔵 **Lacrado** (tipo = NOVO) — vai pra aba Estoque
- 🟣 **Não Ativado** (tipo = NAO_ATIVADO)
- 🟡 **Usado** (tipo = SEMINOVO) — vai pra aba Seminovos

Ao mudar, salva na hora via `apiPatch`, atualiza o estoque local e mostra mensagem "Condição alterada para Lacrado". O produto migra automaticamente pra aba correta baseado no novo tipo.

## Test plan
- [ ] Abrir uma pendência em Estoque → Pendências → Editar Item
- [ ] No campo "Condição", clicar no select e escolher "🔵 Lacrado"
- [ ] Mensagem "Condição alterada para Lacrado" aparece
- [ ] Produto sai da aba Seminovos e vai pra Estoque normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)