### PR TITLE
fix(estoque): select de condição também disponível pra itens EM ESTOQUE

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -5379,7 +5379,7 @@ export default function EstoquePage() {
                       )}
                       <div>
                         <p className={`text-[10px] uppercase tracking-wider ${mS}`}>Condicao</p>
-                        {canEdit ? (
+                        {(canEdit || isAdmin) ? (
                           <select
                             value={p.tipo === "NAO_ATIVADO" ? "NAO_ATIVADO" : isLac ? "NOVO" : "SEMINOVO"}
                             onChange={async (e) => {


### PR DESCRIPTION
## Resumo

Continuação do PR #153. Nele o select de condição (Lacrado/Usado/Não Ativado) só aparecia pra itens em **PENDÊNCIA/A_CAMINHO** (quando \`canEdit = true\`).

Mas o André precisa mudar a condição de itens que já estão **EM ESTOQUE** também — o caso real foi um iPhone 17 Air 1TB que já estava na aba Seminovos como "Usado", mas na verdade é lacrado e deveria estar na aba de estoque normal.

## Mudança

```diff
-{canEdit ? (
+{(canEdit || isAdmin) ? (
   <select>...</select>
 ) : (
   <span>badge</span>
 )}
```

Agora o select aparece para **qualquer usuário admin**, permitindo mover itens entre Estoque ↔ Seminovos a qualquer momento via modal de detalhes.

## Test plan
- [ ] Abrir Estoque → Seminovos → clicar num item
- [ ] No modal de detalhes, campo "Condição" agora aparece como select (não badge)
- [ ] Mudar pra "🔵 Lacrado" → item sai da aba Seminovos e aparece em Estoque

🤖 Generated with [Claude Code](https://claude.com/claude-code)