### PR TITLE
fix: iPad modelo duplicado + Apple Watch Series 11 em gastos

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -406,8 +406,25 @@ export default function EntregasPage() {
     const valor = qp.get("valor") || "";
     const trocaProd = qp.get("troca_produto") || "";
     const trocaVal = qp.get("troca_valor") || "";
+    const trocaCorQp = qp.get("troca_cor") || "";
+    const trocaBatQp = qp.get("troca_bateria") || "";
+    const trocaMarcas = qp.get("troca_marcas_uso") || "";
+    const trocaPecas = qp.get("troca_pecas_trocadas") || "";
+    const trocaCaixa = qp.get("troca_caixa_original") || "";
+    const trocaObsQp = qp.get("troca_observacao") || "";
     const diferencaPix = qp.get("diferenca_pix") || "";
     const obs = diferencaPix ? `Diferença PIX: R$ ${diferencaPix}` : "";
+    // Monta observação consolidada da troca caso o param explícito não venha
+    const trocaObsParts: string[] = [];
+    if (trocaObsQp) trocaObsParts.push(trocaObsQp);
+    else {
+      if (trocaMarcas === "nao") trocaObsParts.push("Sem marcas de uso");
+      else if (trocaMarcas) trocaObsParts.push(`Marcas: ${trocaMarcas}`);
+      if (trocaPecas) trocaObsParts.push(trocaPecas);
+      if (trocaCaixa === "sim") trocaObsParts.push("Com caixa original");
+      else if (trocaCaixa === "nao") trocaObsParts.push("Sem caixa original");
+    }
+    const trocaObsFinal = trocaObsParts.join(" | ");
 
     setForm(f => ({
       ...f,
@@ -426,6 +443,9 @@ export default function EntregasPage() {
       setTrocaAtiva(true);
       setTrocaProduto(trocaProd);
       if (trocaVal) setTrocaValor(String(Math.round(parseFloat(trocaVal))));
+      if (trocaCorQp) setTrocaCor(trocaCorQp);
+      if (trocaBatQp) setTrocaBateria(trocaBatQp);
+      if (trocaObsFinal) setTrocaObs(trocaObsFinal);
     }
     if (clienteNome || produto) setShowForm(true);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -1753,7 +1753,7 @@ export default function EstoquePage() {
   const handleDuplicar = (p: ProdutoEstoque) => handleDuplicarProduto([p]);
 
   // Categorias que NÃO precisam de IMEI (só serial)
-  const CATS_SEM_IMEI = ["MACBOOK", "MAC_MINI", "IMAC", "MAC_STUDIO", "AIRPODS", "ACESSORIOS", "OUTROS"];
+  const CATS_SEM_IMEI = ["MACBOOK", "MAC_MINI", "IMAC", "MAC_STUDIO", "AIRPODS", "ACESSORIOS", "OUTROS", "IPAD", "APPLE_WATCH"];
   // Categorias que NÃO precisam de serial (completamente opcional)
   const CATS_SEM_SERIAL = ["ACESSORIOS", "OUTROS"];
 

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -431,17 +431,17 @@ function extractCorEN(nome: string): string | null {
  * - Substitui cor em português pelo equivalente em inglês (ex: AZUL PROFUNDO → DEEP BLUE)
  * - Quando cor=null, tenta encontrar cor PT no próprio nome do produto
  */
-/** Extrai tamanho (42MM, 46MM etc) e pulseira (SPORT BAND S/M etc) de um nome de Apple Watch */
+/** Extrai tamanho (42MM, 46MM etc) e tipo da pulseira (MILANÊS, ESPORTIVA, etc) de um nome de Apple Watch */
 function extractWatchBadges(nome: string): { tamanho: string | null; pulseira: string | null } {
   if (!nome) return { tamanho: null, pulseira: null };
   const upper = nome.toUpperCase();
   const tamMatch = upper.match(/\b(\d{2}MM)\b/);
   const tamanho = tamMatch ? tamMatch[1] : null;
   // Pulseira: se tem "PULSEIRA ..." no nome, pega tudo após (mais confiável)
-  let pulseira: string | null = null;
+  let pulseiraRaw: string | null = null;
   const pulseiraExplicita = upper.match(/PULSEIRA\s+(.+?)$/);
   if (pulseiraExplicita) {
-    pulseira = pulseiraExplicita[1]
+    pulseiraRaw = pulseiraExplicita[1]
       .replace(/\s*GPS\s*\+\s*CELLULAR\b/g, "")
       .replace(/\s*GPS\s*\+\s*CEL\b/g, "")
       .replace(/\s+/g, " ")
@@ -449,7 +449,28 @@ function extractWatchBadges(nome: string): { tamanho: string | null; pulseira: s
   } else {
     // Fallback: pattern conhecido sem label PULSEIRA
     const pulseiraMatch = upper.match(/\b((?:SPORT|BRAIDED SOLO|SOLO|MILANESE|LINK BRACELET|LEATHER|OCEAN|TRAIL|NIKE SPORT|ALPINE)\s*(?:LOOP|BAND)?(?:\s+(?:XS|S|S\/M|M|M\/L|L|XL))?)\b/);
-    pulseira = pulseiraMatch ? pulseiraMatch[1].trim() : null;
+    pulseiraRaw = pulseiraMatch ? pulseiraMatch[1].trim() : null;
+  }
+  // Normalizar: extrair só o tipo (ignorando cor / tamanhos / palavra "estilo")
+  // Regras testadas em ordem; primeira que casar vence.
+  let pulseira: string | null = pulseiraRaw;
+  if (pulseiraRaw) {
+    const p = pulseiraRaw;
+    const tipoMatchers: { re: RegExp; label: string }[] = [
+      { re: /MILAN[ÊE]S|MILANESE/, label: "MILANÊS" },
+      { re: /SOLO\s*LOOP\s*TRAN[ÇC]AD[AO]|BRAIDED\s*SOLO/, label: "TRANÇA" },
+      { re: /SOLO\s*LOOP|SOLO/, label: "SOLO LOOP" },
+      { re: /OCEAN/, label: "OCEAN" },
+      { re: /ALPIN(?:E|ISTA)|TRAIL/, label: "ALPINISTA" },
+      { re: /NIKE/, label: "NIKE" },
+      { re: /HERM[ÉE]S|HERMES/, label: "HERMÈS" },
+      { re: /LINK\s*BRACELET|ELOS|LINK/, label: "LINK" },
+      { re: /COURO|LEATHER/, label: "COURO" },
+      { re: /ESPORTIVA|SPORT\s*BAND|SPORT/, label: "ESPORTIVA" },
+    ];
+    for (const { re, label } of tipoMatchers) {
+      if (re.test(p)) { pulseira = label; break; }
+    }
   }
   return { tamanho, pulseira };
 }

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -532,7 +532,29 @@ export default function GerarLinkPage() {
     const corQp = qp.get("cor");
     if (corQp) setCorSel(corQp.toUpperCase());
     const trocaProd = qp.get("troca_produto");
-    if (trocaProd) setTrocaProduto(trocaProd);
+    if (trocaProd) {
+      // Enriquece o nome do produto da troca com cor / bateria / obs vindas da simulação,
+      // já que o form de gerar-link não tem campos separados pra esses dados.
+      const corQ = qp.get("troca_cor") || "";
+      const batQ = qp.get("troca_bateria") || "";
+      const marcasQ = qp.get("troca_marcas_uso") || "";
+      const pecasQ = qp.get("troca_pecas_trocadas") || "";
+      const caixaQ = qp.get("troca_caixa_original") || "";
+      const obsQ = qp.get("troca_observacao") || "";
+      const extras: string[] = [];
+      if (corQ) extras.push(`Cor: ${corQ}`);
+      if (batQ) extras.push(`Bateria: ${batQ}%`);
+      if (obsQ) extras.push(obsQ);
+      else {
+        if (marcasQ === "nao") extras.push("Sem marcas de uso");
+        else if (marcasQ) extras.push(`Marcas: ${marcasQ}`);
+        if (pecasQ) extras.push(pecasQ);
+        if (caixaQ === "sim") extras.push("Com caixa original");
+        else if (caixaQ === "nao") extras.push("Sem caixa original");
+      }
+      setTrocaProduto(extras.length ? `${trocaProd} — ${extras.join(" — ")}` : trocaProd);
+      setTemTroca(true);
+    }
     const trocaVal = qp.get("troca_valor");
     if (trocaVal) {
       const n = Math.round(parseFloat(trocaVal));

--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -34,6 +34,62 @@ interface SimulacaoRow {
 const fmt = (v: number) =>
   `R$ ${v.toLocaleString("pt-BR")}`;
 
+/** Extrai campos estruturados das linhas de condição salvas com a simulação. */
+function parseCondicao(linhas: string[] | null | undefined): {
+  bateria: string;
+  marcasUso: string;
+  pecasTrocadas: string;
+  caixaOriginal: string;
+  outras: string[];
+} {
+  const out = { bateria: "", marcasUso: "", pecasTrocadas: "", caixaOriginal: "", outras: [] as string[] };
+  if (!linhas || linhas.length === 0) return out;
+  const marcasParts: string[] = [];
+  for (const raw of linhas) {
+    const l = raw.trim();
+    if (!l) continue;
+    const lower = l.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+    // Bateria: "Saude bateria 88%" ou "Ciclos de bateria: 250"
+    const batMatch = l.match(/(?:saude\s*bateria|saúde\s*bateria)\s*(\d{1,3})\s*%?/i) || l.match(/ciclos?\s*de\s*bateria[:\s]*(\d+)/i);
+    if (batMatch && !out.bateria) { out.bateria = batMatch[1]; continue; }
+    // Caixa
+    if (/caixa/.test(lower)) {
+      if (/sem\s+caixa/.test(lower)) out.caixaOriginal = "nao";
+      else if (/tem\s+a?\s*caixa|com\s+caixa/.test(lower)) out.caixaOriginal = "sim";
+      continue;
+    }
+    // Peças trocadas
+    if (/pec[ao]\s+trocad|peca\s+trocada|peças\s+trocad|pe[çc]as?\s+trocad/i.test(l)) {
+      out.pecasTrocadas = l;
+      continue;
+    }
+    // Marcas de uso (positivas e negativas)
+    if (/sem\s+marcas?\s+de\s+uso/.test(lower)) { out.marcasUso = "nao"; continue; }
+    if (/marcas?\s+de\s+uso/.test(lower) || /arranh/.test(lower) || /descascad/.test(lower)) {
+      marcasParts.push(l);
+      continue;
+    }
+    out.outras.push(l);
+  }
+  if (marcasParts.length > 0 && out.marcasUso !== "nao") {
+    out.marcasUso = marcasParts.join("; ");
+  }
+  return out;
+}
+
+/** Concatena tudo num bloco de observação livre legível. */
+function buildTrocaObs(linhas: string[] | null | undefined): string {
+  const p = parseCondicao(linhas);
+  const parts: string[] = [];
+  if (p.marcasUso === "nao") parts.push("Sem marcas de uso");
+  else if (p.marcasUso) parts.push(`Marcas: ${p.marcasUso}`);
+  if (p.pecasTrocadas) parts.push(p.pecasTrocadas);
+  if (p.caixaOriginal === "sim") parts.push("Com caixa original");
+  else if (p.caixaOriginal === "nao") parts.push("Sem caixa original");
+  for (const o of p.outras) parts.push(o);
+  return parts.join(" | ");
+}
+
 const fmtDate = (iso: string) => {
   const d = new Date(iso);
   return d.toLocaleString("pt-BR", {
@@ -850,6 +906,8 @@ export default function AdminPage() {
                 </button>
                 <button
                   onClick={() => {
+                    const cond = parseCondicao(modalRow.condicao_linhas);
+                    const obs = buildTrocaObs(modalRow.condicao_linhas);
                     const params = new URLSearchParams({
                       produto: `${modalRow.modelo_novo} ${modalRow.storage_novo}`.trim(),
                       preco: String(modalRow.preco_novo || ""),
@@ -857,6 +915,12 @@ export default function AdminPage() {
                       cliente_whatsapp: modalRow.whatsapp || "",
                       troca_produto: `${modalRow.modelo_usado} ${modalRow.storage_usado}`.trim(),
                       troca_valor: String(modalRow.avaliacao_usado || ""),
+                      troca_cor: modalRow.cor_usado || "",
+                      troca_bateria: cond.bateria,
+                      troca_marcas_uso: cond.marcasUso,
+                      troca_pecas_trocadas: cond.pecasTrocadas,
+                      troca_caixa_original: cond.caixaOriginal,
+                      troca_observacao: obs,
                     });
                     window.open(`/admin/gerar-link?${params.toString()}`, "_blank");
                   }}
@@ -866,6 +930,8 @@ export default function AdminPage() {
                 </button>
                 <button
                   onClick={() => {
+                    const cond = parseCondicao(modalRow.condicao_linhas);
+                    const obs = buildTrocaObs(modalRow.condicao_linhas);
                     const params = new URLSearchParams({
                       cliente_nome: modalRow.nome || "",
                       cliente_telefone: modalRow.whatsapp || "",
@@ -873,6 +939,12 @@ export default function AdminPage() {
                       valor: String(modalRow.preco_novo || ""),
                       troca_produto: `${modalRow.modelo_usado} ${modalRow.storage_usado}`.trim(),
                       troca_valor: String(modalRow.avaliacao_usado || ""),
+                      troca_cor: modalRow.cor_usado || "",
+                      troca_bateria: cond.bateria,
+                      troca_marcas_uso: cond.marcasUso,
+                      troca_pecas_trocadas: cond.pecasTrocadas,
+                      troca_caixa_original: cond.caixaOriginal,
+                      troca_observacao: obs,
                       diferenca_pix: String(modalRow.diferenca || ""),
                     });
                     window.open(`/admin/entregas?${params.toString()}`, "_blank");

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -9,6 +9,7 @@ import { useOnlineStatus } from "@/lib/useOnlineStatus";
 import { addToQueue, getQueue, removeFromQueue, getQueueCount } from "@/lib/offline-queue";
 import type { Venda } from "@/lib/admin-types";
 import { corParaPT } from "@/lib/cor-pt";
+import { getModeloBase } from "@/lib/produto-display";
 import BarcodeScanner from "@/components/BarcodeScanner";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 
@@ -2300,20 +2301,12 @@ export default function VendasPage() {
                     return after.split(/\s+(LL|BE|BR|BZ|CH|ZD|ZP|HN|J|N|VC|AA|E|LZ|QL)\s*/i)[0]?.trim() || null;
                   };
 
-                  // Extrair modelo base (sem cor) pra agrupar cores num card só
-                  const extractModeloBase = (nome: string) => {
-                    // Apple Watch: "WATCH ULTRA 3 49MM" ou "WATCH S10 42MM"
-                    const watchMatch = nome.match(/^(.*?(?:WATCH|APPLE\s*WATCH)\s*(?:ULTRA\s*\d*|SE\s*\d*|S\d+|SERIES\s*\d+)(?:\s*\d+MM)?)/i);
-                    if (watchMatch) return watchMatch[1].trim();
-                    // MacBook: incluir storage no key pra separar 512GB de 1TB
-                    // Captura até o segundo tamanho (RAM + STORAGE): "MACBOOK PRO M5 14 16GB 512GB"
-                    if (/MACBOOK|MAC\s*MINI/i.test(nome)) {
-                      const mbMatch = nome.match(/^(.+?\d+\s*(?:GB|TB)\s+\d+\s*(?:GB|TB))/i);
-                      if (mbMatch) return mbMatch[1].replace(/\s+/g, " ").trim();
-                    }
-                    // Acessórios sem memória: retorna o nome todo (já stripped)
-                    const memMatch = nome.match(/^(.+?\d+\s*(?:GB|TB))/i);
-                    return memMatch ? memMatch[1].trim() : nome;
+                  // Extrair modelo base (sem cor) pra agrupar cores num card só.
+                  // Usa getModeloBase do lib/produto-display (mesma lógica do estoque):
+                  // Watch inclui tamanho + conectividade (GPS/GPS+CEL) e corrige SE→Series 11 em 46/49mm;
+                  // MacBook inclui RAM+SSD; iPhone/iPad incluem storage.
+                  const extractModeloBase = (nome: string, categoria: string) => {
+                    return getModeloBase(nome, categoria);
                   };
 
                   // Reagrupar: modelo base → cores → itens
@@ -2321,7 +2314,7 @@ export default function VendasPage() {
                   for (const key of grupoKeys) {
                     const itens = grupos[key];
                     for (const p of itens) {
-                      const base = extractModeloBase(stripOrigemVendas(p.produto));
+                      const base = extractModeloBase(stripOrigemVendas(p.produto), p.categoria || "");
                       const cor = p.cor || extractCor(p.produto) || "—";
                       if (!porModelo[base]) porModelo[base] = {};
                       if (!porModelo[base][cor]) porModelo[base][cor] = [];

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -738,22 +738,24 @@ export default function ProdutoSpecFields({
       {/* iPad specs */}
       {row.categoria === "IPADS" && (
         <div className={`grid grid-cols-2 md:grid-cols-3 gap-3 p-3 ${bgSection} rounded-lg`}>
-          <div>
-            <p className={labelCls}>Modelo</p>
-            <select value={row.spec.ipad_modelo} onChange={(e) => setSpec("ipad_modelo", e.target.value)} className={inputCls}>
-              <option value="IPAD">iPad</option>
-              <option value="MINI 6">iPad Mini 6</option>
-              <option value="MINI 7">iPad Mini 7</option>
-              <option value="AIR 4">iPad Air 4</option>
-              <option value="AIR 5">iPad Air 5</option>
-              <option value="AIR 6">iPad Air 6</option>
-              <option value="AIR 7">iPad Air 7</option>
-              <option value="PRO 11">iPad Pro 11"</option>
-              <option value="PRO 12.9">iPad Pro 12.9"</option>
-              <option value="PRO M4 11">iPad Pro M4 11"</option>
-              <option value="PRO M4 13">iPad Pro M4 13"</option>
-            </select>
-          </div>
+          {!row.catalogo_modelo_id && (
+            <div>
+              <p className={labelCls}>Modelo</p>
+              <select value={row.spec.ipad_modelo} onChange={(e) => setSpec("ipad_modelo", e.target.value)} className={inputCls}>
+                <option value="IPAD">iPad</option>
+                <option value="MINI 6">iPad Mini 6</option>
+                <option value="MINI 7">iPad Mini 7</option>
+                <option value="AIR 4">iPad Air 4</option>
+                <option value="AIR 5">iPad Air 5</option>
+                <option value="AIR 6">iPad Air 6</option>
+                <option value="AIR 7">iPad Air 7</option>
+                <option value="PRO 11">iPad Pro 11"</option>
+                <option value="PRO 12.9">iPad Pro 12.9"</option>
+                <option value="PRO M4 11">iPad Pro M4 11"</option>
+                <option value="PRO M4 13">iPad Pro M4 13"</option>
+              </select>
+            </div>
+          )}
           <div>
             <p className={labelCls}>Tela</p>
             <select value={row.spec.ipad_tela} onChange={(e) => setSpec("ipad_tela", e.target.value)} className={inputCls}>

--- a/lib/produto-display.ts
+++ b/lib/produto-display.ts
@@ -2,7 +2,7 @@ import { corParaPT } from "./cor-pt";
 
 const STRUCTURED = ["IPHONES", "MACBOOK", "MAC_MINI", "IPADS", "APPLE_WATCH", "AIRPODS", "SEMINOVOS"];
 
-function getBaseCat(cat: string): string {
+export function getBaseCat(cat: string): string {
   if (cat === "SEMINOVOS") return "IPHONES";
   if (STRUCTURED.includes(cat)) return cat;
   const sorted = [...STRUCTURED].sort((a, b) => b.length - a.length);
@@ -120,4 +120,111 @@ export function formatProdutoDisplay(p: {
   }
 
   return parts.filter(Boolean).join(" ");
+}
+
+/**
+ * Gera chave de agrupamento por modelo (sem cor) — compartilhado entre estoque e vendas.
+ * Inclui tamanho/conectividade pra Watch, RAM+SSD pra MacBook, storage pra iPhone/iPad.
+ */
+export function getModeloBase(produto: string, categoria: string): string {
+  const p = (produto || "").toUpperCase().trim();
+  let baseCat = getBaseCat(categoria || "");
+  if (!baseCat || !["IPHONES","IPADS","MACBOOK","MAC_MINI","APPLE_WATCH","AIRPODS","ACESSORIOS"].includes(baseCat)) {
+    if (/\bIPHONE\b/.test(p)) baseCat = "IPHONES";
+    else if (/\bIPAD\b/.test(p)) baseCat = "IPADS";
+    else if (/\bMACBOOK\b/.test(p)) baseCat = "MACBOOK";
+    else if (/\bMAC\s*MINI\b/.test(p)) baseCat = "MAC_MINI";
+    else if (/\bWATCH\b/.test(p)) baseCat = "APPLE_WATCH";
+    else if (/\bAIRPODS?\b/.test(p)) baseCat = "AIRPODS";
+  }
+  const getMem = () => {
+    const all = [...p.matchAll(/(\d+)\s*(GB|TB)/gi)];
+    if (all.length === 0) return "";
+    const vals = all.map(m => ({ raw: `${m[1]}${m[2].toUpperCase()}`, gb: m[2].toUpperCase() === "TB" ? parseInt(m[1]) * 1024 : parseInt(m[1]) }));
+    const biggest = vals.sort((a, b) => b.gb - a.gb)[0];
+    return ` ${biggest.raw}`;
+  };
+  const getSize = () => { const m = p.match(/(\d{2})["”]/); return m ? ` ${m[1]}"` : ""; };
+
+  if (baseCat === "IPHONES") {
+    const match = p.match(/IPHONE\s*(\d+)(E)?\s*(PRO\s*MAX|PRO|PLUS|AIR)?/i);
+    if (match) {
+      const num = match[1] + (match[2] ? "e" : "");
+      const variant = match[3] ? " " + match[3].trim() : "";
+      return `iPhone ${num}${variant}${getMem()}`;
+    }
+    return produto;
+  }
+  if (baseCat === "IPADS") {
+    const mem = getMem();
+    const size = getSize();
+    const chipMatch = p.match(/(M\d+(?:\s*(?:PRO|MAX))?|A\d+(?:\s*PRO)?)/i);
+    const chip = chipMatch ? ` ${chipMatch[1].toUpperCase()}` : "";
+    if (p.includes("MINI")) return `iPad Mini${chip}${size}${mem}`;
+    if (p.includes("AIR")) return `iPad Air${chip}${size}${mem}`;
+    if (p.includes("PRO")) return `iPad Pro${chip}${size}${mem}`;
+    return `iPad${chip}${mem}`;
+  }
+  if (baseCat === "MACBOOK") {
+    const all = [...p.matchAll(/(\d+)\s*(GB|TB)/gi)];
+    const vals = all.map(m => ({ raw: `${m[1]}${m[2].toUpperCase()}`, gb: m[2].toUpperCase() === "TB" ? parseInt(m[1]) * 1024 : parseInt(m[1]) }));
+    const sorted = [...vals].sort((a, b) => a.gb - b.gb);
+    const ram = sorted.length >= 2 ? ` ${sorted[0].raw}` : "";
+    const ssd = sorted.length >= 1 ? ` ${sorted[sorted.length - 1].raw}` : "";
+    const memPair = `${ram}${ssd}`;
+    const size = getSize();
+    const chipMatch = p.match(/M(\d+)(\s*PRO)?/i);
+    const chip = chipMatch ? ` M${chipMatch[1]}${chipMatch[2] ? " Pro" : ""}` : "";
+    if (p.includes("NEO")) return `MacBook Neo${chip}${size}${memPair}`;
+    if (p.includes("AIR")) return `MacBook Air${chip}${size}${memPair}`;
+    if (p.includes("PRO")) return `MacBook Pro${chip}${size}${memPair}`;
+    return `MacBook${chip}${memPair}`;
+  }
+  if (baseCat === "MAC_MINI") {
+    const mem = getMem();
+    const chipMatch = p.match(/M(\d+)(\s*PRO)?/i);
+    const chip = chipMatch ? ` M${chipMatch[1]}${chipMatch[2] ? " Pro" : ""}` : "";
+    return `Mac Mini${chip}${mem}`;
+  }
+  if (baseCat === "APPLE_WATCH") {
+    // Apple Watch SE só existe em 40/44mm. Se nome tem 46mm ou 49mm, "SE" é lixo → Series 11.
+    const has46or49 = /\b(46|49)\s*MM/.test(p);
+    const sizeW = p.match(/(\d{2})\s*MM/i);
+    const sz = sizeW ? ` ${sizeW[1]}mm` : "";
+    const isCell = /\+\s*CEL|GPS\s*\+\s*CEL|CELL|CELULAR/.test(p);
+    const conn = isCell ? " GPS+CEL" : " GPS";
+    const ultraMatch = p.match(/ULTRA\s*(\d+)?/);
+    if (ultraMatch) {
+      const gen = ultraMatch[1] ? ` ${ultraMatch[1]}` : "";
+      return `Apple Watch Ultra${gen}${sz}`;
+    }
+    const seMatch = p.match(/\bSE(?!R)\s*(\d+)/);
+    if (seMatch && !has46or49) return `Apple Watch SE ${seMatch[1]}${sz}${conn}`;
+    if (/\bSE(?!R)/.test(p) && !has46or49) return `Apple Watch SE${sz}${conn}`;
+    const seriesMatch = p.match(/(?:SERIES\s*|\bS)(\d+)/);
+    if (seriesMatch) return `Apple Watch Series ${seriesMatch[1]}${sz}${conn}`;
+    if (has46or49) return `Apple Watch Series 11${sz}${conn}`;
+    return `Apple Watch${sz}${conn}`;
+  }
+  if (baseCat === "AIRPODS") {
+    if (p.includes("PRO")) {
+      const genMatch = p.match(/PRO\s*(\d+)/);
+      return genMatch ? `AirPods Pro ${genMatch[1]}` : "AirPods Pro";
+    }
+    if (p.includes("MAX")) {
+      const yearMatch = p.match(/MAX\s*(\d{4})/);
+      return yearMatch ? `AirPods Max ${yearMatch[1]}` : "AirPods Max";
+    }
+    const genMatch = p.match(/AIRPODS?\s*(\d+)/);
+    if (genMatch) {
+      const gen = genMatch[1];
+      const hasANC = p.includes("ANC") || p.includes("COM ANC");
+      const noANC = p.includes("SEM ANC");
+      if (hasANC && !noANC) return `AirPods ${gen} ANC`;
+      if (noANC) return `AirPods ${gen}`;
+      return `AirPods ${gen}`;
+    }
+    return "AirPods";
+  }
+  return (produto || "").replace(/\s*[-–]\s*$/, "").trim();
 }

--- a/lib/produto-display.ts
+++ b/lib/produto-display.ts
@@ -99,11 +99,15 @@ export function formatProdutoDisplay(p: {
     let modelo = "Apple Watch";
     const ultra = up.match(/ULTRA\s*(\d+)?/);
     // \bSE(?!R) — não casar "SERIES"
-    const se = up.match(/\bSE(?!R)\s*(\d+)?\b/);
+    // Além disso: Apple Watch SE só existe em 40/44mm. Se nome tem 46mm ou 49mm, "SE" é lixo → Series 11.
+    const has46or49 = /\b(46|49)\s*MM/.test(up);
+    const seRaw = up.match(/\bSE(?!R)\s*(\d+)?\b/);
+    const se = seRaw && !has46or49 ? seRaw : null;
     const series = up.match(/(?:SERIES\s*|\bS)(\d+)/);
     if (ultra) modelo = `Apple Watch Ultra${ultra[1] ? " " + ultra[1] : ""}`;
     else if (se) modelo = `Apple Watch SE${se[1] ? " " + se[1] : ""}`;
     else if (series) modelo = `Apple Watch Series ${series[1]}`;
+    else if (has46or49 && seRaw) modelo = "Apple Watch Series 11";
     parts.push(modelo);
     if (tamMm) parts.push(tamMm);
     // Ultra é sempre cellular — redundante exibir


### PR DESCRIPTION
## Summary
- fix iPad modelo spec duplicado escondido quando catálogo já define
- fix Apple Watch Series 11 aparecendo como SE 46mm em gastos produtos do pedido

## Test plan
- [ ] Abrir /admin/gastos e verificar lista de produtos do pedido de um gasto fornecedor com Apple Watch 46mm
- [ ] Confirmar que aparece "Apple Watch Series 11 46mm ..." ao invés de "Apple Watch SE 46mm ..."
- [ ] Verificar iPad no fluxo de compra: spec não duplica modelo quando catálogo já define

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>