### PR TITLE
feat(gerar-link): horário com slots de 30min (10h-19h)

### DIFF
--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -1674,9 +1674,14 @@ export default function GerarLinkPage() {
             <label className={labelCls}>Horario</label>
             <select value={horario} onChange={(e) => setHorario(e.target.value)} className={inputCls}>
               <option value="">-- Opcional --</option>
-              <option value="Manha">Manha</option>
-              <option value="Tarde">Tarde</option>
-              <option value="Noite">Noite</option>
+              {(() => {
+                const opts: string[] = [];
+                for (let h = 10; h <= 19; h++) {
+                  opts.push(`${String(h).padStart(2, "0")}:00`);
+                  if (h < 19) opts.push(`${String(h).padStart(2, "0")}:30`);
+                }
+                return opts.map((t) => <option key={t} value={t}>{t}</option>);
+              })()}
             </select>
           </div>
           <div>


### PR DESCRIPTION
## Resumo

No form de **Gerar Link**, o campo "Horário" tinha só 3 opções de turno: Manhã / Tarde / Noite. O André pediu pra trocar por **horários específicos** em intervalos de 30 minutos, assim fica muito mais preciso pra marcar entrega com o cliente.

## Mudança

Antes:
- Opcional
- Manha
- Tarde
- Noite

Agora:
- Opcional
- 10:00, 10:30
- 11:00, 11:30
- 12:00, 12:30
- ...
- 19:00

Total de 19 slots (10:00 até 19:00 em intervalos de 30min).

## Test plan
- [ ] Abrir /admin/gerar-link → criar link novo
- [ ] No campo "Horário" ver todos os slots de 10:00 até 19:00
- [ ] Selecionar um horário e gerar o link

🤖 Generated with [Claude Code](https://claude.com/claude-code)