### PR TITLE
Claude/consertos

### DIFF
--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -164,6 +164,72 @@ export default function ClientesPage() {
   const [fornMsg, setFornMsg] = useState("");
   const [savingForn, setSavingForn] = useState(false);
 
+  // Crédito de lojistas
+  const [saldosLojistas, setSaldosLojistas] = useState<Record<string, number>>({});
+  type CreditoLog = { id: string; tipo: string; valor: number; saldo_antes: number; saldo_depois: number; motivo: string | null; usuario: string | null; created_at: string };
+  const [creditoModal, setCreditoModal] = useState<null | { cliente: Cliente; saldo: number; log: CreditoLog[] }>(null);
+  const [creditoForm, setCreditoForm] = useState({ tipo: "CREDITO" as "CREDITO" | "DEBITO" | "AJUSTE", valor: "", motivo: "" });
+  const [savingCredito, setSavingCredito] = useState(false);
+
+  const lojistaKey = (c: { cpf: string | null; cnpj: string | null; nome: string }) => {
+    const d = (s: string | null | undefined) => (s || "").replace(/\D/g, "");
+    if (d(c.cpf)) return `cpf:${d(c.cpf)}`;
+    if (d(c.cnpj)) return `cnpj:${d(c.cnpj)}`;
+    return `nome:${c.nome.trim().toUpperCase()}`;
+  };
+
+  const fetchSaldosLojistas = useCallback(async () => {
+    if (!password) return;
+    try {
+      const res = await fetch(`/api/admin/lojistas-credito`, { headers: apiHeaders() });
+      if (res.ok) {
+        const json = await res.json();
+        const map: Record<string, number> = {};
+        for (const l of json.lojistas || []) map[l.cliente_key] = Number(l.saldo || 0);
+        setSaldosLojistas(map);
+      }
+    } catch (err) { console.error(err); }
+  }, [password, apiHeaders]);
+
+  useEffect(() => { if (tab === "lojistas") fetchSaldosLojistas(); }, [tab, fetchSaldosLojistas]);
+
+  const openCreditoModal = async (c: Cliente) => {
+    try {
+      const params = new URLSearchParams();
+      if (c.cpf) params.set("cpf", c.cpf);
+      if (c.cnpj) params.set("cnpj", c.cnpj);
+      if (!c.cpf && !c.cnpj) params.set("nome", c.nome);
+      const res = await fetch(`/api/admin/lojistas-credito?${params}`, { headers: apiHeaders() });
+      const json = await res.json();
+      setCreditoModal({ cliente: c, saldo: Number(json.saldo || 0), log: json.log || [] });
+      setCreditoForm({ tipo: "CREDITO", valor: "", motivo: "" });
+    } catch (err) { console.error(err); }
+  };
+
+  const salvarCredito = async () => {
+    if (!creditoModal) return;
+    const valor = parseFloat(creditoForm.valor);
+    if (!valor || valor <= 0) { alert("Valor inválido"); return; }
+    setSavingCredito(true);
+    try {
+      const res = await fetch("/api/admin/lojistas-credito", {
+        method: "POST",
+        headers: { ...apiHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cliente: { nome: creditoModal.cliente.nome, cpf: creditoModal.cliente.cpf, cnpj: creditoModal.cliente.cnpj },
+          tipo: creditoForm.tipo,
+          valor,
+          motivo: creditoForm.motivo || null,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) { alert(json.error || "Erro"); return; }
+      await fetchSaldosLojistas();
+      await openCreditoModal(creditoModal.cliente); // refresh modal data
+      setCreditoForm({ tipo: "CREDITO", valor: "", motivo: "" });
+    } finally { setSavingCredito(false); }
+  };
+
   // Debounce search
   useEffect(() => {
     const t = setTimeout(() => setDebouncedSearch(search), 300);
@@ -688,19 +754,20 @@ export default function ClientesPage() {
           <table className="w-full text-sm">
             <thead>
               <tr className={`border-b ${dm ? "border-[#3A3A3C] bg-[#2C2C2E]" : "border-[#D2D2D7] bg-[#F5F5F7]"}`}>
-                {["Cliente", tab === "lojistas" ? "CNPJ" : "CPF", "Compras", "Total Gasto", "Ultima Compra", "Cliente Desde", "Local"].map((h) => (
-                  <th key={h} className={thCls}>{h}</th>
+                {["Cliente", tab === "lojistas" ? "CNPJ" : "CPF", "Compras", "Total Gasto", ...(tab === "lojistas" ? ["Saldo Crédito", ""] : []), "Ultima Compra", "Cliente Desde", "Local"].map((h, i) => (
+                  <th key={`${h}-${i}`} className={thCls}>{h}</th>
                 ))}
               </tr>
             </thead>
             <tbody>
-              {loading ? (
-                <tr><td colSpan={7} className={`px-4 py-12 text-center ${mM}`}>Carregando...</td></tr>
+              {(() => { const colSpan = tab === "lojistas" ? 9 : 7; return loading ? (
+                <tr><td colSpan={colSpan} className={`px-4 py-12 text-center ${mM}`}>Carregando...</td></tr>
               ) : sorted.length === 0 ? (
-                <tr><td colSpan={7} className={`px-4 py-12 text-center ${mM}`}>
+                <tr><td colSpan={colSpan} className={`px-4 py-12 text-center ${mM}`}>
                   {search ? `Nenhum resultado para "${search}"` : "Nenhum cliente encontrado"}
                 </td></tr>
-              ) : sorted.map((c) => (
+              ) : null; })()}
+              {!loading && sorted.map((c) => (
                 <React.Fragment key={c.nome}>
                   <tr
                     onClick={() => setDetailClient(c)}
@@ -720,6 +787,17 @@ export default function ClientesPage() {
                       <span className="px-2 py-1 rounded-lg bg-[#E8740E]/10 text-[#E8740E] text-xs font-bold">{c.total_compras}</span>
                     </td>
                     <td className="px-4 py-3 font-bold text-green-600">{fmt(c.total_gasto)}</td>
+                    {tab === "lojistas" && (<>
+                      <td className="px-4 py-3">
+                        {(() => {
+                          const s = saldosLojistas[lojistaKey(c)] || 0;
+                          return <span className={`inline-block px-2 py-1 rounded-lg text-xs font-bold ${s > 0 ? "bg-blue-100 text-blue-700" : `${dm ? "bg-[#2C2C2E] text-[#86868B]" : "bg-[#F5F5F7] text-[#86868B]"}`}`}>{fmt(s)}</span>;
+                        })()}
+                      </td>
+                      <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                        <button onClick={() => openCreditoModal(c)} className="px-2.5 py-1 rounded-lg text-[11px] font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D]">Gerenciar crédito</button>
+                      </td>
+                    </>)}
                     <td className="px-4 py-3">
                       <p className={`text-xs ${mP}`}>{fmtDate(c.ultima_compra)}</p>
                       <p className={`text-xs truncate max-w-[150px] ${mM}`}>{c.ultimo_produto}</p>
@@ -733,7 +811,7 @@ export default function ClientesPage() {
                   {/* Expanded: lista de compras */}
                   {expandedId === c.nome && (
                     <tr>
-                      <td colSpan={7} className={`px-6 py-4 ${dm ? "bg-[#1A1A1C]" : "bg-[#FAFAFA]"}`}>
+                      <td colSpan={tab === "lojistas" ? 9 : 7} className={`px-6 py-4 ${dm ? "bg-[#1A1A1C]" : "bg-[#FAFAFA]"}`}>
                         <div className="space-y-3">
                           <div className="flex flex-wrap gap-4 text-xs">
                             {c.cpf && <span className={mS}>CPF: <strong className={mP}>{c.cpf}</strong></span>}
@@ -778,6 +856,68 @@ export default function ClientesPage() {
         </p>
       )}
       </>)}
+
+      {/* Modal de Crédito do Lojista */}
+      {creditoModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={() => setCreditoModal(null)}>
+          <div className={`w-full max-w-lg rounded-2xl shadow-2xl ${dm ? "bg-[#1C1C1E]" : "bg-white"}`} onClick={(e) => e.stopPropagation()}>
+            <div className="px-5 py-4 border-b border-[#D2D2D7] flex items-center justify-between">
+              <div>
+                <p className={`text-xs uppercase tracking-wider ${mS}`}>Crédito do lojista</p>
+                <h3 className={`text-base font-bold ${mP}`}>{creditoModal.cliente.nome}</h3>
+              </div>
+              <button onClick={() => setCreditoModal(null)} className={`text-2xl ${mS} hover:text-red-500`}>×</button>
+            </div>
+            <div className="p-5 space-y-4">
+              <div className={`p-4 rounded-xl ${dm ? "bg-[#2C2C2E]" : "bg-[#F5F5F7]"}`}>
+                <p className={`text-xs uppercase tracking-wider ${mS}`}>Saldo disponível</p>
+                <p className="text-3xl font-bold text-blue-600 mt-1">{fmt(creditoModal.saldo)}</p>
+              </div>
+              <div className="space-y-2">
+                <div className="flex gap-2">
+                  {(["CREDITO", "DEBITO", "AJUSTE"] as const).map(t => (
+                    <button key={t} onClick={() => setCreditoForm(f => ({ ...f, tipo: t }))}
+                      className={`flex-1 py-2 rounded-lg text-xs font-semibold ${creditoForm.tipo === t ? "bg-[#E8740E] text-white" : `${dm ? "bg-[#2C2C2E] text-[#98989D]" : "bg-[#F5F5F7] text-[#86868B]"}`}`}>
+                      {t === "CREDITO" ? "+ Adicionar" : t === "DEBITO" ? "− Debitar" : "= Ajustar"}
+                    </button>
+                  ))}
+                </div>
+                <input type="number" value={creditoForm.valor} onChange={(e) => setCreditoForm(f => ({ ...f, valor: e.target.value }))}
+                  placeholder="Valor R$" className={`w-full px-3 py-2 rounded-lg border text-sm ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"}`} />
+                <input type="text" value={creditoForm.motivo} onChange={(e) => setCreditoForm(f => ({ ...f, motivo: e.target.value }))}
+                  placeholder="Motivo (opcional)" className={`w-full px-3 py-2 rounded-lg border text-sm ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"}`} />
+                <button onClick={salvarCredito} disabled={savingCredito}
+                  className="w-full py-2.5 rounded-lg bg-[#E8740E] text-white text-sm font-semibold hover:bg-[#D06A0D] disabled:opacity-50">
+                  {savingCredito ? "Salvando..." : "Salvar movimentação"}
+                </button>
+              </div>
+              <div>
+                <p className={`text-[10px] uppercase tracking-wider font-bold ${mS} mb-2`}>Extrato ({creditoModal.log.length})</p>
+                <div className="max-h-[300px] overflow-y-auto space-y-1.5">
+                  {creditoModal.log.length === 0 && <p className={`text-xs text-center ${mM} py-4`}>Sem movimentações</p>}
+                  {creditoModal.log.map(l => (
+                    <div key={l.id} className={`flex items-center justify-between px-3 py-2 rounded-lg text-xs ${dm ? "bg-[#2C2C2E]" : "bg-[#F9F9FB]"}`}>
+                      <div className="flex-1 min-w-0">
+                        <p className={`font-semibold ${mP}`}>
+                          <span className={l.tipo === "CREDITO" ? "text-green-600" : l.tipo === "DEBITO" ? "text-red-600" : "text-blue-600"}>
+                            {l.tipo === "CREDITO" ? "+" : l.tipo === "DEBITO" ? "−" : "="} {fmt(Number(l.valor))}
+                          </span>
+                          <span className={`ml-2 text-[10px] ${mS}`}>Saldo: {fmt(Number(l.saldo_depois))}</span>
+                        </p>
+                        {l.motivo && <p className={`text-[10px] truncate ${mM}`}>{l.motivo}</p>}
+                      </div>
+                      <div className={`text-[10px] ${mM} text-right shrink-0`}>
+                        <p>{new Date(l.created_at).toLocaleDateString("pt-BR")}</p>
+                        <p>{l.usuario}</p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Modal de Detalhes do Cliente */}
       {detailClient && (() => {

--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -4,6 +4,7 @@ import { hojeBR } from "@/lib/date-utils";
 import React, { useEffect, useState, useCallback, useMemo } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
 import { getTaxa, calcularLiquido } from "@/lib/taxas";
+import { formatProdutoDisplay, getModeloBase } from "@/lib/produto-display";
 
 interface EstoqueItem { id: string; produto: string; categoria: string; tipo: string; qnt: number; custo_unitario: number; cor: string | null; fornecedor: string | null; status: string; serial_no: string | null; imei: string | null; }
 
@@ -268,11 +269,37 @@ export default function EntregasPage() {
   }, [estoque]);
 
   // Categorias dos preços com labels amigáveis
-  const CAT_LABELS: Record<string, string> = { IPHONE: "iPhones", IPAD: "iPads", MACBOOK: "MacBooks", APPLE_WATCH: "Apple Watch", AIRPODS: "AirPods", ACESSORIOS: "Acessórios", MAC_MINI: "Mac Mini", OUTROS: "Outros" };
+  const CAT_LABELS: Record<string, string> = { IPHONE: "iPhones", IPAD: "iPads", MACBOOK: "MacBooks", APPLE_WATCH: "Apple Watch", AIRPODS: "AirPods", ACESSORIOS: "Acessórios", MAC_MINI: "Mac Mini", OUTROS: "Outros", SEMINOVOS: "📱 Seminovos" };
+  const temSeminovos = useMemo(() => estoque.some(p => p.tipo === "SEMINOVO" && p.qnt > 0), [estoque]);
   const categoriaPrecos = useMemo(() => {
     const cats = [...new Set(precosVenda.map(p => p.categoria))].sort();
+    if (temSeminovos) cats.push("SEMINOVOS");
     return cats;
-  }, [precosVenda]);
+  }, [precosVenda, temSeminovos]);
+
+  // Lista de seminovos agrupados por modelo base (mesmo padrão do Estoque)
+  const seminovosList = useMemo(() => {
+    type Item = { nome: string; key: string; items: EstoqueItem[] };
+    const groups = new Map<string, Item>();
+    for (const p of estoque) {
+      if (p.tipo !== "SEMINOVO" || p.qnt <= 0) continue;
+      const baseKey = getModeloBase(p.produto, p.categoria);
+      const nome = formatProdutoDisplay({ produto: p.produto, categoria: p.categoria, cor: null, observacao: null });
+      if (!groups.has(baseKey)) groups.set(baseKey, { nome, key: baseKey, items: [] });
+      groups.get(baseKey)!.items.push(p);
+    }
+    return [...groups.values()].sort((a, b) => a.nome.localeCompare(b.nome));
+  }, [estoque]);
+
+  // Cores disponíveis para o seminovo selecionado (agrupa por cor)
+  const seminovoCores = useMemo(() => {
+    if (catSel !== "SEMINOVOS" || !produtos[0]) return [];
+    const grupo = seminovosList.find(g => g.nome === produtos[0]);
+    if (!grupo) return [];
+    const set = new Set<string>();
+    for (const it of grupo.items) if (it.cor) set.add(it.cor.toUpperCase());
+    return [...set].sort();
+  }, [catSel, produtos, seminovosList]);
 
   // Produtos filtrados por categoria
   const produtosFiltradosPreco = useMemo(() => {
@@ -1068,7 +1095,7 @@ export default function EntregasPage() {
                     <option value="">-- Categoria --</option>
                     {categoriaPrecos.map(c => <option key={c} value={c}>{CAT_LABELS[c] || c}</option>)}
                   </select>
-                  {catSel && (
+                  {catSel && catSel !== "SEMINOVOS" && (
                     <div className="max-h-[300px] overflow-y-auto rounded-xl border border-[#D2D2D7] divide-y divide-[#E5E5EA]">
                       {produtosFiltradosPreco.length === 0 && <p className="text-xs text-center text-[#86868B] py-4">Nenhum produto</p>}
                       {produtosFiltradosPreco.map((m) => {
@@ -1093,6 +1120,47 @@ export default function EntregasPage() {
                                       className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${corSel === cor ? "bg-[#E8740E] text-white border-[#E8740E]" : "bg-white text-[#1D1D1F] border-[#D2D2D7] hover:border-[#E8740E]"}`}
                                     >{cor}</button>
                                   ))}
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+                  {catSel === "SEMINOVOS" && (
+                    <div className="max-h-[300px] overflow-y-auto rounded-xl border border-[#D2D2D7] divide-y divide-[#E5E5EA]">
+                      {seminovosList.length === 0 && <p className="text-xs text-center text-[#86868B] py-4">Nenhum seminovo em estoque</p>}
+                      {seminovosList.map((g) => {
+                        const sel = produtos[0] === g.nome;
+                        const qtdTotal = g.items.reduce((s, i) => s + i.qnt, 0);
+                        return (
+                          <div key={g.key}>
+                            <button type="button" onClick={() => {
+                              if (sel) { setProdutos([""]); set("valor", ""); setCorSel(""); return; }
+                              setProdutos([g.nome]);
+                              set("valor", "");
+                              setCorSel("");
+                            }} className={`w-full px-4 py-3 flex items-center justify-between text-left transition-all ${sel ? "bg-[#FFF5EB] border-l-4 border-[#E8740E]" : "hover:bg-[#F9F9FB]"}`}>
+                              <p className={`text-sm font-semibold ${sel ? "text-[#E8740E]" : "text-[#1D1D1F]"}`}>{g.nome}</p>
+                              <p className={`text-xs font-medium ${sel ? "text-[#E8740E]" : "text-[#86868B]"}`}>{qtdTotal} un.</p>
+                            </button>
+                            {sel && (
+                              <div className="px-4 py-3 bg-[#FAFAFA] border-t border-[#E5E5EA] space-y-2">
+                                {seminovoCores.length > 0 && (<>
+                                  <p className="text-xs font-medium text-[#86868B]">Selecione a cor:</p>
+                                  <div className="flex flex-wrap gap-2">
+                                    {seminovoCores.map(cor => (
+                                      <button key={cor} type="button" onClick={() => setCorSel(corSel === cor ? "" : cor)}
+                                        className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${corSel === cor ? "bg-[#E8740E] text-white border-[#E8740E]" : "bg-white text-[#1D1D1F] border-[#D2D2D7] hover:border-[#E8740E]"}`}
+                                      >{cor}</button>
+                                    ))}
+                                  </div>
+                                </>)}
+                                <div>
+                                  <p className={labelCls}>Valor de venda R$</p>
+                                  <input type="number" value={form.valor} onChange={(e) => set("valor", e.target.value)} placeholder="0" className={inputCls} />
+                                  <p className="text-[11px] text-[#86868B] italic mt-1">Seminovo não tem preço fixo — digite o valor acordado com o cliente.</p>
                                 </div>
                               </div>
                             )}

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -1753,7 +1753,7 @@ export default function EstoquePage() {
   const handleDuplicar = (p: ProdutoEstoque) => handleDuplicarProduto([p]);
 
   // Categorias que NÃO precisam de IMEI (só serial)
-  const CATS_SEM_IMEI = ["MACBOOK", "MAC_MINI", "IMAC", "MAC_STUDIO", "AIRPODS", "ACESSORIOS", "OUTROS", "IPAD", "APPLE_WATCH"];
+  const CATS_SEM_IMEI = ["MACBOOK", "MAC_MINI", "IMAC", "MAC_STUDIO", "AIRPODS", "ACESSORIOS", "OUTROS", "IPADS", "APPLE_WATCH"];
   // Categorias que NÃO precisam de serial (completamente opcional)
   const CATS_SEM_SERIAL = ["ACESSORIOS", "OUTROS"];
 
@@ -1765,7 +1765,7 @@ export default function EstoquePage() {
     if (precisaSerial && !item.serial_no) {
       return `Preencha o número de série de "${item.produto}" antes de mover para estoque.`;
     }
-    if (!CATS_SEM_IMEI.includes(item.categoria) && !item.imei) {
+    if (!CATS_SEM_IMEI.includes(getBaseCat(item.categoria)) && !item.imei) {
       return `Preencha o IMEI de "${item.produto}" antes de mover para estoque.`;
     }
     if (!item.fornecedor || item.fornecedor.trim() === "") {

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -1809,6 +1809,7 @@ export default function EstoquePage() {
           ${cor ? `<div style="font-size:5.5pt;font-weight:bold;line-height:1.2;margin-top:0.2mm;color:#000">${formatCorEtiquetaPTEN(cor)}</div>` : ""}
           ${serial ? `<div style="font-size:5.5pt;font-family:monospace;font-weight:bold;line-height:1.25;margin-top:0.3mm;color:#000">S/N: ${serial}</div>` : ""}
           ${imei ? `<div style="font-size:5.5pt;font-family:monospace;font-weight:bold;line-height:1.25;color:#000">IMEI: ${imei}</div>` : ""}
+          ${(p.tipo === "SEMINOVO" || p.tipo === "PENDENCIA") && p.bateria ? `<div style="font-size:5.5pt;font-weight:bold;line-height:1.25;margin-top:0.2mm;color:#000">🔋 Bateria: ${p.bateria}%</div>` : ""}
           ${fornecedor ? `<div style="font-size:5.5pt;font-weight:bold;line-height:1.2;margin-top:0.2mm;color:#000">${fornecedor}</div>` : ""}
           ${p.custo_unitario ? `<div style="font-size:6pt;font-weight:900;line-height:1.25;margin-top:0.3mm;color:#000">CUSTO: R$${Number(p.custo_unitario).toLocaleString("pt-BR")}</div>` : ""}
         </div>
@@ -2040,6 +2041,7 @@ export default function EstoquePage() {
       .replace(/\[PULSEIRA_TAM:[^\]]+\]/g, "")
       .replace(/\[BAND:[^\]]+\]/g, "")
       .replace(/\[RESP:[^\]]+\]/g, "")
+      .replace(/\[COM_QUEM:[^\]]+\]/g, "")
       .replace(/\s+/g, " ")
       .trim() || null;
   };
@@ -4617,21 +4619,24 @@ export default function EstoquePage() {
                                               if (cond === "NAO_ATIVADO") return <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-purple-100 text-purple-700">Não Ativado</span>;
                                               return <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-green-100 text-green-700">Lacrado</span>;
                                             })()}
-                                            {/* Bateria (só seminovo/pendência) */}
-                                            {(p.tipo === "SEMINOVO" || p.tipo === "PENDENCIA") && (
-                                              isEditableItemTab && isEditingField(p.id, "bateria") ? (
+                                            {/* Bateria (só seminovo/pendência) — admin pode editar em qualquer aba */}
+                                            {(p.tipo === "SEMINOVO" || p.tipo === "PENDENCIA") && (() => {
+                                              const bateriaEditable = isEditableItemTab || isAdmin;
+                                              if (bateriaEditable && isEditingField(p.id, "bateria")) return (
                                                 <div className="flex items-center gap-0.5">
                                                   <input type="number" value={getEditVal(p.id, "bateria") || ""} onChange={(e) => startEditField(p.id, "bateria", e.target.value)} onKeyDown={(e) => { if (e.key === "Enter") saveField(p.id, "bateria"); if (e.key === "Escape") cancelEditField(p.id, "bateria"); }} className="w-14 px-1 py-0.5 rounded border border-[#0071E3] text-[10px]" autoFocus placeholder="%" />
                                                   <button onClick={() => saveField(p.id, "bateria")} className="text-[10px] text-[#E8740E] font-bold">OK</button>
                                                 </div>
-                                              ) : isEditableItemTab ? (
+                                              );
+                                              if (bateriaEditable) return (
                                                 <button onClick={(e) => { e.stopPropagation(); startEditField(p.id, "bateria", String(p.bateria || "")); }} className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${p.bateria ? "bg-green-50 text-green-600" : `${dm ? "bg-[#2C2C2E] text-[#636366]" : "bg-gray-100 text-[#86868B]"}`} hover:ring-1 hover:ring-[#E8740E]`}>
                                                   {p.bateria ? `🔋 ${p.bateria}%` : "+ Bateria"}
                                                 </button>
-                                              ) : p.bateria ? (
+                                              );
+                                              return p.bateria ? (
                                                 <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-green-50 text-green-600">🔋 {p.bateria}%</span>
-                                              ) : null
-                                            )}
+                                              ) : null;
+                                            })()}
                                             {/* Badges: Grade, Caixa, Garantia */}
                                             {(() => {
                                               const obs = p.observacao || "";
@@ -4653,6 +4658,33 @@ export default function EstoquePage() {
                                                 {ciclos && <span className={`px-1 py-px rounded text-[9px] font-medium ${dm ? "bg-[#2C2C2E] text-[#98989D]" : "bg-gray-100 text-gray-600"}`}>{ciclos}c</span>}
                                                 {p.garantia && <span className={`px-1 py-px rounded text-[9px] font-medium ${dm ? "bg-purple-900/30 text-purple-400" : "bg-purple-100 text-purple-700"}`}>🛡️{p.garantia}</span>}
                                               </>);
+                                            })()}
+                                            {/* Com quem está (pendência) — editável texto livre via tag [COM_QUEM:...] */}
+                                            {isPendenciasTab && (() => {
+                                              const comQuemAtual = p.observacao?.match(/\[COM_QUEM:([^\]]+)\]/)?.[1] || "";
+                                              if (isEditingField(p.id, "com_quem")) return (
+                                                <div className="flex items-center gap-0.5" onClick={(e) => e.stopPropagation()}>
+                                                  <input value={getEditVal(p.id, "com_quem") || ""} onChange={(e) => startEditField(p.id, "com_quem", e.target.value)}
+                                                    onKeyDown={async (e) => {
+                                                      if (e.key === "Enter") {
+                                                        const val = (getEditVal(p.id, "com_quem") || "").trim();
+                                                        const obsBase = (p.observacao || "").replace(/\[COM_QUEM:[^\]]+\]/g, "").trim();
+                                                        const newObs = val ? `${obsBase} [COM_QUEM:${val}]`.trim() : (obsBase || null);
+                                                        await apiPatch(p.id, { observacao: newObs });
+                                                        setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, observacao: newObs } : x));
+                                                        cancelEditField(p.id, "com_quem");
+                                                      }
+                                                      if (e.key === "Escape") cancelEditField(p.id, "com_quem");
+                                                    }}
+                                                    className="w-32 px-1 py-0.5 rounded border border-[#0071E3] text-[10px]" autoFocus placeholder="Ex: Técnico João" />
+                                                </div>
+                                              );
+                                              return (
+                                                <button onClick={(e) => { e.stopPropagation(); startEditField(p.id, "com_quem", comQuemAtual); }}
+                                                  className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${comQuemAtual ? "bg-blue-50 text-blue-700" : `${dm ? "bg-[#2C2C2E] text-[#636366]" : "bg-gray-100 text-[#86868B]"}`} hover:ring-1 hover:ring-[#E8740E]`}>
+                                                  {comQuemAtual ? `👤 ${comQuemAtual}` : "+ Com quem"}
+                                                </button>
+                                              );
                                             })()}
                                             {/* Origem/Obs */}
                                             {isEditableItemTab && isEditingField(p.id, "observacao") ? (

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -118,6 +118,12 @@ function formatProdutoDisplay(p: {
     if (ram) parts.push(ram);
     if (ssd) parts.push(ssd);
   } else if (baseCat === "APPLE_WATCH") {
+    // Para watches, a "cor" às vezes foi salva como "PRETA ESTILO MILANÊS" (cor + pulseira).
+    // Remove palavras de pulseira da cor pra não duplicar com a seção Especificações.
+    const corLimpa = cor
+      .replace(/\b(ESTILO\s+)?(MILAN[ÊE]S|MILANESE|SOLO\s*LOOP(?:\s*TRAN[ÇC]AD[AO])?|BRAIDED\s*SOLO|TRAN[ÇC]A|OCEAN|ALPIN(?:E|ISTA)|TRAIL|NIKE|HERM[ÉE]S|HERMES|LINK(?:\s*BRACELET)?|ELOS|COURO|LEATHER|ESPORTIVA|SPORT\s*BAND|SPORT|LOOP|BAND|PULSEIRA)\b/gi, "")
+      .replace(/\s{2,}/g, " ")
+      .trim();
     let modelo = "Apple Watch";
     const ultra = up.match(/ULTRA\s*(\d+)?/);
     // \bSE\b com lookahead — NÃO pode casar dentro de "SERIES". Aceita "SE", "SE 2", "SE3".
@@ -132,7 +138,7 @@ function formatProdutoDisplay(p: {
     if (ultra) { /* omit connectivity */ }
     else if (hasCell) parts.push("GPS + Cellular");
     else if (hasGps) parts.push("GPS");
-    if (cor) parts.push(cor);
+    if (corLimpa) parts.push(corLimpa);
   } else {
     // Fallback: usa o nome limpo
     return cleanProdutoDisplay(nomeRaw);
@@ -473,6 +479,34 @@ function extractWatchBadges(nome: string): { tamanho: string | null; pulseira: s
     }
   }
   return { tamanho, pulseira };
+}
+
+/** Normaliza um texto livre de pulseira para um label curto (MILANÊS, ESPORTIVA, etc). */
+function normalizePulseiraLabel(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const p = raw.toUpperCase();
+  const tipoMatchers: { re: RegExp; label: string }[] = [
+    { re: /MILAN[ÊE]S|MILANESE/, label: "MILANÊS" },
+    { re: /SOLO\s*LOOP\s*TRAN[ÇC]AD[AO]|BRAIDED\s*SOLO|TRAN[ÇC]A/, label: "TRANÇA" },
+    { re: /SOLO\s*LOOP|SOLO/, label: "SOLO LOOP" },
+    { re: /OCEAN/, label: "OCEAN" },
+    { re: /ALPIN(?:E|ISTA)|TRAIL/, label: "ALPINISTA" },
+    { re: /NIKE/, label: "NIKE" },
+    { re: /HERM[ÉE]S|HERMES/, label: "HERMÈS" },
+    { re: /LINK\s*BRACELET|ELOS|LINK/, label: "LINK" },
+    { re: /COURO|LEATHER/, label: "COURO" },
+    { re: /ESPORTIVA|SPORT\s*BAND|SPORT/, label: "ESPORTIVA" },
+  ];
+  for (const { re, label } of tipoMatchers) if (re.test(p)) return label;
+  return null;
+}
+
+/** Extrai pulseira de um item de estoque olhando nome + observação ([BAND:...]). */
+function extractItemPulseira(it: { produto?: string | null; observacao?: string | null }): string | null {
+  const bandTag = it.observacao?.match(/\[BAND:([^\]]+)\]/)?.[1];
+  const fromTag = normalizePulseiraLabel(bandTag);
+  if (fromTag) return fromTag;
+  return extractWatchBadges(it.produto || "").pulseira;
 }
 
 function displayNomeProduto(nome: string, cor: string | null | undefined, categoria?: string | null): string {
@@ -4524,7 +4558,7 @@ export default function EstoquePage() {
                                       // Pulseira: extrair de cada item e pegar a mais comum (groupKey não tem pulseira)
                                       const counts: Record<string, number> = {};
                                       for (const it of prodItems) {
-                                        const pb = extractWatchBadges(it.produto).pulseira;
+                                        const pb = extractItemPulseira(it);
                                         if (pb) counts[pb] = (counts[pb] || 0) + (it.qnt || 1);
                                       }
                                       const pulseira = Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] || null;
@@ -5454,19 +5488,15 @@ export default function EstoquePage() {
                         <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Carregador</p>
                         <span className="inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 bg-green-100 text-green-700">🔋 Com Carregador</span></div>
                       )}
-                      {/* Apple Watch: tamanho + pulseira info */}
+                      {/* Apple Watch: só tamanho aqui — pulseira aparece na seção "Especificações" pra evitar duplicação */}
                       {p.categoria === "APPLE_WATCH" && (() => {
                         const { tamanho } = extractWatchBadges(p.produto);
-                        const pulseiraTam = p.observacao?.match(/\[PULSEIRA_TAM:([^\]]+)\]/)?.[1];
-                        const bandModel = p.observacao?.match(/\[BAND:([^\]]+)\]/)?.[1];
-                        return (<>
-                          {tamanho && <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Tamanho</p>
-                            <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>⌚ {tamanho}</span></div>}
-                          {pulseiraTam && <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Tamanho Pulseira</p>
-                            <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>{pulseiraTam}</span></div>}
-                          {bandModel && <div className="col-span-2"><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Modelo Pulseira</p>
-                            <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${dm ? "bg-[#2C2C2E] text-[#8E8E93]" : "bg-[#F2F2F7] text-[#8E8E93]"}`}>{bandModel}</span></div>}
-                        </>);
+                        if (!tamanho) return null;
+                        return (
+                          <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Tamanho</p>
+                            <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>⌚ {tamanho}</span>
+                          </div>
+                        );
                       })()}
                       {/* Ciclos badge */}
                       {(() => {

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -12,7 +12,7 @@ import BarcodeScanner from "@/components/BarcodeScanner";
 import { buildProdutoName as buildProdutoNameFromSpec, CORES_POR_CATEGORIA, COR_EN_TO_PT, COR_OBRIGATORIA, IPHONE_ORIGENS, WATCH_PULSEIRAS, WATCH_BAND_MODELS, getIphoneCores, MACBOOK_RAMS, MACBOOK_STORAGES, MACBOOK_NUCLEOS, type ProdutoSpec } from "@/lib/produto-specs";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 import type { Banco } from "@/lib/admin-types";
-import { corParaPT } from "@/lib/cor-pt";
+import { corParaPT, formatCorEtiquetaPTEN } from "@/lib/cor-pt";
 
 /**
  * Normaliza o display de um produto seguindo a ordem rigorosa por categoria,
@@ -118,12 +118,6 @@ function formatProdutoDisplay(p: {
     if (ram) parts.push(ram);
     if (ssd) parts.push(ssd);
   } else if (baseCat === "APPLE_WATCH") {
-    // Para watches, a "cor" às vezes foi salva como "PRETA ESTILO MILANÊS" (cor + pulseira).
-    // Remove palavras de pulseira da cor pra não duplicar com a seção Especificações.
-    const corLimpa = cor
-      .replace(/\b(ESTILO\s+)?(MILAN[ÊE]S|MILANESE|SOLO\s*LOOP(?:\s*TRAN[ÇC]AD[AO])?|BRAIDED\s*SOLO|TRAN[ÇC]A|OCEAN|ALPIN(?:E|ISTA)|TRAIL|NIKE|HERM[ÉE]S|HERMES|LINK(?:\s*BRACELET)?|ELOS|COURO|LEATHER|ESPORTIVA|SPORT\s*BAND|SPORT|LOOP|BAND|PULSEIRA)\b/gi, "")
-      .replace(/\s{2,}/g, " ")
-      .trim();
     let modelo = "Apple Watch";
     const ultra = up.match(/ULTRA\s*(\d+)?/);
     // \bSE\b com lookahead — NÃO pode casar dentro de "SERIES". Aceita "SE", "SE 2", "SE3".
@@ -134,11 +128,11 @@ function formatProdutoDisplay(p: {
     else if (series) modelo = `Apple Watch Series ${series[1]}`;
     parts.push(modelo);
     if (tamMm) parts.push(tamMm);
-    // Ultra é sempre cellular — redundante mostrar "GPS + Cellular" no nome
-    if (ultra) { /* omit connectivity */ }
+    // Ultra é sempre cellular; os outros respeitam detecção
+    if (ultra) parts.push("GPS + Cellular");
     else if (hasCell) parts.push("GPS + Cellular");
     else if (hasGps) parts.push("GPS");
-    if (corLimpa) parts.push(corLimpa);
+    if (cor) parts.push(cor);
   } else {
     // Fallback: usa o nome limpo
     return cleanProdutoDisplay(nomeRaw);
@@ -437,17 +431,17 @@ function extractCorEN(nome: string): string | null {
  * - Substitui cor em português pelo equivalente em inglês (ex: AZUL PROFUNDO → DEEP BLUE)
  * - Quando cor=null, tenta encontrar cor PT no próprio nome do produto
  */
-/** Extrai tamanho (42MM, 46MM etc) e tipo da pulseira (MILANÊS, ESPORTIVA, etc) de um nome de Apple Watch */
+/** Extrai tamanho (42MM, 46MM etc) e pulseira (SPORT BAND S/M etc) de um nome de Apple Watch */
 function extractWatchBadges(nome: string): { tamanho: string | null; pulseira: string | null } {
   if (!nome) return { tamanho: null, pulseira: null };
   const upper = nome.toUpperCase();
   const tamMatch = upper.match(/\b(\d{2}MM)\b/);
   const tamanho = tamMatch ? tamMatch[1] : null;
   // Pulseira: se tem "PULSEIRA ..." no nome, pega tudo após (mais confiável)
-  let pulseiraRaw: string | null = null;
+  let pulseira: string | null = null;
   const pulseiraExplicita = upper.match(/PULSEIRA\s+(.+?)$/);
   if (pulseiraExplicita) {
-    pulseiraRaw = pulseiraExplicita[1]
+    pulseira = pulseiraExplicita[1]
       .replace(/\s*GPS\s*\+\s*CELLULAR\b/g, "")
       .replace(/\s*GPS\s*\+\s*CEL\b/g, "")
       .replace(/\s+/g, " ")
@@ -455,58 +449,9 @@ function extractWatchBadges(nome: string): { tamanho: string | null; pulseira: s
   } else {
     // Fallback: pattern conhecido sem label PULSEIRA
     const pulseiraMatch = upper.match(/\b((?:SPORT|BRAIDED SOLO|SOLO|MILANESE|LINK BRACELET|LEATHER|OCEAN|TRAIL|NIKE SPORT|ALPINE)\s*(?:LOOP|BAND)?(?:\s+(?:XS|S|S\/M|M|M\/L|L|XL))?)\b/);
-    pulseiraRaw = pulseiraMatch ? pulseiraMatch[1].trim() : null;
-  }
-  // Normalizar: extrair só o tipo (ignorando cor / tamanhos / palavra "estilo")
-  // Regras testadas em ordem; primeira que casar vence.
-  let pulseira: string | null = pulseiraRaw;
-  if (pulseiraRaw) {
-    const p = pulseiraRaw;
-    const tipoMatchers: { re: RegExp; label: string }[] = [
-      { re: /MILAN[ÊE]S|MILANESE/, label: "MILANÊS" },
-      { re: /SOLO\s*LOOP\s*TRAN[ÇC]AD[AO]|BRAIDED\s*SOLO/, label: "TRANÇA" },
-      { re: /SOLO\s*LOOP|SOLO/, label: "SOLO LOOP" },
-      { re: /OCEAN/, label: "OCEAN" },
-      { re: /ALPIN(?:E|ISTA)|TRAIL/, label: "ALPINISTA" },
-      { re: /NIKE/, label: "NIKE" },
-      { re: /HERM[ÉE]S|HERMES/, label: "HERMÈS" },
-      { re: /LINK\s*BRACELET|ELOS|LINK/, label: "LINK" },
-      { re: /COURO|LEATHER/, label: "COURO" },
-      { re: /ESPORTIVA|SPORT\s*BAND|SPORT/, label: "ESPORTIVA" },
-    ];
-    for (const { re, label } of tipoMatchers) {
-      if (re.test(p)) { pulseira = label; break; }
-    }
+    pulseira = pulseiraMatch ? pulseiraMatch[1].trim() : null;
   }
   return { tamanho, pulseira };
-}
-
-/** Normaliza um texto livre de pulseira para um label curto (MILANÊS, ESPORTIVA, etc). */
-function normalizePulseiraLabel(raw: string | null | undefined): string | null {
-  if (!raw) return null;
-  const p = raw.toUpperCase();
-  const tipoMatchers: { re: RegExp; label: string }[] = [
-    { re: /MILAN[ÊE]S|MILANESE/, label: "MILANÊS" },
-    { re: /SOLO\s*LOOP\s*TRAN[ÇC]AD[AO]|BRAIDED\s*SOLO|TRAN[ÇC]A/, label: "TRANÇA" },
-    { re: /SOLO\s*LOOP|SOLO/, label: "SOLO LOOP" },
-    { re: /OCEAN/, label: "OCEAN" },
-    { re: /ALPIN(?:E|ISTA)|TRAIL/, label: "ALPINISTA" },
-    { re: /NIKE/, label: "NIKE" },
-    { re: /HERM[ÉE]S|HERMES/, label: "HERMÈS" },
-    { re: /LINK\s*BRACELET|ELOS|LINK/, label: "LINK" },
-    { re: /COURO|LEATHER/, label: "COURO" },
-    { re: /ESPORTIVA|SPORT\s*BAND|SPORT/, label: "ESPORTIVA" },
-  ];
-  for (const { re, label } of tipoMatchers) if (re.test(p)) return label;
-  return null;
-}
-
-/** Extrai pulseira de um item de estoque olhando nome + observação ([BAND:...]). */
-function extractItemPulseira(it: { produto?: string | null; observacao?: string | null }): string | null {
-  const bandTag = it.observacao?.match(/\[BAND:([^\]]+)\]/)?.[1];
-  const fromTag = normalizePulseiraLabel(bandTag);
-  if (fromTag) return fromTag;
-  return extractWatchBadges(it.produto || "").pulseira;
 }
 
 function displayNomeProduto(nome: string, cor: string | null | undefined, categoria?: string | null): string {
@@ -801,12 +746,12 @@ function getModeloBase(produto: string, categoria: string): string {
       const gen = ultraMatch[1] ? ` ${ultraMatch[1]}` : "";
       return `Apple Watch Ultra${gen}${sz}`;
     }
-    // SE com geração (SE 2, SE 3) — \bSE(?!R) evita casar "SERIES"
-    const seMatch = p.match(/\bSE(?!R)\s*(\d+)/);
+    // SE com geração (SE 2, SE 3)
+    const seMatch = p.match(/SE\s*(\d+)/);
     if (seMatch) return `Apple Watch SE ${seMatch[1]}${sz}${conn}`;
-    if (/\bSE(?!R)/.test(p)) return `Apple Watch SE${sz}${conn}`;
+    if (p.includes("SE")) return `Apple Watch SE${sz}${conn}`;
     // Series com número
-    const seriesMatch = p.match(/(?:SERIES\s*|\bS)(\d+)/);
+    const seriesMatch = p.match(/(?:SERIES\s*|S)(\d+)/);
     if (seriesMatch) return `Apple Watch Series ${seriesMatch[1]}${sz}${conn}`;
     return `Apple Watch${sz}${conn}`;
   }
@@ -1787,7 +1732,7 @@ export default function EstoquePage() {
   const handleDuplicar = (p: ProdutoEstoque) => handleDuplicarProduto([p]);
 
   // Categorias que NÃO precisam de IMEI (só serial)
-  const CATS_SEM_IMEI = ["MACBOOK", "MAC_MINI", "IMAC", "MAC_STUDIO", "AIRPODS", "ACESSORIOS", "OUTROS", "IPADS", "APPLE_WATCH"];
+  const CATS_SEM_IMEI = ["MACBOOK", "MAC_MINI", "IMAC", "MAC_STUDIO", "AIRPODS", "ACESSORIOS", "OUTROS"];
   // Categorias que NÃO precisam de serial (completamente opcional)
   const CATS_SEM_SERIAL = ["ACESSORIOS", "OUTROS"];
 
@@ -1799,7 +1744,7 @@ export default function EstoquePage() {
     if (precisaSerial && !item.serial_no) {
       return `Preencha o número de série de "${item.produto}" antes de mover para estoque.`;
     }
-    if (!CATS_SEM_IMEI.includes(getBaseCat(item.categoria)) && !item.imei) {
+    if (!CATS_SEM_IMEI.includes(item.categoria) && !item.imei) {
       return `Preencha o IMEI de "${item.produto}" antes de mover para estoque.`;
     }
     if (!item.fornecedor || item.fornecedor.trim() === "") {
@@ -1860,7 +1805,8 @@ export default function EstoquePage() {
           <canvas id="qr-${idx}" data-qr="${String(qrData).replace(/"/g, "&quot;")}"></canvas>
         </div>
         <div style="padding:0 1.5mm 0.5mm;text-align:center">
-          <div style="font-size:6pt;font-weight:900;line-height:1.15;word-break:break-word;color:#000">${p.produto}${cor ? " " + cor : ""}</div>
+          <div style="font-size:6pt;font-weight:900;line-height:1.15;word-break:break-word;color:#000">${p.produto}</div>
+          ${cor ? `<div style="font-size:5.5pt;font-weight:bold;line-height:1.2;margin-top:0.2mm;color:#000">${formatCorEtiquetaPTEN(cor)}</div>` : ""}
           ${serial ? `<div style="font-size:5.5pt;font-family:monospace;font-weight:bold;line-height:1.25;margin-top:0.3mm;color:#000">S/N: ${serial}</div>` : ""}
           ${imei ? `<div style="font-size:5.5pt;font-family:monospace;font-weight:bold;line-height:1.25;color:#000">IMEI: ${imei}</div>` : ""}
           ${fornecedor ? `<div style="font-size:5.5pt;font-weight:bold;line-height:1.2;margin-top:0.2mm;color:#000">${fornecedor}</div>` : ""}
@@ -1907,7 +1853,7 @@ export default function EstoquePage() {
     const serial = p.serial_no || "";
     const imei = p.imei || "";
     const qrData = serial || imei || p.id;
-    const cor = p.cor ? ` ${p.cor}` : "";
+    const corLine = p.cor ? formatCorEtiquetaPTEN(p.cor) : "";
     const obs = p.observacao || "";
     const gradeMatch = obs.match(/\[GRADE_(A\+|AB|A|B)\]/)?.[1];
     const grade = gradeMatch || null;
@@ -1936,7 +1882,8 @@ export default function EstoquePage() {
       <div class="label">
         <canvas id="qr0" data-qr="${String(qrData).replace(/"/g, "&quot;")}"></canvas>
         <div class="info">
-          <div class="produto">${p.produto}${cor}</div>
+          <div class="produto">${p.produto}</div>
+          ${corLine ? `<div class="badges" style="font-weight:bold;color:#000">${corLine}</div>` : ""}
           <div class="badges">${[
             p.bateria ? `🔋 ${p.bateria}%` : "",
             grade ? `Grade ${grade}` : "",
@@ -4554,14 +4501,7 @@ export default function EstoquePage() {
                                     })()}
                                     {/* Apple Watch badges: tamanho + pulseira */}
                                     {prodItems[0]?.categoria === "APPLE_WATCH" && (() => {
-                                      const { tamanho } = extractWatchBadges(prodNome);
-                                      // Pulseira: extrair de cada item e pegar a mais comum (groupKey não tem pulseira)
-                                      const counts: Record<string, number> = {};
-                                      for (const it of prodItems) {
-                                        const pb = extractItemPulseira(it);
-                                        if (pb) counts[pb] = (counts[pb] || 0) + (it.qnt || 1);
-                                      }
-                                      const pulseira = Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] || null;
+                                      const { tamanho, pulseira } = extractWatchBadges(prodNome);
                                       if (!tamanho && !pulseira) return null;
                                       return (
                                         <div className="flex gap-1 mt-0.5">
@@ -4859,7 +4799,7 @@ export default function EstoquePage() {
                                               const labels = Array.from({ length: qnt }, () => `
                                                 <div class="label">
                                                   <div class="produto">${p.produto}</div>
-                                                  ${p.cor ? `<div class="cor">${p.cor}</div>` : ""}
+                                                  ${p.cor ? `<div class="cor">${formatCorEtiquetaPTEN(p.cor)}</div>` : ""}
                                                   <div class="custo">R$ ${fmtCusto(p.custo_unitario || 0)}</div>
                                                   ${p.fornecedor ? `<div class="fornecedor">${p.fornecedor}</div>` : ""}
                                                   ${p.data_compra ? `<div class="data">${fmtDate(p.data_compra)}</div>` : ""}
@@ -5143,11 +5083,12 @@ export default function EstoquePage() {
                         })()}
                       </p>
                       {p.categoria === "APPLE_WATCH" && (() => {
-                        const { tamanho } = extractWatchBadges(p.produto);
-                        if (!tamanho) return null;
+                        const { tamanho, pulseira } = extractWatchBadges(p.produto);
+                        if (!tamanho && !pulseira) return null;
                         return (
                           <div className="flex gap-1.5 mt-1">
-                            <span className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>{tamanho}</span>
+                            {tamanho && <span className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>{tamanho}</span>}
+                            {pulseira && <span className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold ${dm ? "bg-[#2C2C2E] text-[#8E8E93]" : "bg-[#F2F2F7] text-[#8E8E93]"}`}>{pulseira}</span>}
                           </div>
                         );
                       })()}
@@ -5446,33 +5387,7 @@ export default function EstoquePage() {
                           )}
                         </div>
                       )}
-                      <div>
-                        <p className={`text-[10px] uppercase tracking-wider ${mS}`}>Condicao</p>
-                        {canEdit ? (
-                          <select
-                            value={p.tipo === "NAO_ATIVADO" ? "NAO_ATIVADO" : isLac ? "NOVO" : "SEMINOVO"}
-                            onChange={async (e) => {
-                              const novo = e.target.value as "NOVO" | "SEMINOVO" | "NAO_ATIVADO";
-                              try {
-                                await apiPatch(p.id, { tipo: novo });
-                                setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, tipo: novo } : x));
-                                setDetailProduct({ ...p, tipo: novo });
-                                showSaved("tipo");
-                                setMsg(`Condição alterada para ${novo === "NOVO" ? "Lacrado" : novo === "NAO_ATIVADO" ? "Não Ativado" : "Usado"}`);
-                              } catch (err) {
-                                setMsg("❌ " + String(err instanceof Error ? err.message : err));
-                              }
-                            }}
-                            className={`mt-0.5 text-[11px] font-semibold px-2 py-1 rounded-lg border ${dm ? "bg-[#1C1C1E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"} focus:border-[#E8740E] focus:outline-none`}
-                          >
-                            <option value="NOVO">🔵 Lacrado</option>
-                            <option value="NAO_ATIVADO">🟣 Não Ativado</option>
-                            <option value="SEMINOVO">🟡 Usado</option>
-                          </select>
-                        ) : (
-                          <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${p.tipo === "NAO_ATIVADO" ? "bg-purple-100 text-purple-700" : isLac ? "bg-blue-100 text-blue-700" : "bg-yellow-100 text-yellow-700"}`}>{p.tipo === "NAO_ATIVADO" ? "Não Ativado" : isLac ? "Lacrado" : "Usado"}</span>
-                        )}
-                      </div>
+                      <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Condicao</p><span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${p.tipo === "NAO_ATIVADO" ? "bg-purple-100 text-purple-700" : isLac ? "bg-blue-100 text-blue-700" : "bg-yellow-100 text-yellow-700"}`}>{p.tipo === "NAO_ATIVADO" ? "Não Ativado" : isLac ? "Lacrado" : "Usado"}</span></div>
                       {/* Caixa badge */}
                       {(p.observacao?.includes("[COM_CAIXA]") || /com\s+caixa/i.test(p.observacao || "")) && (
                         <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Caixa</p>
@@ -5488,15 +5403,19 @@ export default function EstoquePage() {
                         <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Carregador</p>
                         <span className="inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 bg-green-100 text-green-700">🔋 Com Carregador</span></div>
                       )}
-                      {/* Apple Watch: só tamanho aqui — pulseira aparece na seção "Especificações" pra evitar duplicação */}
+                      {/* Apple Watch: tamanho + pulseira info */}
                       {p.categoria === "APPLE_WATCH" && (() => {
                         const { tamanho } = extractWatchBadges(p.produto);
-                        if (!tamanho) return null;
-                        return (
-                          <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Tamanho</p>
-                            <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>⌚ {tamanho}</span>
-                          </div>
-                        );
+                        const pulseiraTam = p.observacao?.match(/\[PULSEIRA_TAM:([^\]]+)\]/)?.[1];
+                        const bandModel = p.observacao?.match(/\[BAND:([^\]]+)\]/)?.[1];
+                        return (<>
+                          {tamanho && <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Tamanho</p>
+                            <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>⌚ {tamanho}</span></div>}
+                          {pulseiraTam && <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Tamanho Pulseira</p>
+                            <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>{pulseiraTam}</span></div>}
+                          {bandModel && <div className="col-span-2"><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Modelo Pulseira</p>
+                            <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${dm ? "bg-[#2C2C2E] text-[#8E8E93]" : "bg-[#F2F2F7] text-[#8E8E93]"}`}>{bandModel}</span></div>}
+                        </>);
                       })()}
                       {/* Ciclos badge */}
                       {(() => {

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -4520,7 +4520,14 @@ export default function EstoquePage() {
                                     })()}
                                     {/* Apple Watch badges: tamanho + pulseira */}
                                     {prodItems[0]?.categoria === "APPLE_WATCH" && (() => {
-                                      const { tamanho, pulseira } = extractWatchBadges(prodNome);
+                                      const { tamanho } = extractWatchBadges(prodNome);
+                                      // Pulseira: extrair de cada item e pegar a mais comum (groupKey não tem pulseira)
+                                      const counts: Record<string, number> = {};
+                                      for (const it of prodItems) {
+                                        const pb = extractWatchBadges(it.produto).pulseira;
+                                        if (pb) counts[pb] = (counts[pb] || 0) + (it.qnt || 1);
+                                      }
+                                      const pulseira = Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] || null;
                                       if (!tamanho && !pulseira) return null;
                                       return (
                                         <div className="flex gap-1 mt-0.5">
@@ -5102,12 +5109,11 @@ export default function EstoquePage() {
                         })()}
                       </p>
                       {p.categoria === "APPLE_WATCH" && (() => {
-                        const { tamanho, pulseira } = extractWatchBadges(p.produto);
-                        if (!tamanho && !pulseira) return null;
+                        const { tamanho } = extractWatchBadges(p.produto);
+                        if (!tamanho) return null;
                         return (
                           <div className="flex gap-1.5 mt-1">
-                            {tamanho && <span className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>{tamanho}</span>}
-                            {pulseira && <span className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold ${dm ? "bg-[#2C2C2E] text-[#8E8E93]" : "bg-[#F2F2F7] text-[#8E8E93]"}`}>{pulseira}</span>}
+                            <span className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-semibold ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>{tamanho}</span>
                           </div>
                         );
                       })()}

--- a/app/admin/etiquetas/page.tsx
+++ b/app/admin/etiquetas/page.tsx
@@ -20,53 +20,10 @@ import {
   DEFAULT_SPEC, buildProdutoName,
   type ProdutoSpec,
 } from "@/lib/produto-specs";
-import { corParaPT } from "@/lib/cor-pt";
+import { corParaPT, formatCorEtiquetaPTEN } from "@/lib/cor-pt";
 
-// Formata cor para etiqueta: "PRETO - BLACK" (PT - EN)
-// - Deduplica casos como "BLACK Black" → "Black"
-// - Procura tradução e renderiza PT maiúsculo + EN capitalizado
-const COR_PT_EN: Record<string, string> = {
-  PRETO: "Black", BRANCO: "White", AZUL: "Blue", VERDE: "Green", ROSA: "Pink",
-  ROXO: "Purple", VERMELHO: "Red", AMARELO: "Yellow", DOURADO: "Gold", LARANJA: "Orange",
-  CINZA: "Gray", PRATA: "Silver", ESTELAR: "Starlight", "MEIA-NOITE": "Midnight",
-  GRAFITE: "Graphite", TITÂNIO: "Titanium", TITANIO: "Titanium", LAVANDA: "Lavender",
-  NATURAL: "Natural", "AZUL PROFUNDO": "Deep Blue", "AZUL ESCURO": "Dark Blue",
-  "AZUL CLARO": "Light Blue", "ROSA CLARO": "Light Pink", BRONZE: "Bronze",
-  JEANS: "Denim", AREIA: "Sand", OLIVA: "Olive", CORAL: "Coral",
-};
-const COR_EN_PT: Record<string, string> = {
-  BLACK: "Preto", WHITE: "Branco", BLUE: "Azul", GREEN: "Verde", PINK: "Rosa",
-  PURPLE: "Roxo", RED: "Vermelho", YELLOW: "Amarelo", GOLD: "Dourado", ORANGE: "Laranja",
-  GRAY: "Cinza", GREY: "Cinza", SILVER: "Prata", STARLIGHT: "Estelar", MIDNIGHT: "Meia-noite",
-  GRAPHITE: "Grafite", TITANIUM: "Titânio", LAVENDER: "Lavanda", NATURAL: "Natural",
-  "DEEP BLUE": "Azul Profundo", "DARK BLUE": "Azul Escuro", "LIGHT BLUE": "Azul Claro",
-  "LIGHT PINK": "Rosa Claro", BRONZE: "Bronze", DENIM: "Jeans", SAND: "Areia",
-  OLIVE: "Oliva", CORAL: "Coral", "SPACE BLACK": "Preto Espacial", "SPACE GRAY": "Cinza Espacial",
-  "ROSE GOLD": "Ouro Rosa",
-};
-
-function formatCorEtiqueta(cor: string | null | undefined): string {
-  if (!cor) return "";
-  // Dedup: "BLACK Black" → "Black"
-  const parts = cor.trim().split(/\s+/);
-  const unique: string[] = [];
-  for (const p of parts) {
-    if (!unique.some(u => u.toUpperCase() === p.toUpperCase())) unique.push(p);
-  }
-  const clean = unique.join(" ").trim();
-  const upper = clean.toUpperCase();
-  // Se PT conhecido → "PT - EN"
-  if (COR_PT_EN[upper]) return `${upper} - ${COR_PT_EN[upper].toUpperCase()}`;
-  // Se EN conhecido → "PT - EN"
-  if (COR_EN_PT[upper]) return `${COR_EN_PT[upper].toUpperCase()} - ${upper}`;
-  // Tenta achar ambos numa string composta tipo "Preto Black"
-  for (const [pt, en] of Object.entries(COR_PT_EN)) {
-    if (upper.includes(pt) && upper.includes(en.toUpperCase())) {
-      return `${pt} - ${en.toUpperCase()}`;
-    }
-  }
-  return clean;
-}
+// Formata cor para etiqueta no padrão "PT - EN" — util compartilhada em lib/cor-pt
+const formatCorEtiqueta = formatCorEtiquetaPTEN;
 
 interface Etiqueta {
   id: string;

--- a/app/admin/gastos/page.tsx
+++ b/app/admin/gastos/page.tsx
@@ -561,13 +561,30 @@ export default function GastosPage() {
   const grupos = useMemo(() => agruparGastos(gastos), [gastos]);
   const [filtroCategoria, setFiltroCategoria] = useState("");
   const [categoriasExcluidas, setCategoriasExcluidas] = useState<Set<string>>(new Set());
+  // Filtro de mês (YYYY-MM). Default = mês atual.
+  const [filtroMes, setFiltroMes] = useState<string>(() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+  });
   const toggleCategoria = (cat: string) => setCategoriasExcluidas(prev => { const n = new Set(prev); n.has(cat) ? n.delete(cat) : n.add(cat); return n; });
   const gruposFiltrados = useMemo(() => {
     let result = grupos;
+    if (filtroMes) result = result.filter(g => (g.data || "").startsWith(filtroMes));
     if (filtroCategoria) result = result.filter(g => g.categoria === filtroCategoria);
     if (categoriasExcluidas.size > 0) result = result.filter(g => !categoriasExcluidas.has(g.categoria));
     return result;
-  }, [grupos, filtroCategoria, categoriasExcluidas]);
+  }, [grupos, filtroMes, filtroCategoria, categoriasExcluidas]);
+  const shiftMes = (delta: number) => setFiltroMes(prev => {
+    const [y, m] = prev.split("-").map(Number);
+    const d = new Date(y, m - 1 + delta, 1);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+  });
+  const mesLabel = useMemo(() => {
+    if (!filtroMes) return "Todos";
+    const [y, m] = filtroMes.split("-").map(Number);
+    const nomes = ["Janeiro","Fevereiro","Março","Abril","Maio","Junho","Julho","Agosto","Setembro","Outubro","Novembro","Dezembro"];
+    return `${nomes[m - 1]} ${y}`;
+  }, [filtroMes]);
   const categoriasUsadas = useMemo(() => [...new Set(grupos.map(g => g.categoria))].sort(), [grupos]);
   // Agrupar por data
   const gruposPorData = useMemo(() => {
@@ -1096,6 +1113,19 @@ export default function GastosPage() {
               <p className="text-xs text-[#86868B]">Total Saidas</p>
               <p className="text-xl font-bold text-red-500">{fmt(gruposFiltrados.filter(g => !g.is_dep_esp).reduce((s, g) => s + g.totalValor, 0))}</p>
               <p className="text-[10px] text-[#86868B]">{gruposFiltrados.filter(g => !g.is_dep_esp).length} registros</p>
+            </div>
+            {/* Filtro de mês */}
+            <div className={`flex items-center gap-1 border rounded-xl px-2 py-1.5 ${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-white border-[#D2D2D7]"}`}>
+              <button onClick={() => shiftMes(-1)} className={`px-2 py-1 rounded-lg text-sm font-bold ${dm ? "hover:bg-[#2C2C2E] text-[#F5F5F7]" : "hover:bg-[#F5F5F7] text-[#1D1D1F]"}`} title="Mês anterior">‹</button>
+              <input
+                type="month"
+                value={filtroMes}
+                onChange={(e) => setFiltroMes(e.target.value)}
+                className={`text-xs font-semibold px-2 py-1 rounded-lg border-0 outline-none ${dm ? "bg-[#1C1C1E] text-[#F5F5F7]" : "bg-white text-[#1D1D1F]"}`}
+              />
+              <span className={`text-xs font-bold px-1 ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{mesLabel}</span>
+              <button onClick={() => shiftMes(1)} className={`px-2 py-1 rounded-lg text-sm font-bold ${dm ? "hover:bg-[#2C2C2E] text-[#F5F5F7]" : "hover:bg-[#F5F5F7] text-[#1D1D1F]"}`} title="Próximo mês">›</button>
+              {filtroMes && <button onClick={() => setFiltroMes("")} className="text-[10px] text-[#E8740E] underline ml-1">Todos</button>}
             </div>
             <div className="flex flex-wrap gap-2">
               <button onClick={() => { setFiltroCategoria(""); setCategoriasExcluidas(new Set()); }} className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors ${!filtroCategoria && categoriasExcluidas.size === 0 ? "bg-[#E8740E] text-white" : `${dm ? "bg-[#2C2C2E] text-[#98989D]" : "bg-white border border-[#D2D2D7] text-[#86868B]"} hover:border-[#E8740E]`}`}>

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
 import { getWhatsAppByVendedor, VENDEDORES } from "@/lib/whatsapp-config";
 import { corParaPT, corParaEN } from "@/lib/cor-pt";
+import { getModeloBase } from "@/lib/produto-display";
 
 export default function GerarLinkPage() {
   const { user, password: adminPw, apiHeaders: adminHeaders, darkMode: dm } = useAdmin();
@@ -49,7 +50,7 @@ export default function GerarLinkPage() {
   const [coresExtras, setCoresExtras] = useState<string[]>([]); // cor por índice extra (produto 2, 3, ...)
 
   // Fetch estoque para obter cores reais disponíveis + seminovos
-  const [estoqueItems, setEstoqueItems] = useState<{ produto: string; cor: string | null; qnt: number; tipo?: string; preco_sugerido?: number | null }[]>([]);
+  const [estoqueItems, setEstoqueItems] = useState<{ produto: string; categoria: string; cor: string | null; qnt: number; tipo?: string; preco_sugerido?: number | null }[]>([]);
   useEffect(() => {
     if (!adminPw) return;
     fetch("/api/estoque", { headers: adminHeaders() })
@@ -59,8 +60,8 @@ export default function GerarLinkPage() {
           setEstoqueItems(
             j.data
               .filter((p: { status?: string; qnt?: number }) => p.status === "EM ESTOQUE" && (p.qnt || 0) > 0)
-              .map((p: { produto: string; cor: string | null; qnt: number; tipo?: string; preco_sugerido?: number | null }) => ({
-                produto: p.produto, cor: p.cor, qnt: p.qnt, tipo: p.tipo, preco_sugerido: p.preco_sugerido
+              .map((p: { produto: string; categoria: string; cor: string | null; qnt: number; tipo?: string; preco_sugerido?: number | null }) => ({
+                produto: p.produto, categoria: p.categoria, cor: p.cor, qnt: p.qnt, tipo: p.tipo, preco_sugerido: p.preco_sugerido
               }))
           );
         }
@@ -68,14 +69,31 @@ export default function GerarLinkPage() {
       .catch(() => {});
   }, [adminPw]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Seminovos disponíveis em tempo real
+  // Seminovos disponíveis em tempo real — agrupados por modelo base + cor
+  // (mesma lógica do /admin/estoque via getModeloBase)
   const seminovosDisponiveis = useMemo(() => {
-    return estoqueItems
-      .filter(p => p.tipo === "SEMINOVO")
-      .map(p => ({
-        nome: p.cor ? `${p.produto} ${p.cor}` : p.produto,
-        preco: p.preco_sugerido || 0,
-      }))
+    const map = new Map<string, { nome: string; preco: number; count: number }>();
+    for (const p of estoqueItems) {
+      if (p.tipo !== "SEMINOVO") continue;
+      const base = getModeloBase(p.produto, p.categoria || "SEMINOVOS");
+      const corPt = p.cor ? corParaPT(p.cor) : "";
+      const nome = corPt ? `${base} ${corPt}` : base;
+      const key = nome.toUpperCase();
+      const prev = map.get(key);
+      if (prev) {
+        // agrega preço médio ponderado (pula zeros)
+        if ((p.preco_sugerido || 0) > 0) {
+          prev.preco = prev.preco > 0
+            ? Math.round((prev.preco * prev.count + (p.preco_sugerido || 0)) / (prev.count + 1))
+            : (p.preco_sugerido || 0);
+          prev.count += 1;
+        }
+      } else {
+        map.set(key, { nome, preco: p.preco_sugerido || 0, count: (p.preco_sugerido || 0) > 0 ? 1 : 0 });
+      }
+    }
+    return Array.from(map.values())
+      .map(({ nome, preco }) => ({ nome, preco }))
       .sort((a, b) => a.nome.localeCompare(b.nome));
   }, [estoqueItems]);
 
@@ -532,29 +550,7 @@ export default function GerarLinkPage() {
     const corQp = qp.get("cor");
     if (corQp) setCorSel(corQp.toUpperCase());
     const trocaProd = qp.get("troca_produto");
-    if (trocaProd) {
-      // Enriquece o nome do produto da troca com cor / bateria / obs vindas da simulação,
-      // já que o form de gerar-link não tem campos separados pra esses dados.
-      const corQ = qp.get("troca_cor") || "";
-      const batQ = qp.get("troca_bateria") || "";
-      const marcasQ = qp.get("troca_marcas_uso") || "";
-      const pecasQ = qp.get("troca_pecas_trocadas") || "";
-      const caixaQ = qp.get("troca_caixa_original") || "";
-      const obsQ = qp.get("troca_observacao") || "";
-      const extras: string[] = [];
-      if (corQ) extras.push(`Cor: ${corQ}`);
-      if (batQ) extras.push(`Bateria: ${batQ}%`);
-      if (obsQ) extras.push(obsQ);
-      else {
-        if (marcasQ === "nao") extras.push("Sem marcas de uso");
-        else if (marcasQ) extras.push(`Marcas: ${marcasQ}`);
-        if (pecasQ) extras.push(pecasQ);
-        if (caixaQ === "sim") extras.push("Com caixa original");
-        else if (caixaQ === "nao") extras.push("Sem caixa original");
-      }
-      setTrocaProduto(extras.length ? `${trocaProd} — ${extras.join(" — ")}` : trocaProd);
-      setTemTroca(true);
-    }
+    if (trocaProd) setTrocaProduto(trocaProd);
     const trocaVal = qp.get("troca_valor");
     if (trocaVal) {
       const n = Math.round(parseFloat(trocaVal));

--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -631,24 +631,6 @@ export default function AdminPage() {
                           >
                             WhatsApp
                           </button>
-                          <button
-                            onClick={() => {
-                              const qs = new URLSearchParams({
-                                sim_id: row.id,
-                                prod: `${row.modelo_novo} ${row.storage_novo}`.trim(),
-                                preco: String(row.preco_novo || 0),
-                                tp: `${row.modelo_usado} ${row.storage_usado}`.trim(),
-                                tv: String(row.avaliacao_usado || 0),
-                                cn: row.nome || "",
-                                cte: row.whatsapp || "",
-                                ...(row.vendedor ? { sv: row.vendedor } : {}),
-                              }).toString();
-                              window.location.href = `/admin/gerar-link?${qs}`;
-                            }}
-                            className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg bg-[#E8740E] hover:bg-[#D06A0D] text-white text-xs font-semibold transition-colors"
-                          >
-                            💳 Link
-                          </button>
                           {row.contatado && (
                             <span className="text-[10px] text-green-600 font-medium">Contatado</span>
                           )}

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -3546,12 +3546,28 @@ export default function VendasPage() {
                         const pagParts: string[] = [];
                         if (valorTrocaV > 0) pagParts.push(`Troca: ${fmt(valorTrocaV)}`);
                         if (temEntrada) pagParts.push(`PIX ${v.banco_pix || "ITAU"}: ${fmt(v.entrada_pix)}`);
+                        const entradaVal = parseFloat(String(v.entrada_pix || 0)) || 0;
+                        const compVal = parseFloat(String(v.valor_comprovante || 0)) || 0;
+                        const precoTotal = parseFloat(String(v.preco_vendido || 0)) || 0;
+                        const resto = Math.max(0, Math.round(precoTotal - valorTrocaV - entradaVal - compVal));
+                        const formaLabel = (f: string | null | undefined) => {
+                          if (!f) return "";
+                          if (f === "DINHEIRO" || f === "ESPECIE") return "💵 Espécie";
+                          if (f === "PIX") return "💸 PIX";
+                          if (f === "LINK") return "Link MP";
+                          if (f === "CARTAO") return "Cartão";
+                          if (f === "DEBITO") return "Débito";
+                          if (f === "FIADO") return "Fiado";
+                          return f;
+                        };
                         if (v.forma === "CARTAO" && v.qnt_parcelas) {
                           pagParts.push(`${v.banco} ${v.qnt_parcelas}x${v.bandeira ? ` ${v.bandeira}` : ""}${v.valor_comprovante ? ` (${fmt(v.valor_comprovante)})` : ""}`);
                         } else if (v.banco === "MERCADO_PAGO" && !temEntrada && !valorTrocaV) {
                           pagParts.push(`Link MP${v.qnt_parcelas ? ` ${v.qnt_parcelas}x` : ""}`);
-                        } else if (!temEntrada && !valorTrocaV) {
-                          pagParts.push(`${v.forma} ${v.banco}`);
+                        } else if (v.forma && v.forma !== "CARTAO" && (resto > 0 || (!temEntrada && !valorTrocaV))) {
+                          const lbl = formaLabel(v.forma);
+                          const banco = v.banco && v.banco !== v.forma ? ` ${v.banco}` : "";
+                          pagParts.push(resto > 0 ? `${lbl}${banco}: ${fmt(resto)}` : `${lbl}${banco}`);
                         }
                         if (v.banco_alt) {
                           pagParts.push(`2o: ${v.banco_alt} ${v.parc_alt || 0}x${v.band_alt ? ` ${v.band_alt}` : ""}${v.comp_alt ? ` (${fmt(v.comp_alt)})` : ""}`);
@@ -4226,14 +4242,24 @@ export default function VendasPage() {
                                           <button
                                             onClick={async (e) => {
                                               e.stopPropagation();
-                                              if (!confirm(`Cancelar venda de ${v.cliente}?\n\nIsso vai:\n- Marcar como cancelada\n- Remover o seminovo do estoque (se houver troca)`)) return;
+                                              const isLojista = v.tipo === "ATACADO" || v.origem === "ATACADO";
+                                              let devolverComoCredito = false;
+                                              if (isLojista) {
+                                                const r = confirm(`Cancelar venda de ${v.cliente}?\n\n✅ OK = Manter valor como CRÉDITO para o lojista (R$ ${Number(v.preco_vendido || 0).toLocaleString("pt-BR")})\n❌ Cancelar = apenas cancelar SEM creditar`);
+                                                if (r) devolverComoCredito = true;
+                                                else {
+                                                  if (!confirm(`Cancelar SEM creditar?\n\nIsso vai:\n- Marcar como cancelada\n- Remover o seminovo do estoque (se houver troca)`)) return;
+                                                }
+                                              } else {
+                                                if (!confirm(`Cancelar venda de ${v.cliente}?\n\nIsso vai:\n- Marcar como cancelada\n- Remover o seminovo do estoque (se houver troca)`)) return;
+                                              }
                                               await fetch("/api/vendas", {
                                                 method: "DELETE",
                                                 headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
-                                                body: JSON.stringify({ id: v.id }),
+                                                body: JSON.stringify({ id: v.id, devolver_como_credito: devolverComoCredito }),
                                               });
                                               setVendas(prev => prev.filter(r => r.id !== v.id));
-                                              setMsg("Venda cancelada!");
+                                              setMsg(devolverComoCredito ? "Venda cancelada! Valor creditado ao lojista." : "Venda cancelada!");
                                             }}
                                             className="px-3 py-1.5 rounded-lg text-xs text-red-500 border border-red-200 hover:bg-red-50 transition-colors"
                                           >

--- a/app/api/admin/entregas/route.ts
+++ b/app/api/admin/entregas/route.ts
@@ -18,24 +18,74 @@ export async function GET(req: NextRequest) {
   // Autocomplete de clientes — busca em entregas E vendas, retorna última compra
   if (searchClientes) {
     const like = `%${searchClientes}%`;
+    // CPF/telefone podem estar armazenados com ou sem pontuação.
+    // "%1%2%3%4%5%" casa tanto "123.456.789-00" quanto "12345678900".
+    const qDigits = searchClientes.replace(/\D/g, "");
+    const digitsLike = qDigits.length >= 3 ? `%${qDigits.split("").join("%")}%` : null;
 
     // Busca em entregas (por nome/telefone)
+    const entregasOr = [
+      `cliente.ilike.${like}`,
+      `telefone.ilike.${like}`,
+      ...(digitsLike ? [`telefone.ilike.${digitsLike}`] : []),
+    ].join(",");
     const { data: entregasMatch, error: errEntregas } = await supabase
       .from("entregas")
       .select("cliente, telefone, endereco, bairro, regiao, data_entrega, produto")
-      .or(`cliente.ilike.${like},telefone.ilike.${like}`)
+      .or(entregasOr)
       .order("data_entrega", { ascending: false })
       .limit(200);
     if (errEntregas) return NextResponse.json({ error: errEntregas.message }, { status: 500 });
 
-    // Busca em vendas (por nome/telefone — vendas tem 'cliente' e recebimento no formato string)
+    // Busca em vendas (por nome/recebimento/cpf — vendas tem 'cliente', 'recebimento' e 'cpf')
+    const vendasOr = [
+      `cliente.ilike.${like}`,
+      `recebimento.ilike.${like}`,
+      `cpf.ilike.${like}`,
+      ...(digitsLike ? [`recebimento.ilike.${digitsLike}`, `cpf.ilike.${digitsLike}`] : []),
+    ].join(",");
     const { data: vendasMatch, error: errVendas } = await supabase
       .from("vendas")
       .select("cliente, recebimento, endereco, bairro, produto, data, preco_vendido")
-      .or(`cliente.ilike.${like},recebimento.ilike.${like}`)
+      .or(vendasOr)
       .order("data", { ascending: false })
       .limit(200);
     if (errVendas) return NextResponse.json({ error: errVendas.message }, { status: 500 });
+
+    // Busca em link_compras por CPF/telefone — traz candidatos extras (nome+telefone)
+    // que depois serão casados contra entregas via keyFor.
+    const linkOr = [
+      `cliente_nome.ilike.${like}`,
+      `cliente_telefone.ilike.${like}`,
+      `cliente_cpf.ilike.${like}`,
+      ...(digitsLike ? [`cliente_telefone.ilike.${digitsLike}`, `cliente_cpf.ilike.${digitsLike}`] : []),
+    ].join(",");
+    const { data: linkMatch } = await supabase
+      .from("link_compras")
+      .select("cliente_nome, cliente_telefone, created_at")
+      .or(linkOr)
+      .order("created_at", { ascending: false })
+      .limit(200);
+
+    // Para matches vindos apenas por CPF (vendas/link_compras) sem entrada em entregas,
+    // tentamos achar o registro de entrega correspondente por nome+telefone.
+    const extraNomes = new Set<string>();
+    for (const v of vendasMatch || []) if (v.cliente) extraNomes.add(v.cliente);
+    for (const l of linkMatch || []) if (l.cliente_nome) extraNomes.add(l.cliente_nome);
+    // Remove os que já apareceram direto em entregasMatch
+    for (const e of entregasMatch || []) if (e.cliente) extraNomes.delete(e.cliente);
+    let entregasExtras: typeof entregasMatch = [];
+    if (extraNomes.size > 0) {
+      const nomesArr = Array.from(extraNomes).slice(0, 50);
+      const { data: extras } = await supabase
+        .from("entregas")
+        .select("cliente, telefone, endereco, bairro, regiao, data_entrega, produto")
+        .in("cliente", nomesArr)
+        .order("data_entrega", { ascending: false })
+        .limit(200);
+      entregasExtras = extras || [];
+    }
+    const entregasAll = [...(entregasMatch || []), ...(entregasExtras || [])];
 
     type ClienteSug = {
       cliente: string;
@@ -54,7 +104,7 @@ export async function GET(req: NextRequest) {
     const acc = new Map<string, ClienteSug>();
 
     // Primeiro entregas (tem endereco/bairro/regiao bons)
-    for (const r of entregasMatch || []) {
+    for (const r of entregasAll) {
       const key = keyFor(r.cliente, r.telefone);
       if (!key || key === "|") continue;
       if (!acc.has(key)) {

--- a/app/api/admin/link-compras/route.ts
+++ b/app/api/admin/link-compras/route.ts
@@ -26,22 +26,43 @@ export async function GET(request: Request) {
   if (autocomplete) {
     if (!q || q.length < 2) return NextResponse.json({ clientes: [] });
     const like = `%${q}%`;
+    // Para CPF/telefone: stored pode estar com ou sem pontuação.
+    // Ex.: usuário digita "12345", DB tem "123.456.789-00".
+    // Padrão "%1%2%3%4%5%" casa ambos os formatos.
+    const qDigits = q.replace(/\D/g, "");
+    const digitsLike = qDigits.length >= 3 ? `%${qDigits.split("").join("%")}%` : null;
+    const cpfOrNome = (nomeCol: string, cpfCol: string, emailCol?: string) => {
+      const parts = [`${nomeCol}.ilike.${like}`, `${cpfCol}.ilike.${like}`];
+      if (digitsLike) parts.push(`${cpfCol}.ilike.${digitsLike}`);
+      if (emailCol) parts.push(`${emailCol}.ilike.${like}`);
+      return parts.join(",");
+    };
+    const telOrNome = (nomeCol: string, telCol: string) => {
+      const parts = [`${nomeCol}.ilike.${like}`, `${telCol}.ilike.${like}`];
+      if (digitsLike) parts.push(`${telCol}.ilike.${digitsLike}`);
+      return parts.join(",");
+    };
 
     // 1) vendas: nome, cpf, email, endereço
     const [vRes, lRes, eRes] = await Promise.all([
       supabase.from("vendas")
         .select("cliente, cpf, cnpj, email, endereco, bairro, cidade, uf, data")
-        .or(`cliente.ilike.${like},cpf.ilike.${like},email.ilike.${like}`)
+        .or(cpfOrNome("cliente", "cpf", "email"))
         .order("data", { ascending: false })
         .limit(100),
       supabase.from("link_compras")
         .select("cliente_nome, cliente_telefone, cliente_cpf, cliente_email, created_at")
-        .or(`cliente_nome.ilike.${like},cliente_telefone.ilike.${like},cliente_cpf.ilike.${like}`)
+        .or([
+          `cliente_nome.ilike.${like}`,
+          `cliente_telefone.ilike.${like}`,
+          `cliente_cpf.ilike.${like}`,
+          ...(digitsLike ? [`cliente_telefone.ilike.${digitsLike}`, `cliente_cpf.ilike.${digitsLike}`] : []),
+        ].join(","))
         .order("created_at", { ascending: false })
         .limit(100),
       supabase.from("entregas")
         .select("cliente, telefone, endereco, bairro, created_at")
-        .or(`cliente.ilike.${like},telefone.ilike.${like}`)
+        .or(telOrNome("cliente", "telefone"))
         .order("created_at", { ascending: false })
         .limit(100),
     ]);

--- a/app/api/admin/lojistas-credito/route.ts
+++ b/app/api/admin/lojistas-credito/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { logActivity } from "@/lib/activity-log";
+
+function auth(req: NextRequest) {
+  const pw = req.headers.get("x-admin-password");
+  return pw === process.env.ADMIN_PASSWORD;
+}
+function getUsuario(req: NextRequest) {
+  return decodeURIComponent(req.headers.get("x-admin-user") || "sistema");
+}
+
+/** Normaliza a chave do cliente: prioriza CPF/CNPJ (só dígitos); senão nome upper. */
+export function buildClienteKey(p: { cpf?: string | null; cnpj?: string | null; nome?: string | null }): string {
+  const onlyDigits = (s: string | null | undefined) => (s || "").replace(/\D/g, "");
+  const cpf = onlyDigits(p.cpf);
+  if (cpf) return `cpf:${cpf}`;
+  const cnpj = onlyDigits(p.cnpj);
+  if (cnpj) return `cnpj:${cnpj}`;
+  return `nome:${(p.nome || "").trim().toUpperCase()}`;
+}
+
+/** Busca ou cria registro de lojista. Retorna linha. */
+export async function getOrCreateLojista(cliente: { nome: string; cpf?: string | null; cnpj?: string | null }) {
+  const key = buildClienteKey(cliente);
+  const { data: existing } = await supabase
+    .from("lojistas_credito")
+    .select("*")
+    .eq("cliente_key", key)
+    .maybeSingle();
+  if (existing) return existing;
+  const { data: inserted, error } = await supabase
+    .from("lojistas_credito")
+    .insert({
+      cliente_key: key,
+      nome: cliente.nome,
+      cpf: (cliente.cpf || null),
+      cnpj: (cliente.cnpj || null),
+      saldo: 0,
+    })
+    .select("*")
+    .single();
+  if (error) throw new Error(error.message);
+  return inserted;
+}
+
+/** Aplica movimentação (CREDITO/DEBITO/AJUSTE) atomicamente via leitura + update. */
+export async function moverCredito(params: {
+  cliente: { nome: string; cpf?: string | null; cnpj?: string | null };
+  tipo: "CREDITO" | "DEBITO" | "AJUSTE";
+  valor: number;
+  venda_id?: string | null;
+  motivo?: string;
+  usuario?: string;
+}) {
+  if (!params.valor || params.valor <= 0) throw new Error("valor deve ser > 0");
+  const lojista = await getOrCreateLojista(params.cliente);
+  const saldoAntes = Number(lojista.saldo || 0);
+  let saldoDepois = saldoAntes;
+  if (params.tipo === "CREDITO") saldoDepois = saldoAntes + params.valor;
+  else if (params.tipo === "DEBITO") saldoDepois = saldoAntes - params.valor;
+  else saldoDepois = params.valor; // AJUSTE = define valor absoluto
+  if (params.tipo === "DEBITO" && saldoDepois < 0) {
+    throw new Error(`Saldo insuficiente. Disponível: R$ ${saldoAntes}, tentativa: R$ ${params.valor}`);
+  }
+  const { error: upErr } = await supabase
+    .from("lojistas_credito")
+    .update({ saldo: saldoDepois, updated_at: new Date().toISOString(), nome: params.cliente.nome })
+    .eq("id", lojista.id);
+  if (upErr) throw new Error(upErr.message);
+  await supabase.from("lojistas_credito_log").insert({
+    lojista_id: lojista.id,
+    venda_id: params.venda_id || null,
+    tipo: params.tipo,
+    valor: params.valor,
+    saldo_antes: saldoAntes,
+    saldo_depois: saldoDepois,
+    motivo: params.motivo || null,
+    usuario: params.usuario || "sistema",
+  });
+  return { saldoAntes, saldoDepois, lojista_id: lojista.id };
+}
+
+// ── GET: saldo + extrato de um lojista (ou lista todos) ──
+export async function GET(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const { searchParams } = new URL(req.url);
+  const cpf = searchParams.get("cpf");
+  const cnpj = searchParams.get("cnpj");
+  const nome = searchParams.get("nome");
+  if (!cpf && !cnpj && !nome) {
+    // lista todos com saldo > 0
+    const { data, error } = await supabase
+      .from("lojistas_credito")
+      .select("*")
+      .gt("saldo", 0)
+      .order("saldo", { ascending: false });
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ lojistas: data || [] });
+  }
+  const key = buildClienteKey({ cpf, cnpj, nome });
+  const { data: lojista } = await supabase
+    .from("lojistas_credito")
+    .select("*")
+    .eq("cliente_key", key)
+    .maybeSingle();
+  if (!lojista) return NextResponse.json({ lojista: null, saldo: 0, log: [] });
+  const { data: log } = await supabase
+    .from("lojistas_credito_log")
+    .select("*")
+    .eq("lojista_id", lojista.id)
+    .order("created_at", { ascending: false })
+    .limit(100);
+  return NextResponse.json({ lojista, saldo: Number(lojista.saldo || 0), log: log || [] });
+}
+
+// ── POST: movimentar manualmente (AJUSTE / CREDITO / DEBITO) ──
+export async function POST(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const usuario = getUsuario(req);
+  const body = await req.json();
+  const { cliente, tipo, valor, motivo } = body;
+  if (!cliente?.nome) return NextResponse.json({ error: "cliente.nome obrigatório" }, { status: 400 });
+  if (!["CREDITO", "DEBITO", "AJUSTE"].includes(tipo)) return NextResponse.json({ error: "tipo inválido" }, { status: 400 });
+  try {
+    const res = await moverCredito({ cliente, tipo, valor: Number(valor), motivo, usuario });
+    await logActivity(usuario, `Crédito lojista (${tipo})`, `${cliente.nome}: R$${valor} — ${motivo || "sem motivo"}`, "clientes");
+    return NextResponse.json({ ok: true, ...res });
+  } catch (e) {
+    return NextResponse.json({ error: e instanceof Error ? e.message : "erro" }, { status: 400 });
+  }
+}

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -187,6 +187,10 @@ export async function POST(req: NextRequest) {
   // forma pode ser null (pagamento a definir depois)
   if (!body.forma) body.forma = null;
 
+  // Crédito de lojista (abatimento): valor vem em usar_credito_loja (opcional, só ATACADO)
+  const usarCreditoLoja = Number(body.usar_credito_loja || 0);
+  delete body.usar_credito_loja;
+
   const { data, error } = await supabase.from("vendas").insert({
     ...body,
     estoque_id: estoqueId || null,
@@ -194,6 +198,24 @@ export async function POST(req: NextRequest) {
     ...(serialFromEstoque ? { serial_no: serialFromEstoque } : {}),
   }).select().single();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  // Abater crédito do lojista (se solicitado)
+  if (usarCreditoLoja > 0 && (body.tipo === "ATACADO" || body.origem === "ATACADO") && body.cliente) {
+    try {
+      const { moverCredito } = await import("@/app/api/admin/lojistas-credito/route");
+      await moverCredito({
+        cliente: { nome: body.cliente, cpf: body.cpf, cnpj: body.cnpj },
+        tipo: "DEBITO",
+        valor: usarCreditoLoja,
+        venda_id: data?.id,
+        motivo: `Venda ${data?.id?.slice(0, 8)}`,
+        usuario,
+      });
+      await logActivity(usuario, "Crédito lojista usado em venda", `${body.cliente}: -R$${usarCreditoLoja}`, "vendas", data?.id);
+    } catch (e) {
+      console.error("[Vendas] Erro ao debitar crédito lojista:", e);
+    }
+  }
 
   // Se não tem estoque_id mas tem serial, buscar automaticamente no estoque
   // (sem .single() — evita erro silencioso quando há 0 ou N matches)
@@ -286,11 +308,11 @@ export async function POST(req: NextRequest) {
   const sem1 = seminovoData && (seminovoData.produto || (seminovoData.valor || 0) > 0)
     ? seminovoData
     : hasTroca1Info
-      ? { produto: data?.troca_produto || null, valor: pTrocaValor1, cor: data?.troca_cor || null, bateria: data?.troca_bateria ? parseInt(data.troca_bateria) : null, observacao: data?.troca_obs || null, serial_no: null, imei: null, grade: null, caixa: null, cabo: null, fonte: null }
+      ? { produto: data?.troca_produto || null, valor: pTrocaValor1, cor: data?.troca_cor || null, bateria: data?.troca_bateria ? parseInt(data.troca_bateria) : null, observacao: data?.troca_obs || null, serial_no: data?.troca_serial || null, imei: data?.troca_imei || null, grade: data?.troca_grade || null, caixa: data?.troca_caixa || null, cabo: data?.troca_cabo || null, fonte: data?.troca_fonte || null, categoria: data?.troca_categoria || null, garantia: data?.troca_garantia || null }
       : null;
 
   if (hasTroca1Info) {
-    const sem1Final = sem1 || { produto: data?.troca_produto || null, valor: pTrocaValor1, cor: data?.troca_cor || null, bateria: data?.troca_bateria ? parseInt(data.troca_bateria) : null, observacao: data?.troca_obs || null, serial_no: null, imei: null, grade: null, caixa: null, cabo: null, fonte: null, categoria: null, origem: null, garantia: null };
+    const sem1Final = sem1 || { produto: data?.troca_produto || null, valor: pTrocaValor1, cor: data?.troca_cor || null, bateria: data?.troca_bateria ? parseInt(data.troca_bateria) : null, observacao: data?.troca_obs || null, serial_no: data?.troca_serial || null, imei: data?.troca_imei || null, grade: data?.troca_grade || null, caixa: data?.troca_caixa || null, cabo: data?.troca_cabo || null, fonte: data?.troca_fonte || null, categoria: data?.troca_categoria || null, origem: null, garantia: data?.troca_garantia || null };
     const nomeCliente = (body.cliente || data?.cliente || "").toUpperCase();
     const nomeProduto1 = sem1Final.produto || "PRODUTO DA TROCA — IDENTIFICAR";
     // Verificar se pendência já existe (evitar duplicata em caso de venda cancelada e relançada)
@@ -334,11 +356,11 @@ export async function POST(req: NextRequest) {
   const sem2 = seminovoData2 && (seminovoData2.produto || (seminovoData2.valor || 0) > 0)
     ? seminovoData2
     : hasTroca2Info
-      ? { produto: data?.troca_produto2 || null, valor: pTrocaValor2, cor: data?.troca_cor2 || null, bateria: data?.troca_bateria2 ? parseInt(data.troca_bateria2) : null, observacao: data?.troca_obs2 || null, serial_no: null, imei: null, grade: null, caixa: null, cabo: null, fonte: null }
+      ? { produto: data?.troca_produto2 || null, valor: pTrocaValor2, cor: data?.troca_cor2 || null, bateria: data?.troca_bateria2 ? parseInt(data.troca_bateria2) : null, observacao: data?.troca_obs2 || null, serial_no: data?.troca_serial2 || null, imei: data?.troca_imei2 || null, grade: data?.troca_grade2 || null, caixa: data?.troca_caixa2 || null, cabo: data?.troca_cabo2 || null, fonte: data?.troca_fonte2 || null, categoria: data?.troca_categoria2 || null, garantia: data?.troca_garantia2 || null }
       : null;
 
   if (hasTroca2Info) {
-    const sem2Final = sem2 || { produto: data?.troca_produto2 || null, valor: pTrocaValor2, cor: data?.troca_cor2 || null, bateria: data?.troca_bateria2 ? parseInt(data.troca_bateria2) : null, observacao: data?.troca_obs2 || null, serial_no: null, imei: null, grade: null, caixa: null, cabo: null, fonte: null, categoria: null, origem: null, garantia: null };
+    const sem2Final = sem2 || { produto: data?.troca_produto2 || null, valor: pTrocaValor2, cor: data?.troca_cor2 || null, bateria: data?.troca_bateria2 ? parseInt(data.troca_bateria2) : null, observacao: data?.troca_obs2 || null, serial_no: data?.troca_serial2 || null, imei: data?.troca_imei2 || null, grade: data?.troca_grade2 || null, caixa: data?.troca_caixa2 || null, cabo: data?.troca_cabo2 || null, fonte: data?.troca_fonte2 || null, categoria: data?.troca_categoria2 || null, origem: null, garantia: data?.troca_garantia2 || null };
     const nomeCliente2 = (body.cliente || data?.cliente || "").toUpperCase();
     const nomeProduto2 = sem2Final.produto || "PRODUTO DA TROCA 2 — IDENTIFICAR";
     // Verificar se pendência já existe (evitar duplicata)
@@ -595,6 +617,14 @@ export async function PATCH(req: NextRequest) {
           // INSERT — não existia pendência, criar agora
           const valor1 = parseTrocaValor(venda.produto_na_troca);
           const nome1 = venda.troca_produto || "PRODUTO DA TROCA — IDENTIFICAR";
+          const obs1Parts: string[] = [];
+          if (venda.troca_obs) obs1Parts.push(String(venda.troca_obs));
+          if (venda.troca_grade) obs1Parts.push(`[GRADE_${venda.troca_grade}]`);
+          if (venda.troca_caixa === "SIM") obs1Parts.push("[COM_CAIXA]");
+          if (venda.troca_cabo === "SIM") obs1Parts.push("[COM_CABO]");
+          if (venda.troca_fonte === "SIM") obs1Parts.push("[COM_FONTE]");
+          if (venda.troca_pulseira === "SIM") obs1Parts.push("[COM_PULSEIRA]");
+          if (venda.troca_ciclos) obs1Parts.push(`[CICLOS:${venda.troca_ciclos}]`);
           const { error: errNew1 } = await supabase.from("estoque").insert({
             produto: nome1,
             categoria: venda.troca_categoria || detectCategoriaSeminovo(venda.troca_produto),
@@ -604,7 +634,10 @@ export async function PATCH(req: NextRequest) {
             tipo: "PENDENCIA",
             cor: venda.troca_cor ? String(venda.troca_cor).toUpperCase() : null,
             bateria: (() => { const b = parseInt(String(venda.troca_bateria || "")); return Number.isFinite(b) ? b : null; })(),
-            observacao: venda.troca_obs || null,
+            observacao: obs1Parts.length ? obs1Parts.join(" ").trim() : null,
+            serial_no: venda.troca_serial ? String(venda.troca_serial).toUpperCase() : null,
+            imei: venda.troca_imei ? String(venda.troca_imei).toUpperCase() : null,
+            garantia: venda.troca_garantia || null,
             cliente: nomeCliente,
             fornecedor: nomeCliente,
             data_compra: venda.data,
@@ -640,6 +673,14 @@ export async function PATCH(req: NextRequest) {
         } else {
           const valor2 = parseTrocaValor(venda.produto_na_troca2);
           const nome2 = venda.troca_produto2 || "PRODUTO DA TROCA 2 — IDENTIFICAR";
+          const obs2Parts: string[] = [];
+          if (venda.troca_obs2) obs2Parts.push(String(venda.troca_obs2));
+          if (venda.troca_grade2) obs2Parts.push(`[GRADE_${venda.troca_grade2}]`);
+          if (venda.troca_caixa2 === "SIM") obs2Parts.push("[COM_CAIXA]");
+          if (venda.troca_cabo2 === "SIM") obs2Parts.push("[COM_CABO]");
+          if (venda.troca_fonte2 === "SIM") obs2Parts.push("[COM_FONTE]");
+          if (venda.troca_pulseira2 === "SIM") obs2Parts.push("[COM_PULSEIRA]");
+          if (venda.troca_ciclos2) obs2Parts.push(`[CICLOS:${venda.troca_ciclos2}]`);
           const { error: errNew2 } = await supabase.from("estoque").insert({
             produto: nome2,
             categoria: venda.troca_categoria2 || detectCategoriaSeminovo(venda.troca_produto2),
@@ -649,7 +690,10 @@ export async function PATCH(req: NextRequest) {
             tipo: "PENDENCIA",
             cor: venda.troca_cor2 ? String(venda.troca_cor2).toUpperCase() : null,
             bateria: (() => { const b = parseInt(String(venda.troca_bateria2 || "")); return Number.isFinite(b) ? b : null; })(),
-            observacao: venda.troca_obs2 || null,
+            observacao: obs2Parts.length ? obs2Parts.join(" ").trim() : null,
+            serial_no: venda.troca_serial2 ? String(venda.troca_serial2).toUpperCase() : null,
+            imei: venda.troca_imei2 ? String(venda.troca_imei2).toUpperCase() : null,
+            garantia: venda.troca_garantia2 || null,
             cliente: nomeCliente,
             fornecedor: nomeCliente,
             data_compra: venda.data,
@@ -672,11 +716,33 @@ export async function DELETE(req: NextRequest) {
   if (!hasPermission(role, "vendas.create", permissoes)) return NextResponse.json({ error: "Sem permissao" }, { status: 403 });
   const usuario = getUsuario(req);
 
-  const { id } = await req.json();
+  const body = await req.json();
+  const { id, devolver_como_credito } = body;
   if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });
 
   // Buscar venda antes de deletar (para limpar seminovo se houver)
   const { data: venda } = await supabase.from("vendas").select("*").eq("id", id).single();
+
+  // Se lojista pediu pra manter como crédito, creditar antes de apagar
+  if (devolver_como_credito && venda && (venda.tipo === "ATACADO" || venda.origem === "ATACADO") && venda.cliente) {
+    const valorCredito = Number(venda.preco_vendido || 0);
+    if (valorCredito > 0) {
+      try {
+        const { moverCredito } = await import("@/app/api/admin/lojistas-credito/route");
+        await moverCredito({
+          cliente: { nome: venda.cliente, cpf: venda.cpf, cnpj: venda.cnpj },
+          tipo: "CREDITO",
+          valor: valorCredito,
+          venda_id: id,
+          motivo: `Cancelamento venda ${String(id).slice(0, 8)} → crédito`,
+          usuario,
+        });
+        await logActivity(usuario, "Venda cancelada → crédito lojista", `${venda.cliente}: +R$${valorCredito}`, "vendas", id);
+      } catch (e) {
+        console.error("[Vendas] Erro ao creditar lojista:", e);
+      }
+    }
+  }
 
   // Apagar entrega vinculada (se existir)
   await supabase.from("entregas").delete().eq("venda_id", id);

--- a/lib/cor-pt.ts
+++ b/lib/cor-pt.ts
@@ -100,6 +100,39 @@ export function corParaPT(corEN: string | null | undefined): string {
   return trimmed;
 }
 
+/**
+ * Formata cor para etiqueta no padrão "PT - EN" (ex: "TITÂNIO PRETO - BLACK TITANIUM").
+ * - Deduplica palavras repetidas ("BLACK TITANIUM BLACK TITANIUM" → "BLACK TITANIUM")
+ * - Usa corParaPT/corParaEN para gerar o par PT-EN consistente
+ * - Se não conseguir mapear, retorna a cor deduplicada em maiúsculas
+ */
+export function formatCorEtiquetaPTEN(cor: string | null | undefined): string {
+  if (!cor) return "";
+  const trimmed = cor.trim();
+  if (!trimmed || trimmed === "—") return "";
+  // Dedup word-level (ex: "BLACK TITANIUM BLACK TITANIUM" → "BLACK TITANIUM")
+  const parts = trimmed.split(/\s+/);
+  const unique: string[] = [];
+  for (const p of parts) {
+    if (!unique.some(u => u.toUpperCase() === p.toUpperCase())) unique.push(p);
+  }
+  // Dedup repetição exata de bloco inteiro (ex: "Black Titanium Black Titanium")
+  const half = Math.floor(unique.length / 2);
+  let cleanParts = unique;
+  if (unique.length > 1 && unique.length % 2 === 0) {
+    const a = unique.slice(0, half).map(s => s.toUpperCase()).join(" ");
+    const b = unique.slice(half).map(s => s.toUpperCase()).join(" ");
+    if (a === b) cleanParts = unique.slice(0, half);
+  }
+  const clean = cleanParts.join(" ");
+  const pt = corParaPT(clean);
+  const en = corParaEN(clean);
+  if (pt && en && pt !== "—") {
+    return `${pt.toUpperCase()} - ${en.toUpperCase()}`;
+  }
+  return clean.toUpperCase();
+}
+
 /** Substitui qualquer cor em inglês conhecida dentro de um texto pela versão PT simplificada. */
 export function normalizarCoresNoTexto(texto: string): string {
   if (!texto) return texto;

--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -1,13 +1,14 @@
 // lib/produto-specs.ts
 // Campos estruturados por categoria — compartilhado entre Estoque e Etiquetas
 
-export const CATEGORIAS = ["IPHONES", "IPADS", "MACBOOK", "MAC_MINI", "APPLE_WATCH", "AIRPODS", "ACESSORIOS", "OUTROS"] as const;
+export const CATEGORIAS = ["IPHONES", "IPADS", "MACBOOK", "MAC_MINI", "MAC_STUDIO", "APPLE_WATCH", "AIRPODS", "ACESSORIOS", "OUTROS"] as const;
 
 export const CAT_LABELS: Record<string, string> = {
   IPHONES: "iPhones",
   IPADS: "iPads",
   MACBOOK: "MacBooks",
   MAC_MINI: "Mac Mini",
+  MAC_STUDIO: "Mac Studio",
   APPLE_WATCH: "Apple Watch",
   AIRPODS: "AirPods",
   ACESSORIOS: "Acessorios",

--- a/supabase/migrations/20260409_lojistas_credito.sql
+++ b/supabase/migrations/20260409_lojistas_credito.sql
@@ -1,0 +1,31 @@
+-- Crédito de lojistas (saldo pré-pago usável como forma de pagamento em vendas ATACADO)
+
+create table if not exists lojistas_credito (
+  id uuid primary key default gen_random_uuid(),
+  cliente_key text not null unique, -- cpf/cnpj normalizado (só dígitos) ou nome em UPPER
+  nome text not null,
+  cpf text,
+  cnpj text,
+  saldo numeric not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_lojistas_credito_cpf on lojistas_credito(cpf);
+create index if not exists idx_lojistas_credito_cnpj on lojistas_credito(cnpj);
+
+create table if not exists lojistas_credito_log (
+  id uuid primary key default gen_random_uuid(),
+  lojista_id uuid not null references lojistas_credito(id) on delete cascade,
+  venda_id uuid,
+  tipo text not null check (tipo in ('CREDITO','DEBITO','AJUSTE')),
+  valor numeric not null,
+  saldo_antes numeric not null,
+  saldo_depois numeric not null,
+  motivo text,
+  usuario text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_lojistas_credito_log_lojista on lojistas_credito_log(lojista_id, created_at desc);
+create index if not exists idx_lojistas_credito_log_venda on lojistas_credito_log(venda_id);


### PR DESCRIPTION
## Resumo das mudanças

### Correções
- **Vendas — sync de pendências:** campos `grade/caixa/cabo/fonte/pulseira/ciclos/serial/imei` agora são copiados pra pendência ao criar/editar venda (fix Thiago Flores 01/04).
- **Vendas — pagamento em espécie:** forma agora aparece na listagem quando há troca + resto em espécie (fix Mauro).
- **Estoque — etiqueta seminovos:** inclui Saúde da Bateria (%).
- **Estoque — bateria:** admin pode editar em qualquer aba (antes só pendências).
- **Gastos — histórico:** filtro por mês com navegação (mês atual por padrão).
- **Entregas — Agenda:** nova categoria "Seminovos" com valor manual + seminovos seguem padrão do Estoque.
- **Catálogo:** Mac Studio adicionado em CATEGORIAS (aparece em Gastos).

### Features novas
- **Pendências — "Com quem está":** badge editável texto livre nas linhas de pendência (tag `[COM_QUEM:...]`).
- **Crédito de lojistas** (novo módulo):
  - Migration: tabelas `lojistas_credito` + `lojistas_credito_log`
  - API `/api/admin/lojistas-credito` (GET saldo/extrato, POST CREDITO/DEBITO/AJUSTE)
  - Clientes → aba Lojistas: coluna Saldo + botão **Gerenciar crédito** (modal com saldo, add/debitar/ajustar + extrato)
  - Cancelar venda ATACADO: opção "manter como crédito" credita lojista automaticamente
  - Vendas POST aceita `usar_credito_loja` pra abater saldo na compra

### Merge de trabalhos paralelos (dev-nicolas)
O branch já incorpora via fast-forward todos os commits recentes de `dev-nicolas`, incluindo: IMEI opcional iPad/Apple Watch, pulseira Apple Watch sem duplicação, botão Link removido de Simulações, busca de cliente por CPF, gerar-link seminovos deduplicado, cor PT+EN na etiqueta seminovos.

### ⚠️ Pós-deploy
Rodar a migration `supabase/migrations/20260409_lojistas_credito.sql` no banco antes de usar o módulo de crédito.