### PR TITLE
feat: Mac Studio estruturado + uso de crédito lojista em venda ATACADO

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -127,7 +127,10 @@ export default function VendasPage() {
     cep: "", bairro: "", cidade: "", uf: "",
     // Atacado: frete/entrega cobrado a parte
     frete_valor: "", frete_recebido: false as boolean,
+    // Crédito de lojista (ATACADO): valor a abater do saldo pré-pago
+    usar_credito_loja: "",
   });
+  const [creditoLojistaSaldo, setCreditoLojistaSaldo] = useState(0);
   // Restaurar rascunho do localStorage ao montar
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
@@ -573,6 +576,28 @@ export default function VendasPage() {
     return () => { if (clienteHistoricoTimer.current) clearTimeout(clienteHistoricoTimer.current); };
   }, [form.cliente, fetchClienteHistorico]);
 
+  // Buscar saldo de crédito do lojista quando cliente/cpf/cnpj mudar (só ATACADO)
+  useEffect(() => {
+    if (form.tipo !== "ATACADO" || (!form.cliente && !form.cpf && !form.cnpj)) {
+      setCreditoLojistaSaldo(0);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      try {
+        const params = new URLSearchParams();
+        if (form.cpf) params.set("cpf", form.cpf);
+        if (form.cnpj) params.set("cnpj", form.cnpj);
+        if (!form.cpf && !form.cnpj && form.cliente) params.set("nome", form.cliente);
+        const res = await fetch(`/api/admin/lojistas-credito?${params}`, { headers: { "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") } });
+        if (res.ok) {
+          const json = await res.json();
+          setCreditoLojistaSaldo(Number(json.saldo || 0));
+        }
+      } catch { /* ignore */ }
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [form.tipo, form.cliente, form.cpf, form.cnpj, password, user?.nome]);
+
   // Verificar se já desbloqueou nesta sessão
   useEffect(() => {
     const temPermissaoVendas = user?.permissoes?.some(p => p === "vendas_ver" || p === "vendas_registrar");
@@ -949,6 +974,8 @@ export default function VendasPage() {
       // Entrega atacado (cobrada à parte)
       frete_valor: form.tipo === "ATACADO" ? (parseFloat(String(form.frete_valor).replace(/\./g, "").replace(",", ".")) || 0) : null,
       frete_recebido: form.tipo === "ATACADO" ? !!form.frete_recebido : null,
+      // Crédito de lojista: valor a abater do saldo (backend debita automaticamente)
+      usar_credito_loja: form.tipo === "ATACADO" ? (parseFloat(String(form.usar_credito_loja || "0").replace(/\./g, "").replace(",", ".")) || 0) : 0,
     };
 
     if (prodFields._estoqueId) {
@@ -2041,6 +2068,41 @@ export default function VendasPage() {
                   <p className="text-[10px] text-[#86868B] mt-1">Opcional. Some ao lucro da venda e aparece no card &quot;Faturamento com entregas&quot;.</p>
                 </div>
               </div>
+
+              {/* Crédito de Lojista — aparece quando há saldo */}
+              {creditoLojistaSaldo > 0 && (
+                <div className="p-3 rounded-xl border border-blue-200 bg-blue-50">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="text-xs font-bold uppercase tracking-wider text-blue-700">💳 Crédito do Lojista</span>
+                    <span className="text-sm font-bold text-blue-700">Saldo: R$ {creditoLojistaSaldo.toLocaleString("pt-BR")}</span>
+                  </div>
+                  <div className="flex gap-2 items-end">
+                    <div className="flex-1">
+                      <p className={labelCls}>Usar crédito (R$)</p>
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={form.usar_credito_loja}
+                        onChange={(e) => {
+                          const digits = e.target.value.replace(/\D/g, "");
+                          const v = digits ? Math.min(parseInt(digits), creditoLojistaSaldo) : 0;
+                          set("usar_credito_loja", v ? String(v) : "");
+                        }}
+                        placeholder="0"
+                        className={inputCls}
+                      />
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => set("usar_credito_loja", String(Math.min(creditoLojistaSaldo, parseFloat(form.preco_vendido) || creditoLojistaSaldo)))}
+                      className="px-3 py-2 rounded-lg bg-blue-600 text-white text-xs font-semibold hover:bg-blue-700 whitespace-nowrap"
+                    >
+                      Usar tudo
+                    </button>
+                  </div>
+                  <p className="text-[10px] text-blue-600 mt-1">Este valor será debitado do saldo ao finalizar a venda.</p>
+                </div>
+              )}
             </div>
           ) : (
             <div className="space-y-4">

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -16,6 +16,10 @@ import {
   MAC_MINI_NUCLEOS,
   MAC_MINI_RAMS,
   MAC_MINI_STORAGES,
+  MAC_STUDIO_CHIPS,
+  MAC_STUDIO_NUCLEOS,
+  MAC_STUDIO_RAMS,
+  MAC_STUDIO_STORAGES,
   CORES_POR_CATEGORIA,
   COR_OBRIGATORIA,
   getIphoneCores,
@@ -315,6 +319,8 @@ export default function ProdutoSpecFields({
   const ssdOptionsFinal = cfgOr("ssd", MACBOOK_STORAGES);
   const macMiniRamOptions = cfgOr("ram", MAC_MINI_RAMS);
   const macMiniSsdOptions = cfgOr("ssd", MAC_MINI_STORAGES);
+  const macStudioRamOptions = cfgOr("ram", MAC_STUDIO_RAMS);
+  const macStudioSsdOptions = cfgOr("ssd", MAC_STUDIO_STORAGES);
   // Núcleos: usa chip_air ou chip_pro_max do catálogo (configurado por modelo)
   // Se tem modelo do catálogo selecionado, mostra APENAS o que está configurado
   // Se não tem modelo do catálogo, usa fallback hardcoded
@@ -327,6 +333,9 @@ export default function ProdutoSpecFields({
   const mmNucleosOptions = hasCatalogModel
     ? macNucleosCatalog
     : MAC_MINI_NUCLEOS.map(n => `(${n})`);
+  const msNucleosOptions = hasCatalogModel
+    ? macNucleosCatalog
+    : MAC_STUDIO_NUCLEOS.map(n => `(${n})`);
   const awTamanhoOptions = cfgOr("tamanho_aw", WATCH_TAMANHOS_FULL);
   const awConnOptions = cfgOr("conectividade_aw", ["GPS", "GPS + CEL"]);
   const awBandOptions = cfgOr("pulseiras", WATCH_BAND_MODELS);
@@ -730,6 +739,44 @@ export default function ProdutoSpecFields({
             <p className={labelCls}>Armazenamento</p>
             <select value={row.spec.mm_storage} onChange={(e) => setSpec("mm_storage", e.target.value)} className={inputCls}>
               {macMiniSsdOptions?.map((s) => <option key={s}>{s}</option>)}
+            </select>
+          </div>
+        </div>
+      )}
+
+      {/* Mac Studio specs */}
+      {row.categoria === "MAC_STUDIO" && (
+        <div className={`grid grid-cols-2 md:grid-cols-4 gap-3 p-3 ${bgSection} rounded-lg`}>
+          {!categoryModelos.length && (
+            <div>
+              <p className={labelCls}>Chip</p>
+              <select value={row.spec.ms_chip} onChange={(e) => setSpec("ms_chip", e.target.value)} className={inputCls}>
+                {MAC_STUDIO_CHIPS.map((c) => <option key={c}>{c}</option>)}
+              </select>
+            </div>
+          )}
+          {msNucleosOptions.length > 0 && (
+            <div>
+              <p className={labelCls}>Núcleos</p>
+              <select value={row.spec.ms_nucleos} onChange={(e) => setSpec("ms_nucleos", e.target.value)} className={inputCls}>
+                <option value="">— Selecionar —</option>
+                {msNucleosOptions.map((n) => {
+                  const clean = n.replace(/^\(|\)$/g, "").trim();
+                  return <option key={clean} value={clean}>{clean}</option>;
+                })}
+              </select>
+            </div>
+          )}
+          <div>
+            <p className={labelCls}>RAM</p>
+            <select value={row.spec.ms_ram} onChange={(e) => setSpec("ms_ram", e.target.value)} className={inputCls}>
+              {macStudioRamOptions?.map((r) => <option key={r}>{r}</option>)}
+            </select>
+          </div>
+          <div>
+            <p className={labelCls}>Armazenamento</p>
+            <select value={row.spec.ms_storage} onChange={(e) => setSpec("ms_storage", e.target.value)} className={inputCls}>
+              {macStudioSsdOptions?.map((s) => <option key={s}>{s}</option>)}
             </select>
           </div>
         </div>

--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -15,7 +15,7 @@ export const CAT_LABELS: Record<string, string> = {
   OUTROS: "Outros",
 };
 
-export const STRUCTURED_CATS = ["IPHONES", "MACBOOK", "MAC_MINI", "IPADS", "APPLE_WATCH", "AIRPODS"];
+export const STRUCTURED_CATS = ["IPHONES", "MACBOOK", "MAC_MINI", "MAC_STUDIO", "IPADS", "APPLE_WATCH", "AIRPODS"];
 
 // ── Cores por categoria (PORTUGUÊS) ──
 
@@ -209,6 +209,19 @@ export const MAC_MINI_NUCLEOS = [
 export const MAC_MINI_RAMS = ["8GB", "16GB", "24GB", "32GB", "48GB", "64GB"];
 export const MAC_MINI_STORAGES = ["256GB", "512GB", "1TB", "2TB"];
 
+export const MAC_STUDIO_CHIPS = ["M2 MAX", "M2 ULTRA", "M4 MAX", "M4 ULTRA"];
+export const MAC_STUDIO_NUCLEOS = [
+  "12C CPU/30C GPU",
+  "12C CPU/38C GPU",
+  "14C CPU/32C GPU",
+  "16C CPU/40C GPU",
+  "24C CPU/60C GPU",
+  "24C CPU/76C GPU",
+  "32C CPU/80C GPU",
+];
+export const MAC_STUDIO_RAMS = ["32GB", "48GB", "64GB", "96GB", "128GB", "192GB", "256GB", "512GB"];
+export const MAC_STUDIO_STORAGES = ["512GB", "1TB", "2TB", "4TB", "8TB", "16TB"];
+
 export const IPAD_MODELOS = [
   { value: "IPAD", label: "iPad" },
   { value: "MINI 6", label: "iPad Mini 6" },
@@ -246,6 +259,7 @@ export interface ProdutoSpec {
   ip_modelo: string; ip_linha: string; ip_storage: string; ip_origem: string;
   mb_modelo: string; mb_tela: string; mb_chip: string; mb_nucleos: string; mb_ram: string; mb_storage: string;
   mm_chip: string; mm_nucleos: string; mm_ram: string; mm_storage: string;
+  ms_chip: string; ms_nucleos: string; ms_ram: string; ms_storage: string;
   ipad_modelo: string; ipad_chip: string; ipad_tela: string; ipad_storage: string; ipad_conn: string;
   aw_modelo: string; aw_tamanho: string; aw_conn: string; aw_pulseira: string; aw_band: string;
   air_modelo: string;
@@ -255,6 +269,7 @@ export const DEFAULT_SPEC: ProdutoSpec = {
   ip_modelo: "16", ip_linha: "", ip_storage: "128GB", ip_origem: "",
   mb_modelo: "AIR", mb_tela: '13"', mb_chip: "M4", mb_nucleos: "", mb_ram: "16GB", mb_storage: "256GB",
   mm_chip: "M4", mm_nucleos: "10C CPU/10C GPU", mm_ram: "16GB", mm_storage: "256GB",
+  ms_chip: "M4 MAX", ms_nucleos: "14C CPU/32C GPU", ms_ram: "36GB", ms_storage: "512GB",
   ipad_modelo: "AIR M4", ipad_chip: "", ipad_tela: '11"', ipad_storage: "128GB", ipad_conn: "WIFI",
   aw_modelo: "SERIES 10", aw_tamanho: "42mm", aw_conn: "GPS", aw_pulseira: "", aw_band: "",
   air_modelo: "AIRPODS 4",
@@ -334,6 +349,12 @@ export function buildProdutoName(cat: string, spec: ProdutoSpec, cor?: string): 
       const ram = spec.mm_ram ? ` ${spec.mm_ram}` : "";
       const storage = spec.mm_storage ? ` ${spec.mm_storage}` : "";
       return `MAC MINI ${spec.mm_chip}${nucleos}${ram}${storage}`.toUpperCase();
+    }
+    case "MAC_STUDIO": {
+      const nucleos = spec.ms_nucleos ? ` (${spec.ms_nucleos})` : "";
+      const ram = spec.ms_ram ? ` ${spec.ms_ram}` : "";
+      const storage = spec.ms_storage ? ` ${spec.ms_storage}` : "";
+      return `MAC STUDIO ${spec.ms_chip}${nucleos}${ram}${storage}`.toUpperCase();
     }
     case "MACBOOK": {
       const tipo = spec.mb_modelo === "AIR" ? "MACBOOK AIR" : spec.mb_modelo === "NEO" ? "MACBOOK NEO" : "MACBOOK PRO";

--- a/supabase/migrations/20260409_lojistas_credito.sql
+++ b/supabase/migrations/20260409_lojistas_credito.sql
@@ -29,3 +29,13 @@ create table if not exists lojistas_credito_log (
 
 create index if not exists idx_lojistas_credito_log_lojista on lojistas_credito_log(lojista_id, created_at desc);
 create index if not exists idx_lojistas_credito_log_venda on lojistas_credito_log(venda_id);
+
+-- Grants + RLS
+grant all on lojistas_credito to service_role, authenticated, anon;
+grant all on lojistas_credito_log to service_role, authenticated, anon;
+alter table lojistas_credito enable row level security;
+alter table lojistas_credito_log enable row level security;
+drop policy if exists "service_role_all" on lojistas_credito;
+drop policy if exists "service_role_all" on lojistas_credito_log;
+create policy "service_role_all" on lojistas_credito for all to service_role using (true) with check (true);
+create policy "service_role_all" on lojistas_credito_log for all to service_role using (true) with check (true);


### PR DESCRIPTION
Mac Studio:
- CATEGORIAS e STRUCTURED_CATS incluem MAC_STUDIO
- constantes MAC_STUDIO_CHIPS/NUCLEOS/RAMS/STORAGES
- ProdutoSpec.ms_chip/nucleos/ram/storage + defaults
- buildProdutoName case MAC_STUDIO
- ProdutoSpecFields: bloco de specs Mac Studio idêntico ao Mac Mini

Crédito lojista — uso em venda:
- form vendas: campo usar_credito_loja + state creditoLojistaSaldo
- efeito busca saldo quando tipo=ATACADO + cliente/cpf/cnpj muda
- UI: bloco azul "Crédito do Lojista" aparece quando saldo > 0 (input + "Usar tudo")
- payload envia usar_credito_loja; backend debita automaticamente
- migration: grants + RLS nas tabelas lojistas_credito*