### PR TITLE
fix(vendas): incluir usar_credito_loja nos resets do form

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -1430,7 +1430,7 @@ export default function VendasPage() {
         troca_serial2: "", troca_imei2: "", troca_garantia2: "", troca_pulseira2: "", troca_ciclos2: "",
         serial_no: "", imei: "",
         cep: "", bairro: "", cidade: "", uf: "",
-        frete_valor: "", frete_recebido: false,
+        frete_valor: "", frete_recebido: false, usar_credito_loja: "",
       });
       setCatSel("");
       setEstoqueId("");
@@ -1908,7 +1908,7 @@ export default function VendasPage() {
                     produto_na_troca2: "", troca_produto2: "", troca_cor2: "", troca_categoria2: "", troca_bateria2: "", troca_obs2: "",
                     troca_serial2: "", troca_imei2: "", troca_garantia2: "", troca_pulseira2: "", troca_ciclos2: "",
                     serial_no: "", imei: "", cep: "", bairro: "", cidade: "", uf: "",
-                    frete_valor: "", frete_recebido: false,
+                    frete_valor: "", frete_recebido: false, usar_credito_loja: "",
                   });
                   setCatSel(""); setEstoqueId(""); setProdutoManual(false); setShowSegundaTroca(false);
                   setProdutosCarrinho([]); setEditandoVendaId(null); setEditandoGrupoIds([]); setDuplicadoInfo(null); setLastClienteData(null);
@@ -2513,7 +2513,7 @@ export default function VendasPage() {
                     troca_serial2: "", troca_imei2: "", troca_garantia2: "", troca_pulseira2: "", troca_ciclos2: "",
                     serial_no: "", imei: "",
                     cep: "", bairro: "", cidade: "", uf: "",
-                    frete_valor: "", frete_recebido: false,
+                    frete_valor: "", frete_recebido: false, usar_credito_loja: "",
                   });
                   setShowSegundaTroca(false);
                   setLastClienteData(null);
@@ -4705,7 +4705,7 @@ export default function VendasPage() {
                     troca_serial2: "", troca_imei2: "", troca_garantia2: "", troca_pulseira2: "", troca_ciclos2: "",
                     serial_no: "", imei: "",
                     cep: "", bairro: "", cidade: "", uf: "",
-                    frete_valor: "", frete_recebido: false,
+                    frete_valor: "", frete_recebido: false, usar_credito_loja: "",
                   });
                   setShowSegundaTroca(false);
                   setLastClienteData(null);
@@ -4739,7 +4739,7 @@ export default function VendasPage() {
                     troca_serial2: "", troca_imei2: "", troca_garantia2: "", troca_pulseira2: "", troca_ciclos2: "",
                     serial_no: "", imei: "",
                     cep: "", bairro: "", cidade: "", uf: "",
-                    frete_valor: "", frete_recebido: false,
+                    frete_valor: "", frete_recebido: false, usar_credito_loja: "",
                   });
                   setShowSegundaTroca(false);
                   setLastClienteData(null);


### PR DESCRIPTION
Desde o último PR mergeado, tem 3 commits novos:

1. **`3e07d3a`** — Fix do erro de build anterior: movi os helpers de `lojistas_credito` de `route.ts` pra `lib/lojistas-credito.ts` (Next.js não permite exports arbitrários em arquivos de rota).

2. **`7b45ef3`** — Fix do cálculo do **pagamento em espécie quando tem 2 produtos na troca**: agora soma `produto_na_troca + produto_na_troca2` antes de calcular o resto. Badge de "Troca" também mostra o total somado.

3. **`39ef4d6`** — Fix do erro de build TypeScript: incluí `usar_credito_loja: ""` nos 5 lugares onde o form é resetado (estavam faltando, o TS reclamava que o campo era obrigatório).