### PR TITLE
fix(vendas): usar_credito_loja em todos os setForm restantes

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -1696,7 +1696,7 @@ export default function VendasPage() {
       cidade: "",
       uf: "",
       frete_valor: "",
-      frete_recebido: false,
+      frete_recebido: false, usar_credito_loja: "",
     });
     setCatSel("");
     setEstoqueId("");
@@ -4120,6 +4120,7 @@ export default function VendasPage() {
                                               uf: primaryVenda.uf || "",
                                               frete_valor: primaryVenda.frete_valor != null ? String(primaryVenda.frete_valor) : "",
                                               frete_recebido: !!primaryVenda.frete_recebido,
+                                              usar_credito_loja: "",
                                             });
                                             setProdutoManual(true);
 


### PR DESCRIPTION
3e07d3a — Fix do erro de build anterior: movi os helpers de lojistas_credito de route.ts pra lib/lojistas-credito.ts (Next.js não permite exports arbitrários em arquivos de rota).

7b45ef3 — Fix do cálculo do pagamento em espécie quando tem 2 produtos na troca: agora soma produto_na_troca + produto_na_troca2 antes de calcular o resto. Badge de "Troca" também mostra o total somado.

39ef4d6 — Fix do erro de build TypeScript: incluí usar_credito_loja: "" nos 5 lugares onde o form é resetado (estavam faltando, o TS reclamava que o campo era obrigatório).