### PR TITLE
feat(analytics): cores mais vendidas por modelo

### DIFF
--- a/app/admin/analytics-vendas/page.tsx
+++ b/app/admin/analytics-vendas/page.tsx
@@ -66,6 +66,12 @@ interface RegiaoData {
   cidades: { nome: string; qtd: number }[];
 }
 
+interface CoresPorModelo {
+  modelo: string;
+  totalQnt: number;
+  cores: { cor: string; qnt: number; pct: number }[];
+}
+
 interface AnalyticsVendasData {
   kpi: KPI;
   projecao: ProjecaoData;
@@ -74,6 +80,7 @@ interface AnalyticsVendasData {
   margemCanal: MargemCanal[];
   origemClientes: OrigemCliente[];
   regiao: RegiaoData;
+  coresPorModelo: CoresPorModelo[];
 }
 
 /* ─── Colors ─── */
@@ -227,6 +234,7 @@ export default function AnalyticsVendasPage() {
           pct: o.pct ?? o.percentual ?? 0,
         })),
         regiao: json.vendasPorRegiao || { bairros: [], cidades: [] },
+        coresPorModelo: json.coresPorModelo || [],
       };
       setData(transformed);
     } catch (err: any) {
@@ -451,6 +459,51 @@ export default function AnalyticsVendasPage() {
                 </tbody>
               </table>
             </div>
+          </Section>
+
+          {/* SECTION 3b: Cores mais vendidas por modelo */}
+          <Section title="🎨 Cores mais vendidas por modelo">
+            {data.coresPorModelo.length === 0 ? (
+              <p className="text-sm text-[#86868B] text-center py-8">Sem dados de cores no período</p>
+            ) : (
+              <div className="space-y-3">
+                {data.coresPorModelo.map((m, i) => (
+                  <div key={i} className="p-3 rounded-xl border border-[#E5E5EA] bg-white">
+                    <div className="flex items-center justify-between mb-2 flex-wrap gap-1">
+                      <p className="text-sm font-semibold text-[#1D1D1F]">{m.modelo}</p>
+                      <span className="text-[11px] text-[#86868B]">
+                        {m.totalQnt} un. total
+                      </span>
+                    </div>
+                    {/* Barra empilhada de cores */}
+                    <div className="w-full h-3 rounded-full overflow-hidden flex bg-[#F5F5F7] mb-2">
+                      {m.cores.map((c, j) => (
+                        <div
+                          key={j}
+                          style={{ width: `${c.pct}%`, backgroundColor: PIE_COLORS[j % PIE_COLORS.length] }}
+                          title={`${c.cor}: ${c.qnt} un. (${c.pct}%)`}
+                        />
+                      ))}
+                    </div>
+                    {/* Legenda */}
+                    <div className="flex flex-wrap gap-x-3 gap-y-1">
+                      {m.cores.map((c, j) => (
+                        <div key={j} className="flex items-center gap-1.5 text-[11px]">
+                          <span
+                            className="inline-block w-2.5 h-2.5 rounded-full"
+                            style={{ backgroundColor: PIE_COLORS[j % PIE_COLORS.length] }}
+                          />
+                          <span className="text-[#1D1D1F] font-medium">{c.cor}</span>
+                          <span className="text-[#86868B]">
+                            {c.qnt} un. ({c.pct}%)
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
           </Section>
 
           {/* SECTION 4: Ticket Medio Diario */}

--- a/app/api/admin/analytics-vendas/route.ts
+++ b/app/api/admin/analytics-vendas/route.ts
@@ -395,6 +395,72 @@ export async function GET(req: NextRequest) {
     };
 
     // ---------------------------------------------------------------
+    // 8. CORES MAIS VENDIDAS POR MODELO (current month)
+    //    Agrupa modelo base (sem cor/origem) e conta qntas de cada cor.
+    // ---------------------------------------------------------------
+    const stripDetails = (nome: string) => nome
+      .replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ|ZD|ZP|CH|AA|E|LZ|QL|N)\s*(\([^)]*\))?/gi, "")
+      .replace(/[-–]?\s*(IP\s+)?-?\s*(CHIP\s+)?(F[ÍI]SICO\s*\+?\s*)?E-?SIM/gi, "")
+      .replace(/-\s*E-?SIM/gi, "")
+      .replace(/\s{2,}/g, " ")
+      .trim();
+
+    // Lista de cores conhecidas para detectar cor no fim do nome do produto
+    const CORES_KNOWN = [
+      "PRETO", "BRANCO", "PRATA", "DOURADO", "AZUL", "VERDE", "ROSA", "ROXO",
+      "VERMELHO", "AMARELO", "ESTELAR", "MEIA-NOITE", "TEAL", "ULTRAMARINO",
+      "LAVANDA", "SAGE", "MIDNIGHT", "LARANJA", "CINZA", "NATURAL", "GRAFITE",
+      "TITANIO PRETO", "TITANIO BRANCO", "TITANIO NATURAL", "TITANIO AZUL",
+      "TITANIO DESERTO", "DEEP PURPLE", "PACIFIC BLUE", "ALPINE GREEN",
+      "SIERRA BLUE", "GRAPHITE", "JET BLACK",
+      "LARANJA CÓSMICO", "LARANJA COSMICO", "AZUL PROFUNDO", "AZUL NÉVOA",
+      "AZUL NEVOA", "AZUL CÉU", "AZUL CEU", "PRETO ESPACIAL", "CINZA ESPACIAL",
+      "DOURADO CLARO", "CLOUD WHITE", "SKY BLUE", "SALVIA", "SÁLVIA",
+      "PRETO BRILHANTE", "ÍNDIGO", "INDIGO", "BLUE TITANIUM", "BLACK TITANIUM",
+      "WHITE TITANIUM", "NATURAL TITANIUM", "DESERT TITANIUM",
+    ].sort((a, b) => b.length - a.length); // prefere match mais longo primeiro
+
+    const extractModeloCor = (nome: string): { modelo: string; cor: string } => {
+      const cleaned = stripDetails(nome);
+      const up = cleaned.toUpperCase();
+      // Tenta encontrar uma cor conhecida no fim do nome
+      for (const cor of CORES_KNOWN) {
+        const idx = up.lastIndexOf(cor);
+        if (idx >= 0 && idx + cor.length >= up.length - 3) {
+          // cor está no fim (tolerância de 3 chars para sufixos tipo "--sim")
+          const modelo = cleaned.substring(0, idx).trim().replace(/\s*-\s*$/, "").trim();
+          return { modelo, cor };
+        }
+      }
+      return { modelo: cleaned, cor: "" };
+    };
+
+    // modelo -> { totalQnt, cores: { cor -> qnt } }
+    const modeloCoresMap: Record<string, { totalQnt: number; cores: Record<string, number> }> = {};
+    for (const v of vendasMesAtual) {
+      const prod = v.produto || "";
+      if (!prod) continue;
+      const { modelo, cor } = extractModeloCor(prod);
+      if (!modelo) continue;
+      if (!modeloCoresMap[modelo]) modeloCoresMap[modelo] = { totalQnt: 0, cores: {} };
+      modeloCoresMap[modelo].totalQnt++;
+      const corKey = cor || "(sem cor)";
+      modeloCoresMap[modelo].cores[corKey] = (modeloCoresMap[modelo].cores[corKey] || 0) + 1;
+    }
+
+    // Top 15 modelos com suas cores ordenadas
+    const coresPorModelo = Object.entries(modeloCoresMap)
+      .map(([modelo, d]) => ({
+        modelo,
+        totalQnt: d.totalQnt,
+        cores: Object.entries(d.cores)
+          .map(([cor, qnt]) => ({ cor, qnt, pct: Math.round((qnt / d.totalQnt) * 100) }))
+          .sort((a, b) => b.qnt - a.qnt),
+      }))
+      .sort((a, b) => b.totalQnt - a.totalQnt)
+      .slice(0, 15);
+
+    // ---------------------------------------------------------------
     // RESPONSE
     // ---------------------------------------------------------------
     return NextResponse.json({
@@ -405,6 +471,7 @@ export async function GET(req: NextRequest) {
       origemClientes,
       vendasPorRegiao,
       projecao,
+      coresPorModelo,
     });
   } catch (err) {
     console.error("Erro analytics-vendas:", err);


### PR DESCRIPTION
## Resumo

Nova análise em **Analytics de Vendas** mostrando quais **cores** de cada modelo mais vendem no mês atual. Útil pra decidir quais cores comprar do fornecedor e manter em estoque.

## Como funciona

### Backend
1. Pega todas as vendas do mês atual
2. Pra cada produto vendido, extrai:
   - **Modelo base** (remove origem LL/JPA/HN/etc, remove sufixos como e-SIM)
   - **Cor** (detecta uma das 50+ cores conhecidas em PT e EN)
3. Agrupa por modelo → conta cores → calcula porcentagem
4. Retorna os **top 15 modelos** mais vendidos com breakdown

### Frontend
Nova seção **"🎨 Cores mais vendidas por modelo"** logo depois do Ranking de Produtos. Cada modelo mostra:

```
iPhone 17 Pro Max 256GB                    30 un. total
████████████░░░░░░░░░░░░░
🟧 Laranja Cósmico  12 un. (40%)
🟦 Prata            9 un. (30%)
🟪 Azul Profundo    6 un. (20%)
⬛ Preto Titânio    3 un. (10%)
```

Visual claro: barra empilhada colorida + legenda com quantidade e percentual.

## Test plan
- [ ] Abrir /admin/analytics-vendas
- [ ] Scroll até achar "🎨 Cores mais vendidas por modelo" (depois de Ranking de Produtos)
- [ ] Ver os top 15 modelos do mês com breakdown de cores
- [ ] Verificar se as cores batem com as vendas reais

## Observação
Essa análise vai ajudar depois a implementar o **#1 estoque mínimo por giro** incluindo cor — exemplo: "preciso de 8 iPhone 17 Pro Max Laranja + 6 Prata + 4 Azul" em vez de só "14 iPhone 17 Pro Max".

🤖 Generated with [Claude Code](https://claude.com/claude-code)