### PR TITLE
fix: credito lojista (strict key) + mac mini chip no display

### DIFF
--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -171,11 +171,14 @@ export default function ClientesPage() {
   const [creditoForm, setCreditoForm] = useState({ tipo: "CREDITO" as "CREDITO" | "DEBITO" | "AJUSTE", valor: "", motivo: "" });
   const [savingCredito, setSavingCredito] = useState(false);
 
+  const normalizeNome = (n: string | null | undefined) =>
+    (n || "").normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/\s+/g, " ").trim().toUpperCase();
+
   const lojistaKey = (c: { cpf: string | null; cnpj: string | null; nome: string }) => {
     const d = (s: string | null | undefined) => (s || "").replace(/\D/g, "");
     if (d(c.cpf)) return `cpf:${d(c.cpf)}`;
     if (d(c.cnpj)) return `cnpj:${d(c.cnpj)}`;
-    return `nome:${c.nome.trim().toUpperCase()}`;
+    return `nome:${normalizeNome(c.nome)}`;
   };
 
   const fetchSaldosLojistas = useCallback(async () => {
@@ -184,14 +187,12 @@ export default function ClientesPage() {
       const res = await fetch(`/api/admin/lojistas-credito`, { headers: apiHeaders() });
       if (res.ok) {
         const json = await res.json();
+        // STRICT: indexa APENAS pelo cliente_key canônico. Nada de fallback por nome/cpf/cnpj soltos
+        // (isso antes causava colisões se rows antigas tivessem cliente_key vazio/genérico).
         const map: Record<string, number> = {};
-        // Indexa por cliente_key E por nome upper — garante que a UI acha o saldo por qualquer chave
         for (const l of json.lojistas || []) {
-          const saldo = Number(l.saldo || 0);
-          if (l.cliente_key) map[l.cliente_key] = saldo;
-          if (l.nome) map[`nome:${String(l.nome).trim().toUpperCase()}`] = saldo;
-          if (l.cpf) map[`cpf:${String(l.cpf).replace(/\D/g, "")}`] = saldo;
-          if (l.cnpj) map[`cnpj:${String(l.cnpj).replace(/\D/g, "")}`] = saldo;
+          if (!l.cliente_key) continue;
+          map[l.cliente_key] = Number(l.saldo || 0);
         }
         setSaldosLojistas(map);
       }
@@ -897,6 +898,25 @@ export default function ClientesPage() {
                   className="w-full py-2.5 rounded-lg bg-[#E8740E] text-white text-sm font-semibold hover:bg-[#D06A0D] disabled:opacity-50">
                   {savingCredito ? "Salvando..." : "Salvar movimentação"}
                 </button>
+                {creditoModal.saldo > 0 && (
+                  <button
+                    onClick={async () => {
+                      if (!creditoModal) return;
+                      if (!confirm(`Apagar o saldo de crédito de ${creditoModal.cliente.nome}? (R$ ${creditoModal.saldo.toLocaleString("pt-BR")})`)) return;
+                      const params = new URLSearchParams();
+                      if (creditoModal.cliente.cpf) params.set("cpf", creditoModal.cliente.cpf);
+                      if (creditoModal.cliente.cnpj) params.set("cnpj", creditoModal.cliente.cnpj);
+                      if (!creditoModal.cliente.cpf && !creditoModal.cliente.cnpj) params.set("nome", creditoModal.cliente.nome);
+                      const res = await fetch(`/api/admin/lojistas-credito?${params}`, { method: "DELETE", headers: apiHeaders() });
+                      const j = await res.json();
+                      if (!res.ok) { alert(j.error || "Erro"); return; }
+                      await fetchSaldosLojistas();
+                      setCreditoModal(null);
+                    }}
+                    className="w-full py-2 rounded-lg bg-red-600 text-white text-xs font-semibold hover:bg-red-700">
+                    Apagar saldo deste lojista
+                  </button>
+                )}
               </div>
               <div>
                 <p className={`text-[10px] uppercase tracking-wider font-bold ${mS} mb-2`}>Extrato ({creditoModal.log.length})</p>

--- a/app/api/admin/lojistas-credito/route.ts
+++ b/app/api/admin/lojistas-credito/route.ts
@@ -52,6 +52,28 @@ export async function GET(req: NextRequest) {
   return NextResponse.json({ lojista, saldo: Number(lojista.saldo || 0), log: log || [] });
 }
 
+// ── DELETE: zera saldo e apaga linha de um lojista específico (ou ?all=1 pra limpar tudo) ──
+export async function DELETE(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const usuario = getUsuario(req);
+  const { searchParams } = new URL(req.url);
+  if (searchParams.get("all") === "1") {
+    const { error } = await supabase.from("lojistas_credito").delete().gt("saldo", -1);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    await logActivity(usuario, "Crédito lojistas BULK reset", "Zerou todos os saldos", "clientes");
+    return NextResponse.json({ ok: true, bulk: true });
+  }
+  const cpf = searchParams.get("cpf");
+  const cnpj = searchParams.get("cnpj");
+  const nome = searchParams.get("nome");
+  if (!cpf && !cnpj && !nome) return NextResponse.json({ error: "cpf, cnpj ou nome obrigatório" }, { status: 400 });
+  const key = buildClienteKey({ cpf, cnpj, nome });
+  const { error } = await supabase.from("lojistas_credito").delete().eq("cliente_key", key);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  await logActivity(usuario, "Crédito lojista apagado", `${nome || cpf || cnpj}`, "clientes");
+  return NextResponse.json({ ok: true });
+}
+
 // ── POST: movimentar manualmente (AJUSTE / CREDITO / DEBITO) ──
 export async function POST(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/lib/lojistas-credito.ts
+++ b/lib/lojistas-credito.ts
@@ -1,13 +1,23 @@
 import { supabase } from "@/lib/supabase";
 
-/** Normaliza a chave do cliente: prioriza CPF/CNPJ (só dígitos); senão nome upper. */
+/** Normaliza nome: tira acentos, colapsa espaços, upper. Garante match 1-pra-1 entre UIs. */
+function normalizeNome(n: string | null | undefined): string {
+  return (n || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toUpperCase();
+}
+
+/** Normaliza a chave do cliente: prioriza CPF/CNPJ (só dígitos); senão nome normalizado. */
 export function buildClienteKey(p: { cpf?: string | null; cnpj?: string | null; nome?: string | null }): string {
   const onlyDigits = (s: string | null | undefined) => (s || "").replace(/\D/g, "");
   const cpf = onlyDigits(p.cpf);
   if (cpf) return `cpf:${cpf}`;
   const cnpj = onlyDigits(p.cnpj);
   if (cnpj) return `cnpj:${cnpj}`;
-  return `nome:${(p.nome || "").trim().toUpperCase()}`;
+  return `nome:${normalizeNome(p.nome)}`;
 }
 
 /** Busca ou cria registro de lojista. Retorna linha. */
@@ -45,6 +55,7 @@ export async function moverCredito(params: {
 }) {
   if (!params.valor || params.valor <= 0) throw new Error("valor deve ser > 0");
   const lojista = await getOrCreateLojista(params.cliente);
+  if (!lojista?.id) throw new Error("lojista inválido (sem id) — operação abortada");
   const saldoAntes = Number(lojista.saldo || 0);
   let saldoDepois = saldoAntes;
   if (params.tipo === "CREDITO") saldoDepois = saldoAntes + params.valor;
@@ -53,11 +64,15 @@ export async function moverCredito(params: {
   if (params.tipo === "DEBITO" && saldoDepois < 0) {
     throw new Error(`Saldo insuficiente. Disponível: R$ ${saldoAntes}, tentativa: R$ ${params.valor}`);
   }
-  const { error: upErr } = await supabase
+  const { data: updated, error: upErr } = await supabase
     .from("lojistas_credito")
     .update({ saldo: saldoDepois, updated_at: new Date().toISOString(), nome: params.cliente.nome })
-    .eq("id", lojista.id);
+    .eq("id", lojista.id)
+    .select("id");
   if (upErr) throw new Error(upErr.message);
+  if (!updated || updated.length !== 1) {
+    throw new Error(`moverCredito: update afetou ${updated?.length ?? 0} linhas (esperado 1)`);
+  }
   await supabase.from("lojistas_credito_log").insert({
     lojista_id: lojista.id,
     venda_id: params.venda_id || null,

--- a/lib/produto-display.ts
+++ b/lib/produto-display.ts
@@ -91,7 +91,14 @@ export function formatProdutoDisplay(p: {
     if (ssd) parts.push(ssd);
     if (cor) parts.push(cor);
   } else if (baseCat === "MAC_MINI") {
-    parts.push("Mac Mini");
+    // Extrai chip (M1/M2/M3/M4 + opcional PRO/MAX) do nome/observação
+    const chipM = up.match(/M(\d+)\s*(PRO\s*MAX|PRO|MAX)?/);
+    let chip = "";
+    if (chipM) {
+      const variant = chipM[2] ? " " + chipM[2].replace(/\s+/g, " ").replace(/PRO MAX/i, "Pro Max").replace(/PRO/i, "Pro").replace(/MAX/i, "Max") : "";
+      chip = ` M${chipM[1]}${variant}`;
+    }
+    parts.push("Mac Mini" + chip);
     if (ram) parts.push(ram);
     if (ssd) parts.push(ssd);
     if (cor) parts.push(cor);


### PR DESCRIPTION
- lojistas-credito: normaliza nome (acentos/spaces) na buildClienteKey
- moverCredito: aborta se lojista.id ausente + verifica update afetou 1 linha
- clientes: indexacao STRICT por cliente_key (remove fallback colisionavel)
- DELETE /api/admin/lojistas-credito (individual + ?all=1 bulk reset)
- modal Gerenciar credito: botao "Apagar saldo deste lojista"
- produto-display: Mac Mini agora mostra chip M4/M4 Pro no nome