### PR TITLE
fix: lojistas agrupam por nome + bulk reset saldo + bloco credito sem…

### DIFF
--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -746,6 +746,23 @@ export default function ClientesPage() {
         </div>
       </div>
 
+      {tab === "lojistas" && (
+        <div className="flex justify-end">
+          <button
+            onClick={async () => {
+              if (!confirm("Zerar os saldos de crédito de TODOS os lojistas? Isso apaga o histórico e zera a tabela lojistas_credito. Não pode ser desfeito.")) return;
+              const res = await fetch(`/api/admin/lojistas-credito?all=1`, { method: "DELETE", headers: apiHeaders() });
+              const j = await res.json();
+              if (!res.ok) { alert(j.error || "Erro"); return; }
+              await fetchSaldosLojistas();
+              alert("Todos os saldos foram zerados.");
+            }}
+            className="px-3 py-1.5 rounded-lg bg-red-600 text-white text-xs font-semibold hover:bg-red-700">
+            Zerar todos os saldos de crédito
+          </button>
+        </div>
+      )}
+
       {/* Sort */}
       <div className="flex items-center gap-2">
         <span className={`text-xs ${mS}`}>Ordenar:</span>

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -2080,8 +2080,8 @@ export default function VendasPage() {
                 </div>
               </div>
 
-              {/* Crédito de Lojista — aparece quando há saldo */}
-              {creditoLojistaSaldo > 0 && (
+              {/* Crédito de Lojista — aparece sempre em ATACADO, mesmo sem saldo (facilita cadastrar/ver) */}
+              {form.tipo === "ATACADO" && form.cliente && (
                 <div className="p-3 rounded-xl border border-blue-200 bg-blue-50">
                   <div className="flex items-center justify-between mb-2">
                     <span className="text-xs font-bold uppercase tracking-wider text-blue-700">💳 Crédito do Lojista</span>

--- a/app/api/admin/clientes/route.ts
+++ b/app/api/admin/clientes/route.ts
@@ -327,7 +327,10 @@ export async function GET(req: NextRequest) {
     const cnpj = (v.cnpj || "").trim();
 
     let key: string;
-    if (cpf) {
+    if (isAtacado) {
+      // Lojistas: SEMPRE agrupa por nome normalizado, ignora cpf/cnpj inconsistentes
+      key = `nome:${normalizeLojistaNome(nome)}`;
+    } else if (cpf) {
       if (cpfToKey.has(cpf)) { key = cpfToKey.get(cpf)!; }
       else { key = `cpf:${cpf}`; cpfToKey.set(cpf, key); }
     } else if (cnpj) {

--- a/supabase/migrations/20260408_reset_lojistas_credito.sql
+++ b/supabase/migrations/20260408_reset_lojistas_credito.sql
@@ -2,5 +2,5 @@
 -- que aplicava o mesmo saldo pra múltiplos lojistas. Depois de rodar, readicionar
 -- manualmente o saldo correto no modal "Gerenciar crédito".
 
-delete from lojistas_credito_log;
-delete from lojistas_credito;
+delete from lojistas_credito_log where id is not null;
+delete from lojistas_credito where id is not null;

--- a/supabase/migrations/20260408b_clientes_resumo_atacado_nome.sql
+++ b/supabase/migrations/20260408b_clientes_resumo_atacado_nome.sql
@@ -1,5 +1,5 @@
--- RPC que retorna clientes/lojistas já agrupados via SQL (elimina scan + group em JS).
--- Usa chave cpf (se houver) ou nome uppercase como identificador.
+-- Ajusta clientes_resumo: lojistas ATACADO agrupam SEMPRE por nome normalizado
+-- (ignora cpf/cnpj que frequentemente estão inconsistentes entre vendas do mesmo lojista).
 
 create or replace function clientes_resumo(
   p_is_lojista boolean,
@@ -38,8 +38,6 @@ as $$
   keyed as (
     select
       case
-        -- Lojistas ATACADO: SEMPRE agrupa por nome normalizado (ignora cnpj/cpf que frequentemente
-        -- tão vazios ou inconsistentes) — unifica "021 TECH" e "021 TECH ATACADO".
         when (tipo = 'ATACADO' or origem = 'ATACADO') then
           'nome:' || regexp_replace(upper(trim(cliente)), '\s+(ATACADO|ATAC|LOJAS?|STORE|IMPORTS?|CELL|CEL)\b.*$', '', 'i')
         when coalesce(cpf, '') <> '' then 'cpf:' || cpf
@@ -76,5 +74,3 @@ as $$
   where is_lojista = p_is_lojista
   order by total_gasto desc;
 $$;
-
-grant execute on function clientes_resumo(boolean, text) to service_role, authenticated, anon;

--- a/supabase/migrations/20260408c_reset_lojistas_credito_retry.sql
+++ b/supabase/migrations/20260408c_reset_lojistas_credito_retry.sql
@@ -1,0 +1,5 @@
+-- Retry do reset de lojistas_credito (a versao anterior falhou por DELETE sem WHERE).
+-- Supabase exige WHERE em todo DELETE.
+
+delete from lojistas_credito_log where id is not null;
+delete from lojistas_credito where id is not null;


### PR DESCRIPTION
…pre visivel

- RPC/fallback: lojistas ATACADO agrupam SEMPRE por nome normalizado (ignora cpf/cnpj inconsistente) — unifica 021 TECH + 021 TECH ATACADO
- botao "Zerar todos os saldos de credito" na aba Lojistas
- vendas/page: bloco Credito do Lojista aparece sempre em ATACADO quando tem cliente (nao so quando saldo > 0) — facilita cadastrar/usar
- nova migration 20260408c_reset_lojistas_credito_retry (com WHERE)
- nova migration 20260408b_clientes_resumo_atacado_nome (ajusta RPC)