### PR TITLE
fix(vendas PATCH): remove usar_credito_loja do update (coluna nao exi…

### DIFF
--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -498,6 +498,7 @@ export async function PATCH(req: NextRequest) {
   delete fields._seminovo;
   delete fields._seminovo2;
   delete fields._estoque_id;
+  delete fields.usar_credito_loja; // virtual — só usado no POST
 
   // Todos os campos de troca existem na tabela vendas após migration 20260406_vendas_troca_serial_imei
   const { data, error } = await supabase.from("vendas").update(fields).eq("id", id).select();


### PR DESCRIPTION
…ste na tabela)

Campo virtual, so usado no POST pra debitar saldo. Ao editar venda causava erro 'Could not find the usar_credito_loja column of vendas in the schema cache'.