### PR TITLE
refactor(lojistas): nova tabela 'lojistas' com UUID auto + API /api/a…

### DIFF
--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -164,36 +164,32 @@ export default function ClientesPage() {
   const [fornMsg, setFornMsg] = useState("");
   const [savingForn, setSavingForn] = useState(false);
 
-  // Crédito de lojistas
-  const [saldosLojistas, setSaldosLojistas] = useState<Record<string, number>>({});
+  // Crédito de lojistas — usa a tabela `lojistas` nova (UUID auto)
+  const [saldosLojistas, setSaldosLojistas] = useState<Record<string, number>>({}); // indexa por nome upper → saldo
   type CreditoLog = { id: string; tipo: string; valor: number; saldo_antes: number; saldo_depois: number; motivo: string | null; usuario: string | null; created_at: string };
-  const [creditoModal, setCreditoModal] = useState<null | { cliente: Cliente; saldo: number; log: CreditoLog[] }>(null);
+  const [creditoModal, setCreditoModal] = useState<null | { cliente: Cliente; lojista_id: string; saldo: number; log: CreditoLog[] }>(null);
   const [creditoForm, setCreditoForm] = useState({ tipo: "CREDITO" as "CREDITO" | "DEBITO" | "AJUSTE", valor: "", motivo: "" });
   const [savingCredito, setSavingCredito] = useState(false);
 
   const normalizeNome = (n: string | null | undefined) =>
     (n || "").normalize("NFD").replace(/[\u0300-\u036f]/g, "").replace(/\s+/g, " ").trim().toUpperCase();
 
-  const lojistaKey = (c: { cpf: string | null; cnpj: string | null; nome: string }) => {
-    const d = (s: string | null | undefined) => (s || "").replace(/\D/g, "");
-    if (d(c.cpf)) return `cpf:${d(c.cpf)}`;
-    if (d(c.cnpj)) return `cnpj:${d(c.cnpj)}`;
-    return `nome:${normalizeNome(c.nome)}`;
-  };
+  // Lookup do saldo no mapa por nome normalizado (mesma chave usada em fetchSaldosLojistas)
+  const lojistaKey = (c: { cpf: string | null; cnpj: string | null; nome: string }) => normalizeNome(c.nome);
 
   const fetchSaldosLojistas = useCallback(async () => {
     if (!password) return;
     try {
-      const res = await fetch(`/api/admin/lojistas-credito?_t=${Date.now()}`, { headers: apiHeaders(), cache: "no-store" });
+      // Nova tabela `lojistas` — cada row tem id UUID + saldo_credito. Indexa por nome upper.
+      const res = await fetch(`/api/admin/lojistas?_t=${Date.now()}`, { headers: apiHeaders(), cache: "no-store" });
       if (res.ok) {
         const json = await res.json();
-        console.log("[lojistas-credito] API retornou", json._count, "rows:", json.lojistas?.map((l: { cliente_key: string; saldo: number }) => ({ key: l.cliente_key, saldo: l.saldo })));
-        // STRICT: indexa APENAS pelo cliente_key canônico. Nada de fallback por nome/cpf/cnpj soltos
-        // (isso antes causava colisões se rows antigas tivessem cliente_key vazio/genérico).
         const map: Record<string, number> = {};
         for (const l of json.lojistas || []) {
-          if (!l.cliente_key) continue;
-          map[l.cliente_key] = Number(l.saldo || 0);
+          const nomeKey = normalizeNome(l.nome);
+          if (nomeKey && Number(l.saldo_credito || 0) > 0) {
+            map[nomeKey] = Number(l.saldo_credito || 0);
+          }
         }
         setSaldosLojistas(map);
       }
@@ -204,13 +200,32 @@ export default function ClientesPage() {
 
   const openCreditoModal = async (c: Cliente) => {
     try {
-      const params = new URLSearchParams();
-      if (c.cpf) params.set("cpf", c.cpf);
-      if (c.cnpj) params.set("cnpj", c.cnpj);
-      if (!c.cpf && !c.cnpj) params.set("nome", c.nome);
-      const res = await fetch(`/api/admin/lojistas-credito?${params}`, { headers: apiHeaders() });
-      const json = await res.json();
-      setCreditoModal({ cliente: c, saldo: Number(json.saldo || 0), log: json.log || [] });
+      // 1) Busca lojistas existentes pra encontrar um que bate pelo nome
+      const list = await fetch(`/api/admin/lojistas?_t=${Date.now()}`, { headers: apiHeaders(), cache: "no-store" });
+      const lj = await list.json();
+      const alvo = (lj.lojistas || []).find((l: { id: string; nome: string }) => normalizeNome(l.nome) === normalizeNome(c.nome));
+      let lojistaId: string;
+      let saldo = 0;
+      let log: CreditoLog[] = [];
+      if (alvo) {
+        lojistaId = alvo.id;
+        // Busca saldo + log
+        const det = await fetch(`/api/admin/lojistas?id=${lojistaId}&_t=${Date.now()}`, { headers: apiHeaders(), cache: "no-store" });
+        const dj = await det.json();
+        saldo = Number(dj.lojista?.saldo_credito || 0);
+        log = dj.log || [];
+      } else {
+        // Auto-cria com UUID novo
+        const create = await fetch(`/api/admin/lojistas`, {
+          method: "POST",
+          headers: { ...apiHeaders(), "Content-Type": "application/json" },
+          body: JSON.stringify({ nome: c.nome, cpf: c.cpf, cnpj: c.cnpj }),
+        });
+        const cj = await create.json();
+        if (!create.ok) { alert(cj.error || "Erro ao cadastrar lojista"); return; }
+        lojistaId = cj.lojista.id;
+      }
+      setCreditoModal({ cliente: c, lojista_id: lojistaId, saldo, log });
       setCreditoForm({ tipo: "CREDITO", valor: "", motivo: "" });
     } catch (err) { console.error(err); }
   };
@@ -221,11 +236,12 @@ export default function ClientesPage() {
     if (!valor || valor <= 0) { alert("Valor inválido"); return; }
     setSavingCredito(true);
     try {
-      const res = await fetch("/api/admin/lojistas-credito", {
+      const res = await fetch("/api/admin/lojistas", {
         method: "POST",
         headers: { ...apiHeaders(), "Content-Type": "application/json" },
         body: JSON.stringify({
-          cliente: { nome: creditoModal.cliente.nome, cpf: creditoModal.cliente.cpf, cnpj: creditoModal.cliente.cnpj },
+          action: "mover_saldo",
+          lojista_id: creditoModal.lojista_id,
           tipo: creditoForm.tipo,
           valor,
           motivo: creditoForm.motivo || null,
@@ -233,18 +249,11 @@ export default function ClientesPage() {
       });
       const json = await res.json();
       if (!res.ok) { alert(json.error || "Erro"); return; }
-      // Debug: valida que só 1 linha ficou no banco pra essa chave
-      try {
-        const check = await fetch(`/api/admin/lojistas-credito?_t=${Date.now()}`, { headers: apiHeaders(), cache: "no-store" });
-        const cj = await check.json();
-        const total = cj.lojistas?.length ?? 0;
-        console.log(`[DEBUG credito] Após salvar, DB tem ${total} lojistas com saldo>0:`, cj.lojistas);
-        if (total > 1) {
-          alert(`ATENÇÃO: Após salvar, ${total} lojistas estão com saldo. Esperado: 1. Abra o console pra ver detalhes.`);
-        }
-      } catch { /* ignore */ }
       await fetchSaldosLojistas();
-      await openCreditoModal(creditoModal.cliente); // refresh modal data
+      // Refresh modal com dados novos
+      const det = await fetch(`/api/admin/lojistas?id=${creditoModal.lojista_id}&_t=${Date.now()}`, { headers: apiHeaders(), cache: "no-store" });
+      const dj = await det.json();
+      setCreditoModal(m => m ? { ...m, saldo: Number(dj.lojista?.saldo_credito || 0), log: dj.log || [] } : null);
       setCreditoForm({ tipo: "CREDITO", valor: "", motivo: "" });
     } finally { setSavingCredito(false); }
   };
@@ -786,8 +795,14 @@ export default function ClientesPage() {
         <div className="flex justify-end">
           <button
             onClick={async () => {
-              if (!confirm("Zerar os saldos de crédito de TODOS os lojistas? Isso apaga o histórico e zera a tabela lojistas_credito. Não pode ser desfeito.")) return;
-              const res = await fetch(`/api/admin/lojistas-credito?all=1`, { method: "DELETE", headers: apiHeaders() });
+              if (!confirm("Zerar os saldos de crédito de TODOS os lojistas? Isso apaga todos os cadastros da tabela lojistas. Não pode ser desfeito.")) return;
+              // Busca lista, deleta cada um
+              const lj = await fetch(`/api/admin/lojistas`, { headers: apiHeaders() });
+              const ljJson = await lj.json();
+              for (const l of ljJson.lojistas || []) {
+                await fetch(`/api/admin/lojistas?id=${l.id}`, { method: "DELETE", headers: apiHeaders() });
+              }
+              const res = new Response(JSON.stringify({ ok: true }));
               const j = await res.json();
               if (!res.ok) { alert(j.error || "Erro"); return; }
               await fetchSaldosLojistas();
@@ -964,12 +979,8 @@ export default function ClientesPage() {
                   <button
                     onClick={async () => {
                       if (!creditoModal) return;
-                      if (!confirm(`Apagar o saldo de crédito de ${creditoModal.cliente.nome}? (R$ ${creditoModal.saldo.toLocaleString("pt-BR")})`)) return;
-                      const params = new URLSearchParams();
-                      if (creditoModal.cliente.cpf) params.set("cpf", creditoModal.cliente.cpf);
-                      if (creditoModal.cliente.cnpj) params.set("cnpj", creditoModal.cliente.cnpj);
-                      if (!creditoModal.cliente.cpf && !creditoModal.cliente.cnpj) params.set("nome", creditoModal.cliente.nome);
-                      const res = await fetch(`/api/admin/lojistas-credito?${params}`, { method: "DELETE", headers: apiHeaders() });
+                      if (!confirm(`Apagar o cadastro de lojista de ${creditoModal.cliente.nome}? (saldo R$ ${creditoModal.saldo.toLocaleString("pt-BR")})`)) return;
+                      const res = await fetch(`/api/admin/lojistas?id=${creditoModal.lojista_id}`, { method: "DELETE", headers: apiHeaders() });
                       const j = await res.json();
                       if (!res.ok) { alert(j.error || "Erro"); return; }
                       await fetchSaldosLojistas();

--- a/app/api/admin/lojistas/route.ts
+++ b/app/api/admin/lojistas/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { logActivity } from "@/lib/activity-log";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+const noCacheHeaders = { "Cache-Control": "no-store, no-cache, must-revalidate", "Pragma": "no-cache" };
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+function getUsuario(req: NextRequest) {
+  return decodeURIComponent(req.headers.get("x-admin-user") || "sistema");
+}
+
+// ── GET: lista todos os lojistas cadastrados ──
+export async function GET(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: noCacheHeaders });
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  if (id) {
+    const { data: lojista, error } = await supabase.from("lojistas").select("*").eq("id", id).maybeSingle();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCacheHeaders });
+    if (!lojista) return NextResponse.json({ lojista: null, log: [] }, { headers: noCacheHeaders });
+    const { data: log } = await supabase
+      .from("lojistas_movimentacoes")
+      .select("*")
+      .eq("lojista_id", id)
+      .order("created_at", { ascending: false })
+      .limit(100);
+    return NextResponse.json({ lojista, log: log || [] }, { headers: noCacheHeaders });
+  }
+  const { data, error } = await supabase.from("lojistas").select("*").order("nome");
+  if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCacheHeaders });
+  return NextResponse.json({ lojistas: data || [], _count: data?.length ?? 0 }, { headers: noCacheHeaders });
+}
+
+// ── POST: cria novo lojista OU movimenta saldo ──
+export async function POST(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: noCacheHeaders });
+  const usuario = getUsuario(req);
+  const body = await req.json();
+
+  // Movimentar saldo: requer lojista_id + tipo + valor
+  if (body.action === "mover_saldo") {
+    const { lojista_id, tipo, valor, motivo, venda_id } = body;
+    if (!lojista_id) return NextResponse.json({ error: "lojista_id obrigatório" }, { status: 400, headers: noCacheHeaders });
+    if (!["CREDITO", "DEBITO", "AJUSTE"].includes(tipo)) return NextResponse.json({ error: "tipo inválido" }, { status: 400, headers: noCacheHeaders });
+    const { data, error } = await supabase.rpc("mover_saldo_lojista", {
+      p_lojista_id: lojista_id,
+      p_tipo: tipo,
+      p_valor: Number(valor),
+      p_venda_id: venda_id || null,
+      p_motivo: motivo || null,
+      p_usuario: usuario,
+    });
+    if (error) return NextResponse.json({ error: error.message }, { status: 400, headers: noCacheHeaders });
+    await logActivity(usuario, `Saldo lojista (${tipo})`, `id=${lojista_id}: R$${valor}`, "clientes");
+    return NextResponse.json({ ok: true, ...(data as object) }, { headers: noCacheHeaders });
+  }
+
+  // Cadastrar novo lojista
+  const { nome, cpf, cnpj, observacao } = body;
+  if (!nome?.trim()) return NextResponse.json({ error: "nome obrigatório" }, { status: 400, headers: noCacheHeaders });
+  const { data, error } = await supabase
+    .from("lojistas")
+    .insert({ nome: nome.trim(), cpf: cpf || null, cnpj: cnpj || null, observacao: observacao || null, saldo_credito: 0 })
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCacheHeaders });
+  await logActivity(usuario, "Cadastrou lojista", nome.trim(), "clientes", data.id);
+  return NextResponse.json({ ok: true, lojista: data }, { headers: noCacheHeaders });
+}
+
+// ── PATCH: edita nome/cpf/cnpj ──
+export async function PATCH(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: noCacheHeaders });
+  const body = await req.json();
+  const { id, nome, cpf, cnpj, observacao } = body;
+  if (!id) return NextResponse.json({ error: "id obrigatório" }, { status: 400, headers: noCacheHeaders });
+  const upd: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (nome !== undefined) upd.nome = nome;
+  if (cpf !== undefined) upd.cpf = cpf || null;
+  if (cnpj !== undefined) upd.cnpj = cnpj || null;
+  if (observacao !== undefined) upd.observacao = observacao || null;
+  const { error } = await supabase.from("lojistas").update(upd).eq("id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCacheHeaders });
+  return NextResponse.json({ ok: true }, { headers: noCacheHeaders });
+}
+
+// ── DELETE: remove lojista (cascade no log) ──
+export async function DELETE(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: noCacheHeaders });
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  if (!id) return NextResponse.json({ error: "id obrigatório" }, { status: 400, headers: noCacheHeaders });
+  const { error } = await supabase.from("lojistas").delete().eq("id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCacheHeaders });
+  return NextResponse.json({ ok: true }, { headers: noCacheHeaders });
+}

--- a/supabase/migrations/20260408e_lojistas_table_uuid.sql
+++ b/supabase/migrations/20260408e_lojistas_table_uuid.sql
@@ -1,0 +1,104 @@
+-- Tabela persistente de lojistas com UUID auto — resolve o problema de
+-- identificacao ambígua por nome. Cada lojista é um cadastro único com id
+-- próprio, desvinculado do texto do nome em vendas.
+
+create table if not exists lojistas (
+  id uuid primary key default gen_random_uuid(),
+  nome text not null,
+  cpf text,
+  cnpj text,
+  saldo_credito numeric not null default 0,
+  observacao text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists idx_lojistas_nome on lojistas(upper(nome));
+create index if not exists idx_lojistas_cnpj on lojistas(cnpj);
+create index if not exists idx_lojistas_cpf on lojistas(cpf);
+
+-- Log de movimentacoes (mesmo padrao do lojistas_credito_log mas referencia lojistas)
+create table if not exists lojistas_movimentacoes (
+  id uuid primary key default gen_random_uuid(),
+  lojista_id uuid not null references lojistas(id) on delete cascade,
+  venda_id uuid,
+  tipo text not null check (tipo in ('CREDITO','DEBITO','AJUSTE')),
+  valor numeric not null,
+  saldo_antes numeric not null,
+  saldo_depois numeric not null,
+  motivo text,
+  usuario text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_lojistas_mov_lojista on lojistas_movimentacoes(lojista_id, created_at desc);
+
+grant all on lojistas to service_role, authenticated, anon;
+grant all on lojistas_movimentacoes to service_role, authenticated, anon;
+alter table lojistas enable row level security;
+alter table lojistas_movimentacoes enable row level security;
+drop policy if exists "service_role_all" on lojistas;
+drop policy if exists "service_role_all" on lojistas_movimentacoes;
+create policy "service_role_all" on lojistas for all to service_role using (true) with check (true);
+create policy "service_role_all" on lojistas_movimentacoes for all to service_role using (true) with check (true);
+
+-- Function atomica pra movimentar saldo por UUID — elimina qualquer chance
+-- de afetar linhas erradas (SELECT FOR UPDATE + WHERE id = uuid).
+create or replace function mover_saldo_lojista(
+  p_lojista_id uuid,
+  p_tipo text,
+  p_valor numeric,
+  p_venda_id uuid,
+  p_motivo text,
+  p_usuario text
+) returns jsonb
+language plpgsql
+as $$
+declare
+  v_saldo_antes numeric := 0;
+  v_saldo_depois numeric := 0;
+begin
+  if p_valor is null or p_valor <= 0 then
+    raise exception 'valor deve ser > 0';
+  end if;
+  if p_tipo not in ('CREDITO', 'DEBITO', 'AJUSTE') then
+    raise exception 'tipo invalido: %', p_tipo;
+  end if;
+
+  select coalesce(saldo_credito, 0) into v_saldo_antes
+  from lojistas
+  where id = p_lojista_id
+  for update;
+
+  if not found then
+    raise exception 'lojista nao encontrado: %', p_lojista_id;
+  end if;
+
+  if p_tipo = 'CREDITO' then
+    v_saldo_depois := v_saldo_antes + p_valor;
+  elsif p_tipo = 'DEBITO' then
+    v_saldo_depois := v_saldo_antes - p_valor;
+    if v_saldo_depois < 0 then
+      raise exception 'Saldo insuficiente. Disponivel: %, tentativa: %', v_saldo_antes, p_valor;
+    end if;
+  else
+    v_saldo_depois := p_valor;
+  end if;
+
+  update lojistas
+  set saldo_credito = v_saldo_depois, updated_at = now()
+  where id = p_lojista_id;
+
+  insert into lojistas_movimentacoes (lojista_id, venda_id, tipo, valor, saldo_antes, saldo_depois, motivo, usuario)
+  values (p_lojista_id, p_venda_id, p_tipo, p_valor, v_saldo_antes, v_saldo_depois, p_motivo, p_usuario);
+
+  return jsonb_build_object(
+    'lojista_id', p_lojista_id,
+    'saldo_antes', v_saldo_antes,
+    'saldo_depois', v_saldo_depois
+  );
+end;
+$$;
+
+grant execute on function mover_saldo_lojista(uuid, text, numeric, uuid, text, text)
+  to service_role, authenticated, anon;


### PR DESCRIPTION
…dmin/lojistas

Elimina totalmente a identificacao ambigua por nome/cliente_key.

Backend:
- migration 20260408e: cria tabelas lojistas + lojistas_movimentacoes
- function SQL mover_saldo_lojista(uuid, tipo, valor) atomica
- nova API /api/admin/lojistas (GET list, GET id, POST novo, POST mover_saldo, PATCH, DELETE)

Frontend (clientes/page.tsx):
- fetchSaldosLojistas agora le da tabela lojistas (indexa por nome upper)
- openCreditoModal auto-cria cadastro na tabela lojistas quando clica pela 1a vez (matching por nome normalizado)
- salvarCredito usa UUID do lojista (nao depende mais de nome)
- "Apagar saldo" e bulk reset tambem usam a nova API

Agora cada lojista tem UUID proprio na DB — impossivel propagar saldo entre lojistas distintos.