### PR TITLE
feat(estoque): botão Imprimir Todas Etiquetas na toolbar

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -2747,6 +2747,30 @@ export default function EstoquePage() {
               {selectMode ? "Cancelar" : "Selecionar"}
             </button>
           )}
+          {isAdmin && (tab === "estoque" || tab === "seminovos") && !selectMode && (
+            <button
+              onClick={() => {
+                // Filtra itens visíveis (da aba atual) que têm serial ou IMEI
+                const itensVisiveis = tab === "estoque"
+                  ? estoque.filter(p => !isReservado(p) && p.tipo === "NOVO" && p.status === "EM ESTOQUE" && p.qnt > 0)
+                  : estoque.filter(p => !isReservado(p) && (p.tipo === "SEMINOVO" || p.tipo === "NAO_ATIVADO") && p.status !== "ESGOTADO");
+                const comSerial = itensVisiveis.filter(p => p.serial_no || p.imei);
+                const semSerial = itensVisiveis.length - comSerial.length;
+                if (comSerial.length === 0) {
+                  setMsg("⚠️ Nenhum produto nessa aba tem serial/IMEI cadastrado. Cadastre primeiro antes de imprimir.");
+                  return;
+                }
+                if (semSerial > 0) {
+                  if (!confirm(`${comSerial.length} produto(s) com serial/IMEI serão impressos.\n\n⚠️ ${semSerial} produto(s) SEM serial/IMEI serão ignorados (precisa cadastrar o serial primeiro).\n\nContinuar?`)) return;
+                }
+                handlePrintEtiquetaDirect(comSerial);
+                setMsg(`🏷️ ${comSerial.length} etiqueta(s) enviada(s) pra impressão!${semSerial > 0 ? ` (${semSerial} ignorados por falta de serial)` : ""}`);
+              }}
+              className={`px-4 py-2 rounded-xl text-[12px] font-semibold transition-all ${bgCard} border ${borderCard} text-[#E8740E] hover:bg-[#E8740E] hover:text-white hover:border-[#E8740E]`}
+            >
+              🏷️ Imprimir Todas Etiquetas
+            </button>
+          )}
           {isAdmin && tab === "seminovos" && !selectMode && (
             <button
               onClick={() => { setBalanceMode(!balanceMode); if (balanceMode) setBalanceSelected(new Set()); }}


### PR DESCRIPTION
## Resumo

Botão **"🏷️ Imprimir Todas Etiquetas"** direto na toolbar das abas **Estoque** e **Seminovos** — sem precisar entrar em modo seleção.

### O problema
Produtos antigos (em estoque há 1-3 meses) não tinham etiqueta QR porque a funcionalidade foi implementada recentemente. Pra etiquetar o estoque inteiro, antes precisava selecionar um por um.

### A solução
Um clique e imprime tudo:

1. Clica no botão
2. Sistema **filtra automaticamente** só quem tem serial/IMEI cadastrado
3. Se existem itens **sem serial**, mostra aviso: *"X serão impressos, Y ignorados por falta de serial. Continuar?"*
4. Gera todas as etiquetas de uma vez
5. Mostra feedback: *"🏷️ 42 etiqueta(s) enviada(s) pra impressão! (3 ignorados por falta de serial)"*

### Fluxo prático sugerido pra etiquetagem do estoque inteiro

1. **Laynne pega cada caixa** da prateleira
2. Confere se tem serial/IMEI no sistema (escaneia ou busca)
3. Se **não tem**, cadastra na hora (editar item → serial)
4. Quando todos estiverem cadastrados, clica **"Imprimir Todas Etiquetas"**
5. Em 2-3 horas resolve o estoque inteiro

## Test plan
- [ ] Abrir Estoque → ver botão "🏷️ Imprimir Todas Etiquetas" na toolbar
- [ ] Clicar → se todos têm serial, imprime direto
- [ ] Se alguns não têm serial → mostra aviso com contagem antes de imprimir
- [ ] Se nenhum tem serial → mostra mensagem "cadastre primeiro"
- [ ] Conferir que etiqueta NÃO mostra preço (PR #182 anterior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)