### PR TITLE
fix(gerar-link): soma preços múltiplos produtos + desconto no link

### DIFF
--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -10,6 +10,8 @@ export default function GerarLinkPage() {
 
   const [produtos, setProdutos] = useState<string[]>([""]);
   const [preco, setPreco] = useState("");
+  // Preços individuais por produto (idx → preco numérico), pra somar quando tem 2+ produtos
+  const [precosPorProduto, setPrecosPorProduto] = useState<Record<number, number>>({});
   const [produtoManual, setProdutoManual] = useState(false);
   const [catSel, setCatSel] = useState("");
   const [pickerIdx, setPickerIdx] = useState<number | null>(null);
@@ -1310,10 +1312,18 @@ export default function GerarLinkPage() {
                         const sel = produtos[pickerIdx!] === m.nome;
                         return (
                           <button key={m.nome} onClick={() => {
+                            const idx = pickerIdx!;
                             const np = [...produtos];
-                            np[pickerIdx!] = sel ? "" : m.nome;
+                            np[idx] = sel ? "" : m.nome;
                             setProdutos(np);
-                            if (pickerIdx === 0) { setPreco(sel ? "" : (m.preco > 0 ? m.preco.toLocaleString("pt-BR") : "")); setCorSel(""); }
+                            // Guarda preço individual desse produto e recalcula soma
+                            const novosPrecos = { ...precosPorProduto };
+                            if (sel) { delete novosPrecos[idx]; } else { novosPrecos[idx] = m.preco || 0; }
+                            setPrecosPorProduto(novosPrecos);
+                            // Soma de todos os produtos selecionados
+                            const soma = Object.values(novosPrecos).reduce((s, v) => s + v, 0);
+                            setPreco(soma > 0 ? soma.toLocaleString("pt-BR") : "");
+                            if (idx === 0) setCorSel("");
                             if (!sel) { setPickerIdx(null); setCatSel(""); }
                           }} className={`w-full px-4 py-3 flex items-center justify-between text-left transition-all ${sel ? (dm ? "bg-[#E8740E]/20 border-l-4 border-[#E8740E]" : "bg-[#FFF5EB] border-l-4 border-[#E8740E]") : (dm ? "hover:bg-[#2C2C2E]" : "hover:bg-[#F9F9FB]")}`}>
                             <p className={`text-sm font-semibold ${sel ? "text-[#E8740E]" : (dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]")}`}>{m.nome}</p>
@@ -1329,7 +1339,7 @@ export default function GerarLinkPage() {
           </>
         ) : (
           <div className="space-y-3">
-            <select value={catSel} onChange={(e) => { setCatSel(e.target.value); setProdutos([""]); setPreco(""); setCorSel(""); }} className={inputCls}>
+            <select value={catSel} onChange={(e) => { setCatSel(e.target.value); setProdutos([""]); setPreco(""); setCorSel(""); setPrecosPorProduto({}); }} className={inputCls}>
               <option value="">-- Categoria --</option>
               {categoriaPrecos.map(c => <option key={c} value={c}>{CAT_LABELS[c] || c}</option>)}
               <option value="SEMINOVOS">📱 Seminovos (em estoque)</option>
@@ -1346,7 +1356,7 @@ export default function GerarLinkPage() {
                     return (
                       <div key={m.nome}>
                         <button onClick={() => {
-                          if (sel) { setProdutos([""]); setPreco(""); setCorSel(""); return; }
+                          if (sel) { setProdutos([""]); setPreco(""); setCorSel(""); setPrecosPorProduto({}); return; }
                           setProdutos([m.nome]);
                           setPreco(m.preco > 0 ? m.preco.toLocaleString("pt-BR") : "");
                           setCorSel("");

--- a/app/c/[d]/page.tsx
+++ b/app/c/[d]/page.tsx
@@ -7,7 +7,7 @@ import { Metadata } from "next";
 const KEY_MAP: Record<string, string> = {
   p: "produto", v: "preco", w: "whatsapp", f: "forma",
   x: "parcelas", e: "entrada_pix", l: "local", s: "vendedor",
-  sh: "shopping", h: "horario", dt: "data_entrega",
+  sh: "shopping", h: "horario", dt: "data_entrega", dc: "desconto",
   tp: "troca_produto", tv: "troca_valor", tc: "troca_cor",
   tp2: "troca_produto2", tv2: "troca_valor2", tc2: "troca_cor2",
   p2: "produto2", p3: "produto3", p4: "produto4", p5: "produto5",

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -80,6 +80,7 @@ function CompraForm() {
   const trocaCor2Param = searchParams.get("troca_cor2") || "";
   const trocaCaixaParam = searchParams.get("troca_caixa") || "";
   const trocaCaixa2Param = searchParams.get("troca_caixa2") || "";
+  const descontoParam = searchParams.get("desconto") || "";
   const nomeParam = searchParams.get("nome") || "";
   const cpfParam = searchParams.get("cpf") || "";
   const emailParam = searchParams.get("email") || "";
@@ -309,7 +310,8 @@ function CompraForm() {
   const [entradaPixManual, setEntradaPixManual] = useState(entradaPixParam || "");
 
   // Installment calculations
-  const valorBase = preco > 0 ? (trocaNum > 0 ? preco - trocaNum : preco) : 0;
+  const descontoNum = parseFloat(descontoParam) || 0;
+  const valorBase = preco > 0 ? Math.max(preco - descontoNum - trocaNum, 0) : 0;
   const entradaPixNum = parseFloat(entradaPixManual || entradaPixParam) || 0;
   const valorParcelar = entradaPixNum > 0 ? Math.max(valorBase - entradaPixNum, 0) : valorBase;
   const parcOpts = useMemo(() => {
@@ -352,7 +354,8 @@ function CompraForm() {
       : "Entrega - Residencia";
 
     // Valor base para cálculos (usa precoFinal definido acima)
-    const valorBaseFinal = trocaNum > 0 ? Math.max(precoFinal - trocaNum, 0) : precoFinal;
+    const descontoFinal = parseFloat(descontoParam) || 0;
+    const valorBaseFinal = Math.max(precoFinal - descontoFinal - trocaNum, 0);
     const entradaFinal = entradaPixNum || parseFloat(entradaPixParam) || 0;
     const valorParcelarFinal = entradaFinal > 0 ? Math.max(valorBaseFinal - entradaFinal, 0) : valorBaseFinal;
 


### PR DESCRIPTION
## Resumo

Dois bugs encontrados pelo André ao gerar link de compra com 2x Mac Mini M4 Pro:

### Bug 1: Preço Base não somava produto 2
**Antes:** Selecionava 2 produtos iguais (R$ 12.497 cada), Preço Base ficava R$ 12.497 (só o primeiro).
**Agora:** Mantém `precosPorProduto` (Record de idx → preco) e soma todos. Preço Base = R$ 24.994.

### Bug 2: Desconto não aparecia no link do cliente
**Antes:** André aplicava desconto de R$ 800, mas o cliente via R$ 24.994 (sem desconto).
**Agora:**
- `dc` → `desconto` adicionado ao KEY_MAP do shortlink decoder
- Página `/compra` lê `?desconto=X` e aplica: `valorBase = preco - desconto - troca`
- Cliente vê R$ 24.194 (com desconto aplicado)

## Arquivos alterados
- `app/admin/gerar-link/page.tsx` — novo state `precosPorProduto`, soma ao selecionar
- `app/c/[d]/page.tsx` — `dc` → `desconto` no KEY_MAP
- `app/compra/page.tsx` — lê `descontoParam` e aplica em `valorBase` e `valorBaseFinal`

## Test plan
- [ ] Gerar link com 2 produtos iguais → Preço Base deve ser a SOMA dos dois
- [ ] Aplicar desconto R$ 800 → Preço Base final = soma - 800
- [ ] Abrir o link como cliente → valor mostrado deve ter desconto aplicado
- [ ] Testar com PIX (valor à vista com desconto)
- [ ] Testar com cartão parcelado (parcelas calculadas sobre valor com desconto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)