### PR TITLE
feat(estoque): editar origem da compra no modal de detalhes

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -6405,6 +6405,38 @@ export default function EstoquePage() {
                       </button>
                     ) : <p className={`text-[13px] ${mP} mt-0.5`}>Não informado</p>}
                   </div>
+                  {/* Origem da compra */}
+                  <div>
+                    <p className={`text-[10px] uppercase tracking-wider ${mS}`}>Origem da Compra</p>
+                    {isAdmin ? (
+                      <select
+                        value={p.origem_compra || ""}
+                        onChange={async (e) => {
+                          const val = e.target.value || null;
+                          try {
+                            await apiPatch(p.id, { origem_compra: val });
+                            setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, origem_compra: val } : x));
+                            setDetailProduct({ ...p, origem_compra: val });
+                            showSaved("origem_compra");
+                          } catch (err) { setMsg("❌ " + String(err instanceof Error ? err.message : err)); }
+                        }}
+                        className={`mt-0.5 text-[12px] font-semibold w-full px-2 py-1.5 rounded-lg border ${dm ? "bg-[#1C1C1E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"} focus:border-[#E8740E] focus:outline-none`}
+                      >
+                        <option value="">— Não definido —</option>
+                        <option value="RJ">🏙️ Rio de Janeiro</option>
+                        <option value="SAO_PAULO">🚚 São Paulo</option>
+                        <option value="PARAGUAI">🇵🇾 Paraguai</option>
+                        <option value="EUA">🇺🇸 Estados Unidos</option>
+                      </select>
+                    ) : (
+                      <p className={`text-[13px] ${mP} mt-0.5`}>
+                        {p.origem_compra === "RJ" ? "🏙️ Rio de Janeiro" :
+                         p.origem_compra === "SAO_PAULO" ? "🚚 São Paulo" :
+                         p.origem_compra === "PARAGUAI" ? "🇵🇾 Paraguai" :
+                         p.origem_compra === "EUA" ? "🇺🇸 Estados Unidos" : "—"}
+                      </p>
+                    )}
+                  </div>
                 </div>
                 {(p.tipo === "PENDENCIA" || p.status === "PENDENTE") && (
                   <div className="mt-3">


### PR DESCRIPTION
## Resumo

Permite editar a **Origem da Compra** de qualquer produto direto no modal de detalhes (1 clique).

### O que foi adicionado

No modal que abre ao clicar num produto (qualquer aba — Estoque, A Caminho, Seminovos, etc), agora aparece abaixo de **Fornecedor**:

```
FORNECEDOR
MEGA
[Ver perfil]

ORIGEM DA COMPRA
[🇺🇸 Estados Unidos ▼]    ← select editável (admin)
```

Ao mudar:
- Salva na hora via apiPatch
- Mostra feedback ✓ (igual serial/IMEI/cor)
- O resumo por origem na aba A Caminho atualiza automaticamente

### Pra que serve

Os produtos que já estão A Caminho foram cadastrados **antes** da feature de origem (PR #191). Com esse modal editável, você clica em cada um e define a origem sem precisar recadastrar.

## Test plan
- [ ] Abrir produto na aba A Caminho → ver campo "Origem da Compra" com select
- [ ] Mudar pra "🇺🇸 Estados Unidos" → salva na hora
- [ ] Fechar e reabrir → valor persistiu
- [ ] Resumo no topo da aba A Caminho atualiza com a nova contagem

🤖 Generated with [Claude Code](https://claude.com/claude-code)