### PR TITLE
fix: 2º aparelho troca no link + cores Apple Watch

### DIFF
--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -204,6 +204,8 @@ export default function GerarLinkPage() {
   const [temSegundaTroca, setTemSegundaTroca] = useState(false);
   const [trocaCondicao, setTrocaCondicao] = useState("");
   const [trocaCor, setTrocaCor] = useState("");
+  const [trocaCondicao2, setTrocaCondicao2] = useState("");
+  const [trocaCor2, setTrocaCor2] = useState("");
   const [trocaProduto2, setTrocaProduto2] = useState("");
   const [trocaValor2, setTrocaValor2] = useState("");
   const [generatedLink, setGeneratedLink] = useState("");
@@ -510,6 +512,8 @@ export default function GerarLinkPage() {
           troca_cor: trocaCor || null,
           troca_produto2: temSegundaTroca ? (trocaProduto2 || null) : null,
           troca_valor2: temSegundaTroca ? (Number(trocaValor2.replace(/\./g, "").replace(",", ".")) || 0) : 0,
+          troca_condicao2: temSegundaTroca ? trocaCondicao2 || null : null,
+          troca_cor2: temSegundaTroca ? trocaCor2 || null : null,
           vendedor: vendedorNome || null,
           cliente_nome: cliNome.trim() || null,
           cliente_telefone: cliTelefone.trim() || null,
@@ -616,6 +620,10 @@ export default function GerarLinkPage() {
       const n = Math.round(parseFloat(trocaVal2Qp));
       if (!isNaN(n) && n > 0) setTrocaValor2(n.toLocaleString("pt-BR"));
     }
+    const trocaCond2Qp = qp.get("troca_condicao2");
+    if (trocaCond2Qp) setTrocaCondicao2(trocaCond2Qp);
+    const trocaCor2Qp = qp.get("troca_cor2");
+    if (trocaCor2Qp) setTrocaCor2(trocaCor2Qp);
     // Modo manual quando vem de simulação
     if (qp.get("produto")) setProdutoManual(true);
   }, []);
@@ -771,6 +779,8 @@ export default function GerarLinkPage() {
     if (temSegundaTroca && trocaProduto2) shortData.tp2 = trocaProduto2;
     const rawTroca2Data = trocaValor2.replace(/\./g, "").replace(",", ".");
     if (temSegundaTroca && rawTroca2Data && rawTroca2Data !== "0") shortData.tv2 = rawTroca2Data;
+    if (temSegundaTroca && trocaCondicao2) shortData.tcd2 = trocaCondicao2;
+    if (temSegundaTroca && trocaCor2) shortData.tc2 = trocaCor2;
     if (pagamentoPago) shortData.pp = pagamentoPago;
 
     // Dados do cliente pré-preenchidos (quando o vendedor incluir)
@@ -826,6 +836,8 @@ export default function GerarLinkPage() {
               troca_cor: trocaCor || null,
               troca_produto2: temSegundaTroca ? trocaProduto2 || null : null,
               troca_valor2: temSegundaTroca ? Number(trocaValor2.replace(/\./g, "").replace(",", ".")) || 0 : 0,
+              troca_condicao2: temSegundaTroca ? trocaCondicao2 || null : null,
+              troca_cor2: temSegundaTroca ? trocaCor2 || null : null,
               vendedor: vendedorNome || null,
               simulacao_id: simulacaoId,
             }),

--- a/app/api/catalogo-cores/route.ts
+++ b/app/api/catalogo-cores/route.ts
@@ -26,7 +26,7 @@ export async function GET(req: NextRequest) {
       .from("catalogo_modelo_configs")
       .select("modelo_id, tipo_chave, valor")
       .in("modelo_id", modeloIds)
-      .eq("tipo_chave", "cores");
+      .in("tipo_chave", ["cores", "cores_aw"]);
     if (e2) return NextResponse.json({ modelos: {} });
 
     const idToNome: Record<string, string> = {};

--- a/app/c/[d]/page.tsx
+++ b/app/c/[d]/page.tsx
@@ -9,7 +9,7 @@ const KEY_MAP: Record<string, string> = {
   x: "parcelas", e: "entrada_pix", l: "local", s: "vendedor",
   sh: "shopping", h: "horario", dt: "data_entrega", dc: "desconto",
   tp: "troca_produto", tv: "troca_valor", tc: "troca_cor", tcd: "troca_cond",
-  tp2: "troca_produto2", tv2: "troca_valor2", tc2: "troca_cor2",
+  tp2: "troca_produto2", tv2: "troca_valor2", tc2: "troca_cor2", tcd2: "troca_cond2",
   p2: "produto2", p3: "produto3", p4: "produto4", p5: "produto5",
   pp: "pagamento_pago",
   short: "short",


### PR DESCRIPTION
## Summary
- 2º aparelho na troca agora salva condição e cor corretamente no link e no banco
- Apple Watch agora mostra cores no gerar-link (antes buscava só `cores`, agora busca `cores` + `cores_aw`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)