### PR TITLE
fix(usados): garantia removida dos descontos gerais

### DIFF
--- a/app/admin/usados/page.tsx
+++ b/app/admin/usados/page.tsx
@@ -354,6 +354,9 @@ export function UsadosContent() {
       if (!descByModel[modeloOriginal][cond]) descByModel[modeloOriginal][cond] = [];
       descByModel[modeloOriginal][cond].push(d);
     } else {
+      // Garantia é sempre por modelo, não aparece em gerais
+      const condLow = d.condicao.toLowerCase();
+      if (condLow === "garantia apple" || condLow === "garantia") return;
       if (!descGerais[d.condicao]) descGerais[d.condicao] = [];
       descGerais[d.condicao].push(d);
     }


### PR DESCRIPTION
Garantia é individual por modelo, não global. Removida da seção Descontos Gerais.