### PR TITLE
fix(usados): remove Bateria dos Descontos Gerais

### DIFF
--- a/app/admin/usados/page.tsx
+++ b/app/admin/usados/page.tsx
@@ -354,9 +354,9 @@ export function UsadosContent() {
       if (!descByModel[modeloOriginal][cond]) descByModel[modeloOriginal][cond] = [];
       descByModel[modeloOriginal][cond].push(d);
     } else {
-      // Garantia é sempre por modelo, não aparece em gerais
+      // Bateria e Garantia são sempre por modelo, não aparecem em gerais
       const condLow = d.condicao.toLowerCase();
-      if (condLow === "garantia apple" || condLow === "garantia") return;
+      if (condLow === "garantia apple" || condLow === "garantia" || condLow === "bateria") return;
       if (!descGerais[d.condicao]) descGerais[d.condicao] = [];
       descGerais[d.condicao].push(d);
     }


### PR DESCRIPTION
Bateria é sempre por modelo, assim como Garantia. Descontos Gerais agora só tem: Descascado/Amassado, Riscos Laterais, Riscos na Tela.