### PR TITLE
feat(encomendas): finalizar encomenda cria venda + nome em caixa alta

### DIFF
--- a/app/admin/encomendas/page.tsx
+++ b/app/admin/encomendas/page.tsx
@@ -419,6 +419,94 @@ export default function EncomendasPage() {
   // ─── Status change ─────────────────────────────────────────────────────────
 
   const handleStatusChange = async (enc: Encomenda, newStatus: string) => {
+    // ── Finalizar: cria venda automaticamente ──
+    if (newStatus === "FINALIZADO") {
+      if (!confirm(`Finalizar encomenda de ${enc.cliente} como venda?`)) return;
+
+      try {
+        const vendaPayload: Record<string, unknown> = {
+          data: enc.data,
+          cliente: enc.cliente,
+          cpf: enc.cpf || null,
+          email: enc.email || null,
+          produto: enc.produto,
+          fornecedor: enc.fornecedor || null,
+          custo: enc.custo || 0,
+          preco_vendido: enc.valor_venda || 0,
+          origem: "ENCOMENDA",
+          tipo: "VENDA",
+          recebimento: "D+0",
+          forma: enc.forma_pagamento || null,
+          banco: enc.banco_sinal || null,
+          sinal_antecipado: enc.sinal_recebido || 0,
+          banco_sinal: enc.banco_sinal || null,
+          notas: enc.obs_financeira || null,
+          _estoque_id: enc.estoque_id || null,
+          // Troca 1
+          produto_na_troca: enc.troca_valor || 0,
+          troca_produto: enc.troca_produto || null,
+          troca_cor: enc.troca_cor || null,
+          troca_categoria: enc.troca_categoria || null,
+          troca_bateria: enc.troca_bateria || null,
+          troca_grade: enc.troca_grade || null,
+          troca_caixa: enc.troca_caixa || null,
+          troca_cabo: enc.troca_cabo || null,
+          troca_fonte: enc.troca_fonte || null,
+          troca_obs: enc.troca_obs || null,
+          troca_serial: enc.troca_serial || null,
+          troca_imei: enc.troca_imei || null,
+          troca_garantia: enc.troca_garantia || null,
+          // Troca 2
+          produto_na_troca2: enc.troca_valor2 || 0,
+          troca_produto2: enc.troca_produto2 || null,
+          troca_cor2: enc.troca_cor2 || null,
+          troca_categoria2: enc.troca_categoria2 || null,
+          troca_bateria2: enc.troca_bateria2 || null,
+          troca_grade2: enc.troca_grade2 || null,
+          troca_caixa2: enc.troca_caixa2 || null,
+          troca_cabo2: enc.troca_cabo2 || null,
+          troca_fonte2: enc.troca_fonte2 || null,
+          troca_obs2: enc.troca_obs2 || null,
+          troca_serial2: enc.troca_serial2 || null,
+          troca_imei2: enc.troca_imei2 || null,
+          troca_garantia2: enc.troca_garantia2 || null,
+        };
+
+        const res = await fetch("/api/vendas", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", ...hdrs() },
+          body: JSON.stringify(vendaPayload),
+        });
+        const json = await res.json();
+
+        if (!res.ok) {
+          setMsg(`Erro ao criar venda: ${json.error}`);
+          return;
+        }
+
+        const vendaId = json.data?.id;
+
+        // Atualizar encomenda com status FINALIZADO e venda_id
+        await fetch("/api/encomendas", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json", ...hdrs() },
+          body: JSON.stringify({ id: enc.id, status: "FINALIZADO", venda_id: vendaId }),
+        });
+
+        setEncomendas((prev) =>
+          prev.map((e) =>
+            e.id === enc.id ? { ...e, status: "FINALIZADO", venda_id: vendaId } : e
+          )
+        );
+        setMsg("Encomenda finalizada! Venda registrada.");
+        return;
+      } catch (err) {
+        setMsg(`Erro ao finalizar: ${err}`);
+        return;
+      }
+    }
+
+    // ── Outros status: apenas atualiza ──
     await fetch("/api/encomendas", {
       method: "PATCH",
       headers: { "Content-Type": "application/json", ...hdrs() },
@@ -643,7 +731,7 @@ export default function EncomendasPage() {
                 <p className={labelCls}>Cliente *</p>
                 <input
                   value={form.cliente}
-                  onChange={(e) => set("cliente", e.target.value)}
+                  onChange={(e) => set("cliente", e.target.value.toUpperCase())}
                   className={inputCls}
                   placeholder="Nome do cliente"
                 />

--- a/app/api/encomendas/route.ts
+++ b/app/api/encomendas/route.ts
@@ -16,6 +16,7 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const body = await req.json();
+  if (body.cliente) body.cliente = String(body.cliente).toUpperCase();
   const { data, error } = await supabase.from("encomendas").insert({ ...body, updated_at: new Date().toISOString() }).select().single();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
@@ -29,6 +30,7 @@ export async function PATCH(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { id, ...fields } = await req.json();
   if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });
+  if (fields.cliente) fields.cliente = String(fields.cliente).toUpperCase();
   const { error } = await supabase.from("encomendas").update({ ...fields, updated_at: new Date().toISOString() }).eq("id", id);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -2,7 +2,7 @@
 // Tipos do sistema administrativo TigrãoImports
 // ============================================
 
-export type Origem = "ANUNCIO" | "RECOMPRA" | "INDICACAO" | "ATACADO" | "NAO_INFORMARAM";
+export type Origem = "ANUNCIO" | "RECOMPRA" | "INDICACAO" | "ATACADO" | "NAO_INFORMARAM" | "ENCOMENDA";
 export type TipoVenda = "VENDA" | "UPGRADE" | "ATACADO";
 export type Banco = "ITAU" | "INFINITE" | "MERCADO_PAGO" | "ESPECIE";
 export type FormaPagamento = "PIX" | "CARTAO" | "DEBITO" | "ESPECIE" | "DINHEIRO" | "FIADO";

--- a/supabase/migrations/20260409k_vendas_origem_encomenda.sql
+++ b/supabase/migrations/20260409k_vendas_origem_encomenda.sql
@@ -1,0 +1,14 @@
+-- Adiciona 'ENCOMENDA' e 'NAO_INFORMARAM' ao constraint de origem das vendas
+ALTER TABLE vendas DROP CONSTRAINT IF EXISTS vendas_origem_check;
+ALTER TABLE vendas ADD CONSTRAINT vendas_origem_check
+  CHECK (origem IN ('ANUNCIO','RECOMPRA','INDICACAO','ATACADO','NAO_INFORMARAM','ENCOMENDA'));
+
+-- Endereco do cliente na encomenda
+ALTER TABLE encomendas ADD COLUMN IF NOT EXISTS cep TEXT;
+ALTER TABLE encomendas ADD COLUMN IF NOT EXISTS endereco TEXT;
+ALTER TABLE encomendas ADD COLUMN IF NOT EXISTS bairro TEXT;
+ALTER TABLE encomendas ADD COLUMN IF NOT EXISTS numero TEXT;
+ALTER TABLE encomendas ADD COLUMN IF NOT EXISTS complemento TEXT;
+
+-- Converte nomes de clientes existentes em encomendas para CAIXA ALTA
+UPDATE encomendas SET cliente = UPPER(cliente) WHERE cliente IS NOT NULL AND cliente <> UPPER(cliente);


### PR DESCRIPTION
## Summary
- Ao marcar encomenda como **FINALIZADO**, cria venda automaticamente com `origem: ENCOMENDA`
- Se houver troca, pendência é criada automaticamente pela API de vendas
- Nome do cliente em **CAIXA ALTA** no formulário e API de encomendas
- Migration corrige constraint `vendas_origem_check` (adiciona `NAO_INFORMARAM` + `ENCOMENDA`)
- Migration converte nomes existentes para caixa alta

## Test plan
- [ ] Rodar migration `20260409k_vendas_origem_encomenda.sql` em `/admin/migrations`
- [ ] Criar nova encomenda e verificar que nome fica em caixa alta
- [ ] Mudar status de encomenda para FINALIZADO e verificar que venda aparece em Vendas
- [ ] Verificar que encomenda com troca cria pendência no estoque

🤖 Generated with [Claude Code](https://claude.com/claude-code)