### PR TITLE
fix(entregas): incluir todos produtos ao encaminhar link multi-produto

### DIFF
--- a/app/api/admin/link-compras/encaminhar-entrega/route.ts
+++ b/app/api/admin/link-compras/encaminhar-entrega/route.ts
@@ -45,7 +45,17 @@ export async function POST(request: Request) {
 
   if (!cliente) return NextResponse.json({ error: "Nome do cliente ausente — cliente ainda não preencheu?" }, { status: 400 });
 
-  const produtoTxt = link.cor ? `${link.produto}` : link.produto;
+  // Combinar produto principal + extras (multi-produto)
+  const prods = [link.produto];
+  if (link.produtos_extras) {
+    try {
+      const extras = typeof link.produtos_extras === "string"
+        ? JSON.parse(link.produtos_extras)
+        : link.produtos_extras;
+      if (Array.isArray(extras)) prods.push(...extras);
+    } catch { /* ignore */ }
+  }
+  const produtoTxt = prods.join(" + ");
 
   const { data: entrega, error: e2 } = await supabase
     .from("entregas")


### PR DESCRIPTION
Quando link de compra tinha produtos_extras (2+ produtos), a entrega só mostrava o primeiro. Agora combina todos com " + " no campo produto.