### PR TITLE
hotfix: corrigir crash do admin (React hooks order)

### DIFF
--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -200,6 +200,14 @@ export default function AdminShell({ children }: { children: ReactNode }) {
   // Hooks devem ser chamados ANTES de qualquer return condicional
   const { isOnline } = useOnlineStatus();
 
+  const apiHeadersFn = useCallback((extra?: Record<string, string>) => ({
+    "x-admin-password": password,
+    "x-admin-user": encodeURIComponent(user?.nome || "sistema"),
+    "x-admin-role": user?.role || "admin",
+    "x-admin-permissoes": JSON.stringify(user?.permissoes ?? []),
+    ...extra,
+  }), [password, user?.nome, user?.role, user?.permissoes]);
+
   if (!ready) return null;
 
   // Login screen
@@ -257,14 +265,6 @@ export default function AdminShell({ children }: { children: ReactNode }) {
     "--admin-input-bg": "#1A1A1A",
     "--admin-accent": "#E8740E",
   } as React.CSSProperties : {};
-
-  const apiHeadersFn = useCallback((extra?: Record<string, string>) => ({
-    "x-admin-password": password,
-    "x-admin-user": encodeURIComponent(user?.nome || "sistema"),
-    "x-admin-role": user?.role || "admin",
-    "x-admin-permissoes": JSON.stringify(user?.permissoes ?? []),
-    ...extra,
-  }), [password, user?.nome, user?.role, user?.permissoes]);
 
   return (
     <AdminContext.Provider value={{


### PR DESCRIPTION
## HOTFIX - Site fora do ar

O `useCallback` do `apiHeadersFn` estava posicionado DEPOIS do `return` condicional do login screen. Isso causava React error #310 (hooks mudam entre renders) — quando o usuário não está logado, o hook não era executado, mas ao logar, passava a ser.

**Fix:** Mover o `useCallback` para antes de qualquer `return` condicional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)