### PR TITLE
hotfix: páginas carregando infinito (fetch inicial)

### DIFF
--- a/lib/useAutoRefetch.ts
+++ b/lib/useAutoRefetch.ts
@@ -18,6 +18,8 @@ export function useAutoRefetch(refetch: () => void, enabled: boolean = true, int
   useEffect(() => {
     if (!enabled) return;
     const call = () => { try { refetchRef.current(); } catch { /* ignore */ } };
+    // Fetch inicial imediato na montagem
+    call();
     const interval = intervalMs > 0 ? setInterval(call, intervalMs) : null;
     // Refetch ao focar apenas se a aba esteve oculta (evita re-fetch em toda troca de foco de janela)
     let wasHidden = false;


### PR DESCRIPTION
## HOTFIX — Todas as páginas admin ficam em "Carregando..." infinito

O `useAutoRefetch` com default `intervalMs=0` não fazia fetch inicial.
Páginas que dependiam dele (15+ páginas) nunca carregavam dados.

**Fix:** Chamar callback imediatamente ao montar o hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)