### PR TITLE
perf: otimizar queries para reduzir memória Supabase

### DIFF
--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -14,8 +14,9 @@ export async function GET(req: NextRequest) {
 
   const { data, error } = await supabase
     .from("simulacoes")
-    .select("*")
-    .order("created_at", { ascending: false });
+    .select("id,created_at,nome,telefone,modelo,armazenamento,valor_avaliacao,status,cor,categoria")
+    .order("created_at", { ascending: false })
+    .limit(500);
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });

--- a/app/api/estoque/route.ts
+++ b/app/api/estoque/route.ts
@@ -48,12 +48,14 @@ export async function GET(req: NextRequest) {
     const { data: estoqueItems } = await supabase
       .from("estoque")
       .select("*")
-      .ilike("imei", `%${imeiSearch}%`);
+      .ilike("imei", `%${imeiSearch}%`)
+      .limit(50);
 
     const { data: vendaItems } = await supabase
       .from("vendas")
       .select("*")
-      .ilike("imei", `%${imeiSearch}%`);
+      .ilike("imei", `%${imeiSearch}%`)
+      .limit(50);
 
     return NextResponse.json({ estoque: estoqueItems ?? [], vendas: vendaItems ?? [] });
   }
@@ -183,7 +185,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ data });
   }
 
-  let query = supabase.from("estoque").select("*").order("categoria").order("produto").range(0, 49999);
+  let query = supabase.from("estoque").select("*").order("categoria").order("produto").limit(2000);
   if (categoria) query = query.eq("categoria", categoria);
   const statusFilter = searchParams.get("status");
   if (statusFilter) query = query.eq("status", statusFilter);

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -99,7 +99,7 @@ export async function GET(req: NextRequest) {
   const fornecedor = searchParams.get("fornecedor");
   if (fornecedor) query = query.ilike("fornecedor", fornecedor);
 
-  const limit = searchParams.get("limit") ? parseInt(searchParams.get("limit")!) : 1000;
+  const limit = searchParams.get("limit") ? parseInt(searchParams.get("limit")!) : 500;
   const { data, error } = await query.limit(limit);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ data });


### PR DESCRIPTION
## Summary
O Supabase MICRO estava a 906MB/1GB de memória. Otimizações:

- **Estoque**: `range(0, 49999)` → `limit(2000)` (maior economia, ~90% menos memória)
- **Stats**: `select("*")` sem limite → colunas específicas + `limit(500)`
- **IMEI search**: sem limite → `limit(50)` em estoque e vendas
- **Vendas**: default de 1000 → 500 registros

🤖 Generated with [Claude Code](https://claude.com/claude-code)