### PR TITLE
fix+feat: termo procedência + simulações + badge pulseira + simulador interno

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -5436,12 +5436,18 @@ export default function EstoquePage() {
                   {p.tipo === "PENDENCIA" && (
                     <button
                       onClick={async () => {
+                        const condicaoParts: string[] = [];
+                        if (p.bateria) condicaoParts.push(`Bateria ${p.bateria}%`);
+                        if (p.status) condicaoParts.push(p.status);
+                        if (p.garantia) condicaoParts.push(`Garantia: ${p.garantia}`);
+                        if (p.observacao) condicaoParts.push(p.observacao);
                         const aparelhos = [{
                           modelo: p.produto,
+                          capacidade: "",
                           cor: p.cor || "",
                           imei: p.imei || "",
                           serial: p.serial_no || "",
-                          condicao: p.bateria ? `Bateria ${p.bateria}%` : "",
+                          condicao: condicaoParts.join(", "),
                         }];
                         try {
                           const res = await fetch("/api/admin/termo-procedencia", {

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -4855,7 +4855,7 @@ export default function EstoquePage() {
                                     })()}
                                     {/* Apple Watch badges: tamanho + pulseira */}
                                     {prodItems[0]?.categoria === "APPLE_WATCH" && (() => {
-                                      const { tamanho, pulseira } = extractWatchBadges(prodNome);
+                                      const { tamanho, pulseira } = extractWatchBadges(prodItems[0]?.produto || prodNome);
                                       if (!tamanho && !pulseira) return null;
                                       return (
                                         <div className="flex gap-1 mt-0.5">
@@ -5861,9 +5861,9 @@ export default function EstoquePage() {
                       )}
                       {/* Apple Watch: tamanho + pulseira info */}
                       {p.categoria === "APPLE_WATCH" && (() => {
-                        const { tamanho } = extractWatchBadges(p.produto);
+                        const { tamanho, pulseira: pulseiraFromName } = extractWatchBadges(p.produto);
                         const pulseiraTam = p.observacao?.match(/\[PULSEIRA_TAM:([^\]]+)\]/)?.[1];
-                        const bandModel = p.observacao?.match(/\[BAND:([^\]]+)\]/)?.[1];
+                        const bandModel = p.observacao?.match(/\[BAND:([^\]]+)\]/)?.[1] || pulseiraFromName;
                         return (<>
                           {tamanho && <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Tamanho</p>
                             <span className={`inline-block px-2.5 py-1 rounded-full text-[11px] font-semibold mt-0.5 ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#E5E5EA] text-[#636366]"}`}>⌚ {tamanho}</span></div>}
@@ -6291,9 +6291,15 @@ export default function EstoquePage() {
                           const obs = getLatestObs();
                           const cleaned = obs.replace(/\[BAND:[^\]]+\]/g, "").trim();
                           const finalObs = val ? `${cleaned} [BAND:${val}]`.trim() : (cleaned || null);
-                          await apiPatch(p.id, { observacao: finalObs });
-                          setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, observacao: finalObs } : x));
-                          setDetailProduct(prev => prev ? { ...prev, observacao: finalObs } : null);
+                          // Also update pulseira in product name to keep them in sync
+                          const currentProduto = p.produto || "";
+                          const nomeSemPulseira = currentProduto.replace(/\s*PULSEIRA\s+.*$/i, "").trim();
+                          const novoProduto = val ? `${nomeSemPulseira} PULSEIRA ${val}`.toUpperCase() : nomeSemPulseira;
+                          const updates: Record<string, unknown> = { observacao: finalObs };
+                          if (novoProduto !== currentProduto) updates.produto = novoProduto;
+                          await apiPatch(p.id, updates);
+                          setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, observacao: finalObs, ...(novoProduto !== currentProduto ? { produto: novoProduto } : {}) } : x));
+                          setDetailProduct(prev => prev ? { ...prev, observacao: finalObs, ...(novoProduto !== currentProduto ? { produto: novoProduto } : {}) } : null);
                           showSaved("band_model");
                         }} className={selCls}>
                           <option value="">— Selecionar —</option>

--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import { useAdmin } from "@/components/admin/AdminShell";
 import { useAutoRefetch } from "@/lib/useAutoRefetch";
 import TradeInQuestionsAdmin from "@/components/admin/TradeInQuestionsAdmin";
+import TradeInCalculatorMulti from "@/components/TradeInCalculatorMulti";
 import { corParaPT } from "@/lib/cor-pt";
 
 const FunnelPanel = dynamic(() => import("@/app/admin/analytics/page"), { ssr: false });
@@ -126,7 +127,7 @@ export default function AdminPage() {
   const [filterModelo, setFilterModelo] = useState("");
   const [filterFrom, setFilterFrom] = useState("");
   const [filterTo, setFilterTo] = useState("");
-  const [mainTab, setMainTab] = useState<"simulacoes" | "followup" | "funil" | "perguntas" | "whatsapp">("simulacoes");
+  const [mainTab, setMainTab] = useState<"simulacoes" | "followup" | "funil" | "perguntas" | "whatsapp" | "simulador">("simulacoes");
   const [followUpLoading, setFollowUpLoading] = useState<string | null>(null);
 
   const fetchData = useCallback(async (pw: string) => {
@@ -265,10 +266,10 @@ export default function AdminPage() {
     <div className="space-y-6">
       {/* Main tabs: Simulações / Funil */}
       <div className="flex gap-2 items-center flex-wrap">
-        {(["simulacoes", "followup", "funil", "perguntas", "whatsapp"] as const).map((t) => (
+        {(["simulacoes", "simulador", "followup", "funil", "perguntas", "whatsapp"] as const).map((t) => (
           <button key={t} onClick={() => setMainTab(t)}
             className={`px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors ${mainTab === t ? "bg-[#E8740E] text-white" : "bg-white border border-[#D2D2D7] text-[#86868B] hover:border-[#E8740E]"}`}>
-            {t === "simulacoes" ? "Simulacoes" : t === "followup" ? `Follow-up (${data.filter(d => d.status === "SAIR" && !d.follow_up_enviado).length})` : t === "perguntas" ? "Perguntas Trade-In" : t === "whatsapp" ? "WhatsApp" : "Funil de Conversao"}
+            {t === "simulacoes" ? "Simulacoes" : t === "simulador" ? "Simulador Interno" : t === "followup" ? `Follow-up (${data.filter(d => d.status === "SAIR" && !d.follow_up_enviado).length})` : t === "perguntas" ? "Perguntas Trade-In" : t === "whatsapp" ? "WhatsApp" : "Funil de Conversao"}
           </button>
         ))}
         <div className="flex-1" />
@@ -294,6 +295,19 @@ export default function AdminPage() {
 
       {/* WhatsApp Config tab */}
       {mainTab === "whatsapp" && <WhatsAppConfigPanel password={password} />}
+
+      {/* Simulador Interno tab */}
+      {mainTab === "simulador" && (
+        <div className="bg-white border border-[#D2D2D7] rounded-2xl overflow-hidden shadow-sm">
+          <div className="p-4 border-b border-[#D2D2D7] bg-[#F5F5F7]">
+            <h2 className="font-bold text-[#1D1D1F]">Simulador Interno</h2>
+            <p className="text-sm text-[#86868B] mt-1">Use o simulador abaixo para calcular valores de troca internamente, sem gerar registro de cliente.</p>
+          </div>
+          <div className="max-w-2xl mx-auto py-6 px-4">
+            <TradeInCalculatorMulti vendedor={null} temaParam="clean" />
+          </div>
+        </div>
+      )}
 
       {/* Follow-up tab */}
       {mainTab === "followup" && (() => {

--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
 import dynamic from "next/dynamic";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { useAutoRefetch } from "@/lib/useAutoRefetch";
 import TradeInQuestionsAdmin from "@/components/admin/TradeInQuestionsAdmin";
 import { corParaPT } from "@/lib/cor-pt";
 
@@ -151,6 +152,7 @@ export default function AdminPage() {
   useEffect(() => {
     if (password) fetchData(password);
   }, [password, fetchData]);
+  useAutoRefetch(useCallback(() => { if (password) fetchData(password); }, [password, fetchData]), !!password);
 
   // Unique models for filter dropdown — must be before any early return (Rules of Hooks)
   const uniqueModelos = useMemo(() => {

--- a/app/api/admin/termo-procedencia/route.ts
+++ b/app/api/admin/termo-procedencia/route.ts
@@ -41,11 +41,41 @@ export async function POST(req: NextRequest) {
   const body = await req.json();
   const usuario = getUsuario(req);
 
-  const { cliente_nome, cliente_cpf, aparelhos, venda_id, encomenda_id, pendencia_id, cidade, gerar_pdf } = body;
+  let { cliente_nome, cliente_cpf, aparelhos, venda_id, encomenda_id, pendencia_id, cidade, gerar_pdf } = body;
 
-  if (!cliente_nome || !cliente_cpf) {
-    return NextResponse.json({ error: "cliente_nome e cliente_cpf obrigatórios" }, { status: 400 });
+  // Se faltar nome/CPF, tentar buscar da venda ou encomenda vinculada
+  if ((!cliente_nome || !cliente_cpf) && venda_id) {
+    const { data: venda } = await supabase.from("vendas").select("cliente,cpf").eq("id", venda_id).maybeSingle();
+    if (venda) {
+      if (!cliente_nome) cliente_nome = venda.cliente;
+      if (!cliente_cpf) cliente_cpf = venda.cpf;
+    }
   }
+  if ((!cliente_nome || !cliente_cpf) && encomenda_id) {
+    const { data: enc } = await supabase.from("encomendas").select("cliente,cpf").eq("id", encomenda_id).maybeSingle();
+    if (enc) {
+      if (!cliente_nome) cliente_nome = enc.cliente;
+      if (!cliente_cpf) cliente_cpf = enc.cpf;
+    }
+  }
+  if ((!cliente_nome || !cliente_cpf) && pendencia_id) {
+    // Pendência: buscar cliente do estoque, e CPF da venda mais recente desse cliente
+    const { data: pend } = await supabase.from("estoque").select("cliente").eq("id", pendencia_id).maybeSingle();
+    if (pend?.cliente) {
+      if (!cliente_nome) cliente_nome = pend.cliente;
+      if (!cliente_cpf) {
+        const { data: vendaCliente } = await supabase.from("vendas").select("cpf").ilike("cliente", pend.cliente).not("cpf", "is", null).limit(1).maybeSingle();
+        if (vendaCliente?.cpf) cliente_cpf = vendaCliente.cpf;
+      }
+    }
+  }
+
+  if (!cliente_nome) {
+    return NextResponse.json({ error: "cliente_nome não encontrado — preencha ou vincule a uma venda" }, { status: 400 });
+  }
+  // CPF pode ficar vazio se não encontrado (será campo em branco no PDF)
+  if (!cliente_cpf) cliente_cpf = "";
+
   if (!aparelhos || !Array.isArray(aparelhos) || aparelhos.length === 0) {
     return NextResponse.json({ error: "aparelhos (array) obrigatório com pelo menos 1 item" }, { status: 400 });
   }


### PR DESCRIPTION
## Summary

### Termo de Procedência
- API busca nome/CPF automaticamente da venda, encomenda ou pendência vinculada
- CPF não obrigatório (fica em branco no PDF se não encontrado)
- Pendências enviam mais campos: bateria, status, garantia, observação

### Simulações
- Corrigido página em branco (adicionado useAutoRefetch)
- Nova aba **"🔧 Simulador Interno"** — equipe faz simulação de troca sem depender do cliente

### Apple Watch — Badge Pulseira
- Badge visual da pulseira na listagem (ex: [49MM] [NATURAL MILANÊS])
- "Modelo Pulseira" no modal busca do nome do produto como fallback
- Mudar dropdown de pulseira atualiza nome do produto

## Após merge
- Rodar migration `20260410b_termos_procedencia.sql` em `/admin/migrations` (se ainda não rodou)

## Test plan
- [ ] Gerar termo pela pendência → busca nome/CPF da venda vinculada
- [ ] Simulações carregam normalmente
- [ ] Aba "Simulador Interno" funciona com avaliação completa
- [ ] Apple Watch mostra badge da pulseira na listagem
- [ ] Mudar pulseira no modal → atualiza nome + badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)