### PR TITLE
fix+feat: simulações + badge pulseira + filtro bateria + fix estoque

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -810,6 +810,7 @@ export default function EstoquePage() {
   const [historicoLogs, setHistoricoLogs] = useState<{ id: string; created_at: string; usuario: string; acao: string; produto_nome: string; campo: string; valor_anterior: string; valor_novo: string; detalhes: string }[]>([]);
   const [historicoLoading, setHistoricoLoading] = useState(false);
   const [filterCat, setFilterCat] = useState("");
+  const [filterBateria, setFilterBateria] = useState("");
   const [search, setSearch] = useState("");
   const [filterDataCompra, setFilterDataCompra] = useState("");
   const [acaminhoFilter, setAcaminhoFilter] = useState<"pendentes" | "recebidos" | "todos">("pendentes");
@@ -2349,6 +2350,14 @@ export default function EstoquePage() {
 
   const filtered = currentList.filter((p) => {
     if (filterCat && p.categoria !== filterCat) return false;
+    if (filterBateria) {
+      const bat = p.bateria;
+      if (filterBateria === "90" && (!bat || bat < 90)) return false;
+      if (filterBateria === "85" && (!bat || bat < 85 || bat >= 90)) return false;
+      if (filterBateria === "80" && (!bat || bat < 80 || bat >= 85)) return false;
+      if (filterBateria === "low" && (!bat || bat >= 80)) return false;
+      if (filterBateria === "none" && bat) return false;
+    }
     if (filterDataCompra && tab === "acaminho" && p.data_compra !== filterDataCompra) return false;
     if (search) {
       const s = search.toLowerCase();
@@ -2839,6 +2848,16 @@ export default function EstoquePage() {
                 {CATEGORIAS.map((c) => <option key={c} value={c}>{dynamicCatLabels[c] || c}</option>)}
               </select>
             )}
+            {(tab === "seminovos" || tab === "pendencias") && (
+              <select value={filterBateria} onChange={(e) => setFilterBateria(e.target.value)} className={`px-2.5 py-1.5 rounded-lg border text-[11px] ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#E5E5EA]"}`}>
+                <option value="">🔋 Bateria</option>
+                <option value="90">90%+</option>
+                <option value="85">85-89%</option>
+                <option value="80">80-84%</option>
+                <option value="low">Abaixo de 80%</option>
+                <option value="none">Sem info</option>
+              </select>
+            )}
             {tab === "acaminho" && (<>
               {/* Filtro: Pendentes / Recebidos / Todos */}
               <div className={`flex rounded-lg overflow-hidden border text-[11px] font-semibold ${dm ? "border-[#3A3A3C]" : "border-[#E5E5EA]"}`}>
@@ -2919,9 +2938,9 @@ export default function EstoquePage() {
                 {label}
               </button>
             ))}
-            {(filterLinha || filterCaract.length > 0) && (
+            {(filterLinha || filterCaract.length > 0 || filterBateria) && (
               <button
-                onClick={() => { setFilterLinha(""); setFilterCaract([]); }}
+                onClick={() => { setFilterLinha(""); setFilterCaract([]); setFilterBateria(""); }}
                 className="px-2 py-1 rounded-lg text-[11px] font-medium text-red-400 hover:text-red-300 border border-red-400/30 hover:border-red-400/60 transition-colors"
               >
                 ✕ Limpar filtros
@@ -4898,6 +4917,21 @@ export default function EstoquePage() {
                                             const en = corEnOriginal(p.cor);
                                             return <>{pt}{en && en.toLowerCase() !== pt.toLowerCase() && <span className={`ml-1 text-[12px] ${textSecondary}`}>{en}</span>}</>;
                                           })()}
+                                          {/* Pulseira badge extraído do nome do produto */}
+                                          {(() => {
+                                            const pulseiraMatch = p.produto?.match(/PULSEIRA\s+(.+)/i);
+                                            if (!pulseiraMatch) return null;
+                                            return <span className={`ml-1.5 px-1.5 py-0.5 rounded text-[9px] font-medium ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#F0F0F0] text-[#86868B]"}`}>{pulseiraMatch[1]}</span>;
+                                          })()}
+                                          {/* Bateria badge colorido (só seminovos) */}
+                                          {p.bateria && p.tipo === "SEMINOVO" && (
+                                            <span className={`ml-1.5 px-1.5 py-0.5 rounded text-[9px] font-bold ${
+                                              p.bateria >= 90 ? "bg-green-100 text-green-700" :
+                                              p.bateria >= 85 ? "bg-yellow-100 text-yellow-700" :
+                                              p.bateria >= 80 ? "bg-orange-100 text-orange-700" :
+                                              "bg-red-100 text-red-700"
+                                            }`}>🔋 {p.bateria}%</span>
+                                          )}
                                         </td>
                                         <td className={`px-3 py-2.5 text-right`}>
                                           <span className={`text-sm font-bold ${p.qnt === 1 ? "text-yellow-500" : "text-green-500"}`}>

--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -139,8 +139,13 @@ export default function AdminPage() {
       if (res.ok) {
         const json = await res.json();
         setData(json.data ?? []);
+      } else {
+        // Evitar tela em branco — setar array vazio se erro
+        setData([]);
       }
-    } catch { /* ignore */ }
+    } catch {
+      setData([]);
+    }
     setLoading(false);
   }, []);
 

--- a/supabase/migrations/20260410c_fix_estoque_vendido_duplicata.sql
+++ b/supabase/migrations/20260410c_fix_estoque_vendido_duplicata.sql
@@ -1,0 +1,12 @@
+-- Fix: produto vendido JFXC1Q4Q3K ainda aparece em estoque
+-- Marcar como ESGOTADO (foi vendido para G THREE LTDA)
+UPDATE estoque
+SET status = 'ESGOTADO', qnt = 0, updated_at = now()
+WHERE serial_no = 'JFXC1Q4Q3K' AND status != 'ESGOTADO';
+
+-- Fix: iPhone 17 Air 1TB duplicado — remover o que tem IMEI errado (manter o com serial correto)
+-- Identificar: o item com serial_no preenchido é o correto. O que tem só IMEI é o errado.
+-- Nota: precisa verificar manualmente os IDs exatos antes de rodar.
+-- Este SQL identifica o duplicado: mesmo produto + cor, sem serial, com IMEI
+-- DELETE FROM estoque WHERE produto ILIKE '%IPHONE 17 AIR%1TB%' AND serial_no IS NULL AND imei IS NOT NULL AND status = 'EM ESTOQUE';
+-- ^ Comentado para segurança — verificar manualmente antes de rodar


### PR DESCRIPTION
## Summary

### Simulações
- Corrige página em branco (seta data=[] em caso de erro API)

### Estoque — Badge pulseira individual
- Badge da pulseira agora aparece em cada unidade individual (linhas amarelas)
- Ex: "Titânio Natural Natural Titanium [NATURAL ESTILO MILANÊS]"

### Estoque — Filtro de bateria
- Badge bateria colorido: 🟢 90%+ | 🟡 85-89% | 🟠 80-84% | 🔴 <80%
- Dropdown de filtro por faixa (visível em seminovos/pendências)
- Limpar filtros inclui bateria

### Migration
- JFXC1Q4Q3K marcado como ESGOTADO (vendido para G THREE LTDA)
- SQL para duplicata iPhone 17 Air 1TB (comentado, verificar IDs antes)

## Após merge
Rodar migrations em `/admin/migrations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)