### PR TITLE
fix: simulações zeradas - query com colunas erradas

### DIFF
--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
 
   const { data, error } = await supabase
     .from("simulacoes")
-    .select("id,created_at,nome,telefone,modelo,armazenamento,valor_avaliacao,status,cor,categoria")
+    .select("*")
     .order("created_at", { ascending: false })
     .limit(500);
 


### PR DESCRIPTION
## Summary
- Restaura `select("*")` na API de simulações
- Commit aa541a3 trocou por colunas que não existem na tabela (`telefone` → `whatsapp`, `modelo` → `modelo_novo`, etc)
- Dados não foram perdidos, apenas a query não retornava nada

🤖 Generated with [Claude Code](https://claude.com/claude-code)