### PR TITLE
fix: Bianca acessar página vendas com vendas_andamento

### DIFF
--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -135,7 +135,7 @@ export default function AdminNav({ userRole, userPermissoes }: AdminNavProps) {
 
   // Aliases: se o usuário tem qualquer uma dessas permissões, pode ver o item
   const PAGE_ALIASES: Record<string, string[]> = {
-    vendas_ver: ["vendas_ver", "vendas_registrar"],
+    vendas_ver: ["vendas_ver", "vendas_andamento", "vendas_registrar"],
   };
 
   function canSee(pageKey: string): boolean {

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -145,9 +145,16 @@ export function pathToPageKey(path: string): string | null {
   return PATH_TO_KEY[path] || null;
 }
 
+/** Pages that can be accessed with ANY of these alternative keys */
+const PATH_ALTERNATIVES: Record<string, string[]> = {
+  "/admin/vendas": ["vendas_ver", "vendas_andamento", "vendas_registrar"],
+};
+
 /** Check if a user can access a page by URL path */
 export function canAccessPage(role: string, page: string, permissoes?: string[]): boolean {
   if (role === "admin") return true;
+  const alts = PATH_ALTERNATIVES[page];
+  if (alts) return alts.some(k => (permissoes ?? []).includes(k));
   const key = PATH_TO_KEY[page];
   if (!key) return false;
   return (permissoes ?? []).includes(key);


### PR DESCRIPTION
## Summary
- `/admin/vendas` agora aceita `vendas_andamento` como permissão alternativa
- Sidebar mostra "Vendas" para quem tem `vendas_andamento`

🤖 Generated with [Claude Code](https://claude.com/claude-code)