### PR TITLE
fix+feat: simulações + vendas reset + endereço + simulador interno + correções dados

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -984,7 +984,7 @@ export default function EntregasPage() {
                   if (r.cliente) set("cliente", r.cliente);
                   if (r.telefone) set("telefone", r.telefone);
                   if (r.bairro) set("bairro", r.bairro);
-                  if (r.endereco) { set("endereco", r.endereco); set("endereco_entrega", r.endereco); }
+                  if (r.endereco) { set("endereco", r.endereco); if (!form.endereco_entrega?.trim()) set("endereco_entrega", r.endereco); }
                   if (r.horario) set("horario", r.horario);
                   if (r.vendedor) set("vendedor", r.vendedor);
                   if (r.local_entrega) set("local_entrega", r.local_entrega);

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -285,8 +285,9 @@ export default function GerarLinkPage() {
     if (c.telefone) setCliTelefone(c.telefone);
     if (c.cpf) setCliCpf(c.cpf);
     if (c.email) setCliEmail(c.email);
-    if (c.endereco) setCliEndereco(c.endereco);
-    if (c.bairro) setCliBairro(c.bairro);
+    // Só preenche endereço se o campo estiver vazio (preserva edição manual)
+    if (c.endereco && !cliEndereco.trim()) setCliEndereco(c.endereco);
+    if (c.bairro && !cliBairro.trim()) setCliBairro(c.bairro);
     setIncluirDadosCliente(true);
     setShowCliSugs(false);
   };
@@ -710,10 +711,11 @@ export default function GerarLinkPage() {
     if (d.email) { setCliEmail(d.email); encontrados.push("E-mail"); }
     if (d.telefone) { setCliTelefone(d.telefone); encontrados.push("Telefone"); }
     if (d.cep) { setCliCep(d.cep); encontrados.push("CEP"); }
-    if (d.endereco) { setCliEndereco(d.endereco); encontrados.push("Endereço"); }
-    if (d.numero) { setCliNumero(d.numero); encontrados.push("Número"); }
-    if (d.complemento) { setCliComplemento(d.complemento); encontrados.push("Complemento"); }
-    if (d.bairro) { setCliBairro(d.bairro); encontrados.push("Bairro"); }
+    // Só preenche endereço se o campo estiver vazio (preserva edição manual)
+    if (d.endereco) { if (!cliEndereco.trim()) setCliEndereco(d.endereco); encontrados.push("Endereço"); }
+    if (d.numero) { if (!cliNumero.trim()) setCliNumero(d.numero); encontrados.push("Número"); }
+    if (d.complemento) { if (!cliComplemento.trim()) setCliComplemento(d.complemento); encontrados.push("Complemento"); }
+    if (d.bairro) { if (!cliBairro.trim()) setCliBairro(d.bairro); encontrados.push("Bairro"); }
     if (encontrados.length === 0) setParseMsg("❌ Não consegui identificar nenhum dado. Verifique o formato.");
     else setParseMsg(`✅ ${encontrados.length} campo(s) extraído(s): ${encontrados.join(", ")}`);
     setTimeout(() => setParseMsg(""), 5000);

--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -5,8 +5,17 @@ import dynamic from "next/dynamic";
 import { useAdmin } from "@/components/admin/AdminShell";
 import { useAutoRefetch } from "@/lib/useAutoRefetch";
 import TradeInQuestionsAdmin from "@/components/admin/TradeInQuestionsAdmin";
-import TradeInCalculatorMulti from "@/components/TradeInCalculatorMulti";
 import { corParaPT } from "@/lib/cor-pt";
+import {
+  calculateTradeInValue,
+  calculateIPadTradeInValue,
+  calculateMacBookTradeInValue,
+  calculateQuote,
+  getDiscountsForModel,
+  formatBRL,
+} from "@/lib/calculations";
+import type { ConditionData, IPadConditionData, MacBookConditionData, ModelDiscounts } from "@/lib/calculations";
+import type { UsedDeviceValue } from "@/lib/types";
 
 const FunnelPanel = dynamic(() => import("@/app/admin/analytics/page"), { ssr: false });
 
@@ -302,17 +311,7 @@ export default function AdminPage() {
       {mainTab === "whatsapp" && <WhatsAppConfigPanel password={password} />}
 
       {/* Simulador Interno tab */}
-      {mainTab === "simulador" && (
-        <div className="bg-white border border-[#D2D2D7] rounded-2xl overflow-hidden shadow-sm">
-          <div className="p-4 border-b border-[#D2D2D7] bg-[#F5F5F7]">
-            <h2 className="font-bold text-[#1D1D1F]">Simulador Interno</h2>
-            <p className="text-sm text-[#86868B] mt-1">Use o simulador abaixo para calcular valores de troca internamente, sem gerar registro de cliente.</p>
-          </div>
-          <div className="max-w-2xl mx-auto py-6 px-4">
-            <TradeInCalculatorMulti vendedor={null} temaParam="clean" />
-          </div>
-        </div>
-      )}
+      {mainTab === "simulador" && <SimuladorInterno password={password} />}
 
       {/* Follow-up tab */}
       {mainTab === "followup" && (() => {
@@ -1262,6 +1261,421 @@ function WhatsAppConfigPanel({ password }: { password: string }) {
           className="w-full py-3 rounded-xl text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#F5A623] transition-colors disabled:opacity-50">
           {saving ? "Salvando..." : "Salvar"}
         </button>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────
+// Simulador Interno — formulário simples
+// ──────────────────────────────────────────
+
+type UsadoCategoria = "iPhone" | "iPad" | "MacBook" | "Apple Watch";
+const USADO_CATEGORIAS: UsadoCategoria[] = ["iPhone", "iPad", "MacBook", "Apple Watch"];
+
+interface PrecosRow {
+  modelo: string;
+  armazenamento: string;
+  preco_pix: number;
+  categoria?: string;
+  status?: string;
+}
+
+const inputCls = "w-full px-3 py-2 rounded-lg bg-[#F5F5F7] border border-[#D2D2D7] text-sm text-[#1D1D1F] placeholder-[#86868B] focus:outline-none focus:border-[#E8740E] transition-colors";
+const labelCls = "block text-xs font-semibold text-[#86868B] mb-1";
+const checkCls = "w-4 h-4 accent-[#E8740E] rounded";
+
+function SimuladorInterno({ password }: { password: string }) {
+  // --- Data from APIs ---
+  const [usedValues, setUsedValues] = useState<UsedDeviceValue[]>([]);
+  const [excludedModels, setExcludedModels] = useState<string[]>([]);
+  const [discountRules, setDiscountRules] = useState<{ condicao: string; detalhe: string; desconto: number }[]>([]);
+  const [modelDiscounts, setModelDiscounts] = useState<Record<string, Partial<ModelDiscounts>>>({});
+  const [precos, setPrecos] = useState<PrecosRow[]>([]);
+  const [loadingData, setLoadingData] = useState(true);
+
+  // --- Usado (trade-in) ---
+  const [usadoCat, setUsadoCat] = useState<UsadoCategoria>("iPhone");
+  const [usadoModelo, setUsadoModelo] = useState("");
+  const [usadoStorage, setUsadoStorage] = useState("");
+  const [bateria, setBateria] = useState(100);
+  const [marcasUso, setMarcasUso] = useState(false);
+  const [arranhoes, setArranhoes] = useState(false);
+  const [trincado, setTrincado] = useState(false);
+  const [defeito, setDefeito] = useState(false);
+  const [manutencao, setManutencao] = useState<"no" | "apple" | "thirdParty">("no");
+  const [garantiaApple, setGarantiaApple] = useState(false);
+  const [garantiaMes, setGarantiaMes] = useState<number>(1);
+  const [garantiaAno, setGarantiaAno] = useState<number>(new Date().getFullYear());
+  const [caixaOriginal, setCaixaOriginal] = useState(false);
+  // MacBook extras
+  const [ciclosBateria, setCiclosBateria] = useState(0);
+  const [tecladoCondition, setTecladoCondition] = useState<"perfect" | "sticky">("perfect");
+  const [temCarregador, setTemCarregador] = useState(true);
+  // iPad extras
+  const [temPencil, setTemPencil] = useState(false);
+
+  // --- Novo (compra) ---
+  const [novoCat, setNovoCat] = useState("");
+  const [novoModelo, setNovoModelo] = useState("");
+
+  // Fetch data
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [usadosRes, precosRes] = await Promise.all([
+          fetch("/api/usados"),
+          fetch("/api/admin/precos", { headers: { "x-admin-password": password } }),
+        ]);
+        if (cancelled) return;
+        const usadosJson = await usadosRes.json();
+        const precosJson = await precosRes.json();
+        setUsedValues(usadosJson.usedValues || []);
+        setExcludedModels(usadosJson.excludedModels || []);
+        setDiscountRules(usadosJson.discountRules || []);
+        setModelDiscounts(usadosJson.modelDiscounts || {});
+        setPrecos((precosJson.data || []).filter((p: PrecosRow) => p.status === "ativo"));
+      } catch (err) {
+        console.error("Erro ao carregar dados do simulador:", err);
+      }
+      if (!cancelled) setLoadingData(false);
+    })();
+    return () => { cancelled = true; };
+  }, [password]);
+
+  // --- Derived: usado models/storages ---
+  const usadoModelos = useMemo(() => {
+    const prefix = usadoCat === "Apple Watch" ? "Apple Watch" : usadoCat;
+    const models = [...new Set(
+      usedValues
+        .filter((v) => v.modelo.startsWith(prefix))
+        .filter((v) => !excludedModels.includes(v.modelo))
+        .map((v) => v.modelo)
+    )].sort();
+    return models;
+  }, [usedValues, excludedModels, usadoCat]);
+
+  const usadoStorages = useMemo(() => {
+    if (!usadoModelo) return [];
+    return [...new Set(usedValues.filter((v) => v.modelo === usadoModelo).map((v) => v.armazenamento))];
+  }, [usedValues, usadoModelo]);
+
+  // Reset selections on category change
+  useEffect(() => { setUsadoModelo(""); setUsadoStorage(""); }, [usadoCat]);
+  useEffect(() => { setUsadoStorage(""); }, [usadoModelo]);
+
+  // --- Derived: novo categories/models ---
+  const novoCategorias = useMemo(() => {
+    return [...new Set(precos.map((p) => p.categoria || "IPHONE"))].sort();
+  }, [precos]);
+
+  const novoModelos = useMemo(() => {
+    if (!novoCat) return [];
+    return [...new Set(
+      precos
+        .filter((p) => (p.categoria || "IPHONE") === novoCat)
+        .map((p) => `${p.modelo} ${p.armazenamento}`)
+    )].sort();
+  }, [precos, novoCat]);
+
+  useEffect(() => { setNovoModelo(""); }, [novoCat]);
+
+  // --- Calculate trade-in value ---
+  const baseValue = useMemo(() => {
+    if (!usadoModelo || !usadoStorage) return 0;
+    const found = usedValues.find((v) => v.modelo === usadoModelo && v.armazenamento === usadoStorage);
+    return found?.valorBase || 0;
+  }, [usedValues, usadoModelo, usadoStorage]);
+
+  const tradeInValue = useMemo(() => {
+    if (!baseValue) return 0;
+    if (defeito) return 0;
+
+    const isMac = usadoCat === "MacBook";
+    const isIPad = usadoCat === "iPad";
+
+    if (isMac) {
+      const cond: MacBookConditionData = {
+        screenScratch: arranhoes ? "multiple" : "none",
+        bodyScratch: marcasUso ? "heavy" : "none",
+        batteryCycles: ciclosBateria,
+        keyboardCondition: tecladoCondition,
+        hasCharger: temCarregador,
+        hasDamage: trincado,
+        hasWarranty: garantiaApple,
+        warrantyMonth: garantiaApple ? garantiaMes : null,
+        warrantyYear: garantiaApple ? garantiaAno : null,
+        hasOriginalBox: caixaOriginal,
+      };
+      return calculateMacBookTradeInValue(baseValue, cond);
+    }
+
+    if (isIPad) {
+      const cond: IPadConditionData = {
+        screenScratch: arranhoes ? "multiple" : "none",
+        sideScratch: "none",
+        peeling: marcasUso ? "heavy" : "none",
+        battery: bateria,
+        hasDamage: trincado,
+        partsReplaced: manutencao,
+        hasWarranty: garantiaApple,
+        warrantyMonth: garantiaApple ? garantiaMes : null,
+        warrantyYear: garantiaApple ? garantiaAno : null,
+        hasOriginalBox: caixaOriginal,
+        hasApplePencil: temPencil,
+        hasWearMarks: undefined,
+      };
+      return calculateIPadTradeInValue(baseValue, cond);
+    }
+
+    // iPhone / Apple Watch — use the same iPhone logic
+    const md = getDiscountsForModel(usadoModelo, modelDiscounts);
+    const cond: ConditionData = {
+      screenScratch: arranhoes ? "multiple" : "none",
+      sideScratch: "none",
+      peeling: marcasUso ? "heavy" : "none",
+      battery: bateria,
+      hasDamage: trincado,
+      partsReplaced: manutencao,
+      hasWarranty: garantiaApple,
+      warrantyMonth: garantiaApple ? garantiaMes : null,
+      warrantyYear: garantiaApple ? garantiaAno : null,
+      hasOriginalBox: caixaOriginal,
+    };
+    return calculateTradeInValue(baseValue, cond, md);
+  }, [baseValue, usadoCat, usadoModelo, bateria, marcasUso, arranhoes, trincado, defeito, manutencao, garantiaApple, garantiaMes, garantiaAno, caixaOriginal, ciclosBateria, tecladoCondition, temCarregador, temPencil, modelDiscounts]);
+
+  // --- New device price ---
+  const newPrice = useMemo(() => {
+    if (!novoModelo) return 0;
+    // novoModelo = "iPhone 16 Pro 256GB" — find it in precos
+    const found = precos.find((p) => `${p.modelo} ${p.armazenamento}` === novoModelo);
+    return found?.preco_pix || 0;
+  }, [precos, novoModelo]);
+
+  // --- Quote ---
+  const quote = useMemo(() => {
+    if (!newPrice) return null;
+    return calculateQuote(tradeInValue, newPrice);
+  }, [tradeInValue, newPrice]);
+
+  const catLabel: Record<string, string> = {
+    IPHONE: "iPhone", IPHONES: "iPhone", IPAD: "iPad", IPADS: "iPad",
+    MACBOOK: "MacBook", APPLE_WATCH: "Apple Watch", AIRPODS: "AirPods",
+    ACESSORIOS: "Acessorios", MAC_MINI: "Mac Mini", MAC_STUDIO: "Mac Studio",
+    OUTROS: "Outros",
+  };
+
+  if (loadingData) {
+    return (
+      <div className="bg-white border border-[#D2D2D7] rounded-2xl p-8 shadow-sm text-center">
+        <p className="text-[#86868B]">Carregando dados do simulador...</p>
+      </div>
+    );
+  }
+
+  const months = ["Janeiro", "Fevereiro", "Marco", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"];
+
+  return (
+    <div className="bg-white border border-[#D2D2D7] rounded-2xl overflow-hidden shadow-sm">
+      <div className="p-4 border-b border-[#D2D2D7] bg-[#F5F5F7]">
+        <h2 className="font-bold text-[#1D1D1F]">Simulador Interno</h2>
+        <p className="text-sm text-[#86868B] mt-1">Calcule valores de troca internamente, sem gerar registro de cliente.</p>
+      </div>
+
+      <div className="p-5 space-y-6 max-w-3xl mx-auto">
+        {/* ─── APARELHO USADO ─── */}
+        <div className="border border-[#D2D2D7] rounded-xl p-4 space-y-4">
+          <h3 className="font-semibold text-[#1D1D1F] text-sm">Aparelho Usado (trade-in)</h3>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div>
+              <label className={labelCls}>Categoria</label>
+              <select className={inputCls} value={usadoCat} onChange={(e) => setUsadoCat(e.target.value as UsadoCategoria)}>
+                {USADO_CATEGORIAS.map((c) => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className={labelCls}>Modelo</label>
+              <select className={inputCls} value={usadoModelo} onChange={(e) => setUsadoModelo(e.target.value)}>
+                <option value="">Selecione</option>
+                {usadoModelos.map((m) => <option key={m} value={m}>{m}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className={labelCls}>Armazenamento</label>
+              <select className={inputCls} value={usadoStorage} onChange={(e) => setUsadoStorage(e.target.value)}>
+                <option value="">Selecione</option>
+                {usadoStorages.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </div>
+          </div>
+
+          {/* Bateria / Ciclos */}
+          {usadoCat === "MacBook" ? (
+            <div>
+              <label className={labelCls}>Ciclos de bateria</label>
+              <input type="number" className={inputCls} value={ciclosBateria} min={0} max={9999}
+                onChange={(e) => setCiclosBateria(Number(e.target.value))} placeholder="Ex: 250" />
+            </div>
+          ) : (
+            <div>
+              <label className={labelCls}>Saude da bateria (%)</label>
+              <input type="number" className={inputCls} value={bateria} min={0} max={100}
+                onChange={(e) => setBateria(Math.min(100, Math.max(0, Number(e.target.value))))} />
+            </div>
+          )}
+
+          {/* Checkboxes de condicao */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-y-2 gap-x-4">
+            <label className="flex items-center gap-2 text-sm text-[#1D1D1F] cursor-pointer">
+              <input type="checkbox" className={checkCls} checked={marcasUso} onChange={(e) => setMarcasUso(e.target.checked)} />
+              Marcas de uso
+            </label>
+            <label className="flex items-center gap-2 text-sm text-[#1D1D1F] cursor-pointer">
+              <input type="checkbox" className={checkCls} checked={arranhoes} onChange={(e) => setArranhoes(e.target.checked)} />
+              Arranhoes
+            </label>
+            <label className="flex items-center gap-2 text-sm text-[#1D1D1F] cursor-pointer">
+              <input type="checkbox" className={checkCls} checked={trincado} onChange={(e) => setTrincado(e.target.checked)} />
+              Trincado
+            </label>
+            <label className="flex items-center gap-2 text-sm text-[#1D1D1F] cursor-pointer">
+              <input type="checkbox" className={checkCls} checked={defeito} onChange={(e) => setDefeito(e.target.checked)} />
+              Defeito
+            </label>
+            <label className="flex items-center gap-2 text-sm text-[#1D1D1F] cursor-pointer">
+              <input type="checkbox" className={checkCls} checked={caixaOriginal} onChange={(e) => setCaixaOriginal(e.target.checked)} />
+              Caixa original
+            </label>
+            {usadoCat === "iPad" && (
+              <label className="flex items-center gap-2 text-sm text-[#1D1D1F] cursor-pointer">
+                <input type="checkbox" className={checkCls} checked={temPencil} onChange={(e) => setTemPencil(e.target.checked)} />
+                Apple Pencil
+              </label>
+            )}
+            {usadoCat === "MacBook" && (
+              <>
+                <label className="flex items-center gap-2 text-sm text-[#1D1D1F] cursor-pointer">
+                  <input type="checkbox" className={checkCls} checked={temCarregador} onChange={(e) => setTemCarregador(e.target.checked)} />
+                  Carregador
+                </label>
+                <label className="flex items-center gap-2 text-sm text-[#1D1D1F] cursor-pointer">
+                  <input type="checkbox" className={checkCls} checked={tecladoCondition === "sticky"} onChange={(e) => setTecladoCondition(e.target.checked ? "sticky" : "perfect")} />
+                  Teclado grudando
+                </label>
+              </>
+            )}
+          </div>
+
+          {/* Manutencao */}
+          {usadoCat !== "MacBook" && (
+            <div>
+              <label className={labelCls}>Manutencao / Pecas trocadas</label>
+              <select className={inputCls} value={manutencao} onChange={(e) => setManutencao(e.target.value as "no" | "apple" | "thirdParty")}>
+                <option value="no">Nenhuma peca trocada</option>
+                <option value="apple">Trocada na Apple (autorizada)</option>
+                <option value="thirdParty">Trocada fora da Apple (rejeita)</option>
+              </select>
+            </div>
+          )}
+
+          {/* Garantia Apple */}
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 text-sm text-[#1D1D1F] cursor-pointer">
+              <input type="checkbox" className={checkCls} checked={garantiaApple} onChange={(e) => setGarantiaApple(e.target.checked)} />
+              <span className="font-semibold text-xs text-[#86868B]">Garantia Apple</span>
+            </label>
+            {garantiaApple && (
+              <div className="grid grid-cols-2 gap-3 pl-6">
+                <div>
+                  <label className={labelCls}>Mes vencimento</label>
+                  <select className={inputCls} value={garantiaMes} onChange={(e) => setGarantiaMes(Number(e.target.value))}>
+                    {months.map((m, i) => <option key={i} value={i + 1}>{m}</option>)}
+                  </select>
+                </div>
+                <div>
+                  <label className={labelCls}>Ano</label>
+                  <select className={inputCls} value={garantiaAno} onChange={(e) => setGarantiaAno(Number(e.target.value))}>
+                    {[2025, 2026, 2027, 2028].map((y) => <option key={y} value={y}>{y}</option>)}
+                  </select>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Valor avaliado */}
+          {baseValue > 0 && (
+            <div className="bg-[#F5F5F7] rounded-lg p-3 flex items-center justify-between">
+              <span className="text-sm text-[#86868B]">Valor base: <b className="text-[#1D1D1F]">{formatBRL(baseValue)}</b></span>
+              <span className="text-sm font-bold" style={{ color: tradeInValue > 0 ? "#2ECC71" : "#E74C3C" }}>
+                Avaliado: {formatBRL(tradeInValue)}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* ─── APARELHO NOVO ─── */}
+        <div className="border border-[#D2D2D7] rounded-xl p-4 space-y-4">
+          <h3 className="font-semibold text-[#1D1D1F] text-sm">Aparelho Novo (compra)</h3>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label className={labelCls}>Categoria</label>
+              <select className={inputCls} value={novoCat} onChange={(e) => setNovoCat(e.target.value)}>
+                <option value="">Selecione</option>
+                {novoCategorias.map((c) => <option key={c} value={c}>{catLabel[c] || c}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className={labelCls}>Modelo + Armazenamento</label>
+              <select className={inputCls} value={novoModelo} onChange={(e) => setNovoModelo(e.target.value)}>
+                <option value="">Selecione</option>
+                {novoModelos.map((m) => <option key={m} value={m}>{m}</option>)}
+              </select>
+            </div>
+          </div>
+
+          {newPrice > 0 && (
+            <div className="bg-[#F5F5F7] rounded-lg p-3">
+              <span className="text-sm text-[#86868B]">Preco PIX: </span>
+              <span className="text-sm font-bold text-[#1D1D1F]">{formatBRL(newPrice)}</span>
+            </div>
+          )}
+        </div>
+
+        {/* ─── RESULTADO ─── */}
+        {quote && (
+          <div className="border-2 border-[#E8740E] rounded-xl p-5 space-y-3 bg-[#FFF8F0]">
+            <h3 className="font-bold text-[#E8740E] text-sm">Resultado da Simulacao</h3>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <span className="text-[#86868B]">Valor do usado avaliado:</span>
+              <span className="text-right font-semibold text-[#2ECC71]">{formatBRL(quote.tradeInValue)}</span>
+              <span className="text-[#86868B]">Preco do novo:</span>
+              <span className="text-right font-semibold text-[#1D1D1F]">{formatBRL(quote.newPrice)}</span>
+              <span className="text-[#86868B] font-bold">Diferenca a pagar (PIX):</span>
+              <span className="text-right font-bold text-[#E8740E] text-base">{formatBRL(quote.difference)}</span>
+            </div>
+            {/* Parcelas */}
+            <div className="border-t border-[#E8740E]/20 pt-3 mt-2">
+              <p className="text-xs font-semibold text-[#86868B] mb-2">Parcelas (sobre a diferenca):</p>
+              <div className="grid grid-cols-3 gap-2">
+                {[12, 18, 21].map((n) => {
+                  const inst = quote.installments.find((i) => i.parcelas === n);
+                  if (!inst) return null;
+                  return (
+                    <div key={n} className="bg-white border border-[#D2D2D7] rounded-lg p-2 text-center">
+                      <p className="text-xs text-[#86868B]">{n}x</p>
+                      <p className="font-bold text-sm text-[#1D1D1F]">{formatBRL(inst.valorParcela)}</p>
+                      <p className="text-[10px] text-[#86868B]">Total: {formatBRL(inst.total)}</p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -1352,7 +1352,28 @@ export default function VendasPage() {
             setEditandoGrupoIds([]);
             setDuplicadoInfo(null);
             setProdutosCarrinho([]);
-            clearProductFields();
+            setLastClienteData(null);
+            // Limpar TODOS os campos (cliente + produto) após edição
+            setForm({
+              data: hojeBR(),
+              cliente: "", cpf: "", cnpj: "", email: "", endereco: "", pessoa: "PF" as "PF" | "PJ", origem: "", tipo: "", produto: "", fornecedor: "",
+              custo: "", preco_vendido: "", valor_comprovante_input: "", banco: "ITAU", forma: "",
+              qnt_parcelas: "", bandeira: "", local: "", produto_na_troca: "",
+              entrada_pix: "", banco_pix: "ITAU", entrada_especie: "", banco_2nd: "", banco_alt: "",
+              forma_alt: "", parc_alt: "", band_alt: "", comp_alt: "", sinal_antecipado: "", banco_sinal: "",
+              entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
+              valor_total_venda: "",
+              troca_produto: "", troca_cor: "", troca_categoria: "", troca_bateria: "", troca_obs: "",
+              troca_grade: "", troca_caixa: "", troca_cabo: "", troca_fonte: "", troca_pulseira: "", troca_ciclos: "", troca_garantia: "",
+              troca_serial: "", troca_imei: "",
+              produto_na_troca2: "", troca_produto2: "", troca_cor2: "", troca_categoria2: "", troca_bateria2: "", troca_obs2: "", troca_grade2: "", troca_caixa2: "", troca_cabo2: "", troca_fonte2: "",
+              troca_serial2: "", troca_imei2: "", troca_garantia2: "", troca_pulseira2: "", troca_ciclos2: "",
+              serial_no: "", imei: "",
+              cep: "", bairro: "", cidade: "", uf: "",
+              frete_valor: "", frete_recebido: false, usar_credito_loja: "",
+            });
+            setCatSel(""); setEstoqueId(""); setProdutoManual(false); setShowSegundaTroca(false);
+            localStorage.removeItem("tigrao_venda_draft");
             setMsg(`${editandoGrupoIds.length} vendas atualizadas com sucesso!`);
             fetchVendas();
             fetchEstoque();
@@ -1372,7 +1393,28 @@ export default function VendasPage() {
             setEditandoGrupoIds([]);
             setDuplicadoInfo(null);
             setProdutosCarrinho([]);
-            clearProductFields();
+            setLastClienteData(null);
+            // Limpar TODOS os campos (cliente + produto) após edição
+            setForm({
+              data: hojeBR(),
+              cliente: "", cpf: "", cnpj: "", email: "", endereco: "", pessoa: "PF" as "PF" | "PJ", origem: "", tipo: "", produto: "", fornecedor: "",
+              custo: "", preco_vendido: "", valor_comprovante_input: "", banco: "ITAU", forma: "",
+              qnt_parcelas: "", bandeira: "", local: "", produto_na_troca: "",
+              entrada_pix: "", banco_pix: "ITAU", entrada_especie: "", banco_2nd: "", banco_alt: "",
+              forma_alt: "", parc_alt: "", band_alt: "", comp_alt: "", sinal_antecipado: "", banco_sinal: "",
+              entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
+              valor_total_venda: "",
+              troca_produto: "", troca_cor: "", troca_categoria: "", troca_bateria: "", troca_obs: "",
+              troca_grade: "", troca_caixa: "", troca_cabo: "", troca_fonte: "", troca_pulseira: "", troca_ciclos: "", troca_garantia: "",
+              troca_serial: "", troca_imei: "",
+              produto_na_troca2: "", troca_produto2: "", troca_cor2: "", troca_categoria2: "", troca_bateria2: "", troca_obs2: "", troca_grade2: "", troca_caixa2: "", troca_cabo2: "", troca_fonte2: "",
+              troca_serial2: "", troca_imei2: "", troca_garantia2: "", troca_pulseira2: "", troca_ciclos2: "",
+              serial_no: "", imei: "",
+              cep: "", bairro: "", cidade: "", uf: "",
+              frete_valor: "", frete_recebido: false, usar_credito_loja: "",
+            });
+            setCatSel(""); setEstoqueId(""); setProdutoManual(false); setShowSegundaTroca(false);
+            localStorage.removeItem("tigrao_venda_draft");
             setMsg("Venda atualizada com sucesso!");
             fetchVendas();
             fetchEstoque();
@@ -4829,6 +4871,7 @@ export default function VendasPage() {
                   setEstoqueId("");
                   setProdutoManual(false);
                   setProdutosCarrinho([]);
+                  localStorage.removeItem("tigrao_venda_draft");
                 }}
                 className="flex-1 py-3 rounded-xl bg-[#E8740E] text-white font-semibold hover:bg-[#F5A623] transition-colors disabled:opacity-50"
               >
@@ -4863,6 +4906,7 @@ export default function VendasPage() {
                   setEstoqueId("");
                   setProdutoManual(false);
                   setProdutosCarrinho([]);
+                  localStorage.removeItem("tigrao_venda_draft");
                   setMsg("");
                 }}
                 className={`flex-1 py-3 rounded-xl font-semibold transition-colors ${dm ? "bg-[#3A3A3C] text-[#F5F5F7] hover:bg-[#4A4A4C]" : "bg-[#E5E5EA] text-[#1D1D1F] hover:bg-[#D2D2D7]"}`}

--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
 
   const { data, error } = await supabase
     .from("simulacoes")
-    .select("id,created_at,nome,telefone,modelo,armazenamento,valor_avaliacao,status,cor,categoria")
+    .select("*")
     .order("created_at", { ascending: false })
     .limit(500);
 

--- a/supabase/migrations/20260410d_correcoes_estoque_vendas.sql
+++ b/supabase/migrations/20260410d_correcoes_estoque_vendas.sql
@@ -1,0 +1,80 @@
+-- ============================================================
+-- CORREÇÕES DE DADOS — 10/04/2026
+-- ============================================================
+
+-- 1. DELETAR duplicata iPhone 17 Air 1TB (IMEI errado)
+DELETE FROM estoque WHERE imei = '356523760126756' OR serial_no = '356523760126756';
+
+-- 2. Marcar ESGOTADO: JFXC1Q4Q3K (vendido para G THREE LTDA)
+UPDATE estoque SET status = 'ESGOTADO', qnt = 0, updated_at = now()
+WHERE serial_no = 'JFXC1Q4Q3K' AND status != 'ESGOTADO';
+
+-- 3. Marcar ESGOTADO: GC4F560VQM — AirPods Pro 3 (vendido 11/10/25 - Ramon Mendes Guimarães)
+UPDATE estoque SET status = 'ESGOTADO', qnt = 0, updated_at = now()
+WHERE serial_no = 'GC4F560VQM' AND status != 'ESGOTADO';
+
+-- 4. Criar vendas do sistema antigo + marcar ESGOTADO
+
+-- 4a. HPVP9MTC7J → Raphael Nunes de Carvalho — R$ 9.029,81 (03/02/26)
+INSERT INTO vendas (data, cliente, produto, preco_vendido, origem, tipo, serial_no, recebimento, created_at)
+SELECT '2026-02-03', 'RAPHAEL NUNES DE CARVALHO', e.produto, 9029.81, 'NAO_INFORMARAM', 'VENDA', 'HPVP9MTC7J', 'D+0', now()
+FROM estoque e WHERE e.serial_no = 'HPVP9MTC7J' LIMIT 1;
+UPDATE estoque SET status = 'ESGOTADO', qnt = 0, updated_at = now()
+WHERE serial_no = 'HPVP9MTC7J' AND status != 'ESGOTADO';
+
+-- 4b. DM64TR2VTP → Rafael da Silva Lopes (CPF 015.987.293-65) — R$ 9.897,00 (20/11/25)
+INSERT INTO vendas (data, cliente, cpf, produto, preco_vendido, origem, tipo, serial_no, recebimento, created_at)
+SELECT '2025-11-20', 'RAFAEL DA SILVA LOPES', '015.987.293-65', e.produto, 9897.00, 'NAO_INFORMARAM', 'VENDA', 'DM64TR2VTP', 'D+0', now()
+FROM estoque e WHERE e.serial_no = 'DM64TR2VTP' LIMIT 1;
+UPDATE estoque SET status = 'ESGOTADO', qnt = 0, updated_at = now()
+WHERE serial_no = 'DM64TR2VTP' AND status != 'ESGOTADO';
+
+-- 4c. G7KM2MWMW9 → Integral Construtora (CNPJ 35.824.033/0001-30) — R$ 8.726,00 (27/11/25)
+INSERT INTO vendas (data, cliente, cnpj, produto, preco_vendido, origem, tipo, serial_no, recebimento, created_at)
+SELECT '2025-11-27', 'INTEGRAL CONSTRUTORA', '35.824.033/0001-30', e.produto, 8726.00, 'NAO_INFORMARAM', 'VENDA', 'G7KM2MWMW9', 'D+0', now()
+FROM estoque e WHERE e.serial_no = 'G7KM2MWMW9' LIMIT 1;
+UPDATE estoque SET status = 'ESGOTADO', qnt = 0, updated_at = now()
+WHERE serial_no = 'G7KM2MWMW9' AND status != 'ESGOTADO';
+
+-- 4d. M5DVPK2RQ2 → Raphael Lima Santos de Pinho — R$ 8.879,17 (12/02/26)
+INSERT INTO vendas (data, cliente, produto, preco_vendido, origem, tipo, serial_no, recebimento, created_at)
+SELECT '2026-02-12', 'RAPHAEL LIMA SANTOS DE PINHO', e.produto, 8879.17, 'NAO_INFORMARAM', 'VENDA', 'M5DVPK2RQ2', 'D+0', now()
+FROM estoque e WHERE e.serial_no = 'M5DVPK2RQ2' LIMIT 1;
+UPDATE estoque SET status = 'ESGOTADO', qnt = 0, updated_at = now()
+WHERE serial_no = 'M5DVPK2RQ2' AND status != 'ESGOTADO';
+
+-- 4e. GC4F560VQM → Ramon Mendes Guimarães (CPF 058.809.757-89) — R$ 2.497,00 (11/10/25)
+INSERT INTO vendas (data, cliente, cpf, produto, preco_vendido, origem, tipo, serial_no, recebimento, created_at)
+SELECT '2025-10-11', 'RAMON MENDES GUIMARAES', '058.809.757-89', e.produto, 2497.00, 'NAO_INFORMARAM', 'VENDA', 'GC4F560VQM', 'D+0', now()
+FROM estoque e WHERE e.serial_no = 'GC4F560VQM' LIMIT 1;
+
+-- 5. Mac Mini: corrigir produto para 24GB/512GB
+UPDATE estoque SET produto = REPLACE(produto, '16GB', '24GB'), updated_at = now()
+WHERE serial_no IN ('H92HRV797J', 'H07G4V02QQ') AND produto ILIKE '%16GB%';
+
+-- 6. Gastos — desvincular itens errados dos pedidos
+-- Caso 1 (12:54, R$ 40.250): remover HPVP9MTC7J, DM64TR2VTP, G7KM2MWMW9
+-- Caso 2 (11:48, R$ 24.150): remover M5DVPK2RQ2
+-- Esses itens são vinculados via pedido_fornecedor_id no estoque.
+-- Limpar o vínculo dos itens errados:
+UPDATE estoque SET pedido_fornecedor_id = NULL, updated_at = now()
+WHERE serial_no IN ('HPVP9MTC7J', 'DM64TR2VTP', 'G7KM2MWMW9', 'M5DVPK2RQ2');
+
+-- Vincular os itens corretos ao gasto do Caso 1 (12:54)
+-- Precisamos do ID do gasto. Usar subquery:
+UPDATE estoque SET pedido_fornecedor_id = (
+  SELECT id FROM gastos
+  WHERE descricao ILIKE '%CRISTIANO%' AND data = '2026-03-30' AND horario = '12:54:00'
+  LIMIT 1
+), updated_at = now()
+WHERE serial_no IN ('GY2V22WCJR', 'MGX1F4CP70', 'LGVM2Y0FHK', 'D7C4G764N2')
+  AND pedido_fornecedor_id IS NULL;
+
+-- Vincular os itens corretos ao gasto do Caso 2 (11:48)
+UPDATE estoque SET pedido_fornecedor_id = (
+  SELECT id FROM gastos
+  WHERE descricao ILIKE '%CRISTIANO%' AND data = '2026-03-30' AND horario = '11:48:00'
+  LIMIT 1
+), updated_at = now()
+WHERE serial_no IN ('F9CXCQP49N', 'JGW4RM9JMX')
+  AND pedido_fornecedor_id IS NULL;


### PR DESCRIPTION
## Summary

### Simulações
- **Dados restaurados** — select(*) voltou na API (colunas erradas causavam listagem vazia)
- **Simulador Interno simplificado** — formulário direto: aparelho usado + condição → aparelho novo → resultado com parcelas. Não usa mais o calculador público.

### Vendas
- **Reset completo** após salvar — limpa cliente, CPF, endereço, produto, troca, TUDO
- Remove draft do localStorage ao finalizar

### Entregas / Gerar Link
- **Endereço de entrega não sobrescrito** pelo cadastro do cliente após edição manual

### Migration — Correções de dados
- Deletar duplicata #356523760126756 (IMEI errado)
- Marcar ESGOTADO: JFXC1Q4Q3K (G THREE LTDA), GC4F560VQM (Ramon Mendes)
- Criar 5 vendas do sistema antigo com valores corretos
- Gastos 30/03: desvincular itens errados + vincular corretos
- Mac Mini: H92HRV797J e H07G4V02QQ → 24GB/512GB

## Após merge
Rodar migrations em `/admin/migrations`:
- `20260410d_correcoes_estoque_vendas.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)