### PR TITLE
feat: enviar NF por email ao finalizar venda

### DIFF
--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -605,6 +605,24 @@ export async function PATCH(req: NextRequest) {
       if (!ok) console.error("[Vendas] Falha ao enviar notificação Telegram para:", venda.cliente);
       else console.log("[Vendas] Notificação Telegram enviada com sucesso para:", venda.cliente);
     }).catch(err => console.error("[Vendas] Erro notificação Telegram:", err));
+
+    // Enviar Nota Fiscal por email ao cliente (se tem email + NF anexada)
+    if (venda.email && venda.nota_fiscal_url) {
+      import("@/lib/email").then(({ enviarNotaFiscal }) => {
+        enviarNotaFiscal({
+          to: venda.email!,
+          clienteNome: venda.cliente || "Cliente",
+          produto: `${venda.produto || ""}${venda.cor ? ` ${venda.cor}` : ""}`.trim(),
+          valor: Number(venda.preco_vendido || 0),
+          notaFiscalUrl: venda.nota_fiscal_url!,
+        }).then(() => {
+          console.log("[Vendas] NF enviada por email para:", venda.email);
+          logActivity(usuario, "NF enviada por email", `${venda.cliente} → ${venda.email}`, "vendas", id).catch(() => {});
+        }).catch(err => {
+          console.error("[Vendas] Erro ao enviar NF por email:", err);
+        });
+      }).catch(err => console.error("[Vendas] Erro ao importar email:", err));
+    }
   }
 
   // Se tem reajustes, sincronizar com tabela reajustes (para relatório da noite)

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -32,3 +32,68 @@ export async function enviarRelatorioPDF(opts: {
 
   return info;
 }
+
+/**
+ * Envia a Nota Fiscal por email ao cliente quando a venda é finalizada.
+ * Baixa o PDF da URL pública (Supabase Storage) e envia como anexo.
+ */
+export async function enviarNotaFiscal(opts: {
+  to: string;
+  clienteNome: string;
+  produto: string;
+  valor: number;
+  notaFiscalUrl: string;
+}) {
+  // Baixar o PDF da URL pública
+  const res = await fetch(opts.notaFiscalUrl);
+  if (!res.ok) throw new Error(`Falha ao baixar NF: ${res.status}`);
+  const pdfBuffer = Buffer.from(await res.arrayBuffer());
+
+  const valorFmt = opts.valor.toLocaleString("pt-BR", { minimumFractionDigits: 2 });
+
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+      <div style="text-align: center; margin-bottom: 24px;">
+        <h1 style="color: #E8740E; font-size: 24px; margin: 0;">TigrãoImports</h1>
+        <p style="color: #86868B; font-size: 14px; margin: 4px 0 0;">Sua Nota Fiscal</p>
+      </div>
+
+      <div style="background: #FFF8F0; border: 1px solid #F5DEB3; border-radius: 12px; padding: 20px; margin-bottom: 20px;">
+        <p style="margin: 0 0 8px; color: #1D1D1F; font-size: 16px;">
+          Olá, <strong>${opts.clienteNome}</strong>! 👋
+        </p>
+        <p style="margin: 0; color: #6E6E73; font-size: 14px; line-height: 1.5;">
+          Sua compra foi finalizada com sucesso! Segue em anexo a Nota Fiscal referente ao produto:
+        </p>
+      </div>
+
+      <div style="background: #F5F5F7; border-radius: 12px; padding: 16px; margin-bottom: 20px;">
+        <p style="margin: 0 0 4px; font-size: 14px; color: #86868B;">Produto</p>
+        <p style="margin: 0 0 12px; font-size: 16px; color: #1D1D1F; font-weight: 600;">${opts.produto}</p>
+        <p style="margin: 0 0 4px; font-size: 14px; color: #86868B;">Valor</p>
+        <p style="margin: 0; font-size: 18px; color: #E8740E; font-weight: 700;">R$ ${valorFmt}</p>
+      </div>
+
+      <p style="color: #86868B; font-size: 12px; text-align: center; margin: 24px 0 0;">
+        Obrigado por comprar com a TigrãoImports! 🐯<br>
+        Em caso de dúvidas, entre em contato conosco.
+      </p>
+    </div>
+  `;
+
+  const info = await transporter.sendMail({
+    from: `"TigrãoImports" <${process.env.EMAIL_USER}>`,
+    to: opts.to,
+    subject: `Nota Fiscal — ${opts.produto} — TigrãoImports`,
+    html,
+    attachments: [
+      {
+        filename: `NF_TigraoImports_${opts.clienteNome.replace(/\s+/g, "_")}.pdf`,
+        content: pdfBuffer,
+        contentType: "application/pdf",
+      },
+    ],
+  });
+
+  return info;
+}


### PR DESCRIPTION
## Summary
- Ao finalizar venda com email do cliente + NF anexada, envia NF por email automaticamente
- Template HTML com dados da compra (produto, valor) + PDF em anexo
- Usa nodemailer/Gmail já configurado
- Log de atividade registrado

## Test plan
- [ ] Finalizar venda com email + NF → email chega com PDF
- [ ] Finalizar venda sem email → não envia (sem erro)
- [ ] Finalizar venda sem NF → não envia (sem erro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)