### PR TITLE
fix: correções estoque/vendas/gastos + lojistas + nucleos MacBook Neo

### DIFF
--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -153,6 +153,8 @@ export default function ClientesPage() {
     return n;
   });
   const [detailClient, setDetailClient] = useState<Cliente | null>(null);
+  const [detailVendas, setDetailVendas] = useState<VendaResumo[]>([]);
+  const [loadingVendas, setLoadingVendas] = useState(false);
   const [editing, setEditing] = useState(false);
   const [editForm, setEditForm] = useState({ nome: "", cpf: "", email: "", bairro: "", cidade: "", uf: "", cep: "", endereco: "" });
   const [savingClient, setSavingClient] = useState(false);
@@ -855,7 +857,19 @@ export default function ClientesPage() {
               {!loading && sorted.map((c) => (
                 <React.Fragment key={c.nome}>
                   <tr
-                    onClick={() => setDetailClient(c)}
+                    onClick={async () => {
+                      setDetailClient(c);
+                      setDetailVendas([]);
+                      setLoadingVendas(true);
+                      try {
+                        const res = await fetch(`/api/admin/clientes?client_vendas=${encodeURIComponent(c.nome)}`, { headers: apiHeaders() });
+                        if (res.ok) {
+                          const json = await res.json();
+                          setDetailVendas(json.vendas || []);
+                        }
+                      } catch { /* ignore */ }
+                      setLoadingVendas(false);
+                    }}
                     className={`${rowCls} ${expandedId === c.nome ? (dm ? "bg-[#2C2C2E]" : "bg-[#FFF8F0]") : ""}`}
                   >
                     <td className="px-4 py-3">
@@ -1037,7 +1051,7 @@ export default function ClientesPage() {
 
         const saveEdit = async () => {
           setSavingClient(true);
-          for (const v of c.vendas) {
+          for (const v of detailVendas) {
             const updates: Record<string, string | null> = {};
             if (editForm.nome && editForm.nome !== c.nome) updates.cliente = editForm.nome.toUpperCase();
             if (editForm.cpf !== (c.cpf || "")) updates.cpf = editForm.cpf || null;
@@ -1165,12 +1179,14 @@ export default function ClientesPage() {
               )}
 
               <div className={`mx-5 mt-3 p-4 rounded-xl border ${mSec}`}>
-                <p className={`text-xs font-bold ${mP} mb-3`}>Ultimas Operacoes ({c.vendas.length})</p>
-                {c.vendas.length === 0 ? (
+                <p className={`text-xs font-bold ${mP} mb-3`}>Ultimas Operacoes ({loadingVendas ? "..." : detailVendas.length})</p>
+                {loadingVendas ? (
+                  <p className={`text-sm text-center py-4 ${mS}`}>Carregando...</p>
+                ) : detailVendas.length === 0 ? (
                   <p className={`text-sm text-center py-4 ${mS}`}>Nenhuma operacao encontrada</p>
                 ) : (
                   <div className="space-y-1.5 max-h-[300px] overflow-y-auto">
-                    {c.vendas.map((v) => (
+                    {detailVendas.map((v) => (
                       <div key={v.id} className={`flex items-center justify-between px-3 py-2.5 rounded-lg text-xs ${dm ? "bg-[#1C1C1E] hover:bg-[#252525]" : "bg-white hover:bg-[#F5F5F7]"} transition-colors`}>
                         <div className="flex items-center gap-3 flex-1 min-w-0">
                           <span className={`shrink-0 ${mS}`}>{fmtDate(v.data)}</span>

--- a/app/api/admin/catalogo/route.ts
+++ b/app/api/admin/catalogo/route.ts
@@ -19,13 +19,50 @@ export async function GET(req: NextRequest) {
     const allConfigs = req.nextUrl.searchParams.get("all_configs");
 
     // Return configs for a specific model
+    // If no model-specific configs exist for a spec type, fall back to
+    // the global spec values defined in catalogo_spec_valores for that category.
     if (modeloId) {
-      const { data, error } = await supabase
+      const { data: modelConfigs, error } = await supabase
         .from("catalogo_modelo_configs")
         .select("*")
         .eq("modelo_id", modeloId);
       if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-      return NextResponse.json({ configs: data ?? [] });
+
+      // If model has configs, return them directly
+      if (modelConfigs && modelConfigs.length > 0) {
+        return NextResponse.json({ configs: modelConfigs });
+      }
+
+      // No model-specific configs → fall back to category-level spec values
+      // 1) Find the model's categoria_key
+      const { data: modelo } = await supabase
+        .from("catalogo_modelos")
+        .select("categoria_key")
+        .eq("id", modeloId)
+        .maybeSingle();
+      if (!modelo?.categoria_key) {
+        return NextResponse.json({ configs: [] });
+      }
+
+      // 2) Get which spec types this category uses
+      const { data: catSpecs } = await supabase
+        .from("catalogo_categoria_specs")
+        .select("tipo_chave")
+        .eq("categoria_key", modelo.categoria_key);
+      if (!catSpecs || catSpecs.length === 0) {
+        return NextResponse.json({ configs: [] });
+      }
+
+      const specTypes = catSpecs.map(s => s.tipo_chave);
+
+      // 3) Get all global values for those spec types
+      const { data: specValues } = await supabase
+        .from("catalogo_spec_valores")
+        .select("tipo_chave, valor")
+        .in("tipo_chave", specTypes)
+        .order("ordem");
+
+      return NextResponse.json({ configs: specValues ?? [] });
     }
 
     // Return ALL model configs (used by estoque page to know all valid colors per model)

--- a/app/api/admin/clientes/route.ts
+++ b/app/api/admin/clientes/route.ts
@@ -13,6 +13,20 @@ export async function GET(req: NextRequest) {
   const search = searchParams.get("search")?.trim() || "";
   const tab = searchParams.get("tab") || "clientes";
 
+  // =========== Vendas de um cliente específico (lazy load) ===========
+  const clientVendas = searchParams.get("client_vendas");
+  if (clientVendas) {
+    const { data, error } = await supabase
+      .from("vendas")
+      .select("id,data,produto,preco_vendido,forma,banco,serial_no,imei")
+      .ilike("cliente", clientVendas)
+      .neq("status_pagamento", "CANCELADO")
+      .order("data", { ascending: false })
+      .limit(200);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ vendas: data || [] });
+  }
+
   // =========== TAB: FORNECEDORES ===========
   if (tab === "fornecedores") {
     // 1) Buscar cadastro de fornecedores (tabela master)

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -537,6 +537,30 @@ export async function PATCH(req: NextRequest) {
   const { data, error } = await supabase.from("vendas").update(fields).eq("id", id).select();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
+  // Se serial_no foi atualizado, marcar estoque correspondente como ESGOTADO
+  // (previne itens vendidos que ficam "EM ESTOQUE" por falta de vínculo)
+  if (fields.serial_no && data && data.length > 0) {
+    const serialU = String(fields.serial_no).toUpperCase();
+    const vendaEstoqueId = data[0].estoque_id;
+    const { data: estoqueItems } = await supabase
+      .from("estoque")
+      .select("id")
+      .eq("serial_no", serialU)
+      .eq("status", "EM ESTOQUE");
+    if (estoqueItems && estoqueItems.length > 0) {
+      const idsParaEsgotar = estoqueItems
+        .filter(e => e.id !== vendaEstoqueId)
+        .map(e => e.id);
+      // Se a venda não tem estoque_id, esgotar TODOS com esse serial
+      const ids = vendaEstoqueId ? idsParaEsgotar : estoqueItems.map(e => e.id);
+      if (ids.length > 0) {
+        await supabase.from("estoque")
+          .update({ qnt: 0, status: "ESGOTADO", updated_at: new Date().toISOString() })
+          .in("id", ids);
+      }
+    }
+  }
+
   // Enviar notificação no Telegram quando venda é FINALIZADA
   if (fields.status_pagamento === "FINALIZADO" && data && data.length > 0) {
     const venda = data[0];

--- a/supabase/migrations/20260410_fix_estoque_vendido_em_estoque.sql
+++ b/supabase/migrations/20260410_fix_estoque_vendido_em_estoque.sql
@@ -1,0 +1,149 @@
+-- =====================================================================
+-- Migration: Correções de dados estoque/vendas/gastos — 2026-04-10
+-- =====================================================================
+
+-- 1. ESGOTADO genérico: itens em estoque com serial vendido
+-- ─────────────────────────────────────────────────────────
+UPDATE estoque e
+SET status = 'ESGOTADO', qnt = 0, updated_at = NOW()
+WHERE e.status = 'EM ESTOQUE'
+  AND e.serial_no IS NOT NULL AND e.serial_no != ''
+  AND EXISTS (
+    SELECT 1 FROM vendas v
+    WHERE UPPER(v.serial_no) = UPPER(e.serial_no)
+      AND COALESCE(v.status_pagamento,'') != 'CANCELADO'
+  );
+
+-- 2. ESGOTADO específico: JFXC1Q4Q3K e GC4F560VQM (já vendidos)
+-- ─────────────────────────────────────────────────────────────────
+UPDATE estoque
+SET status = 'ESGOTADO', qnt = 0, updated_at = NOW()
+WHERE serial_no IN ('JFXC1Q4Q3K', 'GC4F560VQM')
+  AND status != 'ESGOTADO';
+
+-- 3. Recriar iPhone 17 Air 1TB apagado por engano (troca Mauro Mantuano)
+-- ─────────────────────────────────────────────────────────────────────────
+-- Só insere se não existir (proteção contra rodar 2x)
+INSERT INTO estoque (
+  produto, categoria, qnt, custo_unitario, status, tipo,
+  serial_no, imei, fornecedor, cliente, updated_at
+)
+SELECT
+  'IPHONE 17 AIR 1TB', 'IPHONES', 1, 0, 'EM ESTOQUE', 'SEMINOVO',
+  'HLHW9X274W', '356523760126756', 'MAURO MANTUANO', 'MAURO MANTUANO', NOW()
+WHERE NOT EXISTS (
+  SELECT 1 FROM estoque WHERE serial_no = 'HLHW9X274W'
+);
+
+-- 4. Gastos 30/03 — desvincular itens errados, vincular corretos
+-- ─────────────────────────────────────────────────────────────────
+-- Gasto 1: pedido que já contém CQXMP7M2T2 (correto)
+-- Errados: HPVP9MTC7J, DM64TR2VTP, G7KM2MWMW9
+-- Corretos a vincular: GY2V22WCJR, MGX1F4CP70, LGVM2Y0FHK, D7C4G764N2
+
+DO $$
+DECLARE
+  v_pedido1 UUID;
+  v_pedido2 UUID;
+BEGIN
+  -- Encontrar pedido_fornecedor_id do gasto 1 via item correto já vinculado
+  SELECT pedido_fornecedor_id INTO v_pedido1
+  FROM estoque WHERE serial_no = 'CQXMP7M2T2' AND pedido_fornecedor_id IS NOT NULL
+  LIMIT 1;
+
+  IF v_pedido1 IS NOT NULL THEN
+    -- Desvincular itens errados do gasto 1
+    UPDATE estoque SET pedido_fornecedor_id = NULL, updated_at = NOW()
+    WHERE serial_no IN ('HPVP9MTC7J', 'DM64TR2VTP', 'G7KM2MWMW9')
+      AND pedido_fornecedor_id = v_pedido1;
+
+    -- Vincular itens corretos ao gasto 1
+    UPDATE estoque SET pedido_fornecedor_id = v_pedido1, updated_at = NOW()
+    WHERE serial_no IN ('GY2V22WCJR', 'MGX1F4CP70', 'LGVM2Y0FHK', 'D7C4G764N2')
+      AND (pedido_fornecedor_id IS NULL OR pedido_fornecedor_id != v_pedido1);
+  END IF;
+
+  -- Gasto 2: pedido que já contém CWF64GQTNQ (correto)
+  -- Errado: M5DVPK2RQ2
+  -- Corretos a vincular: F9CXCQP49N, JGW4RM9JMX
+  SELECT pedido_fornecedor_id INTO v_pedido2
+  FROM estoque WHERE serial_no = 'CWF64GQTNQ' AND pedido_fornecedor_id IS NOT NULL
+  LIMIT 1;
+
+  IF v_pedido2 IS NOT NULL THEN
+    UPDATE estoque SET pedido_fornecedor_id = NULL, updated_at = NOW()
+    WHERE serial_no = 'M5DVPK2RQ2'
+      AND pedido_fornecedor_id = v_pedido2;
+
+    UPDATE estoque SET pedido_fornecedor_id = v_pedido2, updated_at = NOW()
+    WHERE serial_no IN ('F9CXCQP49N', 'JGW4RM9JMX')
+      AND (pedido_fornecedor_id IS NULL OR pedido_fornecedor_id != v_pedido2);
+  END IF;
+END;
+$$;
+
+-- 5. Criar vendas do sistema antigo (itens que foram desvinculados dos gastos)
+-- ──────────────────────────────────────────────────────────────────────────────
+-- Marcar como ESGOTADO e criar vendas com dados do estoque
+
+-- 5a. HPVP9MTC7J → RAPHAEL NUNES DE CARVALHO (03/02/2026)
+INSERT INTO vendas (cliente, produto, data, serial_no, imei, custo, preco_vendido, status_pagamento, tipo, estoque_id)
+SELECT 'RAPHAEL NUNES DE CARVALHO', e.produto, '2026-02-03', e.serial_no, e.imei,
+       e.custo_unitario, e.custo_unitario, 'FINALIZADO', 'VAREJO', e.id
+FROM estoque e WHERE e.serial_no = 'HPVP9MTC7J'
+AND NOT EXISTS (SELECT 1 FROM vendas v WHERE UPPER(v.serial_no) = 'HPVP9MTC7J' AND COALESCE(v.status_pagamento,'') != 'CANCELADO')
+LIMIT 1;
+
+UPDATE estoque SET status = 'ESGOTADO', qnt = 0, updated_at = NOW()
+WHERE serial_no = 'HPVP9MTC7J' AND status != 'ESGOTADO';
+
+-- 5b. DM64TR2VTP → RAFAEL DA SILVA LOPES, CPF 015.987.293-65 (20/11/2025)
+INSERT INTO vendas (cliente, cpf, produto, data, serial_no, imei, custo, preco_vendido, status_pagamento, tipo, estoque_id)
+SELECT 'RAFAEL DA SILVA LOPES', '015.987.293-65', e.produto, '2025-11-20', e.serial_no, e.imei,
+       e.custo_unitario, e.custo_unitario, 'FINALIZADO', 'VAREJO', e.id
+FROM estoque e WHERE e.serial_no = 'DM64TR2VTP'
+AND NOT EXISTS (SELECT 1 FROM vendas v WHERE UPPER(v.serial_no) = 'DM64TR2VTP' AND COALESCE(v.status_pagamento,'') != 'CANCELADO')
+LIMIT 1;
+
+UPDATE estoque SET status = 'ESGOTADO', qnt = 0, updated_at = NOW()
+WHERE serial_no = 'DM64TR2VTP' AND status != 'ESGOTADO';
+
+-- 5c. G7KM2MWMW9 → INTEGRAL CONSTRUTORA, CNPJ 35.824.033/0001-30 (27/11/2025)
+INSERT INTO vendas (cliente, cnpj, produto, data, serial_no, imei, custo, preco_vendido, status_pagamento, tipo, estoque_id)
+SELECT 'INTEGRAL CONSTRUTORA', '35.824.033/0001-30', e.produto, '2025-11-27', e.serial_no, e.imei,
+       e.custo_unitario, e.custo_unitario, 'FINALIZADO', 'VAREJO', e.id
+FROM estoque e WHERE e.serial_no = 'G7KM2MWMW9'
+AND NOT EXISTS (SELECT 1 FROM vendas v WHERE UPPER(v.serial_no) = 'G7KM2MWMW9' AND COALESCE(v.status_pagamento,'') != 'CANCELADO')
+LIMIT 1;
+
+UPDATE estoque SET status = 'ESGOTADO', qnt = 0, updated_at = NOW()
+WHERE serial_no = 'G7KM2MWMW9' AND status != 'ESGOTADO';
+
+-- 5d. M5DVPK2RQ2 → RAPHAEL LIMA SANTOS DE PINHO (12/02/2026)
+INSERT INTO vendas (cliente, produto, data, serial_no, imei, custo, preco_vendido, status_pagamento, tipo, estoque_id)
+SELECT 'RAPHAEL LIMA SANTOS DE PINHO', e.produto, '2026-02-12', e.serial_no, e.imei,
+       e.custo_unitario, e.custo_unitario, 'FINALIZADO', 'VAREJO', e.id
+FROM estoque e WHERE e.serial_no = 'M5DVPK2RQ2'
+AND NOT EXISTS (SELECT 1 FROM vendas v WHERE UPPER(v.serial_no) = 'M5DVPK2RQ2' AND COALESCE(v.status_pagamento,'') != 'CANCELADO')
+LIMIT 1;
+
+UPDATE estoque SET status = 'ESGOTADO', qnt = 0, updated_at = NOW()
+WHERE serial_no = 'M5DVPK2RQ2' AND status != 'ESGOTADO';
+
+-- 6. Mac Mini 24GB/512GB — separar de 16GB/512GB
+-- ────────────────────────────────────────────────
+-- H07G4V02QQ e H92HRV797J são 24GB/512GB, atualizar produto para distinguir
+UPDATE estoque
+SET produto = REPLACE(produto, '16GB/512GB', '24GB/512GB'),
+    updated_at = NOW()
+WHERE serial_no IN ('H07G4V02QQ', 'H92HRV797J')
+  AND produto LIKE '%16GB/512GB%';
+
+-- Se o produto não contém "16GB/512GB" explicitamente, forçar o nome correto
+-- (adapte o nome do produto conforme o padrão usado no sistema)
+UPDATE estoque
+SET produto = REGEXP_REPLACE(produto, '16GB', '24GB'),
+    updated_at = NOW()
+WHERE serial_no IN ('H07G4V02QQ', 'H92HRV797J')
+  AND produto LIKE '%16GB%'
+  AND produto NOT LIKE '%24GB%';


### PR DESCRIPTION
## Summary
- **Migration dados**: ESGOTADO itens vendidos, recriar iPhone 17 Air 1TB apagado, corrigir gastos 30/03 (desvincular errados + vincular corretos), criar 4 vendas sistema antigo, separar Mac Mini 24GB/512GB
- **Fix vendas PATCH**: atualiza estoque ao editar serial_no (previne itens vendidos ficarem EM ESTOQUE)
- **Fix clientes modal**: lazy load vendas no detalhe (Ultimas Operacoes sempre mostrava 0)
- **Fix catalogo API**: fallback para spec_valores da categoria quando modelo não tem configs (nucleos MacBook Neo)

## Test plan
- [ ] Rodar migration `20260410_fix_estoque_vendido_em_estoque.sql` em `/admin/migrations`
- [ ] Verificar que JFXC1Q4Q3K e GC4F560VQM estão ESGOTADO
- [ ] Verificar que HLHW9X274W (17 Air 1TB) voltou ao estoque
- [ ] Verificar gastos 30/03 com itens corretos vinculados
- [ ] Verificar Mac Mini 24GB separado do 16GB
- [ ] Abrir detalhe de lojista → Ultimas Operacoes deve carregar vendas
- [ ] Cadastrar MacBook Neo → nucleos deve mostrar apenas chips_air

🤖 Generated with [Claude Code](https://claude.com/claude-code)