### PR TITLE
fix(catalogo): merge model configs com fallback por spec type

### DIFF
--- a/app/api/admin/catalogo/route.ts
+++ b/app/api/admin/catalogo/route.ts
@@ -19,8 +19,8 @@ export async function GET(req: NextRequest) {
     const allConfigs = req.nextUrl.searchParams.get("all_configs");
 
     // Return configs for a specific model
-    // If no model-specific configs exist for a spec type, fall back to
-    // the global spec values defined in catalogo_spec_valores for that category.
+    // Return configs for a specific model, merging with category-level
+    // fallback for any spec types that have no model-specific configs.
     if (modeloId) {
       const { data: modelConfigs, error } = await supabase
         .from("catalogo_modelo_configs")
@@ -28,41 +28,46 @@ export async function GET(req: NextRequest) {
         .eq("modelo_id", modeloId);
       if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-      // If model has configs, return them directly
-      if (modelConfigs && modelConfigs.length > 0) {
-        return NextResponse.json({ configs: modelConfigs });
-      }
+      // Find which spec types already have model-specific configs
+      const configuredTypes = new Set((modelConfigs || []).map((c: { tipo_chave: string }) => c.tipo_chave));
 
-      // No model-specific configs → fall back to category-level spec values
-      // 1) Find the model's categoria_key
+      // Find the model's categoria_key to get category-level fallbacks
       const { data: modelo } = await supabase
         .from("catalogo_modelos")
         .select("categoria_key")
         .eq("id", modeloId)
         .maybeSingle();
-      if (!modelo?.categoria_key) {
-        return NextResponse.json({ configs: [] });
+
+      let fallbackConfigs: { tipo_chave: string; valor: string }[] = [];
+
+      if (modelo?.categoria_key) {
+        // Get which spec types this category uses
+        const { data: catSpecs } = await supabase
+          .from("catalogo_categoria_specs")
+          .select("tipo_chave")
+          .eq("categoria_key", modelo.categoria_key);
+
+        if (catSpecs && catSpecs.length > 0) {
+          // Find spec types that are NOT configured at model level
+          const missingTypes = catSpecs
+            .map(s => s.tipo_chave)
+            .filter(t => !configuredTypes.has(t));
+
+          if (missingTypes.length > 0) {
+            // Get global values for the missing spec types
+            const { data: specValues } = await supabase
+              .from("catalogo_spec_valores")
+              .select("tipo_chave, valor")
+              .in("tipo_chave", missingTypes)
+              .order("ordem");
+            fallbackConfigs = specValues || [];
+          }
+        }
       }
 
-      // 2) Get which spec types this category uses
-      const { data: catSpecs } = await supabase
-        .from("catalogo_categoria_specs")
-        .select("tipo_chave")
-        .eq("categoria_key", modelo.categoria_key);
-      if (!catSpecs || catSpecs.length === 0) {
-        return NextResponse.json({ configs: [] });
-      }
-
-      const specTypes = catSpecs.map(s => s.tipo_chave);
-
-      // 3) Get all global values for those spec types
-      const { data: specValues } = await supabase
-        .from("catalogo_spec_valores")
-        .select("tipo_chave, valor")
-        .in("tipo_chave", specTypes)
-        .order("ordem");
-
-      return NextResponse.json({ configs: specValues ?? [] });
+      // Merge: model-specific configs + category-level fallback for missing types
+      const merged = [...(modelConfigs || []), ...fallbackConfigs];
+      return NextResponse.json({ configs: merged });
     }
 
     // Return ALL model configs (used by estoque page to know all valid colors per model)


### PR DESCRIPTION
## Summary
- Fix nucleos MacBook Neo: antes só fazia fallback quando modelo não tinha NENHUMA config
- Agora faz merge: configs do modelo + fallback da categoria para spec types faltantes
- Ex: modelo tem configs para `cores`, `ram`, `ssd` mas não `chips_air` → preenche chips_air com valores globais

## Test plan
- [ ] Cadastrar MacBook Neo → nucleos deve mostrar apenas opções de chips_air (6 opções), não todas (10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)