### PR TITLE
feat(cron): alerta automático de queda de preço via WhatsApp

### DIFF
--- a/app/api/cron/alerta-preco/route.ts
+++ b/app/api/cron/alerta-preco/route.ts
@@ -1,0 +1,157 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+function authCron(req: NextRequest) {
+  const secret = req.headers.get("authorization")?.replace("Bearer ", "");
+  return secret === process.env.CRON_SECRET;
+}
+
+function primeiroNome(nome: string): string {
+  return (nome || "").split(" ")[0] || "Cliente";
+}
+
+function fmtBRL(v: number): string {
+  return `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
+}
+
+// Envia mensagem via Z-API (instancia de follow-up)
+async function enviarWhatsApp(phone: string, message: string): Promise<boolean> {
+  const instanceId = process.env.ZAPI_FOLLOWUP_INSTANCE_ID;
+  const token = process.env.ZAPI_FOLLOWUP_TOKEN;
+  const clientToken = process.env.ZAPI_CLIENT_TOKEN ?? "";
+
+  if (!instanceId || !token) {
+    console.log("[AlertaPreco] Z-API nao configurado");
+    return false;
+  }
+
+  const url = `https://api.z-api.io/instances/${instanceId}/token/${token}/send-text`;
+
+  try {
+    let fone = phone.replace(/\D/g, "");
+    if (!fone.startsWith("55")) fone = `55${fone}`;
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Client-Token": clientToken,
+      },
+      body: JSON.stringify({ phone: fone, message }),
+    });
+    const json = await res.json();
+    console.log(`[AlertaPreco] WhatsApp enviado para ${fone}:`, JSON.stringify(json));
+    return res.ok;
+  } catch (err) {
+    console.error(`[AlertaPreco] Erro ao enviar WhatsApp para ${phone}:`, err);
+    return false;
+  }
+}
+
+// Roda todo dia as 11h — verifica se algum produto baixou de preco
+// e avisa o cliente que simulou aquele produto
+export async function GET(req: NextRequest) {
+  if (!authCron(req)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    // 1. Buscar precos atuais da tabela precos
+    const { data: precos, error: errPrecos } = await supabase
+      .from("precos")
+      .select("modelo, armazenamento, preco_pix")
+      .neq("status", "esgotado");
+
+    if (errPrecos || !precos) {
+      console.error("[AlertaPreco] Erro ao buscar precos:", errPrecos);
+      return NextResponse.json({ error: "Erro ao buscar precos" }, { status: 500 });
+    }
+
+    // Montar mapa de precos atuais: "iPhone 16 Pro|256GB" → 5797
+    const precoAtualMap = new Map<string, number>();
+    for (const p of precos) {
+      const key = `${p.modelo}|${p.armazenamento}`;
+      precoAtualMap.set(key, Number(p.preco_pix));
+    }
+
+    // 2. Buscar simulacoes dos ultimos 30 dias que sairam sem fechar
+    //    e ainda nao receberam alerta de preco
+    const trintaDiasAtras = new Date();
+    trintaDiasAtras.setDate(trintaDiasAtras.getDate() - 30);
+    const dataLimite = trintaDiasAtras.toISOString();
+
+    const { data: sims, error: errSims } = await supabase
+      .from("simulacoes")
+      .select("id, nome, whatsapp, modelo_novo, storage_novo, preco_novo, modelo_usado, storage_usado, diferenca, status, alerta_preco_enviado")
+      .gte("created_at", dataLimite)
+      .eq("status", "SAIR")
+      .or("alerta_preco_enviado.is.null,alerta_preco_enviado.eq.false")
+      .order("created_at", { ascending: false });
+
+    if (errSims) {
+      console.error("[AlertaPreco] Erro ao buscar simulacoes:", errSims);
+      return NextResponse.json({ error: errSims.message }, { status: 500 });
+    }
+
+    if (!sims || sims.length === 0) {
+      return NextResponse.json({ ok: true, message: "Nenhuma simulacao elegivel" });
+    }
+
+    // 3. Comparar precos e enviar alertas
+    let alertasEnviados = 0;
+    const erros: string[] = [];
+    const QUEDA_MINIMA = 100; // so avisa se baixou pelo menos R$100
+
+    for (const s of sims) {
+      if (!s.whatsapp || !s.modelo_novo || !s.storage_novo || !s.preco_novo) continue;
+
+      const key = `${s.modelo_novo}|${s.storage_novo}`;
+      const precoAtual = precoAtualMap.get(key);
+
+      if (!precoAtual) continue; // produto nao existe mais no catalogo
+
+      const precoOriginal = Number(s.preco_novo);
+      const queda = precoOriginal - precoAtual;
+
+      if (queda < QUEDA_MINIMA) continue; // nao baixou o suficiente
+
+      // Calcular nova diferenca (preco novo - avaliacao usado)
+      const avaliacaoUsado = Number(s.diferenca || 0) > 0
+        ? precoOriginal - Number(s.diferenca)
+        : 0;
+      const novaDiferenca = avaliacaoUsado > 0 ? precoAtual - avaliacaoUsado : precoAtual;
+
+      const nome = primeiroNome(s.nome);
+      const modeloUsado = s.modelo_usado
+        ? `${s.modelo_usado}${s.storage_usado ? ` ${s.storage_usado}` : ""}`
+        : "seu aparelho";
+
+      const msg = `Oi ${nome}! Tenho uma boa notícia! 🎉\n\nO *${s.modelo_novo} ${s.storage_novo}* que você pesquisou aqui na TIGRÃO IMPORTS *baixou ${fmtBRL(queda)}*!\n\nDando seu ${modeloUsado} na troca, a diferença agora fica em *${fmtBRL(novaDiferenca)}*.\n\nQuer aproveitar essa condição? Estou à disposição! 🐯`;
+
+      const enviou = await enviarWhatsApp(s.whatsapp, msg);
+
+      if (enviou) {
+        alertasEnviados++;
+        await supabase
+          .from("simulacoes")
+          .update({ alerta_preco_enviado: true })
+          .eq("id", s.id);
+      } else {
+        erros.push(s.nome || "Sem nome");
+      }
+
+      // Delay de 3s entre mensagens
+      await new Promise(resolve => setTimeout(resolve, 3000));
+    }
+
+    return NextResponse.json({
+      ok: true,
+      simulacoes_analisadas: sims.length,
+      alertas_enviados: alertasEnviados,
+      erros,
+    });
+  } catch (err) {
+    console.error("[AlertaPreco] Error:", err);
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/app/api/cron/alerta-preco/route.ts
+++ b/app/api/cron/alerta-preco/route.ts
@@ -14,6 +14,16 @@ function fmtBRL(v: number): string {
   return `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
 }
 
+// Normaliza nome pra comparacao: "  João Silva " → "JOAO SILVA"
+function normalizarNome(nome: string): string {
+  return (nome || "")
+    .trim()
+    .toUpperCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // remove acentos
+    .replace(/\s+/g, " ");
+}
+
 // Envia mensagem via Z-API (instancia de follow-up)
 async function enviarWhatsApp(phone: string, message: string): Promise<boolean> {
   const instanceId = process.env.ZAPI_FOLLOWUP_INSTANCE_ID;
@@ -49,7 +59,7 @@ async function enviarWhatsApp(phone: string, message: string): Promise<boolean> 
 }
 
 // Roda todo dia as 11h — verifica se algum produto baixou de preco
-// e avisa o cliente que simulou aquele produto
+// e avisa o cliente que simulou aquele produto (so se ele NAO comprou)
 export async function GET(req: NextRequest) {
   if (!authCron(req)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -67,15 +77,14 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: "Erro ao buscar precos" }, { status: 500 });
     }
 
-    // Montar mapa de precos atuais: "iPhone 16 Pro|256GB" → 5797
+    // Mapa de precos atuais: "iPhone 16 Pro|256GB" → 5797
     const precoAtualMap = new Map<string, number>();
     for (const p of precos) {
       const key = `${p.modelo}|${p.armazenamento}`;
       precoAtualMap.set(key, Number(p.preco_pix));
     }
 
-    // 2. Buscar simulacoes dos ultimos 30 dias que sairam sem fechar
-    //    e ainda nao receberam alerta de preco
+    // 2. Buscar simulacoes dos ultimos 30 dias (status SAIR, sem alerta enviado)
     const trintaDiasAtras = new Date();
     trintaDiasAtras.setDate(trintaDiasAtras.getDate() - 30);
     const dataLimite = trintaDiasAtras.toISOString();
@@ -97,18 +106,45 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ ok: true, message: "Nenhuma simulacao elegivel" });
     }
 
-    // 3. Comparar precos e enviar alertas
+    // 3. Buscar vendas dos ultimos 30 dias pra cruzar (quem ja comprou)
+    const { data: vendas } = await supabase
+      .from("vendas")
+      .select("cliente")
+      .gte("created_at", dataLimite);
+
+    // Montar set de nomes normalizados de quem ja comprou
+    const clientesQueCompraram = new Set<string>();
+    if (vendas) {
+      for (const v of vendas) {
+        if (v.cliente) clientesQueCompraram.add(normalizarNome(v.cliente));
+      }
+    }
+
+    // 4. Comparar precos e enviar alertas
     let alertasEnviados = 0;
+    let jaCompraram = 0;
     const erros: string[] = [];
     const QUEDA_MINIMA = 100; // so avisa se baixou pelo menos R$100
 
     for (const s of sims) {
       if (!s.whatsapp || !s.modelo_novo || !s.storage_novo || !s.preco_novo) continue;
 
+      // Verificar se o cliente ja comprou (match por nome)
+      const nomeNorm = normalizarNome(s.nome);
+      if (clientesQueCompraram.has(nomeNorm)) {
+        jaCompraram++;
+        // Marcar como enviado pra nao checar de novo
+        await supabase
+          .from("simulacoes")
+          .update({ alerta_preco_enviado: true })
+          .eq("id", s.id);
+        continue;
+      }
+
       const key = `${s.modelo_novo}|${s.storage_novo}`;
       const precoAtual = precoAtualMap.get(key);
 
-      if (!precoAtual) continue; // produto nao existe mais no catalogo
+      if (!precoAtual) continue; // produto nao existe mais
 
       const precoOriginal = Number(s.preco_novo);
       const queda = precoOriginal - precoAtual;
@@ -148,6 +184,7 @@ export async function GET(req: NextRequest) {
       ok: true,
       simulacoes_analisadas: sims.length,
       alertas_enviados: alertasEnviados,
+      ja_compraram: jaCompraram,
       erros,
     });
   } catch (err) {

--- a/app/api/cron/followup-simulacoes/route.ts
+++ b/app/api/cron/followup-simulacoes/route.ts
@@ -16,6 +16,16 @@ function primeiroNome(nome: string): string {
   return (nome || "").split(" ")[0] || "Cliente";
 }
 
+// Normaliza nome pra comparacao: "  João Silva " → "JOAO SILVA"
+function normalizarNome(nome: string): string {
+  return (nome || "")
+    .trim()
+    .toUpperCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ");
+}
+
 // Envia mensagem via Z-API (instancia de follow-up)
 async function enviarWhatsApp(phone: string, message: string): Promise<boolean> {
   const instanceId = process.env.ZAPI_FOLLOWUP_INSTANCE_ID;
@@ -30,7 +40,6 @@ async function enviarWhatsApp(phone: string, message: string): Promise<boolean> 
   const url = `https://api.z-api.io/instances/${instanceId}/token/${token}/send-text`;
 
   try {
-    // Formatar telefone: garantir 55 + DDD + numero
     let fone = phone.replace(/\D/g, "");
     if (!fone.startsWith("55")) fone = `55${fone}`;
 
@@ -52,6 +61,7 @@ async function enviarWhatsApp(phone: string, message: string): Promise<boolean> 
 }
 
 // Roda todo dia as 14h — envia WhatsApp automatico pro cliente que simulou e nao fechou
+// Verifica se o cliente ja comprou antes de enviar
 export async function GET(req: NextRequest) {
   if (!authCron(req)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -78,7 +88,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ ok: true, message: "Nenhuma simulacao nos ultimos 3 dias" });
     }
 
-    // Filtrar: status SAIR (nao fechou) E sem follow-up enviado E com whatsapp
+    // Filtrar: status SAIR (nao fechou) E sem follow-up enviado
     const naoConvertidas = sims.filter(s =>
       s.status === "SAIR" && !s.follow_up_enviado
     );
@@ -87,19 +97,42 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ ok: true, message: "Todas simulacoes ja foram acompanhadas" });
     }
 
-    // === ENVIO AUTOMATICO DE WHATSAPP ===
-    // Envia pra quem saiu sem fechar, tem whatsapp, e tem pelo menos 1 dia
+    // Buscar vendas recentes pra cruzar (quem ja comprou)
+    const { data: vendas } = await supabase
+      .from("vendas")
+      .select("cliente")
+      .gte("created_at", dataLimite);
+
+    const clientesQueCompraram = new Set<string>();
+    if (vendas) {
+      for (const v of vendas) {
+        if (v.cliente) clientesQueCompraram.add(normalizarNome(v.cliente));
+      }
+    }
+
+    // Enviar WhatsApp pra quem saiu sem fechar, tem whatsapp, e tem pelo menos 1 dia
     const paraEnviarWA = naoConvertidas.filter(s => {
       const dias = diasAtras(s.created_at);
-      return s.whatsapp && dias >= 1; // espera pelo menos 24h
+      return s.whatsapp && dias >= 1;
     });
 
     let whatsappEnviados = 0;
+    let jaCompraram = 0;
     const whatsappErros: string[] = [];
 
     for (const s of paraEnviarWA) {
-      const nome = primeiroNome(s.nome);
+      // Verificar se o cliente ja comprou
+      const nomeNorm = normalizarNome(s.nome);
+      if (clientesQueCompraram.has(nomeNorm)) {
+        jaCompraram++;
+        await supabase
+          .from("simulacoes")
+          .update({ follow_up_enviado: true })
+          .eq("id", s.id);
+        continue;
+      }
 
+      const nome = primeiroNome(s.nome);
       const modeloUsado = s.modelo_usado ? `${s.modelo_usado}${s.storage_usado ? ` ${s.storage_usado}` : ""}` : "seu aparelho";
       const modeloNovoFull = s.modelo_novo ? `${s.modelo_novo}${s.storage_novo ? ` ${s.storage_novo}` : ""}` : "o produto";
 
@@ -109,7 +142,6 @@ export async function GET(req: NextRequest) {
 
       if (enviou) {
         whatsappEnviados++;
-        // Marcar no banco que o follow-up foi enviado
         await supabase
           .from("simulacoes")
           .update({ follow_up_enviado: true })
@@ -118,7 +150,7 @@ export async function GET(req: NextRequest) {
         whatsappErros.push(s.nome || "Sem nome");
       }
 
-      // Delay de 3s entre mensagens pra nao ser bloqueado
+      // Delay de 3s entre mensagens
       if (paraEnviarWA.indexOf(s) < paraEnviarWA.length - 1) {
         await new Promise(resolve => setTimeout(resolve, 3000));
       }
@@ -129,6 +161,7 @@ export async function GET(req: NextRequest) {
       total_simulacoes: sims.length,
       nao_convertidas: naoConvertidas.length,
       whatsapp_enviados: whatsappEnviados,
+      ja_compraram: jaCompraram,
       whatsapp_erros: whatsappErros,
     });
   } catch (err) {

--- a/supabase/migrations/20260410_alerta_preco_enviado.sql
+++ b/supabase/migrations/20260410_alerta_preco_enviado.sql
@@ -1,0 +1,2 @@
+-- Coluna para marcar que o alerta de queda de preço já foi enviado
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS alerta_preco_enviado BOOLEAN DEFAULT FALSE;

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,10 @@
     {
       "path": "/api/cron/followup-simulacoes",
       "schedule": "0 17 * * *"
+    },
+    {
+      "path": "/api/cron/alerta-preco",
+      "schedule": "0 14 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Novo cron que roda todo dia às 11h (BRT / 14h UTC)
- Compara preço atual dos produtos (tabela `precos`) com o preço que o cliente viu na simulação (`preco_novo`)
- Se o preço baixou R$100+, envia WhatsApp automático pro cliente com a nova condição
- Recalcula a diferença do trade-in com o preço atualizado
- Marca `alerta_preco_enviado=true` pra nunca repetir
- Busca simulações dos últimos 30 dias (status SAIR)

## Arquivos
- `app/api/cron/alerta-preco/route.ts` — endpoint do cron
- `vercel.json` — adicionado schedule 0 14 * * *
- `supabase/migrations/20260410_alerta_preco_enviado.sql` — nova coluna

## Pré-requisito
⚠️ Rodar a migration em `/admin/migrations` após deploy

## Test plan
- [ ] Rodar migration `20260410_alerta_preco_enviado.sql`
- [ ] Chamar GET `/api/cron/alerta-preco` com header Authorization
- [ ] Verificar que só envia quando queda >= R$100

🤖 Generated with [Claude Code](https://claude.com/claude-code)