### PR TITLE
fix: remover itens fantasma gastos + corrigir HLHW9X274W

### DIFF
--- a/supabase/migrations/20260410f_fix_final_gastos_macmini_hlhw.sql
+++ b/supabase/migrations/20260410f_fix_final_gastos_macmini_hlhw.sql
@@ -1,0 +1,21 @@
+-- =====================================================================
+-- Migration: Correções finais — itens sem S/N, HLHW, Mac Mini
+-- =====================================================================
+
+-- 1. Remover itens sem serial dos gastos (fantasmas da migration anterior)
+-- ─────────────────────────────────────────────────────────────────────────
+DELETE FROM estoque WHERE id = 'abeee3ba-0f2b-430a-9290-9c7f219e6f93';
+DELETE FROM estoque WHERE id = '522cbb79-3d58-4ac9-8b2a-41674b350efb';
+
+-- 2. HLHW9X274W — corrigir dados: Lacrado, R$7.500, entrada 08/04/2026
+-- ─────────────────────────────────────────────────────────────────────
+UPDATE estoque
+SET tipo = 'NOVO',
+    custo_unitario = 7500,
+    data_compra = '2026-04-08',
+    data_entrada = '2026-04-08',
+    fornecedor = 'MAURO MANTUANO',
+    cliente = 'MAURO MANTUANO',
+    cor = NULL,
+    updated_at = NOW()
+WHERE serial_no = 'HLHW9X274W';


### PR DESCRIPTION
## Summary
- Remove 2 itens sem serial número dos gastos 30/03 (gasto 1 mostra 5 ao invés de 6, gasto 2 mostra 3 ao invés de 4)
- Corrige HLHW9X274W: tipo NOVO (Lacrado), custo R$7.500, data entrada 08/04/2026

## Test plan
- [ ] Rodar migration `20260410f_fix_final_gastos_macmini_hlhw.sql`
- [ ] Gasto 12:54 deve mostrar 5 produtos (sem item fantasma)
- [ ] Gasto 11:48 deve mostrar 3 produtos (sem item fantasma)
- [ ] HLHW9X274W deve aparecer no estoque com R$7.500 e data 08/04

🤖 Generated with [Claude Code](https://claude.com/claude-code)