### PR TITLE
feat(gerar-link): opção Logística define no horário

### DIFF
--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -2062,6 +2062,7 @@ export default function GerarLinkPage() {
             <label className={labelCls}>Horario</label>
             <select value={horario} onChange={(e) => setHorario(e.target.value)} className={inputCls}>
               <option value="">-- Opcional --</option>
+              <option value="LOGISTICA">🚚 Logística define</option>
               {(() => {
                 const opts: string[] = [];
                 for (let h = 10; h <= 19; h++) {

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -1053,14 +1053,20 @@ function CompraForm() {
           {/* Horário — dinâmico conforme tipo + dia da semana */}
           <div>
             <label className={labelCls}>Horario *</label>
-            <div className="grid grid-cols-4 gap-2">
-              {horariosDisponiveis.map(h => (
-                <button key={h} type="button" onClick={() => setHorario(h)}
-                  className={`py-2.5 rounded-lg text-sm font-medium border transition-colors ${horario === h ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
-                  {h}
-                </button>
-              ))}
-            </div>
+            {horarioParam === "LOGISTICA" ? (
+              <div className="py-3 px-4 rounded-lg bg-[#FFF5EB] border border-[#E8740E]/30 text-sm text-[#86868B]">
+                🚚 O horário da sua entrega será definido pela nossa equipe de logística. Entraremos em contato para confirmar.
+              </div>
+            ) : (
+              <div className="grid grid-cols-4 gap-2">
+                {horariosDisponiveis.map(h => (
+                  <button key={h} type="button" onClick={() => setHorario(h)}
+                    className={`py-2.5 rounded-lg text-sm font-medium border transition-colors ${horario === h ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
+                    {h}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
 
           {local === "Entrega" && (


### PR DESCRIPTION
## Summary
- Adiciona opção "🚚 Logística define" no dropdown de Horário do Gerar Link
- Quando selecionado, o formulário do cliente mostra mensagem informativa e o campo de horário fica congelado (sem opções de horário pra escolher)

## Test plan
- [ ] Abrir Gerar Link → verificar opção "Logística define" no dropdown de Horário
- [ ] Gerar um link com essa opção → abrir o link do cliente → verificar que o campo de horário está travado com mensagem

🤖 Generated with [Claude Code](https://claude.com/claude-code)