### PR TITLE
feat: logística define horário + copiar texto atacado selecionados

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -3962,8 +3962,9 @@ export default function EstoquePage() {
                             const catEmoji: Record<string, string> = { IPHONES: "📱", IPADS: "📱", MACBOOK: "💻", MAC_MINI: "🖥️", APPLE_WATCH: "⌚", AIRPODS: "🎧", ACESSORIOS: "🔌" };
                             const catLabel: Record<string, string> = { IPHONES: "iPhones", IPADS: "iPads", MACBOOK: "MacBooks", MAC_MINI: "Mac Mini", APPLE_WATCH: "Apple Watch", AIRPODS: "AirPods", ACESSORIOS: "Acessórios" };
                             const catOrder = ["AIRPODS", "APPLE_WATCH", "IPADS", "IPHONES", "MACBOOK", "MAC_MINI", "ACESSORIOS"];
+                            const fonte = selectedACaminho.size > 0 ? aCaminho.filter(p => selectedACaminho.has(p.id)) : aCaminho;
                             const groups: Record<string, string[]> = {};
-                            for (const p of aCaminho) {
+                            for (const p of fonte) {
                               const cat = p.categoria || "OUTROS";
                               if (!groups[cat]) groups[cat] = [];
                               const nome = (p.produto || "").replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ|ZD|ZP)\s*(\([^)]*\))?/gi, "")
@@ -3989,11 +3990,11 @@ export default function EstoquePage() {
                               lines.push("");
                             }
                             navigator.clipboard.writeText(lines.join("\n").trim());
-                            setMsg("📋 Texto copiado! Cole no WhatsApp.");
+                            setMsg(selectedACaminho.size > 0 ? `📋 Texto copiado (${selectedACaminho.size} selecionados)!` : "📋 Texto copiado! Cole no WhatsApp.");
                           }}
                           className="px-4 py-2 rounded-xl text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D] transition-colors"
                         >
-                          📋 Copiar Texto Atacado
+                          📋 {selectedACaminho.size > 0 ? `Copiar ${selectedACaminho.size} Selecionados` : "Copiar Texto Atacado"}
                         </button>
                       </div>
                     </div>
@@ -4440,8 +4441,9 @@ export default function EstoquePage() {
                     const catOrder = ["AIRPODS", "APPLE_WATCH", "IPADS", "IPHONES", "MACBOOK", "MAC_MINI", "ACESSORIOS"];
 
                     // Agrupa por categoria → lista de "modelo – cor"
+                    const fonte = selectedACaminho.size > 0 ? aCaminho.filter(p => selectedACaminho.has(p.id)) : aCaminho;
                     const groups: Record<string, string[]> = {};
-                    for (const p of aCaminho) {
+                    for (const p of fonte) {
                       const cat = p.categoria || "OUTROS";
                       if (!groups[cat]) groups[cat] = [];
                       // Extrai nome limpo + cor
@@ -4472,11 +4474,11 @@ export default function EstoquePage() {
                     }
 
                     navigator.clipboard.writeText(lines.join("\n").trim());
-                    setMsg("📋 Texto copiado! Cole no WhatsApp.");
+                    setMsg(selectedACaminho.size > 0 ? `📋 Texto copiado (${selectedACaminho.size} selecionados)!` : "📋 Texto copiado! Cole no WhatsApp.");
                   }}
                   className="px-4 py-2 rounded-xl text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D] transition-colors"
                 >
-                  📋 Copiar Texto Atacado
+                  📋 {selectedACaminho.size > 0 ? `Copiar ${selectedACaminho.size} Selecionados` : "Copiar Texto Atacado"}
                 </button>
                 </div>
               </div>

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -2062,6 +2062,7 @@ export default function GerarLinkPage() {
             <label className={labelCls}>Horario</label>
             <select value={horario} onChange={(e) => setHorario(e.target.value)} className={inputCls}>
               <option value="">-- Opcional --</option>
+              <option value="LOGISTICA">🚚 Logística define</option>
               {(() => {
                 const opts: string[] = [];
                 for (let h = 10; h <= 19; h++) {

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -1053,14 +1053,20 @@ function CompraForm() {
           {/* Horário — dinâmico conforme tipo + dia da semana */}
           <div>
             <label className={labelCls}>Horario *</label>
-            <div className="grid grid-cols-4 gap-2">
-              {horariosDisponiveis.map(h => (
-                <button key={h} type="button" onClick={() => setHorario(h)}
-                  className={`py-2.5 rounded-lg text-sm font-medium border transition-colors ${horario === h ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
-                  {h}
-                </button>
-              ))}
-            </div>
+            {horarioParam === "LOGISTICA" ? (
+              <div className="py-3 px-4 rounded-lg bg-[#FFF5EB] border border-[#E8740E]/30 text-sm text-[#86868B]">
+                🚚 O horário da sua entrega será definido pela nossa equipe de logística. Entraremos em contato para confirmar.
+              </div>
+            ) : (
+              <div className="grid grid-cols-4 gap-2">
+                {horariosDisponiveis.map(h => (
+                  <button key={h} type="button" onClick={() => setHorario(h)}
+                    className={`py-2.5 rounded-lg text-sm font-medium border transition-colors ${horario === h ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
+                    {h}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
 
           {local === "Entrega" && (


### PR DESCRIPTION
## Summary
- **Gerar Link**: opção "🚚 Logística define" no horário — congela o campo no formulário do cliente
- **Estoque → Produtos a Caminho**: botão "Copiar Texto Atacado" agora respeita os checkboxes — seleciona os produtos que chegaram e copia só esses

## Test plan
- [ ] Gerar Link → selecionar "Logística define" → gerar link → abrir → campo horário travado
- [ ] Estoque → Produtos a Caminho → selecionar alguns produtos → botão muda pra "Copiar X Selecionados" → texto copiado só com os selecionados
- [ ] Sem seleção → copia todos como antes

🤖 Generated with [Claude Code](https://claude.com/claude-code)