### PR TITLE
feat: logística define, copiar atacado selecionados, opt-out WhatsApp

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -3962,8 +3962,9 @@ export default function EstoquePage() {
                             const catEmoji: Record<string, string> = { IPHONES: "📱", IPADS: "📱", MACBOOK: "💻", MAC_MINI: "🖥️", APPLE_WATCH: "⌚", AIRPODS: "🎧", ACESSORIOS: "🔌" };
                             const catLabel: Record<string, string> = { IPHONES: "iPhones", IPADS: "iPads", MACBOOK: "MacBooks", MAC_MINI: "Mac Mini", APPLE_WATCH: "Apple Watch", AIRPODS: "AirPods", ACESSORIOS: "Acessórios" };
                             const catOrder = ["AIRPODS", "APPLE_WATCH", "IPADS", "IPHONES", "MACBOOK", "MAC_MINI", "ACESSORIOS"];
+                            const fonte = selectedACaminho.size > 0 ? aCaminho.filter(p => selectedACaminho.has(p.id)) : aCaminho;
                             const groups: Record<string, string[]> = {};
-                            for (const p of aCaminho) {
+                            for (const p of fonte) {
                               const cat = p.categoria || "OUTROS";
                               if (!groups[cat]) groups[cat] = [];
                               const nome = (p.produto || "").replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ|ZD|ZP)\s*(\([^)]*\))?/gi, "")
@@ -3989,11 +3990,11 @@ export default function EstoquePage() {
                               lines.push("");
                             }
                             navigator.clipboard.writeText(lines.join("\n").trim());
-                            setMsg("📋 Texto copiado! Cole no WhatsApp.");
+                            setMsg(selectedACaminho.size > 0 ? `📋 Texto copiado (${selectedACaminho.size} selecionados)!` : "📋 Texto copiado! Cole no WhatsApp.");
                           }}
                           className="px-4 py-2 rounded-xl text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D] transition-colors"
                         >
-                          📋 Copiar Texto Atacado
+                          📋 {selectedACaminho.size > 0 ? `Copiar ${selectedACaminho.size} Selecionados` : "Copiar Texto Atacado"}
                         </button>
                       </div>
                     </div>
@@ -4440,8 +4441,9 @@ export default function EstoquePage() {
                     const catOrder = ["AIRPODS", "APPLE_WATCH", "IPADS", "IPHONES", "MACBOOK", "MAC_MINI", "ACESSORIOS"];
 
                     // Agrupa por categoria → lista de "modelo – cor"
+                    const fonte = selectedACaminho.size > 0 ? aCaminho.filter(p => selectedACaminho.has(p.id)) : aCaminho;
                     const groups: Record<string, string[]> = {};
-                    for (const p of aCaminho) {
+                    for (const p of fonte) {
                       const cat = p.categoria || "OUTROS";
                       if (!groups[cat]) groups[cat] = [];
                       // Extrai nome limpo + cor
@@ -4472,11 +4474,11 @@ export default function EstoquePage() {
                     }
 
                     navigator.clipboard.writeText(lines.join("\n").trim());
-                    setMsg("📋 Texto copiado! Cole no WhatsApp.");
+                    setMsg(selectedACaminho.size > 0 ? `📋 Texto copiado (${selectedACaminho.size} selecionados)!` : "📋 Texto copiado! Cole no WhatsApp.");
                   }}
                   className="px-4 py-2 rounded-xl text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D] transition-colors"
                 >
-                  📋 Copiar Texto Atacado
+                  📋 {selectedACaminho.size > 0 ? `Copiar ${selectedACaminho.size} Selecionados` : "Copiar Texto Atacado"}
                 </button>
                 </div>
               </div>

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -2062,6 +2062,7 @@ export default function GerarLinkPage() {
             <label className={labelCls}>Horario</label>
             <select value={horario} onChange={(e) => setHorario(e.target.value)} className={inputCls}>
               <option value="">-- Opcional --</option>
+              <option value="LOGISTICA">🚚 Logística define</option>
               {(() => {
                 const opts: string[] = [];
                 for (let h = 10; h <= 19; h++) {

--- a/app/api/cron/alerta-preco/route.ts
+++ b/app/api/cron/alerta-preco/route.ts
@@ -91,7 +91,7 @@ export async function GET(req: NextRequest) {
 
     const { data: sims, error: errSims } = await supabase
       .from("simulacoes")
-      .select("id, nome, whatsapp, modelo_novo, storage_novo, preco_novo, modelo_usado, storage_usado, diferenca, status, alerta_preco_enviado")
+      .select("id, nome, whatsapp, modelo_novo, storage_novo, preco_novo, modelo_usado, storage_usado, diferenca, status, alerta_preco_enviado, opt_out_whatsapp")
       .gte("created_at", dataLimite)
       .eq("status", "SAIR")
       .or("alerta_preco_enviado.is.null,alerta_preco_enviado.eq.false")
@@ -102,7 +102,10 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: errSims.message }, { status: 500 });
     }
 
-    if (!sims || sims.length === 0) {
+    // Filtrar opt-out no código (evita conflito de múltiplos .or() no Supabase)
+    const simsElegiveis = (sims || []).filter(s => !s.opt_out_whatsapp);
+
+    if (simsElegiveis.length === 0) {
       return NextResponse.json({ ok: true, message: "Nenhuma simulacao elegivel" });
     }
 
@@ -126,7 +129,7 @@ export async function GET(req: NextRequest) {
     const erros: string[] = [];
     const QUEDA_MINIMA = 100; // so avisa se baixou pelo menos R$100
 
-    for (const s of sims) {
+    for (const s of simsElegiveis) {
       if (!s.whatsapp || !s.modelo_novo || !s.storage_novo || !s.preco_novo) continue;
 
       // Verificar se o cliente ja comprou (match por nome)

--- a/app/api/cron/followup-simulacoes/route.ts
+++ b/app/api/cron/followup-simulacoes/route.ts
@@ -75,7 +75,7 @@ export async function GET(req: NextRequest) {
 
     const { data: sims, error } = await supabase
       .from("simulacoes")
-      .select("id, created_at, nome, whatsapp, modelo_novo, storage_novo, preco_novo, modelo_usado, storage_usado, avaliacao_usado, diferenca, status, contatado, follow_up_enviado, vendedor")
+      .select("id, created_at, nome, whatsapp, modelo_novo, storage_novo, preco_novo, modelo_usado, storage_usado, avaliacao_usado, diferenca, status, contatado, follow_up_enviado, opt_out_whatsapp, vendedor")
       .gte("created_at", dataLimite)
       .order("created_at", { ascending: false });
 
@@ -88,9 +88,9 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ ok: true, message: "Nenhuma simulacao nos ultimos 3 dias" });
     }
 
-    // Filtrar: status SAIR (nao fechou) E sem follow-up enviado
+    // Filtrar: status SAIR (nao fechou) E sem follow-up enviado E sem opt-out
     const naoConvertidas = sims.filter(s =>
-      s.status === "SAIR" && !s.follow_up_enviado
+      s.status === "SAIR" && !s.follow_up_enviado && !s.opt_out_whatsapp
     );
 
     if (naoConvertidas.length === 0) {

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -1053,14 +1053,20 @@ function CompraForm() {
           {/* Horário — dinâmico conforme tipo + dia da semana */}
           <div>
             <label className={labelCls}>Horario *</label>
-            <div className="grid grid-cols-4 gap-2">
-              {horariosDisponiveis.map(h => (
-                <button key={h} type="button" onClick={() => setHorario(h)}
-                  className={`py-2.5 rounded-lg text-sm font-medium border transition-colors ${horario === h ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
-                  {h}
-                </button>
-              ))}
-            </div>
+            {horarioParam === "LOGISTICA" ? (
+              <div className="py-3 px-4 rounded-lg bg-[#FFF5EB] border border-[#E8740E]/30 text-sm text-[#86868B]">
+                🚚 O horário da sua entrega será definido pela nossa equipe de logística. Entraremos em contato para confirmar.
+              </div>
+            ) : (
+              <div className="grid grid-cols-4 gap-2">
+                {horariosDisponiveis.map(h => (
+                  <button key={h} type="button" onClick={() => setHorario(h)}
+                    className={`py-2.5 rounded-lg text-sm font-medium border transition-colors ${horario === h ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
+                    {h}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
 
           {local === "Entrega" && (

--- a/supabase/migrations/20260411_simulacoes_opt_out.sql
+++ b/supabase/migrations/20260411_simulacoes_opt_out.sql
@@ -1,0 +1,2 @@
+-- Opt-out de WhatsApp: cliente pediu pra não receber mais mensagens
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS opt_out_whatsapp BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- **Gerar Link**: opção "🚚 Logística define" no horário — congela campo no formulário do cliente
- **Estoque → Produtos a Caminho**: botão "Copiar Texto Atacado" respeita checkboxes — copia só selecionados
- **Bots WhatsApp**: campo `opt_out_whatsapp` na tabela simulacoes — cliente que pede pra não receber mais mensagens é excluído de todos os bots (follow-up e alerta de preço)

## Test plan
- [ ] Gerar Link → "Logística define" → formulário do cliente com campo travado
- [ ] Estoque → selecionar produtos → "Copiar X Selecionados"
- [ ] Rodar migration `20260411_simulacoes_opt_out.sql` em /admin/migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)