### PR TITLE
fix(followup): usar send-option-list para botões WhatsApp

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -3962,8 +3962,9 @@ export default function EstoquePage() {
                             const catEmoji: Record<string, string> = { IPHONES: "📱", IPADS: "📱", MACBOOK: "💻", MAC_MINI: "🖥️", APPLE_WATCH: "⌚", AIRPODS: "🎧", ACESSORIOS: "🔌" };
                             const catLabel: Record<string, string> = { IPHONES: "iPhones", IPADS: "iPads", MACBOOK: "MacBooks", MAC_MINI: "Mac Mini", APPLE_WATCH: "Apple Watch", AIRPODS: "AirPods", ACESSORIOS: "Acessórios" };
                             const catOrder = ["AIRPODS", "APPLE_WATCH", "IPADS", "IPHONES", "MACBOOK", "MAC_MINI", "ACESSORIOS"];
+                            const fonte = selectedACaminho.size > 0 ? aCaminho.filter(p => selectedACaminho.has(p.id)) : aCaminho;
                             const groups: Record<string, string[]> = {};
-                            for (const p of aCaminho) {
+                            for (const p of fonte) {
                               const cat = p.categoria || "OUTROS";
                               if (!groups[cat]) groups[cat] = [];
                               const nome = (p.produto || "").replace(/\s+(VC|LL|J|BE|BR|HN|IN|ZA|BZ|ZD|ZP)\s*(\([^)]*\))?/gi, "")
@@ -3989,11 +3990,11 @@ export default function EstoquePage() {
                               lines.push("");
                             }
                             navigator.clipboard.writeText(lines.join("\n").trim());
-                            setMsg("📋 Texto copiado! Cole no WhatsApp.");
+                            setMsg(selectedACaminho.size > 0 ? `📋 Texto copiado (${selectedACaminho.size} selecionados)!` : "📋 Texto copiado! Cole no WhatsApp.");
                           }}
                           className="px-4 py-2 rounded-xl text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D] transition-colors"
                         >
-                          📋 Copiar Texto Atacado
+                          📋 {selectedACaminho.size > 0 ? `Copiar ${selectedACaminho.size} Selecionados` : "Copiar Texto Atacado"}
                         </button>
                       </div>
                     </div>
@@ -4440,8 +4441,9 @@ export default function EstoquePage() {
                     const catOrder = ["AIRPODS", "APPLE_WATCH", "IPADS", "IPHONES", "MACBOOK", "MAC_MINI", "ACESSORIOS"];
 
                     // Agrupa por categoria → lista de "modelo – cor"
+                    const fonte = selectedACaminho.size > 0 ? aCaminho.filter(p => selectedACaminho.has(p.id)) : aCaminho;
                     const groups: Record<string, string[]> = {};
-                    for (const p of aCaminho) {
+                    for (const p of fonte) {
                       const cat = p.categoria || "OUTROS";
                       if (!groups[cat]) groups[cat] = [];
                       // Extrai nome limpo + cor
@@ -4472,11 +4474,11 @@ export default function EstoquePage() {
                     }
 
                     navigator.clipboard.writeText(lines.join("\n").trim());
-                    setMsg("📋 Texto copiado! Cole no WhatsApp.");
+                    setMsg(selectedACaminho.size > 0 ? `📋 Texto copiado (${selectedACaminho.size} selecionados)!` : "📋 Texto copiado! Cole no WhatsApp.");
                   }}
                   className="px-4 py-2 rounded-xl text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D] transition-colors"
                 >
-                  📋 Copiar Texto Atacado
+                  📋 {selectedACaminho.size > 0 ? `Copiar ${selectedACaminho.size} Selecionados` : "Copiar Texto Atacado"}
                 </button>
                 </div>
               </div>

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -2062,6 +2062,7 @@ export default function GerarLinkPage() {
             <label className={labelCls}>Horario</label>
             <select value={horario} onChange={(e) => setHorario(e.target.value)} className={inputCls}>
               <option value="">-- Opcional --</option>
+              <option value="LOGISTICA">🚚 Logística define</option>
               {(() => {
                 const opts: string[] = [];
                 for (let h = 10; h <= 19; h++) {

--- a/app/api/cron/alerta-preco/route.ts
+++ b/app/api/cron/alerta-preco/route.ts
@@ -91,7 +91,7 @@ export async function GET(req: NextRequest) {
 
     const { data: sims, error: errSims } = await supabase
       .from("simulacoes")
-      .select("id, nome, whatsapp, modelo_novo, storage_novo, preco_novo, modelo_usado, storage_usado, diferenca, status, alerta_preco_enviado")
+      .select("id, nome, whatsapp, modelo_novo, storage_novo, preco_novo, modelo_usado, storage_usado, diferenca, status, alerta_preco_enviado, opt_out_whatsapp")
       .gte("created_at", dataLimite)
       .eq("status", "SAIR")
       .or("alerta_preco_enviado.is.null,alerta_preco_enviado.eq.false")
@@ -102,7 +102,10 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: errSims.message }, { status: 500 });
     }
 
-    if (!sims || sims.length === 0) {
+    // Filtrar opt-out no código (evita conflito de múltiplos .or() no Supabase)
+    const simsElegiveis = (sims || []).filter(s => !s.opt_out_whatsapp);
+
+    if (simsElegiveis.length === 0) {
       return NextResponse.json({ ok: true, message: "Nenhuma simulacao elegivel" });
     }
 
@@ -126,7 +129,7 @@ export async function GET(req: NextRequest) {
     const erros: string[] = [];
     const QUEDA_MINIMA = 100; // so avisa se baixou pelo menos R$100
 
-    for (const s of sims) {
+    for (const s of simsElegiveis) {
       if (!s.whatsapp || !s.modelo_novo || !s.storage_novo || !s.preco_novo) continue;
 
       // Verificar se o cliente ja comprou (match por nome)

--- a/app/api/cron/followup-simulacoes/route.ts
+++ b/app/api/cron/followup-simulacoes/route.ts
@@ -37,7 +37,7 @@ async function enviarWhatsAppComBotoes(phone: string, message: string, simId: st
     return false;
   }
 
-  const url = `https://api.z-api.io/instances/${instanceId}/token/${token}/send-button-actions`;
+  const url = `https://api.z-api.io/instances/${instanceId}/token/${token}/send-option-list`;
 
   try {
     let fone = phone.replace(/\D/g, "");
@@ -51,13 +51,15 @@ async function enviarWhatsAppComBotoes(phone: string, message: string, simId: st
       },
       body: JSON.stringify({
         phone: fone,
-        title: "Tigrão Imports",
         message,
-        footerText: "Responda clicando em um dos botões abaixo",
-        buttons: [
-          { id: `SIM_${simId}`, label: "✅ Tenho interesse" },
-          { id: `NAO_${simId}`, label: "❌ Não tenho interesse" },
-        ],
+        optionList: {
+          title: "Escolha uma opção",
+          buttonLabel: "Responder",
+          options: [
+            { id: `SIM_${simId}`, title: "✅ Tenho interesse", description: "Quero continuar a negociação" },
+            { id: `NAO_${simId}`, title: "❌ Sem interesse", description: "Não quero receber mais mensagens" },
+          ],
+        },
       }),
     });
     const json = await res.json();

--- a/app/api/cron/followup-simulacoes/route.ts
+++ b/app/api/cron/followup-simulacoes/route.ts
@@ -75,7 +75,7 @@ export async function GET(req: NextRequest) {
 
     const { data: sims, error } = await supabase
       .from("simulacoes")
-      .select("id, created_at, nome, whatsapp, modelo_novo, storage_novo, preco_novo, modelo_usado, storage_usado, avaliacao_usado, diferenca, status, contatado, follow_up_enviado, vendedor")
+      .select("id, created_at, nome, whatsapp, modelo_novo, storage_novo, preco_novo, modelo_usado, storage_usado, avaliacao_usado, diferenca, status, contatado, follow_up_enviado, opt_out_whatsapp, vendedor")
       .gte("created_at", dataLimite)
       .order("created_at", { ascending: false });
 
@@ -88,9 +88,9 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ ok: true, message: "Nenhuma simulacao nos ultimos 3 dias" });
     }
 
-    // Filtrar: status SAIR (nao fechou) E sem follow-up enviado
+    // Filtrar: status SAIR (nao fechou) E sem follow-up enviado E sem opt-out
     const naoConvertidas = sims.filter(s =>
-      s.status === "SAIR" && !s.follow_up_enviado
+      s.status === "SAIR" && !s.follow_up_enviado && !s.opt_out_whatsapp
     );
 
     if (naoConvertidas.length === 0) {

--- a/app/api/cron/followup-simulacoes/route.ts
+++ b/app/api/cron/followup-simulacoes/route.ts
@@ -26,8 +26,8 @@ function normalizarNome(nome: string): string {
     .replace(/\s+/g, " ");
 }
 
-// Envia mensagem via Z-API (instancia de follow-up)
-async function enviarWhatsApp(phone: string, message: string): Promise<boolean> {
+// Envia mensagem com botões via Z-API (instancia de follow-up)
+async function enviarWhatsAppComBotoes(phone: string, message: string, simId: string): Promise<boolean> {
   const instanceId = process.env.ZAPI_FOLLOWUP_INSTANCE_ID;
   const token = process.env.ZAPI_FOLLOWUP_TOKEN;
   const clientToken = process.env.ZAPI_CLIENT_TOKEN ?? "";
@@ -37,7 +37,7 @@ async function enviarWhatsApp(phone: string, message: string): Promise<boolean> 
     return false;
   }
 
-  const url = `https://api.z-api.io/instances/${instanceId}/token/${token}/send-text`;
+  const url = `https://api.z-api.io/instances/${instanceId}/token/${token}/send-button-actions`;
 
   try {
     let fone = phone.replace(/\D/g, "");
@@ -49,10 +49,19 @@ async function enviarWhatsApp(phone: string, message: string): Promise<boolean> 
         "Content-Type": "application/json",
         "Client-Token": clientToken,
       },
-      body: JSON.stringify({ phone: fone, message }),
+      body: JSON.stringify({
+        phone: fone,
+        title: "Tigrão Imports",
+        message,
+        footerText: "Responda clicando em um dos botões abaixo",
+        buttons: [
+          { id: `SIM_${simId}`, label: "✅ Tenho interesse" },
+          { id: `NAO_${simId}`, label: "❌ Não tenho interesse" },
+        ],
+      }),
     });
     const json = await res.json();
-    console.log(`[Followup] WhatsApp enviado para ${fone}:`, JSON.stringify(json));
+    console.log(`[Followup] WhatsApp com botões enviado para ${fone}:`, JSON.stringify(json));
     return res.ok;
   } catch (err) {
     console.error(`[Followup] Erro ao enviar WhatsApp para ${phone}:`, err);
@@ -138,7 +147,7 @@ export async function GET(req: NextRequest) {
 
       const msg = `Oi ${nome}! Tudo bem? 😊\n\nVi que você fez uma simulação de upgrade aqui na TIGRÃO IMPORTS, dando seu ${modeloUsado} na compra do ${modeloNovoFull}.\n\nFicou alguma dúvida? Posso te ajudar a fechar essa troca ainda hoje! Estou à disposição 🐯`;
 
-      const enviou = await enviarWhatsApp(s.whatsapp, msg);
+      const enviou = await enviarWhatsAppComBotoes(s.whatsapp, msg, s.id);
 
       if (enviou) {
         whatsappEnviados++;

--- a/app/api/webhook/zapi-followup/route.ts
+++ b/app/api/webhook/zapi-followup/route.ts
@@ -1,0 +1,115 @@
+// Webhook Z-API — recebe cliques de botões do follow-up
+// Quando cliente clica "Não tenho interesse" → marca opt_out_whatsapp
+// Quando cliente clica "Tenho interesse" → notifica vendedor via Telegram
+
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { sendTelegramMessage } from "@/lib/telegram";
+
+const supabase = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    console.log("[ZAPI Webhook] Recebido:", JSON.stringify(body));
+
+    // Z-API envia o buttonId quando o cliente clica num botão
+    // Formato: { phone, buttonId, ... } ou { button: { id, text }, ... }
+    const buttonId = body.buttonId || body.button?.id || body.buttonPayload || "";
+    const phone = body.phone || body.from || "";
+
+    if (!buttonId) {
+      // Não é um clique de botão, pode ser mensagem normal — ignorar
+      return NextResponse.json({ ok: true, ignored: true });
+    }
+
+    // Extrair ação e ID da simulação do buttonId
+    // Formato: "SIM_{simId}" ou "NAO_{simId}"
+    const parts = buttonId.split("_");
+    const acao = parts[0]; // SIM ou NAO
+    const simId = parts.slice(1).join("_"); // UUID da simulação
+
+    if (!simId || (acao !== "SIM" && acao !== "NAO")) {
+      console.log("[ZAPI Webhook] ButtonId não reconhecido:", buttonId);
+      return NextResponse.json({ ok: true, ignored: true });
+    }
+
+    // Buscar dados da simulação
+    const { data: sim } = await supabase
+      .from("simulacoes")
+      .select("id, nome, whatsapp, modelo_novo, storage_novo, modelo_usado, storage_usado, vendedor")
+      .eq("id", simId)
+      .single();
+
+    if (!sim) {
+      console.log("[ZAPI Webhook] Simulação não encontrada:", simId);
+      return NextResponse.json({ ok: true, error: "sim not found" });
+    }
+
+    if (acao === "NAO") {
+      // Cliente não tem interesse → marcar opt-out em TODAS as simulações desse número
+      const foneNorm = (sim.whatsapp || phone).replace(/\D/g, "");
+      await supabase
+        .from("simulacoes")
+        .update({ opt_out_whatsapp: true, follow_up_enviado: true, alerta_preco_enviado: true })
+        .eq("whatsapp", foneNorm);
+
+      // Também tenta com o formato que pode estar salvo
+      if (foneNorm.length === 11) {
+        await supabase
+          .from("simulacoes")
+          .update({ opt_out_whatsapp: true, follow_up_enviado: true, alerta_preco_enviado: true })
+          .eq("whatsapp", `55${foneNorm}`);
+      }
+
+      console.log(`[ZAPI Webhook] Opt-out: ${sim.nome} (${foneNorm})`);
+
+      // Notificar no Telegram
+      const chatId = process.env.TELEGRAM_VENDAS_CHAT_ID || process.env.TELEGRAM_CHAT_ID || "";
+      if (chatId) {
+        await sendTelegramMessage(
+          `🚫 <b>Cliente não tem interesse</b>\n\n` +
+          `<b>${sim.nome}</b> clicou "Não tenho interesse" no follow-up.\n` +
+          `Modelo: ${sim.modelo_usado || "?"} → ${sim.modelo_novo || "?"}\n` +
+          `Removido de todas as listas automáticas.`,
+          chatId
+        );
+      }
+
+      return NextResponse.json({ ok: true, action: "opt_out", nome: sim.nome });
+    }
+
+    if (acao === "SIM") {
+      // Cliente tem interesse → notificar vendedor pra dar continuidade
+      const chatId = process.env.TELEGRAM_VENDAS_CHAT_ID || process.env.TELEGRAM_CHAT_ID || "";
+      const vendedor = sim.vendedor || "Equipe";
+      const modeloUsado = sim.modelo_usado ? `${sim.modelo_usado}${sim.storage_usado ? ` ${sim.storage_usado}` : ""}` : "?";
+      const modeloNovo = sim.modelo_novo ? `${sim.modelo_novo}${sim.storage_novo ? ` ${sim.storage_novo}` : ""}` : "?";
+      const fone = (sim.whatsapp || "").replace(/\D/g, "");
+      const foneFormatado = fone.startsWith("55") ? fone.slice(2) : fone;
+
+      if (chatId) {
+        await sendTelegramMessage(
+          `🟢 <b>Cliente tem interesse!</b>\n\n` +
+          `<b>${sim.nome}</b> clicou "Tenho interesse" no follow-up!\n` +
+          `📱 ${modeloUsado} → ${modeloNovo}\n` +
+          `📞 ${foneFormatado}\n` +
+          `👤 Vendedor: ${vendedor}\n\n` +
+          `⚡ Entrem em contato agora!`,
+          chatId
+        );
+      }
+
+      console.log(`[ZAPI Webhook] Interesse: ${sim.nome} (${fone})`);
+      return NextResponse.json({ ok: true, action: "interested", nome: sim.nome });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[ZAPI Webhook] Erro:", err);
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/app/api/webhook/zapi-followup/route.ts
+++ b/app/api/webhook/zapi-followup/route.ts
@@ -16,10 +16,17 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     console.log("[ZAPI Webhook] Recebido:", JSON.stringify(body));
 
-    // Z-API envia o buttonId quando o cliente clica num botão
-    // Formato: { phone, buttonId, ... } ou { button: { id, text }, ... }
-    const buttonId = body.buttonId || body.button?.id || body.buttonPayload || "";
-    const phone = body.phone || body.from || "";
+    // Z-API envia o ID da opção selecionada em diferentes formatos
+    // option-list: { listResponseMessage: { singleSelectReply: { selectedRowId } }, phone }
+    // button-actions: { buttonId, phone }
+    // button: { button: { id }, phone }
+    const buttonId = body.listResponseMessage?.singleSelectReply?.selectedRowId
+      || body.buttonId
+      || body.button?.id
+      || body.buttonPayload
+      || body.selectedButtonId
+      || "";
+    const phone = body.phone || body.from || body.chatId || "";
 
     if (!buttonId) {
       // Não é um clique de botão, pode ser mensagem normal — ignorar

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -1053,14 +1053,20 @@ function CompraForm() {
           {/* Horário — dinâmico conforme tipo + dia da semana */}
           <div>
             <label className={labelCls}>Horario *</label>
-            <div className="grid grid-cols-4 gap-2">
-              {horariosDisponiveis.map(h => (
-                <button key={h} type="button" onClick={() => setHorario(h)}
-                  className={`py-2.5 rounded-lg text-sm font-medium border transition-colors ${horario === h ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
-                  {h}
-                </button>
-              ))}
-            </div>
+            {horarioParam === "LOGISTICA" ? (
+              <div className="py-3 px-4 rounded-lg bg-[#FFF5EB] border border-[#E8740E]/30 text-sm text-[#86868B]">
+                🚚 O horário da sua entrega será definido pela nossa equipe de logística. Entraremos em contato para confirmar.
+              </div>
+            ) : (
+              <div className="grid grid-cols-4 gap-2">
+                {horariosDisponiveis.map(h => (
+                  <button key={h} type="button" onClick={() => setHorario(h)}
+                    className={`py-2.5 rounded-lg text-sm font-medium border transition-colors ${horario === h ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
+                    {h}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
 
           {local === "Entrega" && (

--- a/supabase/migrations/20260411_simulacoes_opt_out.sql
+++ b/supabase/migrations/20260411_simulacoes_opt_out.sql
@@ -1,0 +1,2 @@
+-- Opt-out de WhatsApp: cliente pediu pra não receber mais mensagens
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS opt_out_whatsapp BOOLEAN DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- Troca `send-button-actions` por `send-option-list` (formato que funciona no WhatsApp)
- Webhook atualizado para lidar com resposta `listResponseMessage` da Z-API

## Test plan
- [x] Mensagem com botão "Responder" → abre lista com "Tenho interesse" e "Sem interesse"
- [ ] Clicar numa opção → webhook recebe e processa

🤖 Generated with [Claude Code](https://claude.com/claude-code)