### PR TITLE
feat: NF bruto, seminovos caixa alta, WhatsApp lacrado/seminovo, agendar coleta

### DIFF
--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -22,7 +22,8 @@ export default function ConfiguracoesPage() {
 
   // Contato do formulário de troca
   const [principal, setPrincipal] = useState("5521972461357"); // Bianca default
-  const [formularios, setFormularios] = useState(""); // WhatsApp formulários (troca, seminovos, links de compra)
+  const [formLacrados, setFormLacrados] = useState(""); // WhatsApp formulários lacrados
+  const [formSeminovos, setFormSeminovos] = useState(""); // WhatsApp formulários seminovos
   const [vendedores, setVendedores] = useState(VENDEDORES_PADRAO.map(v => ({ ...v })));
 
   const [loading, setLoading] = useState(true);
@@ -40,7 +41,8 @@ export default function ConfiguracoesPage() {
       .then(({ data }) => {
         if (!data) return;
         if (data.whatsapp_principal) setPrincipal(String(data.whatsapp_principal));
-        if (data.whatsapp_formularios) setFormularios(String(data.whatsapp_formularios));
+        if (data.whatsapp_formularios) setFormLacrados(String(data.whatsapp_formularios));
+        if (data.whatsapp_formularios_seminovos) setFormSeminovos(String(data.whatsapp_formularios_seminovos));
         // whatsapp_vendedores pode ser objeto {nome: numero} ou array
         const raw = data.whatsapp_vendedores;
         if (raw && typeof raw === "object" && !Array.isArray(raw)) {
@@ -104,15 +106,20 @@ export default function ConfiguracoesPage() {
     setSaving(true);
     setMsg("");
     try {
-      // salvar como {André: "55...", Bianca: "55...", ...}
+      // salvar com keys normalizadas (lowercase sem acento)
       const waMap: Record<string, string> = {};
       for (const v of vendedores) {
-        if (v.nome) waMap[v.nome] = v.numero;
+        if (v.nome) waMap[v.nome.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "")] = v.numero;
       }
       const res = await fetch("/api/admin/tradein-config", {
         method: "PUT",
         headers: { "x-admin-password": password, "Content-Type": "application/json" },
-        body: JSON.stringify({ whatsapp_principal: principal, whatsapp_formularios: formularios || principal, whatsapp_vendedores: waMap }),
+        body: JSON.stringify({
+          whatsapp_principal: principal,
+          whatsapp_formularios: formLacrados || principal,
+          whatsapp_formularios_seminovos: formSeminovos || principal,
+          whatsapp_vendedores: waMap,
+        }),
       });
       const j = await res.json();
       setMsg(j.ok ? "✅ Salvo com sucesso!" : "❌ Erro: " + (j.error || "desconhecido"));
@@ -186,12 +193,12 @@ export default function ConfiguracoesPage() {
           )}
         </div>
 
-        {/* WhatsApp Formulários */}
+        {/* WhatsApp Troca — Lacrados */}
         <div className="bg-white rounded-xl p-5 shadow-sm border border-[#E8E8ED] space-y-3">
           <div>
-            <p className="font-bold text-[#1D1D1F]">📋 WhatsApp Formulários</p>
+            <p className="font-bold text-[#1D1D1F]">📦 WhatsApp Troca — Lacrados</p>
             <p className="text-xs text-[#86868B] mt-1">
-              Número padrão para receber formulários de troca de lacrados, seminovos e links de compra. Se vazio, usa o número do Formulário de Troca.
+              Número que recebe formulários de troca por aparelhos lacrados (novos). Se vazio, usa o WhatsApp Principal.
             </p>
           </div>
 
@@ -200,37 +207,86 @@ export default function ConfiguracoesPage() {
               <button
                 key={v.nome}
                 type="button"
-                onClick={() => setFormularios(v.numero)}
+                onClick={() => setFormLacrados(v.numero)}
                 className={`px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
-                  formularios === v.numero
+                  formLacrados === v.numero
                     ? "bg-[#E8740E] text-white shadow-sm"
                     : "bg-[#F5F5F7] border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E]"
                 }`}
               >
-                {v.nome} {formularios === v.numero && "✓"}
+                {v.nome} {formLacrados === v.numero && "✓"}
               </button>
             ))}
           </div>
 
           <div>
-            <label className="block text-xs font-medium text-[#86868B] mb-1">Número formulários (DDI + DDD + número)</label>
+            <label className="block text-xs font-medium text-[#86868B] mb-1">Número lacrados (DDI + DDD + número)</label>
             <input
-              value={formularios}
-              onChange={e => setFormularios(e.target.value.replace(/\D/g, ""))}
+              value={formLacrados}
+              onChange={e => setFormLacrados(e.target.value.replace(/\D/g, ""))}
               placeholder="5521972461357"
               className={inputCls}
               inputMode="numeric"
             />
           </div>
 
-          {formularios && (
+          {formLacrados && (
             <a
-              href={`https://wa.me/${formularios}`}
+              href={`https://wa.me/${formLacrados}`}
               target="_blank"
               rel="noreferrer"
               className="inline-flex items-center gap-1 text-xs text-[#E8740E] hover:underline"
             >
-              🔗 Testar: wa.me/{formularios}
+              🔗 Testar: wa.me/{formLacrados}
+            </a>
+          )}
+        </div>
+
+        {/* WhatsApp Troca — Seminovos */}
+        <div className="bg-white rounded-xl p-5 shadow-sm border border-[#E8E8ED] space-y-3">
+          <div>
+            <p className="font-bold text-[#1D1D1F]">📱 WhatsApp Troca — Seminovos</p>
+            <p className="text-xs text-[#86868B] mt-1">
+              Número que recebe formulários de troca por seminovos (usados). Se vazio, usa o WhatsApp Principal.
+            </p>
+          </div>
+
+          <div className="flex gap-2 flex-wrap">
+            {vendedores.filter(v => v.numero).map(v => (
+              <button
+                key={v.nome}
+                type="button"
+                onClick={() => setFormSeminovos(v.numero)}
+                className={`px-4 py-2 rounded-lg text-sm font-semibold transition-all ${
+                  formSeminovos === v.numero
+                    ? "bg-[#E8740E] text-white shadow-sm"
+                    : "bg-[#F5F5F7] border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E]"
+                }`}
+              >
+                {v.nome} {formSeminovos === v.numero && "✓"}
+              </button>
+            ))}
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-[#86868B] mb-1">Número seminovos (DDI + DDD + número)</label>
+            <input
+              value={formSeminovos}
+              onChange={e => setFormSeminovos(e.target.value.replace(/\D/g, ""))}
+              placeholder="5521967442665"
+              className={inputCls}
+              inputMode="numeric"
+            />
+          </div>
+
+          {formSeminovos && (
+            <a
+              href={`https://wa.me/${formSeminovos}`}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-[#E8740E] hover:underline"
+            >
+              🔗 Testar: wa.me/{formSeminovos}
             </a>
           )}
         </div>

--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -46,6 +46,18 @@ const STATUS_CONFIG: Record<EntregaStatus, { label: string; color: string; color
   CANCELADA: { label: "Cancelada", color: "text-red-600", colorDark: "text-red-400", bg: "bg-red-100", bgDark: "bg-red-900/30", border: "border-red-300", borderDark: "border-red-600", icon: "🔴" },
 };
 
+// Labels de status adaptados para coleta
+function getStatusLabel(status: EntregaStatus, tipo: string | null): string {
+  if (tipo === "COLETA") {
+    switch (status) {
+      case "SAIU": return "Saiu p/ Coleta";
+      case "ENTREGUE": return "Coletado";
+      default: return STATUS_CONFIG[status]?.label || status;
+    }
+  }
+  return STATUS_CONFIG[status]?.label || status;
+}
+
 const DIAS_SEMANA = ["Seg", "Ter", "Qua", "Qui", "Sex", "Sab"];
 
 function getWeekRange(offset: number) {
@@ -151,7 +163,13 @@ export default function EntregasPage() {
   const [filtroBia, setFiltroBia] = useState<"todas" | "finalizada" | "pendentes_final" | "comprovante" | "sem_comprovante">("todas");
   const [showForm, setShowForm] = useState(false);
   const [modoSimples, setModoSimples] = useState(false);
+  const [modoColeta, setModoColeta] = useState(false);
   const [rastreio, setRastreio] = useState("");
+  // Campos específicos da coleta (aparelho)
+  const [coletaBateria, setColetaBateria] = useState("");
+  const [coletaEstado, setColetaEstado] = useState<"A+" | "A" | "AB" | "B" | "">("");
+  const [coletaCaixa, setColetaCaixa] = useState<"sim" | "nao" | "">("");
+  const [coletaMarcas, setColetaMarcas] = useState<"sim" | "nao" | "">("");
 
   // Autocomplete de clientes — busca em entregas + vendas, retorna última compra
   type ClienteSug = {
@@ -341,7 +359,7 @@ export default function EntregasPage() {
     for (const p of estoque) {
       if (p.tipo !== "SEMINOVO" || p.qnt <= 0) continue;
       const baseKey = getModeloBase(p.produto, p.categoria);
-      const nome = formatProdutoDisplay({ produto: p.produto, categoria: p.categoria, cor: null, observacao: null });
+      const nome = formatProdutoDisplay({ produto: p.produto, categoria: p.categoria, cor: null, observacao: null }).toUpperCase();
       if (!groups.has(baseKey)) groups.set(baseKey, { nome, key: baseKey, items: [] });
       groups.get(baseKey)!.items.push(p);
     }
@@ -530,6 +548,7 @@ export default function EntregasPage() {
       cliente: clienteNome || f.cliente,
       telefone: clienteTel || f.telefone,
       endereco: endereco || f.endereco,
+      endereco_entrega: endereco || f.endereco_entrega,
       bairro: bairro || f.bairro,
       valor: valor ? String(Math.round(parseFloat(valor))) : f.valor,
       observacao: obs || f.observacao,
@@ -609,22 +628,31 @@ export default function EntregasPage() {
           return parts.length ? parts.join(" | ") : null;
         })(),
         produto: produtosStr || null,
-        tipo: trocaAtiva ? "UPGRADE" : (form.tipo || null),
-        detalhes_upgrade: trocasStr || null,
-        forma_pagamento: jaPago ? "JÁ PAGO" : (formaPagDetalhada || null),
-        valor: valorAPagar > 0 ? valorAPagar : (form.valor ? parseFloat(form.valor) : null),
+        tipo: modoColeta ? "COLETA" : trocaAtiva ? "UPGRADE" : (form.tipo || null),
+        detalhes_upgrade: modoColeta
+          ? (() => {
+              const parts: string[] = [];
+              if (coletaBateria) parts.push(`Bateria: ${coletaBateria}%`);
+              if (coletaEstado) parts.push(`Estado: ${coletaEstado}`);
+              if (coletaCaixa) parts.push(coletaCaixa === "sim" ? "Com caixa" : "Sem caixa");
+              if (coletaMarcas) parts.push(coletaMarcas === "sim" ? "Com marcas de uso" : "Sem marcas de uso");
+              return parts.length ? parts.join("\n") : null;
+            })()
+          : trocasStr || null,
+        forma_pagamento: modoColeta ? null : jaPago ? "JÁ PAGO" : (formaPagDetalhada || null),
+        valor: modoColeta ? null : (valorAPagar > 0 ? valorAPagar : (form.valor ? parseFloat(form.valor) : null)),
         // Campos estruturados pra exibicao detalhada no modal.
         // `entrada` guarda Pix/Espécie/Transferência do pagamento 2 (não-cartão) — NÃO incluímos cartão aqui.
-        entrada: form.forma_pagamento_2 && !isCartao2 && form.valor_2 ? parseFloat(form.valor_2) : null,
-        parcelas: form.parcelas ? parseInt(form.parcelas) : null,
-        valor_total: valorTotalFinal > 0 ? valorTotalFinal : (form.valor ? parseFloat(form.valor) : null),
+        entrada: modoColeta ? null : (form.forma_pagamento_2 && !isCartao2 && form.valor_2 ? parseFloat(form.valor_2) : null),
+        parcelas: modoColeta ? null : (form.parcelas ? parseInt(form.parcelas) : null),
+        valor_total: modoColeta ? null : (valorTotalFinal > 0 ? valorTotalFinal : (form.valor ? parseFloat(form.valor) : null)),
         vendedor: form.vendedor || null,
         regiao: form.regiao || null,
       }),
     });
     const json = await res.json();
     if (json.ok) {
-      setMsg(isEdit ? "Entrega atualizada!" : "Entrega agendada!");
+      setMsg(isEdit ? (modoColeta ? "Coleta atualizada!" : "Entrega atualizada!") : (modoColeta ? "Coleta agendada!" : "Entrega agendada!"));
       setForm({ ...emptyForm, data_entrega: hojeBR() });
       setClienteUltimaCompra(null);
       setProdutos([""]); setTrocas([]); setShowPagAlt(false);
@@ -632,9 +660,11 @@ export default function EntregasPage() {
       setCatSel(""); setEstoqueId("");
       setValorPag1Override("");
       setDesconto(""); setTrocaAtiva(false); setTrocaValor(""); setTrocaProduto(""); setTrocaCor(""); setTrocaBateria(""); setTrocaObs(""); setProdutoManual(false); setSerialBusca("");
+      setColetaBateria(""); setColetaEstado(""); setColetaCaixa(""); setColetaMarcas("");
       setEditingEntregaId(null);
       setRastreio("");
       setModoSimples(false);
+      setModoColeta(false);
       setShowForm(false);
       fetchEntregas();
     } else {
@@ -769,7 +799,7 @@ export default function EntregasPage() {
         <h1 className="text-lg font-bold text-[#1D1D1F]">Agenda de Entregas</h1>
         <div className="flex gap-2">
           <button
-            onClick={() => { setShowForm(!showForm || modoSimples); setModoSimples(false); setMsg(""); }}
+            onClick={() => { setShowForm(!showForm || modoSimples || modoColeta); setModoSimples(false); setModoColeta(false); setMsg(""); }}
             className="px-4 py-2 rounded-xl bg-[#E8740E] text-white text-sm font-semibold hover:bg-[#F5A623] transition-colors"
           >
             {showForm && !modoSimples ? "Fechar" : "+ Nova Entrega"}
@@ -779,12 +809,26 @@ export default function EntregasPage() {
               const willOpen = !(showForm && modoSimples);
               setShowForm(willOpen);
               setModoSimples(willOpen);
+              setModoColeta(false);
               if (willOpen && !form.tipo) set("tipo", "CORREIOS");
               setMsg("");
             }}
             className="px-4 py-2 rounded-xl border-2 border-[#E8740E] text-[#E8740E] text-sm font-semibold hover:bg-[#FFF5EB] transition-colors"
           >
             {showForm && modoSimples ? "Fechar" : "📮 Entrega Simplificada"}
+          </button>
+          <button
+            onClick={() => {
+              const willOpen = !(showForm && modoColeta);
+              setShowForm(willOpen);
+              setModoColeta(willOpen);
+              setModoSimples(false);
+              if (willOpen) set("tipo", "COLETA");
+              setMsg("");
+            }}
+            className="px-4 py-2 rounded-xl border-2 border-green-600 text-green-600 text-sm font-semibold hover:bg-green-50 transition-colors"
+          >
+            {showForm && modoColeta ? "Fechar" : "🛵 Agendar Coleta"}
           </button>
         </div>
       </div>
@@ -800,7 +844,7 @@ export default function EntregasPage() {
         <div className="bg-white border border-[#D2D2D7] rounded-2xl p-4 sm:p-6 shadow-sm space-y-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
-              <h2 className="text-sm font-bold text-[#1D1D1F]">{editingEntregaId ? "✏️ Editar Entrega" : modoSimples ? "📮 Nova Entrega Simplificada (Correios / externa)" : "Agendar Nova Entrega"}</h2>
+              <h2 className="text-sm font-bold text-[#1D1D1F]">{editingEntregaId ? (form.tipo === "COLETA" ? "✏️ Editar Coleta" : "✏️ Editar Entrega") : modoColeta ? "🛵 Agendar Coleta" : modoSimples ? "📮 Nova Entrega Simplificada (Correios / externa)" : "Agendar Nova Entrega"}</h2>
               {editingEntregaId && <button onClick={() => { setEditingEntregaId(null); setForm({ ...emptyForm, data_entrega: hojeBR() }); setProdutos([""]); setTrocaAtiva(false); setTrocaValor(""); setTrocaProduto(""); setDesconto(""); }} className="text-xs text-red-500 hover:underline">Cancelar edição</button>}
               <button
                 type="button"
@@ -1048,9 +1092,8 @@ export default function EntregasPage() {
                         onClick={() => {
                           set("cliente", s.cliente);
                           if (s.telefone) set("telefone", s.telefone);
-                          // Preenche endereco cadastro como referência (readonly).
-                          // O endereco_entrega é preenchido em branco — usuário decide.
-                          if (s.endereco) set("endereco", s.endereco);
+                          // Preenche endereco cadastro + endereco_entrega (admin pode alterar depois)
+                          if (s.endereco) { set("endereco", s.endereco); set("endereco_entrega", s.endereco); }
                           if (s.bairro) set("bairro", s.bairro);
                           if (s.regiao) set("regiao", s.regiao);
                           setClienteUltimaCompra(s.ultima_compra);
@@ -1143,7 +1186,63 @@ export default function EntregasPage() {
                 <input value={rastreio} onChange={(e) => setRastreio(e.target.value)} placeholder="Ex: BR123456789BR" className={inputCls} />
               </div>
             )}
-            {!modoSimples && (<>
+            {/* ==== COLETA ==== */}
+            {modoColeta && (
+              <div className="col-span-2 md:col-span-3 space-y-3 border-t border-green-300 pt-3 mt-1">
+                <p className="text-xs font-semibold text-green-700 uppercase tracking-wider">🛵 Dados da Coleta</p>
+                <div>
+                  <p className={labelCls}>Produto a coletar</p>
+                  <input value={produtos[0] || ""} onChange={(e) => setProdutos([e.target.value])} placeholder="Ex: iPhone 15 128GB Preto" className={inputCls} />
+                </div>
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                  <div>
+                    <p className={labelCls}>Bateria %</p>
+                    <input value={coletaBateria} onChange={(e) => setColetaBateria(e.target.value.replace(/\D/g, ""))} placeholder="Ex: 87" className={inputCls} inputMode="numeric" />
+                  </div>
+                  <div>
+                    <p className={labelCls}>Estado (grade)</p>
+                    <select value={coletaEstado} onChange={(e) => setColetaEstado(e.target.value as typeof coletaEstado)} className={inputCls}>
+                      <option value="">-- Selecionar --</option>
+                      <option value="A+">A+ (Excelente)</option>
+                      <option value="A">A (Muito bom)</option>
+                      <option value="AB">AB (Bom)</option>
+                      <option value="B">B (Regular)</option>
+                    </select>
+                  </div>
+                  <div>
+                    <p className={labelCls}>Caixa original</p>
+                    <select value={coletaCaixa} onChange={(e) => setColetaCaixa(e.target.value as typeof coletaCaixa)} className={inputCls}>
+                      <option value="">-- Selecionar --</option>
+                      <option value="sim">Com caixa</option>
+                      <option value="nao">Sem caixa</option>
+                    </select>
+                  </div>
+                  <div>
+                    <p className={labelCls}>Marcas de uso</p>
+                    <select value={coletaMarcas} onChange={(e) => setColetaMarcas(e.target.value as typeof coletaMarcas)} className={inputCls}>
+                      <option value="">-- Selecionar --</option>
+                      <option value="nao">Sem marcas</option>
+                      <option value="sim">Com marcas</option>
+                    </select>
+                  </div>
+                </div>
+                <div>
+                  <p className={labelCls}>Vendedor</p>
+                  <input value={form.vendedor} onChange={(e) => set("vendedor", e.target.value)} placeholder="Ex: Nicolas" className={inputCls} />
+                </div>
+                <div>
+                  <p className={labelCls}>Motoboy / Responsável</p>
+                  <select value={form.entregador} onChange={(e) => set("entregador", e.target.value)} className={inputCls}>
+                    <option value="">Aguardando motoboy</option>
+                    <option value="Igor">Igor</option>
+                    <option value="Leandro">Leandro</option>
+                    <option value="Retirada">Retirada</option>
+                    <option value="Correios">Correios</option>
+                  </select>
+                </div>
+              </div>
+            )}
+            {!modoSimples && !modoColeta && (<>
             {/* Produto — seleção do estoque ou manual */}
             <div className="col-span-2 md:col-span-3 space-y-3 border-t border-[#E5E5EA] pt-3 mt-1">
               <div className="flex items-center justify-between">
@@ -1571,7 +1670,7 @@ export default function EntregasPage() {
             </div>
             </>)}
             <div>
-              <p className={labelCls}>Data da Entrega</p>
+              <p className={labelCls}>{modoColeta || form.tipo === "COLETA" ? "Data da Coleta" : "Data da Entrega"}</p>
               <input type="date" value={form.data_entrega} onChange={(e) => set("data_entrega", e.target.value)} className={inputCls} />
             </div>
             <div>
@@ -1911,6 +2010,7 @@ export default function EntregasPage() {
                   {e.horario && <span className={`text-sm font-bold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{e.horario}</span>}
                 </div>
                 <div className="flex items-center gap-1">
+                  {e.tipo === "COLETA" && <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-green-600/20 text-green-700">🛵 COLETA</span>}
                   {e.finalizada && <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-green-500/20 text-green-600">✅</span>}
                   {e.comprovante_lancado && <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-blue-500/20 text-blue-600">🧾</span>}
                 </div>
@@ -2401,51 +2501,71 @@ export default function EntregasPage() {
                               : `bg-white border border-[#D2D2D7] text-[#86868B] hover:${c.bg} hover:${c.color} hover:${c.border}`
                           }`}
                         >
-                          {c.icon} {c.label}
+                          {c.icon} {getStatusLabel(status, e.tipo)}
                         </button>
                       );
                     })}
                   </div>
                 </div>
 
-                {/* Copiar formulário motoboy */}
+                {/* Copiar formulário motoboy / coleta */}
                 <div className="pt-2 border-t border-[#D2D2D7]">
                   <button
                     onClick={() => {
-                      const regiao = e.regiao || e.bairro || "";
-                      const isUpgrade = e.tipo === "UPGRADE" || !!e.detalhes_upgrade;
-                      const tipoLabel = isUpgrade ? "UPGRADE (Troca)" : "Compra";
-                      // Limpa detalhes da troca: remove linha "Avaliação: R$ X" (motoboy não precisa saber o valor)
-                      const trocaTexto = e.detalhes_upgrade
-                        ? e.detalhes_upgrade.split("\n").filter(l => !l.startsWith("Avaliação:")).join(" / ")
-                        : "";
-                      // Limpa OBS: remove "Endereço cadastro: ..." (resíduo de entregas antigas)
-                      const obsLimpa = (e.observacao || "")
-                        .split(" | ")
-                        .filter(p => !p.startsWith("Endereço cadastro:"))
-                        .join(" | ")
-                        .trim();
-                      const msg = [
-                        `🛵 *ENTREGA ${regiao.toUpperCase()}* 🛵`,
-                        `🛵`,
-                        `⏰ *HORÁRIO:* ${e.horario || "A combinar"}`,
-                        `📍 *LOCAL:* ${e.endereco || "A definir"} - ${e.bairro || ""}`,
-                        `🍎 *PRODUTO:* ${e.produto || ""}`,
-                        `‼️ *TIPO:* ${tipoLabel}`,
-                        ...(isUpgrade && trocaTexto ? [`🔄 *PRODUTO NA TROCA:* ${trocaTexto}`] : []),
-                        `💵 *PAGAMENTO:* ${formatPagamentoDisplay(e.forma_pagamento, e.valor, e.valor_total, e.entrada, e.parcelas)}`,
-                        `🧑 *CLIENTE:* ${e.cliente || ""}`,
-                        `📞 *CONTATO:* ${e.telefone || ""}`,
-                        obsLimpa ? `OBS: ${obsLimpa}` : "",
-                        `💼 Vendedor: ${e.vendedor || ""}`,
-                        "________________________________",
-                      ].filter(Boolean).join("\n");
-                      navigator.clipboard.writeText(msg);
-                      alert("Formulário copiado! Cole no WhatsApp do motoboy.");
+                      if (e.tipo === "COLETA") {
+                        // Formulário de COLETA — sem valores financeiros
+                        const detalhesAparelho = e.detalhes_upgrade
+                          ? e.detalhes_upgrade.split("\n").filter(l => !l.toLowerCase().startsWith("avaliação") && !l.toLowerCase().startsWith("avaliacao")).join("\n• ")
+                          : "";
+                        const obsLimpa = (e.observacao || "").split(" | ").filter(p => !p.startsWith("Endereço cadastro:")).join(" | ").trim();
+                        const msg = [
+                          `🛵 *COLETA* 🛵`,
+                          ``,
+                          `⏰ *HORÁRIO:* ${e.horario || "Horário a combinar"}`,
+                          `📍 *LOCAL COLETA:* ${e.endereco || "A definir"}${e.bairro ? ` - ${e.bairro}` : ""}`,
+                          `🍎 *PRODUTO:* ${e.produto || ""}`,
+                          ``,
+                          ...(detalhesAparelho ? [`📱 *APARELHO NA COLETA:*`, `• ${detalhesAparelho}`] : []),
+                          ``,
+                          `🧑 *CLIENTE:* ${e.cliente || ""}`,
+                          `📞 *CONTATO:* ${e.telefone || ""}`,
+                          obsLimpa ? `\nOBS: ${obsLimpa}` : "",
+                          ``,
+                          `💼 Vendedor: ${e.vendedor || ""}`,
+                        ].filter(l => l !== undefined).join("\n");
+                        navigator.clipboard.writeText(msg);
+                        alert("Formulário de coleta copiado! Cole no WhatsApp do motoboy.");
+                      } else {
+                        // Formulário de ENTREGA
+                        const regiao = e.regiao || e.bairro || "";
+                        const isUpgrade = e.tipo === "UPGRADE" || !!e.detalhes_upgrade;
+                        const tipoLabel = isUpgrade ? "UPGRADE (Troca)" : "Compra";
+                        const trocaTexto = e.detalhes_upgrade
+                          ? e.detalhes_upgrade.split("\n").filter(l => !l.startsWith("Avaliação:")).join(" / ")
+                          : "";
+                        const obsLimpa = (e.observacao || "").split(" | ").filter(p => !p.startsWith("Endereço cadastro:")).join(" | ").trim();
+                        const msg = [
+                          `🛵 *ENTREGA ${regiao.toUpperCase()}* 🛵`,
+                          `🛵`,
+                          `⏰ *HORÁRIO:* ${e.horario || "A combinar"}`,
+                          `📍 *LOCAL:* ${e.endereco || "A definir"} - ${e.bairro || ""}`,
+                          `🍎 *PRODUTO:* ${e.produto || ""}`,
+                          `‼️ *TIPO:* ${tipoLabel}`,
+                          ...(isUpgrade && trocaTexto ? [`🔄 *PRODUTO NA TROCA:* ${trocaTexto}`] : []),
+                          `💵 *PAGAMENTO:* ${formatPagamentoDisplay(e.forma_pagamento, e.valor, e.valor_total, e.entrada, e.parcelas)}`,
+                          `🧑 *CLIENTE:* ${e.cliente || ""}`,
+                          `📞 *CONTATO:* ${e.telefone || ""}`,
+                          obsLimpa ? `OBS: ${obsLimpa}` : "",
+                          `💼 Vendedor: ${e.vendedor || ""}`,
+                          "________________________________",
+                        ].filter(Boolean).join("\n");
+                        navigator.clipboard.writeText(msg);
+                        alert("Formulário copiado! Cole no WhatsApp do motoboy.");
+                      }
                     }}
-                    className="w-full py-2.5 rounded-xl text-center text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#D06A0D] transition-colors mb-2"
+                    className={`w-full py-2.5 rounded-xl text-center text-sm font-semibold transition-colors mb-2 ${e.tipo === "COLETA" ? "bg-green-600 text-white hover:bg-green-700" : "bg-[#E8740E] text-white hover:bg-[#D06A0D]"}`}
                   >
-                    📋 Copiar Formulário Motoboy
+                    {e.tipo === "COLETA" ? "📋 Copiar Formulário Coleta" : "📋 Copiar Formulário Motoboy"}
                   </button>
                 </div>
 
@@ -2494,6 +2614,26 @@ export default function EntregasPage() {
                         if (obsLine) setTrocaObs(obsLine);
                       }
                       setProdutoManual(true);
+                      // Ativar modo coleta se editando uma coleta
+                      if (e.tipo === "COLETA") {
+                        setModoColeta(true);
+                        setModoSimples(false);
+                        setTrocaAtiva(false);
+                        // Carregar campos do aparelho dos detalhes_upgrade
+                        if (e.detalhes_upgrade) {
+                          const lines = e.detalhes_upgrade.split("\n");
+                          const batLine = lines.find(l => l.startsWith("Bateria:"));
+                          if (batLine) setColetaBateria(batLine.replace("Bateria:", "").replace("%", "").trim());
+                          const estLine = lines.find(l => l.startsWith("Estado:"));
+                          if (estLine) setColetaEstado(estLine.replace("Estado:", "").trim() as "A+" | "A" | "AB" | "B" | "");
+                          if (lines.some(l => l.includes("Com caixa"))) setColetaCaixa("sim");
+                          else if (lines.some(l => l.includes("Sem caixa"))) setColetaCaixa("nao");
+                          if (lines.some(l => l.includes("Com marcas"))) setColetaMarcas("sim");
+                          else if (lines.some(l => l.includes("Sem marcas"))) setColetaMarcas("nao");
+                        }
+                      } else {
+                        setModoColeta(false);
+                      }
                       setEditingEntregaId(e.id);
                       setShowForm(true);
                       setSelectedEntrega(null);

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -93,7 +93,7 @@ export default function GerarLinkPage() {
       if (p.tipo !== "SEMINOVO") continue;
       const base = getModeloBase(p.produto, p.categoria || "SEMINOVOS");
       const corPt = p.cor ? corParaPT(p.cor) : "";
-      const nome = corPt ? `${base} ${corPt}` : base;
+      const nome = (corPt ? `${base} ${corPt}` : base).toUpperCase();
       const key = nome.toUpperCase();
       const prev = map.get(key);
       if (prev) {

--- a/app/admin/orcamento/page.tsx
+++ b/app/admin/orcamento/page.tsx
@@ -447,7 +447,7 @@ export default function OrcamentoPage() {
                 }} className={inputCls}>
                   <option value="">— Selecionar seminovo —</option>
                   {seminovosFiltrados.map(item => {
-                    const nome = cleanSemiNome(item.produto);
+                    const nome = cleanSemiNome(item.produto).toUpperCase();
                     const details = cleanSemiDetails(item);
                     return (
                       <option key={item.id} value={item.id}>

--- a/app/admin/precos/page.tsx
+++ b/app/admin/precos/page.tsx
@@ -160,7 +160,8 @@ function PrecosContent() {
   function inferCategoria(modelo: string): string {
     const m = modelo.toUpperCase();
     if (m.includes("IPHONE") || m.includes("PHONE")) return "IPHONE";
-    if (m.includes("MACBOOK") || m.includes("MAC MINI") || m.includes("IMAC")) return "MACBOOK";
+    if (m.includes("MAC MINI")) return "MAC_MINI";
+    if (m.includes("MACBOOK") || m.includes("IMAC")) return "MACBOOK";
     if (m.includes("IPAD")) return "IPAD";
     if (m.includes("WATCH")) return "APPLE_WATCH";
     if (m.includes("AIRPOD")) return "AIRPODS";

--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -139,7 +139,7 @@ export default function AdminPage() {
   const [filterModelo, setFilterModelo] = useState("");
   const [filterFrom, setFilterFrom] = useState("");
   const [filterTo, setFilterTo] = useState("");
-  const [mainTab, setMainTab] = useState<"simulacoes" | "historico" | "followup" | "funil" | "perguntas" | "whatsapp" | "simulador">("simulacoes");
+  const [mainTab, setMainTab] = useState<"simulacoes" | "historico" | "followup" | "funil" | "perguntas" | "simulador">("simulacoes");
   const [followUpLoading, setFollowUpLoading] = useState<string | null>(null);
   // Histórico: clientes que passaram por todo o funil (simulação → gostei → link gerado → formulário preenchido → chegou no WhatsApp)
   interface HistoricoItem {
@@ -400,10 +400,10 @@ export default function AdminPage() {
     <div className="space-y-6">
       {/* Main tabs: Simulações / Funil */}
       <div className="flex gap-2 items-center flex-wrap">
-        {(["simulacoes", "historico", "simulador", "followup", "funil", "perguntas", "whatsapp"] as const).map((t) => (
+        {(["simulacoes", "historico", "simulador", "followup", "funil", "perguntas"] as const).map((t) => (
           <button key={t} onClick={() => setMainTab(t)}
             className={`px-5 py-2.5 rounded-xl text-sm font-semibold transition-colors ${mainTab === t ? "bg-[#E8740E] text-white" : "bg-white border border-[#D2D2D7] text-[#86868B] hover:border-[#E8740E]"}`}>
-            {t === "simulacoes" ? "Simulacoes" : t === "historico" ? `📋 Histórico (${historico.length})` : t === "simulador" ? "Simulador Interno" : t === "followup" ? `Follow-up (${data.filter(d => d.status === "SAIR" && !d.follow_up_enviado).length})` : t === "perguntas" ? "Perguntas Trade-In" : t === "whatsapp" ? "WhatsApp" : "Funil de Conversao"}
+            {t === "simulacoes" ? "Simulacoes" : t === "historico" ? `📋 Histórico (${historico.length})` : t === "simulador" ? "Simulador Interno" : t === "followup" ? `Follow-up (${data.filter(d => d.status === "SAIR" && !d.follow_up_enviado).length})` : t === "perguntas" ? "Perguntas Trade-In" : "Funil de Conversao"}
           </button>
         ))}
         <div className="flex-1" />
@@ -743,7 +743,7 @@ export default function AdminPage() {
       )}
 
       {/* WhatsApp Config tab */}
-      {mainTab === "whatsapp" && <WhatsAppConfigPanel password={password} />}
+      {/* WhatsApp config removido — centralizado em /admin/configuracoes */}
 
       {/* Simulador Interno tab */}
       {mainTab === "simulador" && <SimuladorInterno password={password} />}
@@ -1721,188 +1721,9 @@ export default function AdminPage() {
   );
 }
 
-/* ── WhatsApp Config Panel ── */
-const VENDEDORES_DEFAULT: { nome: string; label: string; numero: string }[] = [
-  { nome: "andre", label: "Andre", numero: "5521967442665" },
-  { nome: "bianca", label: "Bianca", numero: "5521972461357" },
-];
+/* WhatsApp Config Panel removido — ver /admin/configuracoes */
 
-function WhatsAppConfigPanel({ password }: { password: string }) {
-  const [principal, setPrincipal] = useState("5521967442665");
-  const [formularios, setFormularios] = useState(""); // WhatsApp para formulários (troca, seminovos, links de compra)
-  const defaultVendedores: Record<string, { numero: string; ativo: boolean }> = {};
-  for (const v of VENDEDORES_DEFAULT) defaultVendedores[v.nome] = { numero: v.numero, ativo: true };
-  const [vendedores, setVendedores] = useState<Record<string, { numero: string; ativo: boolean }>>(defaultVendedores);
-  const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [msg, setMsg] = useState("");
-
-  useEffect(() => {
-    fetch("/api/admin/tradein-config", { headers: { "x-admin-password": password } })
-      .then(r => r.json())
-      .then(j => {
-        if (j.data) {
-          setPrincipal(j.data.whatsapp_principal || "5521967442665");
-          if (j.data.whatsapp_formularios) setFormularios(j.data.whatsapp_formularios);
-          // Converter formato antigo (string) pra novo (objeto com ativo)
-          const raw = j.data.whatsapp_vendedores || {};
-          const mapped: Record<string, { numero: string; ativo: boolean }> = {};
-          for (const v of VENDEDORES_DEFAULT) {
-            const existing = raw[v.nome];
-            if (typeof existing === "string") {
-              mapped[v.nome] = { numero: existing, ativo: true };
-            } else if (existing && typeof existing === "object") {
-              mapped[v.nome] = existing;
-            } else {
-              mapped[v.nome] = { numero: v.numero, ativo: true };
-            }
-          }
-          // Outros vendedores extras
-          for (const [k, val] of Object.entries(raw)) {
-            if (!mapped[k]) {
-              mapped[k] = typeof val === "string" ? { numero: val, ativo: true } : (val as { numero: string; ativo: boolean });
-            }
-          }
-          setVendedores(mapped);
-        }
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  }, [password]);
-
-  const salvar = async () => {
-    setSaving(true);
-    setMsg("");
-    try {
-      // Converter pra formato que o TradeInCalculator espera: { nome: "numero" } (só ativos)
-      const waMap: Record<string, string> = {};
-      for (const [nome, v] of Object.entries(vendedores)) {
-        if (v.ativo) waMap[nome] = v.numero;
-      }
-      const res = await fetch("/api/admin/tradein-config", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json", "x-admin-password": password },
-        body: JSON.stringify({ whatsapp_principal: principal, whatsapp_formularios: formularios || principal, whatsapp_vendedores: waMap }),
-      });
-      const j = await res.json();
-      if (j.ok) { setMsg("Salvo!"); setTimeout(() => setMsg(""), 3000); }
-      else setMsg("Erro: " + (j.error || "desconhecido"));
-    } catch { setMsg("Erro de conexao"); }
-    setSaving(false);
-  };
-
-  const toggleVendedor = (nome: string) => {
-    setVendedores(prev => ({
-      ...prev,
-      [nome]: { ...prev[nome], ativo: !prev[nome]?.ativo },
-    }));
-  };
-
-  const setPrincipalFromVendedor = (numero: string) => {
-    setPrincipal(numero);
-  };
-
-  if (loading) return <p className="text-sm text-[#86868B]">Carregando...</p>;
-
-  return (
-    <div className="space-y-4 max-w-lg">
-      {/* Numero principal */}
-      <div className="bg-white border border-[#D2D2D7] rounded-2xl p-5 shadow-sm space-y-4">
-        <div>
-          <h2 className="font-bold text-[#1D1D1F] text-lg">WhatsApp Principal</h2>
-          <p className="text-xs text-[#86868B] mt-0.5">Todas as mensagens do site vao pra esse numero. Clique num vendedor abaixo pra trocar rapido.</p>
-        </div>
-
-        {/* Seletor rapido */}
-        <div className="flex gap-2">
-          {Object.entries(vendedores).filter(([, v]) => v.ativo).map(([nome, v]) => {
-            const isActive = principal === v.numero;
-            return (
-              <button key={nome} onClick={() => setPrincipalFromVendedor(v.numero)}
-                className={`flex-1 py-3 rounded-xl text-sm font-semibold transition-all ${isActive ? "bg-[#E8740E] text-white shadow-md" : "bg-[#F5F5F7] border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E]"}`}>
-                {nome.charAt(0).toUpperCase() + nome.slice(1)}
-                {isActive && <span className="ml-1.5">&#x2705;</span>}
-              </button>
-            );
-          })}
-        </div>
-
-        <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[#F5F5F7] text-sm">
-          <span className="text-[#86868B]">Numero ativo:</span>
-          <span className="font-mono font-semibold text-[#1D1D1F]">{principal.replace(/^55/, "+55 ").replace(/\+(\d{2})\s(\d{2})(\d{5})(\d{4})/, "+$1 ($2) $3-$4")}</span>
-        </div>
-
-        <button onClick={salvar} disabled={saving}
-          className={`w-full py-3 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50 ${msg === "Salvo!" ? "bg-green-500 text-white" : "bg-[#E8740E] text-white hover:bg-[#F5A623]"}`}>
-          {saving ? "Salvando..." : msg === "Salvo!" ? "&#x2705; Salvo!" : "Salvar"}
-        </button>
-      </div>
-
-      {/* WhatsApp Formulários */}
-      <div className="bg-white border border-[#D2D2D7] rounded-2xl p-5 shadow-sm space-y-4">
-        <div>
-          <h2 className="font-bold text-[#1D1D1F] text-lg">WhatsApp Formulários</h2>
-          <p className="text-xs text-[#86868B] mt-0.5">Número padrão para receber formulários de troca de lacrados, seminovos e links de compra. Se vazio, usa o WhatsApp Principal.</p>
-        </div>
-
-        {/* Seletor rapido */}
-        <div className="flex gap-2">
-          {Object.entries(vendedores).filter(([, v]) => v.ativo).map(([nome, v]) => {
-            const isActive = formularios === v.numero;
-            return (
-              <button key={nome} onClick={() => setFormularios(v.numero)}
-                className={`flex-1 py-3 rounded-xl text-sm font-semibold transition-all ${isActive ? "bg-[#E8740E] text-white shadow-md" : "bg-[#F5F5F7] border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E]"}`}>
-                {nome.charAt(0).toUpperCase() + nome.slice(1)}
-                {isActive && <span className="ml-1.5">&#x2705;</span>}
-              </button>
-            );
-          })}
-        </div>
-
-        {formularios && (
-          <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-[#F5F5F7] text-sm">
-            <span className="text-[#86868B]">Numero ativo:</span>
-            <span className="font-mono font-semibold text-[#1D1D1F]">{formularios.replace(/^55/, "+55 ").replace(/\+(\d{2})\s(\d{2})(\d{5})(\d{4})/, "+$1 ($2) $3-$4")}</span>
-          </div>
-        )}
-
-        <button onClick={salvar} disabled={saving}
-          className={`w-full py-3 rounded-xl text-sm font-semibold transition-colors disabled:opacity-50 ${msg === "Salvo!" ? "bg-green-500 text-white" : "bg-[#E8740E] text-white hover:bg-[#F5A623]"}`}>
-          {saving ? "Salvando..." : msg === "Salvo!" ? "&#x2705; Salvo!" : "Salvar"}
-        </button>
-      </div>
-
-      {/* Vendedores com toggle */}
-      <div className="bg-white border border-[#D2D2D7] rounded-2xl p-5 shadow-sm space-y-4">
-        <div>
-          <h2 className="font-bold text-[#1D1D1F]">Vendedores</h2>
-          <p className="text-xs text-[#86868B] mt-0.5">Ative/desative vendedores. Quando ativo, o link ?ref=nome direciona pro numero dele.</p>
-        </div>
-
-        <div className="space-y-3">
-          {Object.entries(vendedores).map(([nome, v]) => (
-            <div key={nome} className={`flex items-center justify-between p-4 rounded-xl border transition-colors ${v.ativo ? "bg-white border-[#D2D2D7]" : "bg-[#F5F5F7] border-[#E8E8ED] opacity-60"}`}>
-              <div className="flex-1">
-                <p className="text-sm font-semibold text-[#1D1D1F]">{nome.charAt(0).toUpperCase() + nome.slice(1)}</p>
-                <p className="text-xs font-mono text-[#86868B]">{v.numero.replace(/^55(\d{2})/, "+55 ($1) ").replace(/(\d{5})(\d{4})$/, "$1-$2")}</p>
-              </div>
-              {/* Toggle estilo iOS */}
-              <button onClick={() => toggleVendedor(nome)}
-                className={`relative w-12 h-7 rounded-full transition-colors duration-200 ${v.ativo ? "bg-green-500" : "bg-[#D2D2D7]"}`}>
-                <span className={`absolute top-0.5 w-6 h-6 bg-white rounded-full shadow transition-transform duration-200 ${v.ativo ? "translate-x-5" : "translate-x-0.5"}`} />
-              </button>
-            </div>
-          ))}
-        </div>
-
-        <button onClick={salvar} disabled={saving}
-          className="w-full py-3 rounded-xl text-sm font-semibold bg-[#E8740E] text-white hover:bg-[#F5A623] transition-colors disabled:opacity-50">
-          {saving ? "Salvando..." : "Salvar"}
-        </button>
-      </div>
-    </div>
-  );
-}
+/* WhatsApp Config Panel removido — ver /admin/configuracoes */
 
 // ──────────────────────────────────────────
 // Simulador Interno — formulário simples

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -1261,10 +1261,8 @@ export default function VendasPage() {
           ? getTaxa(gBanco, gBandeira, gParcelas, gForma === "LINK" ? "CARTAO" : gForma)
           : gForma === "DEBITO" ? 0.75
           : 0;
-        const liqPrinc = gTaxa > 0 ? calcularLiquido(gCompPrinc, gTaxa) : gCompPrinc;
-        const gTaxaAlt = getTaxa(form.banco_alt || "ITAU", form.band_alt || null, parseInt(form.parc_alt) || 0, (form.forma_alt || form.forma || "CARTAO") as "CARTAO" | "LINK");
-        const liqAlt = gTaxaAlt > 0 ? calcularLiquido(gCompAlt, gTaxaAlt) : gCompAlt;
-        payloads[0].preco_vendido = Math.round(liqPrinc + liqAlt + gEntradaPix + gEntradaEspecie + gTroca);
+        // preco_vendido = valor BRUTO (o que o cliente pagou) — sem descontar taxa
+        payloads[0].preco_vendido = Math.round(gCompPrinc + gCompAlt + gEntradaPix + gEntradaEspecie + gTroca);
       }
     }
     if (payloads.length > 1) {
@@ -1284,22 +1282,16 @@ export default function VendasPage() {
             : gForma === "DEBITO" ? 0.75
             : 0;
 
-          // Total líquido from comprovante after tax
-          const totalLiquido = gTaxa > 0 ? calcularLiquido(comprovanteTotal, gTaxa) : comprovanteTotal;
-
           // Cartão alternativo (2o cartão)
           const gCompAlt = parseFloat(form.comp_alt) || 0;
-          const gTaxaAlt = gCompAlt > 0
-            ? getTaxa(form.banco_alt || "ITAU", form.band_alt || null, parseInt(form.parc_alt) || 0, (form.forma_alt || form.forma || "CARTAO") as "CARTAO" | "LINK")
-            : 0;
-          const liqAlt = gCompAlt > 0 ? (gTaxaAlt > 0 ? calcularLiquido(gCompAlt, gTaxaAlt) : gCompAlt) : 0;
 
           // Add entradas (pix, especie) — these are global
           const gEntradaPix = parseFloat(form.entrada_pix) || 0;
           const gEntradaEspecie = parseFloat(form.entrada_especie) || 0;
           // Trocas são por produto — somar todas as trocas de todos os produtos
           const totalTrocas = payloads.reduce((s, p) => s + (parseFloat(String(p.produto_na_troca)) || 0), 0);
-          const totalRecebido = totalLiquido + liqAlt + gEntradaPix + gEntradaEspecie + totalTrocas;
+          // preco_vendido = valor BRUTO (o que o cliente pagou) — sem descontar taxa
+          const totalRecebido = comprovanteTotal + gCompAlt + gEntradaPix + gEntradaEspecie + totalTrocas;
 
           let comprovanteDistribuido = 0;
           let vendidoDistribuido = 0;
@@ -1360,16 +1352,12 @@ export default function VendasPage() {
                 ? getTaxa(gBanco, gBandeira, gParcelas, gForma === "LINK" ? "CARTAO" : gForma)
                 : gForma === "DEBITO" ? 0.75
                 : 0;
-              const totalLiquido = gTaxa > 0 ? calcularLiquido(comprovanteTotal, gTaxa) : comprovanteTotal;
               const gCompAlt = parseFloat(form.comp_alt) || 0;
-              const gTaxaAlt = gCompAlt > 0
-                ? getTaxa(form.banco_alt || "ITAU", form.band_alt || null, parseInt(form.parc_alt) || 0, (form.forma_alt || form.forma || "CARTAO") as "CARTAO" | "LINK")
-                : 0;
-              const liqAlt = gCompAlt > 0 ? (gTaxaAlt > 0 ? calcularLiquido(gCompAlt, gTaxaAlt) : gCompAlt) : 0;
               const gEntradaPix = parseFloat(form.entrada_pix) || 0;
               const gEntradaEspecie = parseFloat(form.entrada_especie) || 0;
               const totalTrocas = groupPayloads.reduce((s, p) => s + (parseFloat(String(p.produto_na_troca)) || 0), 0);
-              const totalRecebido = totalLiquido + liqAlt + gEntradaPix + gEntradaEspecie + totalTrocas;
+              // preco_vendido = valor BRUTO (o que o cliente pagou) — sem descontar taxa
+              const totalRecebido = comprovanteTotal + gCompAlt + gEntradaPix + gEntradaEspecie + totalTrocas;
 
               let comprovanteDistribuido = 0;
               let vendidoDistribuido = 0;

--- a/app/api/admin/tradein-config/route.ts
+++ b/app/api/admin/tradein-config/route.ts
@@ -21,6 +21,7 @@ export async function GET(req: NextRequest) {
   const result = { ...data };
   if (labels._whatsapp_principal) result.whatsapp_principal = labels._whatsapp_principal;
   if (labels._whatsapp_formularios) result.whatsapp_formularios = labels._whatsapp_formularios;
+  if (labels._whatsapp_formularios_seminovos) result.whatsapp_formularios_seminovos = labels._whatsapp_formularios_seminovos;
   if (labels._whatsapp_vendedores) result.whatsapp_vendedores = labels._whatsapp_vendedores;
 
   return NextResponse.json({ data: result });
@@ -37,13 +38,14 @@ export async function PUT(req: NextRequest) {
   if (body.origens !== undefined) updates.origens = body.origens;
 
   // Salvar whatsapp config dentro do campo labels (JSONB) pra não depender de colunas novas
-  if (body.whatsapp_principal !== undefined || body.whatsapp_formularios !== undefined || body.whatsapp_vendedores !== undefined || body.labels !== undefined) {
+  if (body.whatsapp_principal !== undefined || body.whatsapp_formularios !== undefined || body.whatsapp_formularios_seminovos !== undefined || body.whatsapp_vendedores !== undefined || body.labels !== undefined) {
     const { data: current } = await supabase.from("tradein_config").select("labels").limit(1).single();
     const currentLabels = (current?.labels && typeof current.labels === "object") ? current.labels as Record<string, unknown> : {};
     const newLabels = { ...currentLabels };
     if (body.labels !== undefined) Object.assign(newLabels, body.labels);
     if (body.whatsapp_principal !== undefined) newLabels._whatsapp_principal = body.whatsapp_principal;
     if (body.whatsapp_formularios !== undefined) newLabels._whatsapp_formularios = body.whatsapp_formularios;
+    if (body.whatsapp_formularios_seminovos !== undefined) newLabels._whatsapp_formularios_seminovos = body.whatsapp_formularios_seminovos;
     if (body.whatsapp_vendedores !== undefined) newLabels._whatsapp_vendedores = body.whatsapp_vendedores;
     updates.labels = newLabels;
   }

--- a/app/api/tradein-config/route.ts
+++ b/app/api/tradein-config/route.ts
@@ -44,6 +44,7 @@ export async function GET() {
     const result = { ...data };
     if (labels._whatsapp_principal) result.whatsapp_principal = labels._whatsapp_principal;
     if (labels._whatsapp_formularios) result.whatsapp_formularios = labels._whatsapp_formularios;
+    if (labels._whatsapp_formularios_seminovos) result.whatsapp_formularios_seminovos = labels._whatsapp_formularios_seminovos;
     if (labels._whatsapp_vendedores) result.whatsapp_vendedores = labels._whatsapp_vendedores;
 
     return NextResponse.json({ data: result });

--- a/components/TradeInCalculator.tsx
+++ b/components/TradeInCalculator.tsx
@@ -95,15 +95,21 @@ export default function TradeInCalculator({ vendedor: vendedorProp, temaParam }:
 
   const [questionsConfig, setQuestionsConfig] = useState<TradeInQuestion[] | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
-  // Mapa dinâmico de WhatsApp por vendedor — usa DB se disponível
+  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios?: string; whatsapp_formularios_seminovos?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
+  // Mapa dinâmico de WhatsApp por vendedor — usa DB se disponível (normaliza keys pra lowercase)
   const VENDEDOR_WHATSAPP = useMemo(() => {
     const dbMap = tradeinConfig?.whatsapp_vendedores;
-    return dbMap && Object.keys(dbMap).length > 0 ? { ...DEFAULT_VENDEDOR_WHATSAPP, ...dbMap } : DEFAULT_VENDEDOR_WHATSAPP;
+    if (!dbMap || Object.keys(dbMap).length === 0) return DEFAULT_VENDEDOR_WHATSAPP;
+    const normalized: Record<string, string> = {};
+    for (const [key, value] of Object.entries(dbMap)) {
+      normalized[key.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "")] = value;
+    }
+    return { ...DEFAULT_VENDEDOR_WHATSAPP, ...normalized };
   }, [tradeinConfig]);
-  // WhatsApp formulários — usa campo dedicado se disponível, senão principal
+  // WhatsApp formulários — lacrados e seminovos separados
   const whatsappPrincipal: string = tradeinConfig?.whatsapp_principal || config.whatsappNumero;
-  const whatsappFormularios: string = tradeinConfig?.whatsapp_formularios || whatsappPrincipal;
+  const whatsappFormulariosLacrados: string = tradeinConfig?.whatsapp_formularios || whatsappPrincipal;
+  const whatsappFormulariosSeminovos: string = tradeinConfig?.whatsapp_formularios_seminovos || whatsappPrincipal;
   const [deviceType, setDeviceType] = useState<DeviceType>("iphone");
   const [usedModel, setUsedModel] = useState("");
   const [usedStorage, setUsedStorage] = useState("");
@@ -398,7 +404,7 @@ export default function TradeInCalculator({ vendedor: vendedorProp, temaParam }:
           )}
 
           {step === 2 && (
-            <StepNewDevice products={products} tradeInValue={totalTradeInValue} onNext={handleStep2Complete} onBack={() => setStep(hasSecondDevice ? 1.7 : 1)} usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormularios} condition={condition} deviceType={deviceType} tradeinConfig={tradeinConfig}
+            <StepNewDevice products={products} tradeInValue={totalTradeInValue} onNext={handleStep2Complete} onBack={() => setStep(hasSecondDevice ? 1.7 : 1)} usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormulariosSeminovos} condition={condition} deviceType={deviceType} tradeinConfig={tradeinConfig}
               usedModel2={hasSecondDevice ? usedModel2 : undefined} usedStorage2={hasSecondDevice ? usedStorage2 : undefined} usedColor2={hasSecondDevice ? usedColor2 : undefined}
               condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined}
               tradeInValue1={hasSecondDevice ? tradeInValue : undefined} tradeInValue2={hasSecondDevice ? tradeInValue2 : undefined}
@@ -422,7 +428,7 @@ export default function TradeInCalculator({ vendedor: vendedorProp, temaParam }:
               condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined}
               tradeInValue1={hasSecondDevice ? tradeInValue : undefined} tradeInValue2={hasSecondDevice ? tradeInValue2 : undefined}
               clienteNome={clienteNome} clienteWhatsApp={clienteWhatsApp} clienteInstagram={clienteInstagram} clienteOrigem={clienteOrigem}
-              whatsappNumero={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormularios}
+              whatsappNumero={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormulariosLacrados}
               validadeHoras={config.validadeHoras} vendedor={vendedor}
               onReset={handleReset} onCotarOutro={handleCotarOutro}
               onGoToStep={handleGoToStep}

--- a/lib/categorias.ts
+++ b/lib/categorias.ts
@@ -15,6 +15,7 @@ export interface Categoria {
 export const DEFAULT_CATEGORIAS_PRECOS: Categoria[] = [
   { key: "IPHONE", label: "iPhones", emoji: "\u{1F4F1}" },
   { key: "MACBOOK", label: "MacBooks", emoji: "\u{1F4BB}" },
+  { key: "MAC_MINI", label: "Mac Mini", emoji: "\u{1F5A5}\uFE0F" },
   { key: "IPAD", label: "iPads", emoji: "\u{1F4DF}" },
   { key: "APPLE_WATCH", label: "Apple Watch", emoji: "\u231A" },
   { key: "AIRPODS", label: "AirPods", emoji: "\u{1F3A7}" },

--- a/supabase/migrations/20260413_unificar_macmini.sql
+++ b/supabase/migrations/20260413_unificar_macmini.sql
@@ -1,0 +1,3 @@
+-- Unificar categoria MACMINI → MAC_MINI no painel de preços
+-- (Nicolas criou MACMINI manualmente; o sistema usa MAC_MINI)
+UPDATE precos_venda SET categoria = 'MAC_MINI' WHERE categoria = 'MACMINI';


### PR DESCRIPTION
## Summary
- **NF valor bruto**: Nota Fiscal agora mostra valor bruto (pago pelo cliente) em vez de líquido (pós-taxa)
- **Seminovos CAIXA ALTA**: nomes de seminovos exibidos em maiúsculo na seleção de produtos
- **Endereço de entrega**: preenchido automaticamente no autocomplete e query params (prioridade pedido > cadastro)
- **Mac Mini**: categoria própria (MAC_MINI) no painel de preços + migration para unificar duplicata
- **WhatsApp separado**: config lacrados/seminovos centralizada em Configurações, removida de Simulações
- **Agendar Coleta**: nova feature na agenda — formulário simplificado, badge visual, formulário motoboy sem valores

## Test plan
- [ ] Verificar NF em vendas — deve mostrar valor bruto
- [ ] Conferir seleção de seminovos em gerar-link, entregas e orçamento — CAIXA ALTA
- [ ] Testar autocomplete de cliente na entrega — endereço de entrega deve preencher
- [ ] Rodar migration `20260413_unificar_macmini.sql` em `/admin/migrations`
- [ ] Configurações: verificar 2 seções WhatsApp (Lacrados/Seminovos), salvar e testar
- [ ] Simulações: verificar que aba WhatsApp não existe mais
- [ ] Agendar Coleta: criar coleta, verificar card com badge, copiar formulário (sem valores), editar

🤖 Generated with [Claude Code](https://claude.com/claude-code)