### PR TITLE
fix(simulacoes): cor do aparelho usado não salva no formulário de troca

### DIFF
--- a/supabase/migrations/20260414b_simulacoes_cor_usado.sql
+++ b/supabase/migrations/20260414b_simulacoes_cor_usado.sql
@@ -1,0 +1,5 @@
+-- Adicionar colunas cor_usado e cor_usado2 na tabela simulacoes
+-- Necessário para que a cor selecionada pelo cliente no formulário de troca
+-- apareça nos detalhes da simulação no admin
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS cor_usado text;
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS cor_usado2 text;


### PR DESCRIPTION
## Summary
A cor selecionada pelo cliente no formulário de troca não aparecia nos detalhes da simulação porque a coluna `cor_usado` não existia na tabela `simulacoes`. A migration original nunca foi aplicada.

## Migration
- `20260414b_simulacoes_cor_usado.sql` — adiciona colunas `cor_usado` e `cor_usado2`

## Test plan
- [ ] Rodar migration em `/admin/migrations`
- [ ] Fazer uma simulação de troca selecionando cor → verificar que aparece nos detalhes

🤖 Generated with [Claude Code](https://claude.com/claude-code)