### PR TITLE
fix(simulacoes): migration cor_usado — coluna necessária para salvar …

### DIFF
--- a/supabase/migrations/20260414b_simulacoes_cor_usado.sql
+++ b/supabase/migrations/20260414b_simulacoes_cor_usado.sql
@@ -1,0 +1,5 @@
+-- Adicionar colunas cor_usado e cor_usado2 na tabela simulacoes
+-- Necessário para que a cor selecionada pelo cliente no formulário de troca
+-- apareça nos detalhes da simulação no admin
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS cor_usado text;
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS cor_usado2 text;


### PR DESCRIPTION
…cor do aparelho na troca

A migration original (20260407) nunca foi aplicada. Esta recria com nome novo para aparecer em /admin/migrations. Sem ela, a cor é silenciosamente descartada.