### PR TITLE
fix(vendas): PIX + crédito lojista exibidos corretamente

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -4008,10 +4008,10 @@ export default function VendasPage() {
                           pagParts.push(`${v.banco} ${v.qnt_parcelas}x${v.bandeira ? ` ${v.bandeira}` : ""}${v.valor_comprovante ? ` (${fmt(v.valor_comprovante)})` : ""}`);
                         } else if (v.banco === "MERCADO_PAGO") {
                           pagParts.push(`Link MP${v.qnt_parcelas ? ` ${v.qnt_parcelas}x` : ""}${v.valor_comprovante ? ` (${fmt(v.valor_comprovante)})` : ""}`);
-                        } else if (v.forma && v.forma !== "CARTAO") {
+                        } else if (v.forma && v.forma !== "CARTAO" && resto > 0) {
                           const lbl = formaLabel(v.forma);
                           const banco = v.banco && v.banco !== v.forma ? ` ${v.banco}` : "";
-                          pagParts.push(resto > 0 ? `${lbl}${banco}: ${fmt(resto)}` : `${lbl}${banco}`);
+                          pagParts.push(`${lbl}${banco}: ${fmt(resto)}`);
                         }
                         // Sem forma definida mas tem complemento a pagar
                         if (!v.forma && resto > 0) {

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -685,7 +685,7 @@ export async function PATCH(req: NextRequest) {
           to: venda.email!,
           clienteNome: venda.cliente || "Cliente",
           produto: `${venda.produto || ""}${venda.cor ? ` ${venda.cor}` : ""}`.trim(),
-          valor: Number(venda.preco_vendido || 0),
+          valor: Number(venda.preco_vendido || 0) - Number(venda.credito_lojista_usado || 0),
           notaFiscalUrl: venda.nota_fiscal_url!,
         }).then(() => {
           console.log("[Vendas] NF enviada por email para:", venda.email);

--- a/supabase/migrations/20260414b_simulacoes_cor_usado.sql
+++ b/supabase/migrations/20260414b_simulacoes_cor_usado.sql
@@ -1,0 +1,5 @@
+-- Adicionar colunas cor_usado e cor_usado2 na tabela simulacoes
+-- Necessário para que a cor selecionada pelo cliente no formulário de troca
+-- apareça nos detalhes da simulação no admin
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS cor_usado text;
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS cor_usado2 text;

--- a/supabase/migrations/20260414d_fix_credito_lojista_retroativo.sql
+++ b/supabase/migrations/20260414d_fix_credito_lojista_retroativo.sql
@@ -1,0 +1,20 @@
+-- Preencher credito_lojista_usado retroativamente
+-- Abordagem 1: via lojistas_movimentacoes (quando venda_id existe)
+UPDATE vendas v
+SET credito_lojista_usado = m.valor
+FROM lojistas_movimentacoes m
+WHERE m.venda_id = v.id
+  AND m.tipo = 'DEBITO'
+  AND (v.credito_lojista_usado IS NULL OR v.credito_lojista_usado = 0);
+
+-- Abordagem 2: via lojistas_movimentacoes por nome do cliente + data (quando venda_id não foi salvo)
+UPDATE vendas v
+SET credito_lojista_usado = m.valor
+FROM lojistas_movimentacoes m
+JOIN lojistas l ON l.id = m.lojista_id
+WHERE m.tipo = 'DEBITO'
+  AND m.venda_id IS NULL
+  AND UPPER(l.nome) = UPPER(v.cliente)
+  AND m.created_at::date = v.data
+  AND (v.credito_lojista_usado IS NULL OR v.credito_lojista_usado = 0)
+  AND v.tipo = 'ATACADO';

--- a/supabase/migrations/20260414e_fix_credito_loja_siri.sql
+++ b/supabase/migrations/20260414e_fix_credito_loja_siri.sql
@@ -1,0 +1,7 @@
+-- Fix crédito da LOJA SIRI na venda do IPHONE 17 256GB WHITE (serial K76DFL620H)
+-- Crédito usado: R$ 4.060, PIX pago: R$ 890
+UPDATE vendas
+SET credito_lojista_usado = 4060
+WHERE serial_no = 'K76DFL620H'
+  AND cliente = 'LOJA SIRI'
+  AND (credito_lojista_usado IS NULL OR credito_lojista_usado = 0);


### PR DESCRIPTION
## Summary
- Fix: PIX mostra valor correto quando tem crédito lojista (ex: Crédito R$ 4.060 + PIX R$ 890)
- Fix: NF email desconta crédito do valor exibido
- Migration: preenche credito_lojista_usado retroativamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)