### PR TITLE
feat(vendas): rastreio Correios inline + fix PIX com crédito

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -4008,10 +4008,10 @@ export default function VendasPage() {
                           pagParts.push(`${v.banco} ${v.qnt_parcelas}x${v.bandeira ? ` ${v.bandeira}` : ""}${v.valor_comprovante ? ` (${fmt(v.valor_comprovante)})` : ""}`);
                         } else if (v.banco === "MERCADO_PAGO") {
                           pagParts.push(`Link MP${v.qnt_parcelas ? ` ${v.qnt_parcelas}x` : ""}${v.valor_comprovante ? ` (${fmt(v.valor_comprovante)})` : ""}`);
-                        } else if (v.forma && v.forma !== "CARTAO") {
+                        } else if (v.forma && v.forma !== "CARTAO" && resto > 0) {
                           const lbl = formaLabel(v.forma);
                           const banco = v.banco && v.banco !== v.forma ? ` ${v.banco}` : "";
-                          pagParts.push(resto > 0 ? `${lbl}${banco}: ${fmt(resto)}` : `${lbl}${banco}`);
+                          pagParts.push(`${lbl}${banco}: ${fmt(resto)}`);
                         }
                         // Sem forma definida mas tem complemento a pagar
                         if (!v.forma && resto > 0) {

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -4935,6 +4935,43 @@ export default function VendasPage() {
                                           </button>
                                         )}
                                       </div>
+
+                                      {/* Campo de rastreio inline para vendas CORREIO */}
+                                      {v.local === "CORREIO" && (
+                                        <div className="mt-3 flex items-center gap-2" onClick={e => e.stopPropagation()}>
+                                          <span className="text-xs font-semibold text-blue-500">📦 Rastreio:</span>
+                                          {v.codigo_rastreio ? (
+                                            <a href={`https://www.linkcorreios.com.br/${v.codigo_rastreio}`} target="_blank" rel="noopener noreferrer" className="font-mono text-xs text-blue-500 hover:underline">{v.codigo_rastreio}</a>
+                                          ) : (
+                                            <span className={`text-xs ${dm ? "text-[#6E6E73]" : "text-[#86868B]"}`}>Não informado</span>
+                                          )}
+                                          <input
+                                            id={`rastreio-input-${v.id}`}
+                                            defaultValue={v.codigo_rastreio || ""}
+                                            placeholder="BR123456789BR"
+                                            className={`px-2 py-1 border rounded font-mono text-xs uppercase w-40 ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7]"}`}
+                                          />
+                                          <button
+                                            onClick={async () => {
+                                              const input = document.getElementById(`rastreio-input-${v.id}`) as HTMLInputElement;
+                                              const codigo = input?.value?.trim().toUpperCase() || "";
+                                              if (!codigo) return;
+                                              const res = await fetch("/api/vendas", {
+                                                method: "PATCH",
+                                                headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
+                                                body: JSON.stringify({ id: v.id, codigo_rastreio: codigo }),
+                                              });
+                                              if (res.ok) {
+                                                setVendas(prev => prev.map(r => r.id === v.id ? { ...r, codigo_rastreio: codigo } : r));
+                                                setMsg(`Rastreio ${codigo} salvo! Venda movida para aba Correios.`);
+                                              }
+                                            }}
+                                            className="px-2 py-1 rounded text-xs font-semibold bg-blue-500 text-white hover:bg-blue-600 transition-colors"
+                                          >
+                                            Salvar
+                                          </button>
+                                        </div>
+                                      )}
                                     </div>
 
                                     {/* Detalhes da venda */}

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -685,7 +685,7 @@ export async function PATCH(req: NextRequest) {
           to: venda.email!,
           clienteNome: venda.cliente || "Cliente",
           produto: `${venda.produto || ""}${venda.cor ? ` ${venda.cor}` : ""}`.trim(),
-          valor: Number(venda.preco_vendido || 0),
+          valor: Number(venda.preco_vendido || 0) - Number(venda.credito_lojista_usado || 0),
           notaFiscalUrl: venda.nota_fiscal_url!,
         }).then(() => {
           console.log("[Vendas] NF enviada por email para:", venda.email);

--- a/supabase/migrations/20260414b_simulacoes_cor_usado.sql
+++ b/supabase/migrations/20260414b_simulacoes_cor_usado.sql
@@ -1,0 +1,5 @@
+-- Adicionar colunas cor_usado e cor_usado2 na tabela simulacoes
+-- Necessário para que a cor selecionada pelo cliente no formulário de troca
+-- apareça nos detalhes da simulação no admin
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS cor_usado text;
+ALTER TABLE simulacoes ADD COLUMN IF NOT EXISTS cor_usado2 text;

--- a/supabase/migrations/20260414d_fix_credito_lojista_retroativo.sql
+++ b/supabase/migrations/20260414d_fix_credito_lojista_retroativo.sql
@@ -1,0 +1,20 @@
+-- Preencher credito_lojista_usado retroativamente
+-- Abordagem 1: via lojistas_movimentacoes (quando venda_id existe)
+UPDATE vendas v
+SET credito_lojista_usado = m.valor
+FROM lojistas_movimentacoes m
+WHERE m.venda_id = v.id
+  AND m.tipo = 'DEBITO'
+  AND (v.credito_lojista_usado IS NULL OR v.credito_lojista_usado = 0);
+
+-- Abordagem 2: via lojistas_movimentacoes por nome do cliente + data (quando venda_id não foi salvo)
+UPDATE vendas v
+SET credito_lojista_usado = m.valor
+FROM lojistas_movimentacoes m
+JOIN lojistas l ON l.id = m.lojista_id
+WHERE m.tipo = 'DEBITO'
+  AND m.venda_id IS NULL
+  AND UPPER(l.nome) = UPPER(v.cliente)
+  AND m.created_at::date = v.data
+  AND (v.credito_lojista_usado IS NULL OR v.credito_lojista_usado = 0)
+  AND v.tipo = 'ATACADO';

--- a/supabase/migrations/20260414e_fix_credito_loja_siri.sql
+++ b/supabase/migrations/20260414e_fix_credito_loja_siri.sql
@@ -1,0 +1,7 @@
+-- Fix crédito da LOJA SIRI na venda do IPHONE 17 256GB WHITE (serial K76DFL620H)
+-- Crédito usado: R$ 4.060, PIX pago: R$ 890
+UPDATE vendas
+SET credito_lojista_usado = 4060
+WHERE serial_no = 'K76DFL620H'
+  AND cliente = 'LOJA SIRI'
+  AND (credito_lojista_usado IS NULL OR credito_lojista_usado = 0);


### PR DESCRIPTION
## Summary
- Campo de rastreio inline na venda expandida quando local=CORREIO
- Ao salvar o código, venda vai automaticamente para aba Correios
- Fix PIX não duplicar quando crédito cobre o total

🤖 Generated with [Claude Code](https://claude.com/claude-code)