### PR TITLE
fix(zapi-grupos): mostrar detalhes do erro Z-API

### DIFF
--- a/app/admin/zapi-grupos/page.tsx
+++ b/app/admin/zapi-grupos/page.tsx
@@ -9,10 +9,17 @@ interface Grupo {
   ultimaMensagem: string | null;
 }
 
+interface ErroDetalhado {
+  msg: string;
+  status?: number;
+  hint?: string;
+  details?: unknown;
+}
+
 export default function ZapiGruposPage() {
   const { password } = useAdmin();
   const [loading, setLoading] = useState(true);
-  const [erro, setErro] = useState("");
+  const [erro, setErro] = useState<ErroDetalhado | null>(null);
   const [grupos, setGrupos] = useState<Grupo[]>([]);
   const [totalChats, setTotalChats] = useState(0);
   const [copiado, setCopiado] = useState<string | null>(null);
@@ -22,17 +29,25 @@ export default function ZapiGruposPage() {
   useEffect(() => {
     if (!password) return;
     setLoading(true);
-    setErro("");
+    setErro(null);
     fetch("/api/admin/zapi-groups", { headers: { "x-admin-password": password } })
       .then(async (r) => {
         const json = await r.json();
-        if (!r.ok) throw new Error(json.error || "Erro ao buscar grupos");
+        if (!r.ok) {
+          setErro({
+            msg: json.error || "Erro ao buscar grupos",
+            status: json.status,
+            hint: json.hint,
+            details: json.details,
+          });
+          return;
+        }
         setGrupos(json.groups || []);
         setTotalChats(json.totalChats || 0);
         setPhoneConectado(json.phoneConectado || null);
         setNomeConectado(json.nomeConectado || null);
       })
-      .catch((err) => setErro(String(err?.message || err)))
+      .catch((err) => setErro({ msg: String(err?.message || err) }))
       .finally(() => setLoading(false));
   }, [password]);
 
@@ -99,8 +114,25 @@ export default function ZapiGruposPage() {
       )}
 
       {erro && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-900">
-          <strong>Erro:</strong> {erro}
+        <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-900 space-y-2">
+          <div>
+            <strong>Erro:</strong> {erro.msg}
+          </div>
+          {erro.hint && (
+            <div className="text-xs bg-red-100 rounded p-2">
+              <strong>Dica:</strong> {erro.hint}
+            </div>
+          )}
+          {erro.details !== undefined && erro.details !== null && (
+            <details className="text-xs">
+              <summary className="cursor-pointer text-red-700">Detalhes técnicos</summary>
+              <pre className="bg-red-100 rounded p-2 mt-1 overflow-auto max-h-60 whitespace-pre-wrap break-all">
+                {typeof erro.details === "string"
+                  ? erro.details
+                  : JSON.stringify(erro.details, null, 2)}
+              </pre>
+            </details>
+          )}
         </div>
       )}
 

--- a/app/api/admin/zapi-groups/route.ts
+++ b/app/api/admin/zapi-groups/route.ts
@@ -50,8 +50,26 @@ export async function GET(request: Request) {
     const deviceInfo = await deviceRes.json().catch(() => null);
 
     if (!chatsRes.ok) {
+      // Tenta extrair mensagem útil da resposta Z-API. Formatos comuns:
+      //   { error: "mensagem" } / { message: "mensagem" } / "string direta" / null
+      const zapiMsg =
+        (data && typeof data === "object" && (data.error || data.message)) ||
+        (typeof data === "string" ? data : null) ||
+        "sem mensagem";
       return NextResponse.json(
-        { error: "Z-API retornou erro", status: chatsRes.status, details: data },
+        {
+          error: `Z-API erro ${chatsRes.status}: ${zapiMsg}`,
+          status: chatsRes.status,
+          details: data,
+          deviceInfo,
+          instanceIdEndsWith: instanceId.slice(-6),
+          hint:
+            chatsRes.status === 401 || chatsRes.status === 403
+              ? "Token inválido ou expirado. Confira ZAPI_TOKEN e ZAPI_CLIENT_TOKEN no Vercel."
+              : chatsRes.status === 404
+              ? "Instância não encontrada. Confira ZAPI_INSTANCE_ID no Vercel."
+              : "Pode ser que o WhatsApp esteja desconectado na Z-API. Acesse o painel da Z-API e reconecte o número.",
+        },
         { status: 502 }
       );
     }


### PR DESCRIPTION
## Summary
- Página `/admin/zapi-grupos` está retornando erro genérico "Z-API retornou erro" sem detalhes
- Adiciona exibição de status HTTP + mensagem real + dica contextual + JSON expansível
- Necessário pra descobrir qual é o problema real (token? desconectado? instance id?)

## Test plan
- [ ] Abrir `/admin/zapi-grupos` em produção
- [ ] Confirmar que o erro agora mostra "Detalhes técnicos" clicável
- [ ] Verificar o JSON retornado pra identificar a causa raiz