### PR TITLE
fix(mp-webhook): cliente sem nome na notificação

### DIFF
--- a/app/api/mp-webhook/route.ts
+++ b/app/api/mp-webhook/route.ts
@@ -102,10 +102,22 @@ async function handleApprovedPayment(paymentId: string) {
     return;
   }
 
+  // Fallback de dados do cliente: se o link_compras ainda não tem nome/telefone
+  // (cliente pagou antes de preencher o formulário), usamos o que o MP sabe
+  // sobre o pagador (nome do cartão, telefone de cadastro, etc).
+  const nomeMp = [payment.payer?.first_name, payment.payer?.last_name]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+  const telefoneMp =
+    payment.payer?.phone?.area_code && payment.payer?.phone?.number
+      ? `(${payment.payer.phone.area_code}) ${payment.payer.phone.number}`
+      : null;
+
   // Dispara WhatsApp
   const ok = await notifyPagamentoAprovado({
-    cliente: link.cliente_nome || "Cliente sem nome",
-    telefone: link.cliente_telefone,
+    cliente: link.cliente_nome || nomeMp || "Cliente (aguardando formulário)",
+    telefone: link.cliente_telefone || telefoneMp,
     produto: link.produto || "Produto",
     valor: Number(payment.transaction_amount || link.valor || 0),
     parcelas: payment.installments ? String(payment.installments) : link.parcelas,


### PR DESCRIPTION
## Summary
Quando cliente paga via Link MP **antes** de preencher o /compra, a notificação cai no grupo como \"Cliente sem nome\".

Agora usa \`payer.first_name + payer.last_name\` do MP como fallback (e telefone também).

## Test plan
- [ ] Gerar link MP
- [ ] Pagar sem passar pelo /compra
- [ ] Ver notificação no grupo com o nome do pagador