### PR TITLE
feat(tradein): categoria nos seminovos + agendamento D+2 + local Outro

### DIFF
--- a/app/api/tradein-config/route.ts
+++ b/app/api/tradein-config/route.ts
@@ -2,10 +2,10 @@ import { NextResponse } from "next/server";
 
 const DEFAULT_CONFIG = {
   seminovos: [
-    { modelo: "iPhone 15 Pro", storages: ["128GB", "256GB"], ativo: true },
-    { modelo: "iPhone 15 Pro Max", storages: ["256GB", "512GB"], ativo: true },
-    { modelo: "iPhone 16 Pro", storages: ["128GB", "256GB"], ativo: true },
-    { modelo: "iPhone 16 Pro Max", storages: ["256GB"], ativo: true },
+    { modelo: "iPhone 15 Pro", storages: ["128GB", "256GB"], ativo: true, categoria: "iphone" },
+    { modelo: "iPhone 15 Pro Max", storages: ["256GB", "512GB"], ativo: true, categoria: "iphone" },
+    { modelo: "iPhone 16 Pro", storages: ["128GB", "256GB"], ativo: true, categoria: "iphone" },
+    { modelo: "iPhone 16 Pro Max", storages: ["256GB"], ativo: true, categoria: "iphone" },
   ],
   labels: {
     step1_titulo: "Qual é o modelo do seu usado?",
@@ -46,6 +46,15 @@ export async function GET() {
     if (labels._whatsapp_formularios) result.whatsapp_formularios = labels._whatsapp_formularios;
     if (labels._whatsapp_formularios_seminovos) result.whatsapp_formularios_seminovos = labels._whatsapp_formularios_seminovos;
     if (labels._whatsapp_vendedores) result.whatsapp_vendedores = labels._whatsapp_vendedores;
+
+    // Backfill defensivo: garante que todo seminovo tenha categoria (fallback iphone).
+    // Cobre linhas antigas do banco que ainda não passaram pela migration.
+    if (Array.isArray(result.seminovos)) {
+      result.seminovos = (result.seminovos as Record<string, unknown>[]).map((s) => ({
+        ...s,
+        categoria: (s.categoria as string) || "iphone",
+      }));
+    }
 
     return NextResponse.json({ data: result });
   } catch {

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "next/navigation";
 import { useState, useEffect, useMemo, Suspense } from "react";
 import { WHATSAPP_FORMULARIO } from "@/lib/whatsapp-config";
 import { corParaPT } from "@/lib/cor-pt";
+import { getAgendamentoBounds } from "@/lib/date-utils";
 
 function maskCPF(value: string) {
   const digits = value.replace(/\D/g, "").slice(0, 11);
@@ -300,8 +301,24 @@ function CompraForm() {
   const [bairro, setBairro] = useState(bairroParam);
   const [horario, setHorario] = useState(horarioParam);
   const [horariosDisponiveis, setHorariosDisponiveis] = useState<string[]>(["10:00", "11:00", "12:00", "13:00", "14:00", "15:00", "16:00", "17:00"]);
-  const [local, setLocal] = useState<"Loja" | "Entrega" | "Correios">(localParam === "correios" ? "Correios" : localParam === "shopping" || localParam === "residencia" ? "Entrega" : localParam === "loja" ? "Loja" : "Loja");
-  const [tipoEntrega, setTipoEntrega] = useState<"Shopping" | "Residencia">(localParam === "shopping" ? "Shopping" : "Residencia");
+  // "Outro" = entrega em local personalizado (aprovado internamente via gerar-link).
+  // Essa opção nunca aparece para o cliente comum — só se o operador passou
+  // localParam === "outro" no link. Pagamento tratado como "pagar na entrega"
+  // (mesma regra de shopping, sem exigência de antecipação).
+  const [local, setLocal] = useState<"Loja" | "Entrega" | "Correios">(
+    localParam === "correios" ? "Correios"
+      : (localParam === "shopping" || localParam === "residencia" || localParam === "outro") ? "Entrega"
+      : localParam === "loja" ? "Loja"
+      : "Loja"
+  );
+  const [tipoEntrega, setTipoEntrega] = useState<"Shopping" | "Residencia" | "Outro">(
+    localParam === "shopping" ? "Shopping"
+      : localParam === "outro" ? "Outro"
+      : "Residencia"
+  );
+  // Sinaliza que o operador pré-autorizou local personalizado — só mostramos
+  // esse tipo quando este flag estiver ativo.
+  const localOutroHabilitado = localParam === "outro";
   const [shopping, setShopping] = useState(shoppingParam);
   const [dataEntrega, setDataEntrega] = useState(dataEntregaParam);
   const [formaPagamento, setFormaPagamento] = useState(formaParam);
@@ -367,6 +384,9 @@ function CompraForm() {
   const [loadingMp, setLoadingMp] = useState(false);
   const [erroMp, setErroMp] = useState("");
 
+  // Janela de agendamento (hoje a D+2 de calendário, pulando domingos).
+  const agendamentoBounds = useMemo(() => getAgendamentoBounds(), []);
+
   // Installment calculations
   const descontoNum = parseFloat(String(descontoParam)) || 0;
   const valorBase = preco > 0 ? Math.max(preco - descontoNum - trocaNum, 0) : 0;
@@ -410,6 +430,7 @@ function CompraForm() {
     const localStr = local === "Loja" ? "Retirada em loja"
       : local === "Correios" ? "Envio Correios"
       : tipoEntrega === "Shopping" ? `Entrega - Shopping: ${shopping}`
+      : tipoEntrega === "Outro" ? `Entrega - Local combinado: ${shopping || "(a definir)"}`
       : "Entrega - Residência";
 
     // Valor base para cálculos (usa precoFinal definido acima)
@@ -700,7 +721,9 @@ function CompraForm() {
         entrega: {
           local: local === "Correios" ? "Correios" : local === "Loja" ? "Loja" : "Entrega",
           tipoEntrega: local === "Entrega" ? tipoEntrega : undefined,
-          shopping: tipoEntrega === "Shopping" ? shopping : undefined,
+          // Para "Outro", o campo `shopping` guarda o nome do local combinado
+          // (reusamos o mesmo campo pra evitar novo campo no backend).
+          shopping: (tipoEntrega === "Shopping" || tipoEntrega === "Outro") ? shopping : undefined,
           data: dataEntrega,
           horario,
           vendedor,
@@ -1275,7 +1298,8 @@ function CompraForm() {
           </div>
           )}
 
-          {/* Data — seg a sab (não mostra pra Correios) */}
+          {/* Data — janela curta (hoje, +1, +2 calendário) com domingo bloqueado.
+              Bounds computadas em lib/date-utils.getAgendamentoBounds. */}
           {local !== "Correios" && (<div>
             <label className={labelCls}>Data *</label>
             <input type="date" required value={dataEntrega}
@@ -1293,17 +1317,10 @@ function CompraForm() {
                 }
                 setDataEntrega(e.target.value);
               }}
-              min={(() => {
-                const d = new Date();
-                d.setDate(d.getDate() + (d.getHours() >= 18 ? 1 : 0));
-                while (d.getDay() === 0) d.setDate(d.getDate() + 1);
-                // Usar data LOCAL (não UTC) para evitar off-by-one em fusos horários
-                const y = d.getFullYear();
-                const m = String(d.getMonth() + 1).padStart(2, "0");
-                const day = String(d.getDate()).padStart(2, "0");
-                return `${y}-${m}-${day}`;
-              })()}
+              min={agendamentoBounds.min}
+              max={agendamentoBounds.max}
               className={inputCls} />
+            <p className="text-[11px] text-[#86868B] mt-1">Agendamento disponivel para hoje, amanha ou depois de amanha. Domingo indisponivel.</p>
           </div>)}
 
           {/* Horário — dinâmico conforme tipo + dia da semana (não mostra pra Correios) */}
@@ -1328,15 +1345,22 @@ function CompraForm() {
           {local === "Entrega" && (
             <div className="space-y-3">
               <label className="block text-sm font-medium text-[#1D1D1F] mb-2">Local de entrega *</label>
-              <div className="flex gap-3">
-                <label className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 cursor-pointer transition-colors ${tipoEntrega === "Residencia" ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
+              {/* "Outro" só aparece com localParam=outro (exceção liberada pelo operador). */}
+              <div className={`grid gap-3 ${localOutroHabilitado ? "grid-cols-3" : "grid-cols-2"}`}>
+                <label className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 cursor-pointer transition-colors ${tipoEntrega === "Residencia" ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
                   <input type="radio" name="tipoEntrega" value="Residencia" checked={tipoEntrega === "Residencia"} onChange={() => { setTipoEntrega("Residencia"); setShopping(""); }} className="sr-only" />
-                  &#x1F3E0; <span className="font-medium">Residência</span>
+                  &#x1F3E0; <span className="font-medium text-sm">Residência</span>
                 </label>
-                <label className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 cursor-pointer transition-colors ${tipoEntrega === "Shopping" ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
+                <label className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 cursor-pointer transition-colors ${tipoEntrega === "Shopping" ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
                   <input type="radio" name="tipoEntrega" value="Shopping" checked={tipoEntrega === "Shopping"} onChange={() => setTipoEntrega("Shopping")} className="sr-only" />
-                  &#x1F3EC; <span className="font-medium">Shopping</span>
+                  &#x1F3EC; <span className="font-medium text-sm">Shopping</span>
                 </label>
+                {localOutroHabilitado && (
+                  <label className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 cursor-pointer transition-colors ${tipoEntrega === "Outro" ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
+                    <input type="radio" name="tipoEntrega" value="Outro" checked={tipoEntrega === "Outro"} onChange={() => setTipoEntrega("Outro")} className="sr-only" />
+                    &#x1F4CD; <span className="font-medium text-sm">Outro local</span>
+                  </label>
+                )}
               </div>
               {!pagamentoPagoParam && (
                 <div className={`p-3 rounded-lg text-sm font-semibold text-center ${tipoEntrega === "Residencia" ? "bg-yellow-50 border border-yellow-200 text-yellow-700" : "bg-green-50 border border-green-200 text-green-700"}`}>
@@ -1349,7 +1373,14 @@ function CompraForm() {
                   <input type="text" required value={shopping} onChange={(e) => setShopping(e.target.value)} placeholder="Ex: BarraShopping, Village Mall..." className={inputCls} />
                 </div>
               )}
-              {!pagamentoPagoParam && (
+              {tipoEntrega === "Outro" && (
+                <div>
+                  <label className={labelCls}>Local combinado *</label>
+                  <input type="text" required value={shopping} onChange={(e) => setShopping(e.target.value)} placeholder="Ex: Estação do metrô, escritório..." className={inputCls} />
+                  <p className="text-[11px] text-[#86868B] mt-1 italic">Entrega em local personalizado previamente combinado com a equipe.</p>
+                </div>
+              )}
+              {!pagamentoPagoParam && tipoEntrega !== "Outro" && (
                 <div className="p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-xs leading-relaxed">
                   <p><strong>⚠️ Taxa de deslocamento:</strong> Caso a compra nao seja concluida no ato da entrega (falta de limite, divergencia, etc), sera cobrada uma taxa de deslocamento.</p>
                 </div>

--- a/components/StepNewDevice.tsx
+++ b/components/StepNewDevice.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import type { NewProduct, TradeInConfig } from "@/lib/types";
+import type { NewProduct, TradeInConfig, SeminovoCategoria } from "@/lib/types";
+import { SEMINOVO_CATEGORIAS, SEMINOVO_CAT_LABELS } from "@/lib/types";
 import { getUniqueModels, getStoragesForModel, getProductPrice } from "@/lib/sheets";
 import { formatBRL, calculateQuote, getAnyConditionLines, type AnyConditionData, type DeviceType } from "@/lib/calculations";
 import { WHATSAPP_SEMINOVO } from "@/lib/whatsapp-config";
@@ -51,11 +52,12 @@ function getCategory(modelo: string): ProductCategory {
   return "iPhone";
 }
 
-const SEMINOVOS = [
-  { modelo: "iPhone 15 Pro", storages: ["128GB", "256GB"] },
-  { modelo: "iPhone 15 Pro Max", storages: ["256GB", "512GB"] },
-  { modelo: "iPhone 16 Pro", storages: ["128GB", "256GB"] },
-  { modelo: "iPhone 16 Pro Max", storages: ["256GB"] },
+// Defaults usados apenas quando o banco não respondeu ainda
+const SEMINOVOS_DEFAULT: { modelo: string; storages: string[]; ativo: boolean; categoria: SeminovoCategoria }[] = [
+  { modelo: "iPhone 15 Pro", storages: ["128GB", "256GB"], ativo: true, categoria: "iphone" },
+  { modelo: "iPhone 15 Pro Max", storages: ["256GB", "512GB"], ativo: true, categoria: "iphone" },
+  { modelo: "iPhone 16 Pro", storages: ["128GB", "256GB"], ativo: true, categoria: "iphone" },
+  { modelo: "iPhone 16 Pro Max", storages: ["256GB"], ativo: true, categoria: "iphone" },
 ];
 
 export default function StepNewDevice({ products, tradeInValue, onNext, onBack, usedModel, usedStorage, usedColor, whatsappNumber, condition, deviceType, tradeinConfig, usedModel2, usedStorage2, usedColor2, condition2, deviceType2, tradeInValue1, tradeInValue2 }: StepNewDeviceProps) {
@@ -68,12 +70,40 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
   const [semiStorage, setSemiStorage] = useState("");
   const [semiNome, setSemiNome] = useState("");
   const [semiWhatsapp, setSemiWhatsapp] = useState("");
+  // Categoria escolhida no modo seminovo — separada de `category` (lacrado)
+  // porque os dois universos são independentes (mesma divisão do admin).
+  const [semiCat, setSemiCat] = useState<SeminovoCategoria | "">("");
 
-  // Use config from DB or fallback to hardcoded
-  const seminovos = useMemo(() => {
-    const list = tradeinConfig?.seminovos?.filter((s) => s.ativo);
-    return list && list.length > 0 ? list : SEMINOVOS;
+  // Normaliza a lista vinda do DB com categoria (backfill: item sem categoria → iphone).
+  // Inclui apenas ativos, já prontos pra uso.
+  const seminovosAll = useMemo(() => {
+    const raw = tradeinConfig?.seminovos?.filter((s) => s.ativo);
+    const src = raw && raw.length > 0 ? raw : SEMINOVOS_DEFAULT;
+    return src.map((s) => ({
+      modelo: s.modelo,
+      storages: s.storages,
+      categoria: ((s as { categoria?: string }).categoria as SeminovoCategoria) || "iphone",
+    }));
   }, [tradeinConfig]);
+
+  // Categorias com ao menos 1 seminovo ativo (as únicas abas clicáveis).
+  const semiCats = useMemo(() => {
+    const set = new Set<SeminovoCategoria>();
+    seminovosAll.forEach((s) => set.add(s.categoria));
+    return SEMINOVO_CATEGORIAS.filter((c) => set.has(c));
+  }, [seminovosAll]);
+
+  // Categoria efetiva: se o user não escolheu e só existe 1 categoria,
+  // seleciona automaticamente (evita seletor redundante e tela vazia se o
+  // config chega depois do click).
+  const semiCatEffective: SeminovoCategoria | "" = semiCat || (semiCats.length === 1 ? semiCats[0] : "");
+
+  // Filtra pela categoria efetiva.
+  const seminovos = useMemo(
+    () => (semiCatEffective ? seminovosAll.filter((s) => s.categoria === semiCatEffective) : []),
+    [seminovosAll, semiCatEffective]
+  );
+
   const lbl = tradeinConfig?.labels || {};
 
   // Categorias disponíveis (que tenham produtos no catálogo)
@@ -115,7 +145,8 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
   function selectMode(m: "lacrado" | "seminovo") {
     setMode(m);
     setCategory(""); setLine(""); setModel(""); setStorage(""); cancelCmp();
-    setSemiModel(""); setSemiStorage("");
+    setSemiModel(""); setSemiStorage(""); setSemiCat("");
+    // Auto-seleção quando só há 1 categoria é derivada em semiCatEffective.
   }
 
   function selectCategory(c: ProductCategory) {
@@ -297,15 +328,31 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
             <p className="text-[12px]" style={{ color: "var(--ti-muted)" }}>{lbl.seminovo_info || "Aparelhos revisados e em excelente estado. O valor e condicoes serao informados por WhatsApp."}</p>
           </div>
 
-          <Sec title="Modelo seminovo">
-            <div className="grid grid-cols-1 gap-2">
-              {seminovos.map((s) => (
-                <Btn key={s.modelo} sel={semiModel === s.modelo} onClick={() => { setSemiModel(s.modelo); setSemiStorage(""); }} className="text-left">
-                  {s.modelo}
-                </Btn>
-              ))}
-            </div>
-          </Sec>
+          {/* Categoria do seminovo — só aparece se houver mais de uma.
+              Mesma ergonomia do modo lacrado (Categoria → Modelo → Storage). */}
+          {semiCats.length > 1 && (
+            <Sec title="Categoria">
+              <div className="grid grid-cols-2 gap-2">
+                {semiCats.map((c) => (
+                  <Btn key={c} sel={semiCat === c} onClick={() => { setSemiCat(c); setSemiModel(""); setSemiStorage(""); }}>
+                    {SEMINOVO_CAT_LABELS[c].icon} {SEMINOVO_CAT_LABELS[c].label}
+                  </Btn>
+                ))}
+              </div>
+            </Sec>
+          )}
+
+          {semiCatEffective && seminovos.length > 0 && (
+            <Sec title="Modelo seminovo">
+              <div className="grid grid-cols-1 gap-2">
+                {seminovos.map((s) => (
+                  <Btn key={s.modelo} sel={semiModel === s.modelo} onClick={() => { setSemiModel(s.modelo); setSemiStorage(""); }} className="text-left">
+                    {s.modelo}
+                  </Btn>
+                ))}
+              </div>
+            </Sec>
+          )}
 
           {semiModel && (
             <Sec title="Armazenamento">

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -1,6 +1,6 @@
 "use client";
-import React, { useEffect, useState } from "react";
-import { TradeInQuestion, TradeInQuestionOption, SeminovoOption } from "@/lib/types";
+import React, { useEffect, useMemo, useState } from "react";
+import { TradeInQuestion, TradeInQuestionOption, SeminovoOption, SeminovoCategoria, SEMINOVO_CAT_LABELS } from "@/lib/types";
 
 interface Props {
   password: string;
@@ -226,8 +226,8 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
         Gerencie as perguntas do simulador de troca. Altere texto, opções, descontos e ordem. Desative perguntas que não quer exibir.
       </div>
 
-      {/* === CONFIG SECTIONS === */}
-      <TradeInConfigAdmin password={password} />
+      {/* deviceTab drives which seminovo category is shown in "Modelos Seminovo". */}
+      <TradeInConfigAdmin password={password} deviceTab={deviceTab} />
 
       <div className="border-t border-[#E5E5EA] my-6" />
 
@@ -514,10 +514,10 @@ const DEFAULT_LABELS: Record<string, string> = {
 };
 
 const DEFAULT_SEMINOVOS: SeminovoOption[] = [
-  { modelo: "iPhone 15 Pro", storages: ["128GB", "256GB"], ativo: true },
-  { modelo: "iPhone 15 Pro Max", storages: ["256GB", "512GB"], ativo: true },
-  { modelo: "iPhone 16 Pro", storages: ["128GB", "256GB"], ativo: true },
-  { modelo: "iPhone 16 Pro Max", storages: ["256GB"], ativo: true },
+  { modelo: "iPhone 15 Pro", storages: ["128GB", "256GB"], ativo: true, categoria: "iphone" },
+  { modelo: "iPhone 15 Pro Max", storages: ["256GB", "512GB"], ativo: true, categoria: "iphone" },
+  { modelo: "iPhone 16 Pro", storages: ["128GB", "256GB"], ativo: true, categoria: "iphone" },
+  { modelo: "iPhone 16 Pro Max", storages: ["256GB"], ativo: true, categoria: "iphone" },
 ];
 
 const DEFAULT_ORIGENS = ["Anúncio", "Story", "Direct", "WhatsApp", "Indicação", "Já sou cliente"];
@@ -552,7 +552,9 @@ const LABEL_GROUPS: { title: string; keys: { key: string; label: string }[] }[] 
   },
 ];
 
-function TradeInConfigAdmin({ password }: { password: string }) {
+function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceTab: string }) {
+  // Mantemos a lista inteira em memória — o banco persiste tudo num único
+  // JSONB, então precisa voltar completa no PUT. A filtragem é por render.
   const [seminovos, setSeminovos] = useState<SeminovoOption[]>(DEFAULT_SEMINOVOS);
   const [labels, setLabels] = useState<Record<string, string>>(DEFAULT_LABELS);
   const [origens, setOrigens] = useState<string[]>(DEFAULT_ORIGENS);
@@ -564,6 +566,24 @@ function TradeInConfigAdmin({ password }: { password: string }) {
   const [newSemiModelo, setNewSemiModelo] = useState("");
   const [newSemiStorage, setNewSemiStorage] = useState("");
 
+  // Itens sem categoria (pré-migration) caem em "iphone" para compatibilidade.
+  const categoriaAtiva: SeminovoCategoria = (deviceTab as SeminovoCategoria) in SEMINOVO_CAT_LABELS ? (deviceTab as SeminovoCategoria) : "iphone";
+
+  // Índices reais na lista completa — toggles/edições precisam do índice certo
+  // mesmo com a UI filtrada.
+  const visibleIndices = useMemo(
+    () => seminovos.reduce<number[]>((acc, s, i) => {
+      if ((s.categoria || "iphone") === categoriaAtiva) acc.push(i);
+      return acc;
+    }, []),
+    [seminovos, categoriaAtiva]
+  );
+
+  const countCategoriaAtiva = useMemo(
+    () => seminovos.filter((s) => (s.categoria || "iphone") === categoriaAtiva && s.ativo).length,
+    [seminovos, categoriaAtiva]
+  );
+
   function getHeaders() {
     return { "x-admin-password": password, "Content-Type": "application/json" };
   }
@@ -574,7 +594,14 @@ function TradeInConfigAdmin({ password }: { password: string }) {
       .then((json) => {
         const d = json.data;
         if (d) {
-          if (Array.isArray(d.seminovos) && d.seminovos.length > 0) setSeminovos(d.seminovos);
+          if (Array.isArray(d.seminovos) && d.seminovos.length > 0) {
+            // Backfill: itens antigos sem categoria caem em "iphone"
+            const normalized: SeminovoOption[] = d.seminovos.map((s: SeminovoOption) => ({
+              ...s,
+              categoria: (s.categoria as SeminovoCategoria) || "iphone",
+            }));
+            setSeminovos(normalized);
+          }
           if (d.labels && Object.keys(d.labels).length > 0) setLabels({ ...DEFAULT_LABELS, ...d.labels });
           if (Array.isArray(d.origens) && d.origens.length > 0) setOrigens(d.origens);
         }
@@ -645,11 +672,24 @@ function TradeInConfigAdmin({ password }: { password: string }) {
 
       {showMsg()}
 
-      {/* === SEMINOVOS === */}
-      {sectionBtn("seminovos", "Modelos Seminovo", seminovos.filter((s) => s.ativo).length)}
+      {/* === SEMINOVOS ===
+          O botão mostra "(n)" = nº de modelos ativos NA CATEGORIA da aba atual
+          (antes mostrava o total geral, o que causava confusão). */}
+      {sectionBtn("seminovos", `Modelos Seminovo — ${SEMINOVO_CAT_LABELS[categoriaAtiva].label}`, countCategoriaAtiva)}
       {expandedSection === "seminovos" && (
         <div className="border border-[#D2D2D7] rounded-xl bg-white p-4 space-y-3">
-          {seminovos.map((s, si) => (
+          <div className="text-[11px] text-[#86868B] bg-[#F5F5F7] rounded-lg px-3 py-2 leading-relaxed">
+            <strong>{SEMINOVO_CAT_LABELS[categoriaAtiva].label}:</strong> apenas os modelos seminovos desta categoria aparecem aqui.
+            Troque a aba acima para ver/editar outras categorias.
+          </div>
+          {visibleIndices.length === 0 && (
+            <div className="text-center text-sm text-[#86868B] py-4 italic">
+              Nenhum modelo seminovo cadastrado para {SEMINOVO_CAT_LABELS[categoriaAtiva].label}.
+            </div>
+          )}
+          {visibleIndices.map((si) => {
+            const s = seminovos[si];
+            return (
             <div key={si} className={`rounded-lg border border-[#E5E5EA] p-3 space-y-2 ${!s.ativo ? "opacity-50" : ""}`}>
               <div className="flex items-center gap-2">
                 <input
@@ -697,7 +737,7 @@ function TradeInConfigAdmin({ password }: { password: string }) {
                 ))}
                 <div className="inline-flex items-center gap-1">
                   <input
-                    value={si === seminovos.length - 1 ? newSemiStorage : ""}
+                    value={si === visibleIndices[visibleIndices.length - 1] ? newSemiStorage : ""}
                     onChange={(e) => setNewSemiStorage(e.target.value)}
                     onFocus={() => setNewSemiStorage("")}
                     onKeyDown={(e) => {
@@ -713,19 +753,53 @@ function TradeInConfigAdmin({ password }: { password: string }) {
                   />
                 </div>
               </div>
+              {/* Campo de preço — reservado pra futuro. Hoje opcional e escondido
+                  atrás de um detalhamento pra não poluir a UI. O valor já é
+                  persistido no banco (preco?: number), então quando ativarmos
+                  a precificação automática nada precisa ser migrado. */}
+              <details className="text-[11px] text-[#86868B]">
+                <summary className="cursor-pointer select-none hover:text-[#1D1D1F]">
+                  Preço (opcional — uso futuro){typeof s.preco === "number" ? ` · R$ ${s.preco.toLocaleString("pt-BR")}` : ""}
+                </summary>
+                <div className="mt-2 flex items-center gap-2">
+                  <span>R$</span>
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    value={typeof s.preco === "number" ? String(s.preco) : ""}
+                    onChange={(e) => {
+                      const arr = [...seminovos];
+                      const raw = e.target.value.trim();
+                      const num = raw === "" ? undefined : Number(raw);
+                      arr[si] = { ...arr[si], preco: Number.isFinite(num as number) ? (num as number) : undefined };
+                      setSeminovos(arr);
+                    }}
+                    placeholder="Ex: 5500"
+                    className="w-32 px-2 py-1 rounded border border-[#D2D2D7] text-xs focus:outline-none focus:border-[#E8740E]"
+                  />
+                  <span className="text-[10px] italic">Ainda não exibido ao cliente.</span>
+                </div>
+              </details>
             </div>
-          ))}
+            );
+          })}
           <div className="flex gap-2">
             <input
               value={newSemiModelo}
               onChange={(e) => setNewSemiModelo(e.target.value)}
-              placeholder="Ex: iPhone 17 Pro"
+              placeholder={`Ex: ${categoriaAtiva === "iphone" ? "iPhone 17 Pro" : categoriaAtiva === "ipad" ? "iPad Pro M4" : categoriaAtiva === "macbook" ? "MacBook Air M3" : "Apple Watch Series 10"}`}
               className="flex-1 px-3 py-2 rounded-lg border border-dashed border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
             />
             <button
               onClick={() => {
                 if (newSemiModelo.trim()) {
-                  setSeminovos([...seminovos, { modelo: newSemiModelo.trim(), storages: ["128GB", "256GB"], ativo: true }]);
+                  // Novo item herda a categoria da aba aberta.
+                  setSeminovos([...seminovos, {
+                    modelo: newSemiModelo.trim(),
+                    storages: ["128GB", "256GB"],
+                    ativo: true,
+                    categoria: categoriaAtiva,
+                  }]);
                   setNewSemiModelo("");
                 }
               }}

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -15,3 +15,27 @@ export function horaBR(): string {
 export function dataEfetiva(v: { data: string; data_programada?: string | null }): string {
   return v.data_programada || v.data;
 }
+
+/** Formata Date local para YYYY-MM-DD (evita off-by-one por UTC). */
+function fmtLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
+ * Janela de agendamento do Link de Compra: mínimo = hoje (ou amanhã se >=18h),
+ * máximo = min + 2 dias. Domingos são pulados em ambos os extremos.
+ */
+export function getAgendamentoBounds(now: Date = new Date()): { min: string; max: string } {
+  const base = new Date(now);
+  base.setDate(base.getDate() + (base.getHours() >= 18 ? 1 : 0));
+  while (base.getDay() === 0) base.setDate(base.getDate() + 1);
+
+  const max = new Date(base);
+  max.setDate(max.getDate() + 2);
+  if (max.getDay() === 0) max.setDate(max.getDate() + 1);
+
+  return { min: fmtLocalDate(base), max: fmtLocalDate(max) };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -61,11 +61,29 @@ export interface TradeInQuestion {
   device_type: string;
 }
 
-/** Configuração do formulário trade-in (Supabase tradein_config) */
+/** Categoria do seminovo ofertado ao cliente (aba no admin + filtro no StepNewDevice). */
+export type SeminovoCategoria = "iphone" | "ipad" | "macbook" | "watch";
+
+/** Ordem canônica das categorias (usada para abas e filtros). */
+export const SEMINOVO_CATEGORIAS: readonly SeminovoCategoria[] = ["iphone", "ipad", "macbook", "watch"] as const;
+
+/** Label + ícone por categoria. Consumido pelo admin e pelo StepNewDevice. */
+export const SEMINOVO_CAT_LABELS: Record<SeminovoCategoria, { label: string; icon: string }> = {
+  iphone: { label: "iPhone", icon: "📱" },
+  ipad: { label: "iPad", icon: "📱" },
+  macbook: { label: "MacBook", icon: "💻" },
+  watch: { label: "Apple Watch", icon: "⌚" },
+};
+
+/** Configuração do formulário trade-in (Supabase tradein_config).
+ *  `preco` é opcional e reservado para futura precificação direta —
+ *  ainda não aparece no formulário do cliente. */
 export interface SeminovoOption {
   modelo: string;
   storages: string[];
   ativo: boolean;
+  categoria: SeminovoCategoria;
+  preco?: number;
 }
 
 export interface TradeInConfig {

--- a/supabase/migrations/20260416_seminovos_por_categoria.sql
+++ b/supabase/migrations/20260416_seminovos_por_categoria.sql
@@ -1,0 +1,44 @@
+-- ===========================================================
+-- Modelos Seminovo por categoria + base para precificação futura
+-- ===========================================================
+-- Contexto:
+--  Hoje o campo tradein_config.seminovos é um JSONB array de
+--  { modelo, storages[], ativo }. Todos os modelos caem na mesma lista
+--  independente da categoria, então ao trocar de aba (iPhone/iPad/MacBook/
+--  Apple Watch) no admin, o cliente via iPhone em todas.
+--
+-- Esta migration:
+--   1. Adiciona `categoria` (iphone | ipad | macbook | watch) em cada item.
+--   2. Deixa `preco` disponível como campo opcional (não usado agora,
+--      mas já reservado para futura precificação direta na UI).
+--   3. Normaliza os itens existentes para categoria = 'iphone'
+--      (porque hoje só existem iPhones cadastrados).
+-- ===========================================================
+
+-- 1) Garante que os itens existentes tenham categoria = 'iphone'
+UPDATE tradein_config
+SET seminovos = (
+  SELECT jsonb_agg(
+    CASE
+      WHEN elem ? 'categoria' THEN elem
+      ELSE elem || jsonb_build_object('categoria', 'iphone')
+    END
+  )
+  FROM jsonb_array_elements(seminovos) AS elem
+)
+WHERE seminovos IS NOT NULL
+  AND jsonb_typeof(seminovos) = 'array'
+  AND jsonb_array_length(seminovos) > 0;
+
+-- 2) Garante default vazio caso a linha ainda não tenha seminovos
+UPDATE tradein_config
+SET seminovos = '[]'::jsonb
+WHERE seminovos IS NULL;
+
+-- Obs.: O schema do JSONB agora suporta os campos:
+--   { modelo: string, storages: string[], ativo: boolean,
+--     categoria: 'iphone'|'ipad'|'macbook'|'watch',
+--     preco?: number }
+-- A validação fica na aplicação (TypeScript) — não precisa de CHECK no JSONB.
+
+SELECT 'Migration 20260416_seminovos_por_categoria aplicada com sucesso!' AS resultado;


### PR DESCRIPTION
## Resumo
- **Admin Perguntas Trade-In**: seminovos agora ficam presos à aba/categoria ativa. Adicionar em "iPad" salva como iPad (antes saía como iPhone). Campo `preco?` opcional adicionado sem ativar precificação ainda.
- **StepNewDevice**: cliente vê apenas os seminovos da categoria escolhida. Com só 1 categoria ativa, pula o seletor.
- **Link de Compra**: agendamento limitado a hoje/+1/+2 de calendário (helper `getAgendamentoBounds`). Domingo pula pra segunda.
- **Link de Compra**: "Outro local" com pagamento na entrega — aparece só com `?localParam=outro` na URL (exceção liberada pelo operador).
- **Migration**: backfill `categoria: iphone` nos seminovos existentes sem categoria.

## Arquivos
- `supabase/migrations/20260416_seminovos_por_categoria.sql` (novo)
- `lib/types.ts` — `SeminovoCategoria`, `SEMINOVO_CATEGORIAS`, `SEMINOVO_CAT_LABELS`, `SeminovoOption.categoria` + `preco?`
- `lib/date-utils.ts` — `getAgendamentoBounds()`
- `app/api/tradein-config/route.ts` — backfill `categoria` no GET, default
- `components/admin/TradeInQuestionsAdmin.tsx` — filtro por aba + campo preço colapsado
- `components/StepNewDevice.tsx` — seletor de categoria + filtro
- `app/compra/page.tsx` — data `min`/`max` via helper, toggle "Outro"

## Checklist
- [ ] Rodar migration em `/admin/migrations` após deploy
- [ ] Testar trocar de aba no admin e adicionar modelo — deve salvar com a categoria correta
- [ ] Testar flow seminovo no form do cliente — aba deve filtrar
- [ ] Testar agendamento no Link de Compra — só mostra hoje/+1/+2
- [ ] Testar `?localParam=outro` — mostra opção "Outro local" com pagamento na entrega

🤖 Generated with [Claude Code](https://claude.com/claude-code)