### PR TITLE
fix(gerar-link): mostrar TODOS os links no historico (preenchidos estavam escondidos)

### DIFF
--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -1840,14 +1840,9 @@ export default function GerarLinkPage() {
           {!histLoading && histLinks.length === 0 && <p className="text-xs text-[#86868B] text-center py-6">Nenhum link encontrado.</p>}
 
           {(() => {
-            // Esconde links onde o cliente já preencheu o form de compra — esses
-            // aparecem em /admin/simulacoes → Histórico de Formulários. Aqui
-            // mantemos só o que ainda está "Aguardando" (ninguém preencheu).
-            // Preenchido = tem cliente_dados_preenchidos (JSONB) E cliente_preencheu_em.
-            const visiveis = histLinks.filter(l => !(l.cliente_dados_preenchidos && l.cliente_preencheu_em));
-            if (!histLoading && visiveis.length === 0 && histLinks.length > 0) {
-              return <p className="text-xs text-[#86868B] text-center py-6">Todos os links encontrados já foram preenchidos. Consulte em <strong>Simulações → Histórico de Formulários</strong>.</p>;
-            }
+            // Mostra TODOS os links (Aguardando, Preenchido, Entrega criada).
+            // Operador filtra via o dropdown "Status" em cima se quiser ver só um tipo.
+            const visiveis = histLinks;
             return (
           <div className="space-y-2">
             {visiveis.map((l) => (


### PR DESCRIPTION
## CAUSA RAIZ ENCONTRADA

O bug \"links sumindo apos preencher\" reportado pelo Nicolas (Isaac, Camila, Kleber, Thaynara e 15+ outros) **NAO era cache, NAO era Service Worker, NAO era Cloudflare**. Era um filtro JSX escondendo propositalmente os links preenchidos:

\`\`\`ts
// app/admin/gerar-link/page.tsx linha 1847
const visiveis = histLinks.filter(l => !(l.cliente_dados_preenchidos && l.cliente_preencheu_em));
\`\`\`

O comentario original dizia que os preenchidos \"aparecem em /admin/simulacoes → Historico de Formularios\". Mas isso gerava confusao total: operador cria link em \`/admin/gerar-link\`, cliente preenche, e o link 'sumia' pra quem criou.

## Fix

Remove o filtro. Todos os links (Aguardando / Preenchido / Entrega criada) voltam a aparecer em \`/admin/gerar-link\` → Historico.

O dropdown Status adicionado em PR anterior (#463) permite filtrar se operador quiser ver so um tipo:
- Todos status (default)
- ⏳ Aguardando
- 📝 Preenchido
- ✅ Entrega criada

## Impacto

Thaynara, Kleber, Camila, Isaac e outros clientes preenchidos voltam a aparecer na tela. Total de cards sobe de ~34 pra 124 (todos os ativos).

## Validacao

Confirmei via Chrome MCP na maquina do Nicolas:
- API retornava 124 registros ✅
- UI renderizava so 34 ❌
- Causa: filtro \`visiveis\` escondendo 90 cards preenchidos

Apos esse fix: UI renderiza os 124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)