### PR TITLE
fix(simulacoes): Historico de Formularios so mostra clientes do Simulador

### DIFF
--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -246,17 +246,17 @@ export default function AdminPage() {
       let items: HistoricoItem[] = [];
       if (res.ok) {
         const json = await res.json();
-        // Defensivo: garante que todos têm PELO MENOS UM sinal de funil
-        // completo e status diferente de GOSTEI/SAIR (simulação pura).
-        // NÃO exigimos cliente_dados_preenchidos (JSONB) aqui — em casos
-        // legados (POST keepalive falha, entrega criada manualmente, etc.)
-        // o JSONB pode estar null mesmo quando o funil foi completado.
-        // O modal de detalhes lida com entries legado mostrando aviso.
+        // Aqui mostramos APENAS clientes que vieram pelo Simulador de trade-in publico
+        // (formulario de troca no site) e seguiram ate o link de compra.
+        // Links criados manualmente no /admin/gerar-link aparecem so naquela tela,
+        // nao aqui (eles nao vieram pelo funil de trade-in).
+        // Criterio: operador === "Simulador" OU simulacao_id preenchido.
         const valido = (r: HistoricoItem) =>
           (!!r.cliente_preencheu_em || !!r.entrega_id || !!r.pagamento_pago) &&
           r.status !== "GOSTEI" &&
           r.status !== "SAIR" &&
-          r.status !== "AGUARDANDO_MP";
+          r.status !== "AGUARDANDO_MP" &&
+          (r.operador === "Simulador" || !!r.simulacao_id);
         items = (json.data || []).filter(valido);
       }
       setHistorico(items);


### PR DESCRIPTION
## Problema

A aba \`/admin/simulacoes\` → \"Histórico de Formulários\" estava mostrando **todos** os links preenchidos, incluindo os criados manualmente pelos operadores em \`/admin/gerar-link\`. Isso bagunçava a tela, que deveria mostrar só clientes que vieram pelo funil de **trade-in público** (formulário de troca → GOSTEI → link de compra).

Nicolas reportou: \"aqui é para aparecer somente os que vieram pela troca e seguiram direto para o link de compra\".

## Fix

Adiciona filtro adicional no criterio \`valido\`:
\`\`\`ts
(r.operador === \"Simulador\" || !!r.simulacao_id)
\`\`\`

Agora essa aba mostra **apenas**:
1. Links criados pelo Simulador público (\`operador = \"Simulador\"\`)
2. OU ligados diretamente a uma simulação real (\`simulacao_id\` preenchido)

Links manuais (André, Nicolas, Bianca) saem dessa tela e ficam só em \`/admin/gerar-link\`, como deve ser.

## Impacto

Thaynara, Kleber, Camila, Isaac, Lucas Chaves (links manuais) saem do \"Histórico de Formulários\". Só os do Simulador (ex: Georgemesquita) aparecem. O contador de 92 deve cair significativamente.

## Combina com PR #465

A PR #465 (separada) já fez o trabalho simétrico no \`/admin/gerar-link\`: todos os links voltam a aparecer lá (antes os preenchidos sumiam). Com as duas PRs mergeadas, a segregação fica correta:

- \`/admin/gerar-link\` → **todos** os links (manuais + Simulador), filtrável por Status
- \`/admin/simulacoes\` Historico → **só** clientes do funil de trade-in público

🤖 Generated with [Claude Code](https://claude.com/claude-code)