### PR TITLE
fix(entregas): vendedor da entrega passa a ser quem encaminha (Bianca/Andre)

### DIFF
--- a/app/api/admin/link-compras/encaminhar-entrega/route.ts
+++ b/app/api/admin/link-compras/encaminhar-entrega/route.ts
@@ -130,6 +130,31 @@ export async function POST(request: Request) {
   obsParts.push(`Encaminhada do link ${link.short_code}`);
   const observacaoFinal = obsParts.filter(Boolean).join("\n");
 
+  // Vendedor da entrega: se quem esta encaminhando e um vendedor com
+  // recebe_links=true (ex: Bianca triando links da Paloma), ele vira o vendedor
+  // da entrega. Caso contrario (admin Nicolas, ou vendedor sem recebe_links),
+  // mantem o vendedor original do link.
+  let vendedorFinal: string | null = link.vendedor || null;
+  try {
+    const userLogado = getUser(request);
+    if (userLogado && userLogado !== "Sistema") {
+      const { data: cfg } = await supabase
+        .from("tradein_config")
+        .select("labels")
+        .limit(1)
+        .maybeSingle();
+      const labels = (cfg?.labels || {}) as Record<string, unknown>;
+      const recebeMap = (labels._whatsapp_vendedores_recebe_links || {}) as Record<string, boolean>;
+      const norm = (s: string) => s.trim().toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+      const userKey = norm(userLogado);
+      // Procura match case-insensitive e sem acento
+      const recebe = Object.entries(recebeMap).some(([nome, flag]) => norm(nome) === userKey && flag === true);
+      if (recebe) {
+        vendedorFinal = userLogado;
+      }
+    }
+  } catch { /* silent: fallback ja e link.vendedor */ }
+
   const { data: entrega, error: e2 } = await supabase
     .from("entregas")
     .insert({
@@ -154,7 +179,7 @@ export async function POST(request: Request) {
       entrada: entradaVal > 0 ? entradaVal : null,
       parcelas: parcelasNum > 0 ? parcelasNum : null,
       valor_total: valorFinal > 0 ? valorFinal : (valorBase > 0 ? valorBase : null),
-      vendedor: link.vendedor || null,
+      vendedor: vendedorFinal,
     })
     .select()
     .single();


### PR DESCRIPTION
## Problema

Fluxo reportado pelo Nicolas:

1. Nicolas gera link de compra em \`/admin/gerar-link\` escolhendo vendedora **Paloma**
2. Link cai no WhatsApp da **Bianca** (Paloma tem \`recebe_links=false\`, entao roteado pro fallback)
3. Cliente preenche
4. Bianca atende e clica \"Encaminhar entrega\"
5. **Entrega fica no nome da Paloma** — mas quem fechou foi a Bianca

## Fix

No endpoint \`encaminhar-entrega\`, quem encaminha vira o vendedor da entrega — **se for um vendedor ativo com \`recebe_links=true\`**.

Logica:
- Le \`tradein_config.labels._whatsapp_vendedores_recebe_links\` (mapa {nome: bool})
- Normaliza o \`x-admin-user\` (case-insensitive, sem acento)
- Se encontrado com \`recebe_links=true\` → vendedor da entrega = user logado
- Senao → mantem \`link.vendedor\` (comportamento original, nao forca admin Nicolas como vendedor)

## Casos cobertos

| Cenario | Antes | Depois |
|---|---|---|
| Nicolas cria link p/ Paloma → Bianca encaminha | Paloma | **Bianca** ✅ |
| André cria link p/ ele → André encaminha | André | **André** ✅ (sem mudanca) |
| Paloma/Nicole encaminham (se fosse o caso) | Paloma/Nicole | mantem (recebe_links=false) |
| Nicolas admin encaminha manualmente | link.vendedor | mantem link.vendedor (Nicolas nao vira vendedor) |

## Edge cases

- Se \`tradein_config\` nao tem \`_whatsapp_vendedores_recebe_links\`: cai no fallback \`link.vendedor\` (comportamento anterior)
- Se query falha: \`try/catch\` silencioso, usa \`link.vendedor\`
- Nao afeta outros campos da entrega

🤖 Generated with [Claude Code](https://claude.com/claude-code)