### PR TITLE
fix(vendas): editar venda programada nao pode zerar agendamento

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -5036,6 +5036,19 @@ export default function VendasPage() {
                                               setEditandoGrupoIds([]);
                                               setEditandoVendaId(v.id);
                                             }
+                                            // Preservar flag de venda programada no form — senao o PATCH
+                                            // zerava data_programada e mudava status pra AGUARDANDO ao salvar.
+                                            if (primaryVenda.status_pagamento === "PROGRAMADA" || primaryVenda.data_programada) {
+                                              setVendaProgramada(true);
+                                              setDataProgramada(primaryVenda.data_programada || "");
+                                              setProgramadaJaPago(primaryVenda.status_pagamento === "FINALIZADO");
+                                              setProgramadaComSinal(Number(primaryVenda.sinal_antecipado) > 0);
+                                            } else {
+                                              setVendaProgramada(false);
+                                              setDataProgramada("");
+                                              setProgramadaJaPago(false);
+                                              setProgramadaComSinal(false);
+                                            }
                                             setTab("nova");
                                             window.scrollTo({ top: 0, behavior: "smooth" });
                                           }}


### PR DESCRIPTION
## Bug

Nicolas reportou: criou venda programada pro dia 17/04 com sinal antecipado R$ 3.960, foi salvar/editar algum campo, e ao confirmar:
- Venda saiu de PROGRAMADA, virou AGUARDANDO
- \`data_programada\` foi pra null (perdeu o agendamento)
- \`preco_vendido\` zerou, causando \`lucro = -R$ 8.890\` (custo puro)

## Causa raiz

Botão **✏️ Editar** chamava \`setForm(...)\` com os dados da venda, mas **não chamava** \`setVendaProgramada(true)\` nem \`setDataProgramada(...)\`.

Esses states ficam com valor default (\`false\` / \`""\`). Ao salvar, o \`buildPayload()\` faz:
\`\`\`ts
data_programada: vendaProgramada && dataProgramada ? dataProgramada : null,  // -> null
status_pagamento: ... : vendaProgramada ? ... : 'AGUARDANDO',  // -> AGUARDANDO
\`\`\`

## Fix

No fluxo de entrar em edição, detectar se a venda original era programada e setar os states:

\`\`\`ts
if (primaryVenda.status_pagamento === 'PROGRAMADA' || primaryVenda.data_programada) {
  setVendaProgramada(true);
  setDataProgramada(primaryVenda.data_programada || '');
  setProgramadaJaPago(primaryVenda.status_pagamento === 'FINALIZADO');
  setProgramadaComSinal(Number(primaryVenda.sinal_antecipado) > 0);
} else {
  setVendaProgramada(false);
  setDataProgramada('');
  setProgramadaJaPago(false);
  setProgramadaComSinal(false);
}
\`\`\`

## Venda do Pedro

Nicolas vai corrigir manualmente via tela. Pós-merge, ao clicar Editar na venda dele, agora o form vai vir com os campos corretos e não vai mais zerar o agendamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)