### PR TITLE
feat: edit WhatsApp em simulacoes + balanco manual de seminovos

### DIFF
--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -132,6 +132,8 @@ export default function AdminPage() {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkDeleting, setBulkDeleting] = useState(false);
   const [modalRow, setModalRow] = useState<SimulacaoRow | null>(null);
+  const [editingWa, setEditingWa] = useState<{ id: string; valor: string } | null>(null);
+  const [savingWa, setSavingWa] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const [editData, setEditData] = useState<Record<string, string>>({});
   const [savingEdit, setSavingEdit] = useState(false);
@@ -1555,7 +1557,81 @@ export default function AdminPage() {
                       <td className="px-4 py-3 text-[#86868B] whitespace-nowrap text-xs">{fmtDate(row.created_at)}</td>
                       <td className="px-4 py-3 text-[#1D1D1F] font-medium whitespace-nowrap">{row.nome}</td>
                       <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                        <a href={(() => { const n = row.whatsapp.replace(/\D/g, ""); return `https://wa.me/${n.startsWith("55") ? n : `55${n}`}`; })()} target="_blank" rel="noopener noreferrer" className="text-green-600 hover:underline whitespace-nowrap">{row.whatsapp}</a>
+                        {editingWa?.id === row.id ? (
+                          <div className="flex items-center gap-1">
+                            <input
+                              type="text"
+                              value={editingWa.valor}
+                              onChange={(e) => setEditingWa({ id: row.id, valor: e.target.value })}
+                              placeholder="(21) 9XXXX-XXXX"
+                              autoFocus
+                              className="px-2 py-1 rounded border border-[#E8740E] text-xs w-36 focus:outline-none"
+                              onKeyDown={async (e) => {
+                                if (e.key === "Escape") { setEditingWa(null); return; }
+                                if (e.key !== "Enter") return;
+                                // Fall through to save logic below
+                                (e.currentTarget.nextElementSibling as HTMLButtonElement)?.click();
+                              }}
+                            />
+                            <button
+                              disabled={savingWa}
+                              onClick={async () => {
+                                const raw = editingWa.valor.replace(/\D/g, "");
+                                if (raw.length < 10) { alert("WhatsApp invalido. Inclua DDD + numero."); return; }
+                                setSavingWa(true);
+                                try {
+                                  const res = await fetch("/api/admin/simulacoes", {
+                                    method: "PATCH",
+                                    headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
+                                    body: JSON.stringify({ id: row.id, whatsapp: editingWa.valor }),
+                                  });
+                                  const j = await res.json();
+                                  if (!j.ok) { alert("Erro: " + (j.error || "falha")); setSavingWa(false); return; }
+                                  setData((prev) => prev ? prev.map((r) => r.id === row.id ? { ...r, whatsapp: editingWa.valor } : r) : prev);
+                                  setEditingWa(null);
+                                } catch (err) {
+                                  alert("Erro de conexao: " + String(err));
+                                }
+                                setSavingWa(false);
+                              }}
+                              className="text-xs text-green-600 hover:text-green-800 px-1"
+                              title="Salvar"
+                            >
+                              {savingWa ? "..." : "✓"}
+                            </button>
+                            <button
+                              onClick={() => setEditingWa(null)}
+                              className="text-xs text-[#86868B] hover:text-red-500 px-1"
+                              title="Cancelar"
+                            >
+                              ✕
+                            </button>
+                          </div>
+                        ) : (
+                          <div className="flex items-center gap-1 group">
+                            {row.whatsapp && row.whatsapp.replace(/\D/g, "").length >= 10 ? (
+                              <a
+                                href={(() => { const n = row.whatsapp.replace(/\D/g, ""); return `https://wa.me/${n.startsWith("55") ? n : `55${n}`}`; })()}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-green-600 hover:underline whitespace-nowrap"
+                              >
+                                {row.whatsapp}
+                              </a>
+                            ) : (
+                              <span className="text-red-500 text-xs font-medium whitespace-nowrap">⚠ {row.whatsapp || "(vazio)"}</span>
+                            )}
+                            {user?.role === "admin" && (
+                              <button
+                                onClick={() => setEditingWa({ id: row.id, valor: row.whatsapp || "" })}
+                                className="text-xs text-[#86868B] hover:text-[#E8740E] opacity-0 group-hover:opacity-100 transition-opacity"
+                                title="Editar WhatsApp"
+                              >
+                                ✏️
+                              </button>
+                            )}
+                          </div>
+                        )}
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap">
                         {row.vendedor ? (

--- a/app/admin/usados/page.tsx
+++ b/app/admin/usados/page.tsx
@@ -464,6 +464,9 @@ export function UsadosContent() {
 
       {msg && <div className="px-4 py-3 rounded-xl text-sm bg-green-50 text-green-700">{msg}</div>}
 
+      {/* Balanco manual de seminovos */}
+      <BalancoSeminovosSection password={password} userNome={user?.nome || "sistema"} onMsg={setMsg} />
+
       {/* Form adicionar modelo */}
       {showAddModelo && (
         <div className="bg-white border border-[#E8740E]/30 rounded-2xl p-5 shadow-sm space-y-3">
@@ -880,4 +883,187 @@ export function UsadosContent() {
 
 export default function UsadosPage() {
   return <UsadosContent />;
+}
+
+// ====================================================================
+// Balanco manual de seminovos
+// ====================================================================
+
+interface BalancoGrupo {
+  categoria: string;
+  modeloBase: string;
+  qnt: number;
+  custoTotal: number;
+  custoAtual: number;
+  balancoCalculado: number;
+  precisaAtualizar: boolean;
+  qntItens: number;
+}
+
+function BalancoSeminovosSection({
+  password,
+  userNome,
+  onMsg,
+}: {
+  password: string;
+  userNome: string;
+  onMsg: (m: string) => void;
+}) {
+  const [aberto, setAberto] = useState(false);
+  const [grupos, setGrupos] = useState<BalancoGrupo[]>([]);
+  const [selecionados, setSelecionados] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(false);
+  const [aplicando, setAplicando] = useState(false);
+
+  const keyOf = (g: BalancoGrupo) => `${g.categoria}|${g.modeloBase}`;
+
+  const carregar = useCallback(async () => {
+    if (!password) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/recalc-balancos?categoria=SEMINOVOS", {
+        headers: { "x-admin-password": password },
+        cache: "no-store",
+      });
+      const j = await res.json();
+      setGrupos(Array.isArray(j.data) ? j.data : []);
+    } catch { /* silent */ }
+    setLoading(false);
+  }, [password]);
+
+  useEffect(() => {
+    if (aberto) carregar();
+  }, [aberto, carregar]);
+
+  const toggleTodos = () => {
+    if (selecionados.size === grupos.length) setSelecionados(new Set());
+    else setSelecionados(new Set(grupos.map(keyOf)));
+  };
+
+  const toggleUm = (g: BalancoGrupo) => {
+    const k = keyOf(g);
+    const next = new Set(selecionados);
+    if (next.has(k)) next.delete(k);
+    else next.add(k);
+    setSelecionados(next);
+  };
+
+  const aplicarBalanco = async () => {
+    if (selecionados.size === 0) { alert("Selecione ao menos 1 modelo."); return; }
+    const modelos = grupos.filter(g => selecionados.has(keyOf(g))).map(g => ({ categoria: g.categoria, modeloBase: g.modeloBase }));
+    const total = modelos.length;
+    if (!confirm(`Aplicar balanço em ${total} modelo(s) selecionado(s)?`)) return;
+    setAplicando(true);
+    try {
+      const res = await fetch("/api/admin/recalc-balancos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(userNome) },
+        body: JSON.stringify({ modelos }),
+      });
+      const j = await res.json();
+      if (!j.ok) { alert("Erro: " + (j.error || "falha")); setAplicando(false); return; }
+      onMsg(`✓ Balanço aplicado em ${total} modelo(s). ${j.updated} produto(s) atualizado(s).`);
+      setSelecionados(new Set());
+      await carregar();
+    } catch (e) {
+      alert("Erro de conexão: " + String(e));
+    }
+    setAplicando(false);
+  };
+
+  const precisam = grupos.filter(g => g.precisaAtualizar).length;
+
+  return (
+    <div className="bg-white border border-[#D2D2D7] rounded-2xl shadow-sm overflow-hidden">
+      <button
+        onClick={() => setAberto(!aberto)}
+        className="w-full px-5 py-4 flex items-center justify-between hover:bg-[#F5F5F7] transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-lg">📊</span>
+          <div className="text-left">
+            <p className="text-sm font-bold text-[#1D1D1F]">Balanço Manual (Preço Médio)</p>
+            <p className="text-[11px] text-[#86868B]">
+              Selecione os modelos de seminovo e aplique o recálculo de preço médio ponderado
+              {aberto && precisam > 0 && <span className="ml-2 text-[#E8740E] font-semibold">· {precisam} modelo(s) com balanço desatualizado</span>}
+            </p>
+          </div>
+        </div>
+        <span className="text-[#86868B]">{aberto ? "▲" : "▼"}</span>
+      </button>
+
+      {aberto && (
+        <div className="px-5 py-4 border-t border-[#E5E5EA] bg-[#FAFAFA]">
+          {loading && <p className="text-xs text-[#86868B] py-4 text-center">Carregando...</p>}
+          {!loading && grupos.length === 0 && (
+            <p className="text-xs text-[#86868B] py-4 text-center">Nenhum seminovo em estoque encontrado.</p>
+          )}
+          {!loading && grupos.length > 0 && (
+            <>
+              <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
+                <button
+                  onClick={toggleTodos}
+                  className="text-xs text-[#E8740E] hover:underline font-medium"
+                >
+                  {selecionados.size === grupos.length ? "Desmarcar todos" : "Selecionar todos"} ({selecionados.size}/{grupos.length})
+                </button>
+                <button
+                  onClick={aplicarBalanco}
+                  disabled={aplicando || selecionados.size === 0}
+                  className="px-4 py-2 rounded-lg text-sm font-bold bg-[#E8740E] text-white hover:bg-[#D06A0D] disabled:opacity-40 disabled:cursor-not-allowed"
+                >
+                  {aplicando ? "Aplicando..." : `🔄 Fazer balanço dos selecionados (${selecionados.size})`}
+                </button>
+              </div>
+              <div className="overflow-x-auto bg-white rounded-xl border border-[#E5E5EA]">
+                <table className="w-full text-sm">
+                  <thead className="bg-[#F5F5F7]">
+                    <tr>
+                      <th className="px-3 py-2 text-left text-[10px] font-bold text-[#86868B] uppercase"></th>
+                      <th className="px-3 py-2 text-left text-[10px] font-bold text-[#86868B] uppercase">Modelo</th>
+                      <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Qnt</th>
+                      <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Custo Atual</th>
+                      <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Novo Balanço</th>
+                      <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Diferença</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {grupos.map((g) => {
+                      const k = keyOf(g);
+                      const sel = selecionados.has(k);
+                      const diff = g.balancoCalculado - g.custoAtual;
+                      return (
+                        <tr
+                          key={k}
+                          className={`border-t border-[#F5F5F7] hover:bg-[#FAFAFA] cursor-pointer ${sel ? "bg-orange-50" : ""}`}
+                          onClick={() => toggleUm(g)}
+                        >
+                          <td className="px-3 py-2">
+                            <input
+                              type="checkbox"
+                              checked={sel}
+                              onChange={() => toggleUm(g)}
+                              onClick={(e) => e.stopPropagation()}
+                              className="w-4 h-4 accent-[#E8740E]"
+                            />
+                          </td>
+                          <td className="px-3 py-2 text-[#1D1D1F] font-medium">{g.modeloBase}</td>
+                          <td className="px-3 py-2 text-right text-[#1D1D1F] font-mono">{g.qnt}</td>
+                          <td className="px-3 py-2 text-right text-[#86868B] font-mono">{fmt(g.custoAtual)}</td>
+                          <td className={`px-3 py-2 text-right font-mono font-semibold ${g.precisaAtualizar ? "text-[#E8740E]" : "text-[#86868B]"}`}>{fmt(g.balancoCalculado)}</td>
+                          <td className={`px-3 py-2 text-right font-mono ${Math.abs(diff) < 0.01 ? "text-[#86868B]" : diff > 0 ? "text-green-600" : "text-red-600"}`}>
+                            {Math.abs(diff) < 0.01 ? "—" : `${diff > 0 ? "+" : ""}${fmt(diff)}`}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/app/api/admin/recalc-balancos/route.ts
+++ b/app/api/admin/recalc-balancos/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { logActivity } from "@/lib/activity-log";
 import { recalcBalancos } from "@/lib/recalc-balancos";
+import { getModeloBase } from "@/lib/produto-display";
 
 function auth(req: NextRequest) {
   return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
@@ -12,23 +13,117 @@ function getUsuario(req: NextRequest): string {
 }
 
 /**
- * Recalcula o balanço (custo_unitario = preço médio ponderado) de todos
- * os produtos EM ESTOQUE. Agora usa a função compartilhada de lib/.
+ * POST: Recalcula o balanço (preco medio ponderado).
+ *
+ * Body opcional:
+ * - { modelos: [{ categoria, modeloBase }] } — recalcula APENAS os modelos listados.
+ *   Usado pra balanco manual de seminovos na tela /admin/usados.
+ * - { includeSeminovos: true } — inclui SEMINOVOS na passada geral (nao e default).
+ *
+ * Sem body ou vazio: recalcula tudo EXCETO seminovos (comportamento padrao).
  */
 export async function POST(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   try {
-    const { groups, updated } = await recalcBalancos();
+    let body: { modelos?: Array<{ categoria: string; modeloBase: string }>; includeSeminovos?: boolean } = {};
+    try { body = await req.json(); } catch { /* no body = default */ }
+
+    const opts: Parameters<typeof recalcBalancos>[0] = {};
+    if (Array.isArray(body.modelos) && body.modelos.length > 0) {
+      opts.onlyModelos = body.modelos;
+      // Quando manual, permite incluir seminovos (padrão do manual)
+      opts.excludeSeminovos = false;
+    } else if (body.includeSeminovos) {
+      opts.excludeSeminovos = false;
+    }
+
+    const { groups, updated } = await recalcBalancos(opts);
+
+    const descricao = opts.onlyModelos
+      ? `Manual: ${opts.onlyModelos.length} modelo(s), ${updated} produtos atualizados`
+      : `Automatico: ${groups} grupos, ${updated} produtos atualizados`;
 
     await logActivity(
       getUsuario(req),
-      "Recalculou balanços",
-      `${groups} grupos, ${updated} produtos atualizados`,
+      "Recalculou balancos",
+      descricao,
       "estoque"
     );
 
     return NextResponse.json({ ok: true, groups, updated });
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}
+
+/**
+ * GET: Preview do balanço manual de seminovos.
+ * Retorna lista de modelos em estoque da categoria SEMINOVOS, com quantidade,
+ * valor total (custo_compra ponderado) e o balanço calculado (custo médio).
+ * Usado pra UI de seleção antes de aplicar.
+ *
+ * ?categoria=SEMINOVOS (opcional, default SEMINOVOS)
+ */
+export async function GET(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const url = new URL(req.url);
+    const categoria = (url.searchParams.get("categoria") || "SEMINOVOS").toUpperCase();
+
+    const { supabase } = await import("@/lib/supabase");
+    const { data: items, error } = await supabase
+      .from("estoque")
+      .select("id, categoria, produto, cor, qnt, custo_compra, custo_unitario")
+      .eq("status", "EM ESTOQUE")
+      .gt("qnt", 0)
+      .ilike("categoria", categoria)
+      .range(0, 49999);
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+    type Row = { id: string; categoria: string; produto: string; cor: string | null; qnt: number; custo_compra: number; custo_unitario: number };
+    interface Grupo {
+      categoria: string;
+      modeloBase: string;
+      qnt: number;
+      custoTotal: number; // soma(qnt * custo_compra)
+      custoAtual: number; // custo_unitario atual (de um dos itens)
+      balancoCalculado: number; // custoTotal / qnt
+      precisaAtualizar: boolean;
+      qntItens: number; // quantos registros na tabela estoque fazem parte
+    }
+    const groups = new Map<string, Grupo>();
+    for (const raw of (items || []) as unknown as Row[]) {
+      const cc = Number(raw.custo_compra || 0);
+      if (cc <= 0) continue;
+      const modeloBase = getModeloBase(raw.produto, raw.categoria);
+      const key = `${raw.categoria}|${modeloBase}`;
+      const g = groups.get(key) || {
+        categoria: raw.categoria,
+        modeloBase,
+        qnt: 0,
+        custoTotal: 0,
+        custoAtual: Number(raw.custo_unitario || 0),
+        balancoCalculado: 0,
+        precisaAtualizar: false,
+        qntItens: 0,
+      };
+      const q = Number(raw.qnt || 0);
+      g.qnt += q;
+      g.custoTotal += q * cc;
+      g.qntItens += 1;
+      groups.set(key, g);
+    }
+
+    const result = [...groups.values()].map((g) => {
+      g.balancoCalculado = g.qnt > 0 ? Math.round((g.custoTotal / g.qnt) * 100) / 100 : 0;
+      g.precisaAtualizar = Math.abs(g.balancoCalculado - g.custoAtual) > 0.01;
+      return g;
+    }).sort((a, b) => a.modeloBase.localeCompare(b.modeloBase));
+
+    return NextResponse.json({ data: result });
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 500 });
   }

--- a/app/api/admin/simulacoes/route.ts
+++ b/app/api/admin/simulacoes/route.ts
@@ -45,6 +45,7 @@ export async function PATCH(request: Request) {
     "modelo_usado", "storage_usado", "cor_usado", "avaliacao_usado", "condicao_linhas",
     "modelo_usado2", "storage_usado2", "cor_usado2", "avaliacao_usado2", "condicao_linhas2",
     "diferenca", "preco_novo", "vendedor", "forma_pagamento",
+    "nome", "whatsapp",
   ];
   for (const k of editableFields) {
     if (k in patch) allowed[k] = patch[k];

--- a/lib/recalc-balancos.ts
+++ b/lib/recalc-balancos.ts
@@ -6,9 +6,24 @@ import { getModeloBase } from "./produto-display";
  * os produtos EM ESTOQUE, agrupados por (categoria + modelo base via getModeloBase).
  *
  * Pode ser chamado internamente por qualquer route sem HTTP round-trip.
+ *
+ * Opcoes:
+ * - excludeSeminovos: se true (default), NAO mexe em produtos com categoria SEMINOVOS.
+ *   Balanco de seminovos e manual (via /admin/usados), pra evitar distorcao no
+ *   controle financeiro quando chegam produtos de troca com custos diferentes.
+ * - onlyModelos: se passado, recalcula APENAS os modelos listados (modelo base
+ *   retornado por getModeloBase). Ignora outros. Use pra balanco manual seletivo.
+ *
  * Retorna { groups, updated }.
  */
-export async function recalcBalancos(): Promise<{ groups: number; updated: number }> {
+export async function recalcBalancos(opts?: {
+  excludeSeminovos?: boolean;
+  onlyModelos?: Array<{ categoria: string; modeloBase: string }>;
+}): Promise<{ groups: number; updated: number }> {
+  const excludeSeminovos = opts?.excludeSeminovos !== false; // default true
+  const onlyModelos = opts?.onlyModelos;
+  const onlySet = onlyModelos ? new Set(onlyModelos.map(m => `${m.categoria}|${m.modeloBase}`)) : null;
+
   const sb = createClient(
     process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || "",
     process.env.SUPABASE_SERVICE_ROLE_KEY || "",
@@ -28,9 +43,13 @@ export async function recalcBalancos(): Promise<{ groups: number; updated: numbe
   for (const raw of items as unknown as Row[]) {
     const cc = Number(raw.custo_compra || 0);
     if (cc <= 0) continue;
+    // Pular SEMINOVOS no balanco automatico (feito manual via /admin/usados)
+    if (excludeSeminovos && String(raw.categoria || "").toUpperCase() === "SEMINOVOS") continue;
     // Usa getModeloBase para agrupar de forma consistente com o restante do sistema
     const modeloBase = getModeloBase(raw.produto, raw.categoria);
     const key = `${raw.categoria || ""}|${modeloBase}`;
+    // Se filtro de modelos, so processa os selecionados
+    if (onlySet && !onlySet.has(key)) continue;
     if (!groups.has(key)) groups.set(key, []);
     groups.get(key)!.push(raw);
   }


### PR DESCRIPTION
## 1. Edit WhatsApp em simulacoes

Cliente \u00e0s vezes preenche WhatsApp errado/vazio no formul\u00e1rio. Admin agora pode corrigir inline na aba **Simula\u00e7\u00f5es**.

- Bot\u00e3o \u270f\ufe0f aparece no hover ao lado do WhatsApp (s\u00f3 admin)
- Clica \u2192 input inline
- Enter/\u2713 salva, Esc/\u2715 cancela
- Valida\u00e7\u00e3o: m\u00ednimo 10 d\u00edgitos
- WhatsApp vazio/curto destacado em vermelho com \u26a0
- API /api/admin/simulacoes PATCH passou a aceitar \`whatsapp\` e \`nome\`

## 2. Balan\u00e7o manual de seminovos

**Problema:** \`recalcBalancos()\` rodava automaticamente em toda altera\u00e7\u00e3o de estoque, incluindo SEMINOVOS, o que distorcia o controle financeiro (quando chegava produto de troca com custo diferente, rebatia pra frente e pra tr\u00e1s no hist\u00f3rico).

**Fix:**

### Biblioteca (\`lib/recalc-balancos.ts\`)
\`recalcBalancos()\` agora aceita:
- \`excludeSeminovos\` (default **true**) \u2192 autom\u00e1tico nunca toca em SEMINOVOS
- \`onlyModelos: [{categoria, modeloBase}]\` \u2192 recalcula apenas os selecionados

### Endpoint (\`/api/admin/recalc-balancos\`)
- **POST** com body \`{ modelos: [...] }\` \u2192 balan\u00e7o manual nos modelos escolhidos
- **POST** sem body \u2192 comportamento autom\u00e1tico (exclui seminovos)
- **GET** \`?categoria=SEMINOVOS\` \u2192 preview: retorna cada grupo modelo+armazenamento com qnt, custo atual, balan\u00e7o calculado e diferen\u00e7a

### UI (\`/admin/usados\`)
Nova se\u00e7\u00e3o expans\u00edvel **\ud83d\udcca Balan\u00e7o Manual** no topo:
- Carrega via GET a lista de seminovos em estoque agrupados por modelo+armazenamento
- Cada linha: checkbox | Modelo | Qnt | Custo Atual | Novo Balan\u00e7o | Diferen\u00e7a
- Diferen\u00e7a colorida (verde sobe, vermelho desce)
- Modelos com balan\u00e7o desatualizado destacados em laranja no header
- **Selecionar todos / desmarcar todos**
- Bot\u00e3o **\ud83d\udd04 Fazer balan\u00e7o dos selecionados** com confirma\u00e7\u00e3o
- Toast de sucesso mostrando quantos modelos + quantos produtos foram atualizados

## Test plan

- [ ] Preview Vercel: \`/admin/simulacoes\` \u2192 hover em uma linha, clicar \u270f\ufe0f, editar WhatsApp, confirmar que salva
- [ ] Conferir que registro antigo com WhatsApp vazio aparece com \u26a0 vermelho
- [ ] \`/admin/usados\` \u2192 abrir \"Balan\u00e7o Manual\", ver lista de seminovos
- [ ] Selecionar 1 modelo, aplicar balan\u00e7o, conferir atualiza\u00e7\u00e3o
- [ ] Criar/editar um produto NOVO (n\u00e3o seminovo) \u2192 confirmar que balan\u00e7o dele segue autom\u00e1tico (controle segue funcionando pra outras categorias)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)