### PR TITLE
fix(vendas): editar venda agora permite adicionar/remover produtos

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -1256,11 +1256,12 @@ export default function VendasPage() {
       return;
     }
 
-    // Collect all products: cart items + current form
-    // Permite venda pendente sem produto da compra definido ainda (só troca/cliente/pagamento)
+    // Collect all products: cart items + current form (se form tem produto novo,
+    // inclui mesmo se ja tem itens no carrinho — usuario pode estar adicionando
+    // um produto a mais sem clicar em "+ Adicionar ao Carrinho" antes de salvar).
     const allProducts: ProdutoCarrinho[] = [...produtosCarrinho];
     const hasFormContent = !!(form.produto || form.troca_produto || trocaRow.produto || parseFloat(form.produto_na_troca) > 0);
-    if (hasFormContent && produtosCarrinho.length === 0) {
+    if (hasFormContent) {
       allProducts.push(getCurrentProductFields());
     }
 
@@ -1390,7 +1391,8 @@ export default function VendasPage() {
     if (editandoVendaId) {
       try {
         // Edição de grupo (múltiplas vendas)
-        if (editandoGrupoIds.length > 1 && allProducts.length === editandoGrupoIds.length) {
+        // Agora suporta adicionar/remover produtos: PATCH existentes, POST novos, DELETE removidos.
+        if (editandoGrupoIds.length > 1 || (editandoGrupoIds.length >= 1 && allProducts.length > editandoGrupoIds.length)) {
           // Build payloads and redistribute valor_comprovante/preco_vendido proportionally
           const groupPayloads: Record<string, unknown>[] = allProducts.map(p => buildPayload(p));
           const comprovanteTotal = Number(groupPayloads[0]?.valor_comprovante || 0);
@@ -1432,8 +1434,16 @@ export default function VendasPage() {
             }
           }
 
+          // Descobrir grupo_id original (pra novos itens vincularem ao mesmo grupo)
+          const primeiraVenda = vendas.find(v => v.id === editandoGrupoIds[0]);
+          const grupoIdOriginal = (primeiraVenda as unknown as { grupo_id?: string })?.grupo_id
+            || editandoGrupoIds[0]; // fallback: usa id da primeira venda como grupo_id sintetico
+
           let allOk = true;
-          for (let i = 0; i < editandoGrupoIds.length; i++) {
+
+          // 1. PATCH nos produtos que casam com vendas existentes
+          const nPatch = Math.min(allProducts.length, editandoGrupoIds.length);
+          for (let i = 0; i < nPatch; i++) {
             const res = await fetch("/api/vendas", {
               method: "PATCH",
               headers: { "Content-Type": "application/json", "x-admin-password": password },
@@ -1442,7 +1452,38 @@ export default function VendasPage() {
             const json = await res.json();
             if (!json.ok && !json.data) { allOk = false; setMsg("Erro ao atualizar: " + (json.error || "erro desconhecido")); break; }
           }
+
+          // 2. POST novos produtos (se allProducts.length > editandoGrupoIds.length)
+          if (allOk && allProducts.length > editandoGrupoIds.length) {
+            for (let i = editandoGrupoIds.length; i < allProducts.length; i++) {
+              const payload = { ...groupPayloads[i], grupo_id: grupoIdOriginal };
+              const res = await fetch("/api/vendas", {
+                method: "POST",
+                headers: { "Content-Type": "application/json", "x-admin-password": password },
+                body: JSON.stringify(payload),
+              });
+              const json = await res.json();
+              if (!json.ok && !json.data) { allOk = false; setMsg("Erro ao criar novo item: " + (json.error || "erro desconhecido")); break; }
+            }
+          }
+
+          // 3. DELETE vendas removidas (se allProducts.length < editandoGrupoIds.length)
+          if (allOk && allProducts.length < editandoGrupoIds.length) {
+            for (let i = allProducts.length; i < editandoGrupoIds.length; i++) {
+              const res = await fetch(`/api/vendas?id=${editandoGrupoIds[i]}`, {
+                method: "DELETE",
+                headers: { "x-admin-password": password },
+              });
+              if (!res.ok) { allOk = false; setMsg("Erro ao remover item"); break; }
+            }
+          }
+
           if (allOk) {
+            const msgFinal = allProducts.length === editandoGrupoIds.length
+              ? `${editandoGrupoIds.length} vendas atualizadas com sucesso!`
+              : allProducts.length > editandoGrupoIds.length
+                ? `${editandoGrupoIds.length} atualizadas + ${allProducts.length - editandoGrupoIds.length} novas criadas!`
+                : `${allProducts.length} atualizadas + ${editandoGrupoIds.length - allProducts.length} removidas!`;
             setEditandoVendaId(null);
             setEditandoGrupoIds([]);
             setDuplicadoInfo(null);
@@ -1470,7 +1511,7 @@ export default function VendasPage() {
             });
             setCatSel(""); setEstoqueId(""); setProdutoManual(false); setShowSegundaTroca(false);
             localStorage.removeItem("tigrao_venda_draft");
-            setMsg(`${editandoGrupoIds.length} vendas atualizadas com sucesso!`);
+            setMsg(msgFinal);
             fetchVendas();
             fetchEstoque();
           }


### PR DESCRIPTION
## Problema

Nicolas reportou: em uma venda em andamento com mais de 1 item, ao clicar em **Editar** e tentar adicionar mais produtos, o sistema ignorava os novos itens ao salvar. \u00danica sa\u00edda era cancelar a venda inteira e recriar.

## Duas causas encontradas

### 1. Form era ignorado quando tinha itens no carrinho

Linha 1263:
\`\`\`ts
if (hasFormContent && produtosCarrinho.length === 0) {  // \u274c
  allProducts.push(getCurrentProductFields());
}
\`\`\`

Se voc\u00ea preenchia um produto novo no form mas ja tinha itens no carrinho, esse produto novo era **descartado** ao salvar. Voc\u00ea precisava clicar em \"+ Adicionar ao Carrinho\" ANTES de salvar, sen\u00e3o sumia.

**Fix**: removido \`produtosCarrinho.length === 0\`. Agora o form sempre entra no payload se tem produto preenchido.

### 2. Edi\u00e7\u00e3o de grupo n\u00e3o suportava mudan\u00e7a de quantidade

Linha 1394:
\`\`\`ts
if (editandoGrupoIds.length > 1 && allProducts.length === editandoGrupoIds.length) {  // \u274c
  // fluxo de edi\u00e7\u00e3o de grupo (PATCH)
} else {
  // fluxo simples, s\u00f3 PATCH no primeiro produto
}
\`\`\`

Se voc\u00ea tinha grupo de 2 itens e adicionava 1 \u2192 \`2 !== 3\` \u2192 caia no fluxo simples, que PATCHeava s\u00f3 a primeira venda. Os outros itens originais ficavam intocados e o novo sumia.

**Fix**: reescrevi o fluxo pra suportar mudan\u00e7a de quantidade:
- **PATCH** nos N primeiros produtos (que j\u00e1 t\u00eam venda no banco)
- **POST** novos produtos com o mesmo \`grupo_id\` (quando N > original)
- **DELETE** vendas removidas (quando N < original)

Mensagem de sucesso mostra a a\u00e7\u00e3o: \"2 atualizadas + 1 nova criada!\"

## Test plan

- [ ] Preview Vercel: criar venda com 2 produtos
- [ ] Editar venda, adicionar 3\u00ba produto, clicar Salvar
- [ ] Conferir que os 3 produtos aparecem no banco com mesmo grupo_id
- [ ] Editar venda novamente, remover 1 produto, salvar
- [ ] Conferir que voltou a ter 2 produtos
- [ ] Editar 1 produto existente (sem mexer nos outros), salvar \u2014 nada mudou

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)