### PR TITLE
feat: 3 ajustes UX - WhatsApp modal, Marcar invalido, Balanco com preview

### DIFF
--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -36,7 +36,12 @@ interface SimulacaoRow {
   cor_usado?: string | null;
   avaliacao_usado: number;
   diferenca: number;
-  status: "GOSTEI" | "SAIR";
+  status: "GOSTEI" | "SAIR" | "INVALIDO";
+  motivo_invalido?: string | null;
+  obs_invalido?: string | null;
+  respondido_wa?: boolean | null;
+  marcado_invalido_em?: string | null;
+  marcado_invalido_por?: string | null;
   forma_pagamento: string | null;
   condicao_linhas: string[] | null;
   // 2º aparelho na troca
@@ -125,15 +130,16 @@ export default function AdminPage() {
   const { password, user } = useAdmin();
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<SimulacaoRow[] | null>(null);
-  const [tab, setTab] = useState<"todos" | "GOSTEI" | "SAIR" | "PENDENTE">("todos");
+  const [tab, setTab] = useState<"todos" | "GOSTEI" | "SAIR" | "INVALIDO" | "PENDENTE">("todos");
   const [search, setSearch] = useState("");
   const [refreshing, setRefreshing] = useState(false);
   const [deleting, setDeleting] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkDeleting, setBulkDeleting] = useState(false);
   const [modalRow, setModalRow] = useState<SimulacaoRow | null>(null);
-  const [editingWa, setEditingWa] = useState<{ id: string; valor: string } | null>(null);
-  const [savingWa, setSavingWa] = useState(false);
+  // Modais de edicao (WhatsApp + Marcar invalido)
+  const [editWaRow, setEditWaRow] = useState<SimulacaoRow | null>(null);
+  const [invalidarRow, setInvalidarRow] = useState<SimulacaoRow | null>(null);
   const [editMode, setEditMode] = useState(false);
   const [editData, setEditData] = useState<Record<string, string>>({});
   const [savingEdit, setSavingEdit] = useState(false);
@@ -483,6 +489,7 @@ export default function AdminPage() {
   const total = data.length;
   const gostei = data.filter((d) => d.status === "GOSTEI").length;
   const saiu = data.filter((d) => d.status === "SAIR").length;
+  const invalidos = data.filter((d) => d.status === "INVALIDO").length;
   const conversao = total > 0 ? Math.round((gostei / total) * 100) : 0;
   const ticketMedio = total > 0
     ? Math.round(data.reduce((acc, d) => acc + d.diferenca, 0) / total)
@@ -1370,7 +1377,7 @@ export default function AdminPage() {
           {/* Table header */}
           <div className="px-5 py-4 border-b border-[#D2D2D7] flex flex-col sm:flex-row gap-3 sm:items-center justify-between">
             <div className="flex gap-2 flex-wrap">
-              {(["todos", "GOSTEI", "SAIR", "PENDENTE"] as const).map((t) => (
+              {(["todos", "GOSTEI", "SAIR", "INVALIDO", "PENDENTE"] as const).map((t) => (
                 <button
                   key={t}
                   onClick={() => setTab(t)}
@@ -1380,6 +1387,8 @@ export default function AdminPage() {
                         ? "bg-green-100 text-green-700"
                         : t === "SAIR"
                         ? "bg-red-100 text-red-600"
+                        : t === "INVALIDO"
+                        ? "bg-gray-200 text-gray-700"
                         : t === "PENDENTE"
                         ? "bg-yellow-100 text-yellow-700"
                         : "bg-orange-100 text-[#E8740E]"
@@ -1392,6 +1401,8 @@ export default function AdminPage() {
                     ? `Fecharam (${gostei})`
                     : t === "SAIR"
                     ? `Saíram (${saiu})`
+                    : t === "INVALIDO"
+                    ? `Inválidos (${invalidos})`
                     : `Pendente (${pendente})`}
                 </button>
               ))}
@@ -1503,7 +1514,10 @@ export default function AdminPage() {
                   </tr>
                 ) : (
                   filtered.map((row) => (
-                    <tr key={row.id} onClick={() => { setModalRow(row); setModalParcelasVisiveis(null); setEditMode(false); }} className={`border-b border-[#F5F5F7] hover:bg-[#F5F5F7] transition-colors cursor-pointer ${selected.has(row.id) ? "bg-orange-50" : ""}`}>
+                    <tr key={row.id} onClick={() => { setModalRow(row); setModalParcelasVisiveis(null); setEditMode(false); }} className={`border-b border-[#F5F5F7] hover:bg-[#F5F5F7] transition-colors cursor-pointer ${
+                      selected.has(row.id) ? "bg-orange-50" :
+                      row.status === "INVALIDO" ? "bg-gray-100 opacity-60" : ""
+                    }`}>
                       <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
                         <input
                           type="checkbox"
@@ -1557,81 +1571,29 @@ export default function AdminPage() {
                       <td className="px-4 py-3 text-[#86868B] whitespace-nowrap text-xs">{fmtDate(row.created_at)}</td>
                       <td className="px-4 py-3 text-[#1D1D1F] font-medium whitespace-nowrap">{row.nome}</td>
                       <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                        {editingWa?.id === row.id ? (
-                          <div className="flex items-center gap-1">
-                            <input
-                              type="text"
-                              value={editingWa.valor}
-                              onChange={(e) => setEditingWa({ id: row.id, valor: e.target.value })}
-                              placeholder="(21) 9XXXX-XXXX"
-                              autoFocus
-                              className="px-2 py-1 rounded border border-[#E8740E] text-xs w-36 focus:outline-none"
-                              onKeyDown={async (e) => {
-                                if (e.key === "Escape") { setEditingWa(null); return; }
-                                if (e.key !== "Enter") return;
-                                // Fall through to save logic below
-                                (e.currentTarget.nextElementSibling as HTMLButtonElement)?.click();
-                              }}
-                            />
-                            <button
-                              disabled={savingWa}
-                              onClick={async () => {
-                                const raw = editingWa.valor.replace(/\D/g, "");
-                                if (raw.length < 10) { alert("WhatsApp invalido. Inclua DDD + numero."); return; }
-                                setSavingWa(true);
-                                try {
-                                  const res = await fetch("/api/admin/simulacoes", {
-                                    method: "PATCH",
-                                    headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
-                                    body: JSON.stringify({ id: row.id, whatsapp: editingWa.valor }),
-                                  });
-                                  const j = await res.json();
-                                  if (!j.ok) { alert("Erro: " + (j.error || "falha")); setSavingWa(false); return; }
-                                  setData((prev) => prev ? prev.map((r) => r.id === row.id ? { ...r, whatsapp: editingWa.valor } : r) : prev);
-                                  setEditingWa(null);
-                                } catch (err) {
-                                  alert("Erro de conexao: " + String(err));
-                                }
-                                setSavingWa(false);
-                              }}
-                              className="text-xs text-green-600 hover:text-green-800 px-1"
-                              title="Salvar"
+                        <div className="flex items-center gap-1 group">
+                          {row.whatsapp && row.whatsapp.replace(/\D/g, "").length >= 10 ? (
+                            <a
+                              href={(() => { const n = row.whatsapp.replace(/\D/g, ""); return `https://wa.me/${n.startsWith("55") ? n : `55${n}`}`; })()}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-green-600 hover:underline whitespace-nowrap"
                             >
-                              {savingWa ? "..." : "✓"}
-                            </button>
+                              {row.whatsapp}
+                            </a>
+                          ) : (
+                            <span className="text-red-500 text-xs font-medium whitespace-nowrap">⚠ {row.whatsapp || "(vazio)"}</span>
+                          )}
+                          {user?.role === "admin" && (
                             <button
-                              onClick={() => setEditingWa(null)}
-                              className="text-xs text-[#86868B] hover:text-red-500 px-1"
-                              title="Cancelar"
+                              onClick={() => setEditWaRow(row)}
+                              className="text-xs text-[#86868B] hover:text-[#E8740E] opacity-60 hover:opacity-100 ml-1 transition-opacity"
+                              title="Editar contato"
                             >
-                              ✕
+                              ✏️
                             </button>
-                          </div>
-                        ) : (
-                          <div className="flex items-center gap-1 group">
-                            {row.whatsapp && row.whatsapp.replace(/\D/g, "").length >= 10 ? (
-                              <a
-                                href={(() => { const n = row.whatsapp.replace(/\D/g, ""); return `https://wa.me/${n.startsWith("55") ? n : `55${n}`}`; })()}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-green-600 hover:underline whitespace-nowrap"
-                              >
-                                {row.whatsapp}
-                              </a>
-                            ) : (
-                              <span className="text-red-500 text-xs font-medium whitespace-nowrap">⚠ {row.whatsapp || "(vazio)"}</span>
-                            )}
-                            {user?.role === "admin" && (
-                              <button
-                                onClick={() => setEditingWa({ id: row.id, valor: row.whatsapp || "" })}
-                                className="text-xs text-[#86868B] hover:text-[#E8740E] opacity-0 group-hover:opacity-100 transition-opacity"
-                                title="Editar WhatsApp"
-                              >
-                                ✏️
-                              </button>
-                            )}
-                          </div>
-                        )}
+                          )}
+                        </div>
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap">
                         {row.vendedor ? (
@@ -1649,9 +1611,22 @@ export default function AdminPage() {
                       <td className="px-4 py-3 text-[#E8740E] font-bold whitespace-nowrap">{fmt(row.diferenca)}</td>
                       <td className="px-4 py-3 text-[#6E6E73] text-xs max-w-[160px] truncate">{row.forma_pagamento || "—"}</td>
                       <td className="px-4 py-3 whitespace-nowrap">
-                        <span className={`px-2 py-1 rounded-lg text-xs font-semibold ${row.status === "GOSTEI" ? "bg-green-100 text-green-700" : "bg-red-100 text-red-600"}`}>
-                          {row.status === "GOSTEI" ? "Fechou" : "Saiu"}
+                        <span className={`px-2 py-1 rounded-lg text-xs font-semibold ${
+                          row.status === "GOSTEI" ? "bg-green-100 text-green-700" :
+                          row.status === "INVALIDO" ? "bg-gray-200 text-gray-700" :
+                          "bg-red-100 text-red-600"
+                        }`} title={row.status === "INVALIDO" && row.motivo_invalido ? `Motivo: ${row.motivo_invalido}` : undefined}>
+                          {row.status === "GOSTEI" ? "Fechou" : row.status === "INVALIDO" ? "🚫 Inválido" : "Saiu"}
                         </span>
+                        {user?.role === "admin" && row.status !== "INVALIDO" && (
+                          <button
+                            onClick={(e) => { e.stopPropagation(); setInvalidarRow(row); }}
+                            className="ml-2 text-[10px] text-[#86868B] hover:text-red-600 hover:underline"
+                            title="Marcar esse lead como invalido pra troca"
+                          >
+                            🚫 Marcar inválido
+                          </button>
+                        )}
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap" onClick={(e) => e.stopPropagation()}>
                         <button
@@ -1762,6 +1737,34 @@ export default function AdminPage() {
           </div>
         </div>
       </div>
+
+      {/* Modal: Editar WhatsApp */}
+      {editWaRow && (
+        <EditWhatsAppModal
+          row={editWaRow}
+          password={password}
+          userNome={user?.nome || "sistema"}
+          onClose={() => setEditWaRow(null)}
+          onSaved={(novo) => {
+            setData((prev) => prev ? prev.map((r) => r.id === editWaRow.id ? { ...r, whatsapp: novo } : r) : prev);
+            setEditWaRow(null);
+          }}
+        />
+      )}
+
+      {/* Modal: Marcar como inválido */}
+      {invalidarRow && (
+        <InvalidarModal
+          row={invalidarRow}
+          password={password}
+          userNome={user?.nome || "sistema"}
+          onClose={() => setInvalidarRow(null)}
+          onSaved={(patch) => {
+            setData((prev) => prev ? prev.map((r) => r.id === invalidarRow.id ? { ...r, ...patch } : r) : prev);
+            setInvalidarRow(null);
+          }}
+        />
+      )}
 
       {/* Detail Modal */}
       {modalRow && (
@@ -2814,6 +2817,229 @@ function SimuladorInterno({ password }: { password: string }) {
             </div>
           </div>
         )}
+      </div>
+    </div>
+  );
+}
+
+// ====================================================================
+// Modal: Editar WhatsApp do cliente
+// ====================================================================
+
+function EditWhatsAppModal({
+  row,
+  password,
+  userNome,
+  onClose,
+  onSaved,
+}: {
+  row: SimulacaoRow;
+  password: string;
+  userNome: string;
+  onClose: () => void;
+  onSaved: (novoWa: string) => void;
+}) {
+  const [valor, setValor] = useState(row.whatsapp || "");
+  const [saving, setSaving] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  const salvar = async () => {
+    setErro(null);
+    const raw = valor.replace(/\D/g, "");
+    if (raw.length < 10) { setErro("WhatsApp inválido. Inclua DDD + número (ex: (21) 9XXXX-XXXX)."); return; }
+    setSaving(true);
+    try {
+      const res = await fetch("/api/admin/simulacoes", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(userNome) },
+        body: JSON.stringify({ id: row.id, whatsapp: valor }),
+      });
+      const j = await res.json();
+      if (!j.ok) { setErro(j.error || "Erro ao salvar"); setSaving(false); return; }
+      onSaved(valor);
+    } catch (e) {
+      setErro(String(e));
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50" onClick={onClose}>
+      <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold text-[#1D1D1F]">✏️ Editar contato</h2>
+          <button onClick={onClose} className="text-2xl text-[#86868B] hover:text-[#1D1D1F]">×</button>
+        </div>
+
+        <div className="space-y-3">
+          <div>
+            <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wide">Cliente</label>
+            <p className="text-sm text-[#1D1D1F] mt-1">{row.nome}</p>
+          </div>
+
+          <div>
+            <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wide">WhatsApp atual</label>
+            <p className="text-sm text-[#6E6E73] mt-1 font-mono">{row.whatsapp || "(vazio)"}</p>
+          </div>
+
+          <div>
+            <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wide">Novo WhatsApp</label>
+            <input
+              type="text"
+              value={valor}
+              onChange={(e) => setValor(e.target.value)}
+              placeholder="(21) 9XXXX-XXXX"
+              autoFocus
+              onKeyDown={(e) => { if (e.key === "Enter") salvar(); if (e.key === "Escape") onClose(); }}
+              className="w-full mt-1 px-3 py-2 rounded-lg border border-[#D2D2D7] focus:outline-none focus:border-[#E8740E] text-sm"
+            />
+            <p className="text-[10px] text-[#86868B] mt-1">Formato: DDD + 9 dígitos</p>
+          </div>
+
+          {erro && <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">{erro}</p>}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 mt-6 pt-4 border-t border-[#E5E5EA]">
+          <button onClick={onClose} disabled={saving} className="px-4 py-2 rounded-lg text-sm text-[#1D1D1F] hover:bg-[#F5F5F7] font-medium">Cancelar</button>
+          <button onClick={salvar} disabled={saving} className="px-4 py-2 rounded-lg text-sm bg-[#E8740E] text-white font-bold hover:bg-[#D06A0D] disabled:opacity-50">
+            {saving ? "Salvando..." : "💾 Salvar alteração"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ====================================================================
+// Modal: Marcar simulacao como INVALIDO
+// ====================================================================
+
+const MOTIVOS_INVALIDO = [
+  "Aparelho não aceito (modelo)",
+  "Aparelho com defeito",
+  "Já teve manutenção",
+  "Tela paralela",
+  "Cliente desistiu",
+  "Outro",
+] as const;
+
+function InvalidarModal({
+  row,
+  password,
+  userNome,
+  onClose,
+  onSaved,
+}: {
+  row: SimulacaoRow;
+  password: string;
+  userNome: string;
+  onClose: () => void;
+  onSaved: (patch: Partial<SimulacaoRow>) => void;
+}) {
+  const [motivo, setMotivo] = useState<string>("");
+  const [outroMotivo, setOutroMotivo] = useState("");
+  const [obs, setObs] = useState("");
+  const [respondido, setRespondido] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  const salvar = async () => {
+    setErro(null);
+    if (!motivo) { setErro("Selecione um motivo."); return; }
+    const motivoFinal = motivo === "Outro" ? (outroMotivo.trim() || "Outro") : motivo;
+    setSaving(true);
+    try {
+      const patch = {
+        status: "INVALIDO" as const,
+        motivo_invalido: motivoFinal,
+        obs_invalido: obs.trim() || null,
+        respondido_wa: respondido,
+        marcado_invalido_em: new Date().toISOString(),
+        marcado_invalido_por: userNome,
+      };
+      const res = await fetch("/api/admin/simulacoes", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(userNome) },
+        body: JSON.stringify({ id: row.id, ...patch }),
+      });
+      const j = await res.json();
+      if (!j.ok) { setErro(j.error || "Erro ao salvar"); setSaving(false); return; }
+      onSaved(patch);
+    } catch (e) {
+      setErro(String(e));
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50" onClick={onClose}>
+      <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6 max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold text-[#1D1D1F]">🚫 Marcar como Inválido</h2>
+          <button onClick={onClose} className="text-2xl text-[#86868B] hover:text-[#1D1D1F]">×</button>
+        </div>
+
+        <div className="bg-gray-50 rounded-lg p-3 mb-4">
+          <p className="text-sm font-medium text-[#1D1D1F]">{row.nome}</p>
+          <p className="text-xs text-[#6E6E73] mt-0.5">{row.whatsapp} · {row.modelo_usado} {row.storage_usado}</p>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wide block mb-2">Motivo da recusa</label>
+            <select
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] focus:outline-none focus:border-[#E8740E] text-sm"
+            >
+              <option value="">— Selecionar motivo —</option>
+              {MOTIVOS_INVALIDO.map((m) => <option key={m} value={m}>{m}</option>)}
+            </select>
+          </div>
+
+          {motivo === "Outro" && (
+            <div>
+              <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wide block mb-2">Especifique</label>
+              <input
+                type="text"
+                value={outroMotivo}
+                onChange={(e) => setOutroMotivo(e.target.value)}
+                placeholder="Ex: cliente sumiu, não tinha NF..."
+                className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] focus:outline-none focus:border-[#E8740E] text-sm"
+              />
+            </div>
+          )}
+
+          <div>
+            <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wide block mb-2">Observação interna (opcional)</label>
+            <textarea
+              value={obs}
+              onChange={(e) => setObs(e.target.value)}
+              rows={3}
+              placeholder="Detalhes pra você lembrar depois..."
+              className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] focus:outline-none focus:border-[#E8740E] text-sm resize-none"
+            />
+          </div>
+
+          <label className="flex items-center gap-2 cursor-pointer bg-gray-50 p-3 rounded-lg hover:bg-gray-100">
+            <input
+              type="checkbox"
+              checked={respondido}
+              onChange={(e) => setRespondido(e.target.checked)}
+              className="w-4 h-4 accent-[#E8740E]"
+            />
+            <span className="text-sm text-[#1D1D1F]">✅ Já respondido no WhatsApp</span>
+          </label>
+
+          {erro && <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">{erro}</p>}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 mt-6 pt-4 border-t border-[#E5E5EA]">
+          <button onClick={onClose} disabled={saving} className="px-4 py-2 rounded-lg text-sm text-[#1D1D1F] hover:bg-[#F5F5F7] font-medium">Cancelar</button>
+          <button onClick={salvar} disabled={saving} className="px-4 py-2 rounded-lg text-sm bg-red-600 text-white font-bold hover:bg-red-700 disabled:opacity-50">
+            {saving ? "Salvando..." : "🚫 Marcar Inválido"}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/app/admin/usados/page.tsx
+++ b/app/admin/usados/page.tsx
@@ -914,6 +914,7 @@ function BalancoSeminovosSection({
   const [selecionados, setSelecionados] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
   const [aplicando, setAplicando] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   const keyOf = (g: BalancoGrupo) => `${g.categoria}|${g.modeloBase}`;
 
@@ -948,11 +949,15 @@ function BalancoSeminovosSection({
     setSelecionados(next);
   };
 
-  const aplicarBalanco = async () => {
+  const abrirConfirmacao = () => {
     if (selecionados.size === 0) { alert("Selecione ao menos 1 modelo."); return; }
+    setConfirmOpen(true);
+  };
+
+  const aplicarBalanco = async () => {
     const modelos = grupos.filter(g => selecionados.has(keyOf(g))).map(g => ({ categoria: g.categoria, modeloBase: g.modeloBase }));
     const total = modelos.length;
-    if (!confirm(`Aplicar balanço em ${total} modelo(s) selecionado(s)?`)) return;
+    setConfirmOpen(false);
     setAplicando(true);
     try {
       const res = await fetch("/api/admin/recalc-balancos", {
@@ -1008,7 +1013,7 @@ function BalancoSeminovosSection({
                   {selecionados.size === grupos.length ? "Desmarcar todos" : "Selecionar todos"} ({selecionados.size}/{grupos.length})
                 </button>
                 <button
-                  onClick={aplicarBalanco}
+                  onClick={abrirConfirmacao}
                   disabled={aplicando || selecionados.size === 0}
                   className="px-4 py-2 rounded-lg text-sm font-bold bg-[#E8740E] text-white hover:bg-[#D06A0D] disabled:opacity-40 disabled:cursor-not-allowed"
                 >
@@ -1064,6 +1069,118 @@ function BalancoSeminovosSection({
           )}
         </div>
       )}
+
+      {/* Modal de confirmacao com preview */}
+      {confirmOpen && (
+        <ConfirmarBalancoModal
+          gruposSelecionados={grupos.filter(g => selecionados.has(keyOf(g)))}
+          onCancel={() => setConfirmOpen(false)}
+          onConfirm={aplicarBalanco}
+          aplicando={aplicando}
+        />
+      )}
+    </div>
+  );
+}
+
+// Modal de confirmacao com preview dos modelos selecionados
+function ConfirmarBalancoModal({
+  gruposSelecionados,
+  onCancel,
+  onConfirm,
+  aplicando,
+}: {
+  gruposSelecionados: BalancoGrupo[];
+  onCancel: () => void;
+  onConfirm: () => void;
+  aplicando: boolean;
+}) {
+  const qntTotalProdutos = gruposSelecionados.reduce((s, g) => s + g.qnt, 0);
+  const valorTotalAtual = gruposSelecionados.reduce((s, g) => s + g.qnt * g.custoAtual, 0);
+  const valorTotalNovo = gruposSelecionados.reduce((s, g) => s + g.custoTotal, 0);
+  const impactoValor = valorTotalNovo - valorTotalAtual;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50" onClick={onCancel}>
+      <div className="bg-white rounded-2xl shadow-2xl max-w-2xl w-full p-6 max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold text-[#1D1D1F]">🔄 Confirmar Balanço</h2>
+          <button onClick={onCancel} className="text-2xl text-[#86868B] hover:text-[#1D1D1F]">×</button>
+        </div>
+
+        <p className="text-sm text-[#6E6E73] mb-4">
+          Revise os modelos antes de aplicar o balanço. Os valores de <strong>custo_unitario</strong> de cada produto em estoque serão atualizados para o preço médio ponderado.
+        </p>
+
+        {/* Resumo geral */}
+        <div className="bg-gradient-to-br from-[#F5F5F7] to-white border border-[#D2D2D7] rounded-xl p-4 mb-4 grid grid-cols-2 gap-3">
+          <div>
+            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Modelos selecionados</p>
+            <p className="text-xl font-bold text-[#1D1D1F]">{gruposSelecionados.length}</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Total de produtos</p>
+            <p className="text-xl font-bold text-[#1D1D1F]">{qntTotalProdutos}</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Valor atual do estoque</p>
+            <p className="text-sm font-mono font-semibold text-[#1D1D1F]">{fmt(valorTotalAtual)}</p>
+          </div>
+          <div>
+            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Valor após balanço</p>
+            <p className="text-sm font-mono font-semibold text-[#1D1D1F]">{fmt(valorTotalNovo)}</p>
+          </div>
+          <div className="col-span-full pt-2 border-t border-[#E5E5EA]">
+            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Impacto total</p>
+            <p className={`text-lg font-mono font-bold ${Math.abs(impactoValor) < 1 ? "text-[#86868B]" : impactoValor > 0 ? "text-green-600" : "text-red-600"}`}>
+              {impactoValor > 0 ? "+" : ""}{fmt(impactoValor)}
+            </p>
+          </div>
+        </div>
+
+        {/* Lista dos modelos */}
+        <div className="border border-[#E5E5EA] rounded-xl overflow-hidden mb-4">
+          <div className="bg-[#F5F5F7] px-4 py-2 border-b border-[#E5E5EA]">
+            <p className="text-[10px] font-bold text-[#86868B] uppercase tracking-wider">Detalhe por modelo</p>
+          </div>
+          <div className="max-h-64 overflow-y-auto">
+            <table className="w-full text-xs">
+              <thead className="sticky top-0 bg-white">
+                <tr className="border-b border-[#E5E5EA]">
+                  <th className="px-3 py-2 text-left text-[10px] text-[#86868B]">Modelo</th>
+                  <th className="px-3 py-2 text-right text-[10px] text-[#86868B]">Qnt</th>
+                  <th className="px-3 py-2 text-right text-[10px] text-[#86868B]">Atual</th>
+                  <th className="px-3 py-2 text-right text-[10px] text-[#86868B]">Novo</th>
+                  <th className="px-3 py-2 text-right text-[10px] text-[#86868B]">Dif</th>
+                </tr>
+              </thead>
+              <tbody>
+                {gruposSelecionados.map((g) => {
+                  const diff = g.balancoCalculado - g.custoAtual;
+                  return (
+                    <tr key={`${g.categoria}|${g.modeloBase}`} className="border-b border-[#F5F5F7]">
+                      <td className="px-3 py-2 text-[#1D1D1F] font-medium">{g.modeloBase}</td>
+                      <td className="px-3 py-2 text-right text-[#1D1D1F] font-mono">{g.qnt}</td>
+                      <td className="px-3 py-2 text-right text-[#86868B] font-mono">{fmt(g.custoAtual)}</td>
+                      <td className="px-3 py-2 text-right text-[#E8740E] font-mono font-semibold">{fmt(g.balancoCalculado)}</td>
+                      <td className={`px-3 py-2 text-right font-mono ${Math.abs(diff) < 0.01 ? "text-[#86868B]" : diff > 0 ? "text-green-600" : "text-red-600"}`}>
+                        {Math.abs(diff) < 0.01 ? "—" : `${diff > 0 ? "+" : ""}${fmt(diff)}`}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 pt-4 border-t border-[#E5E5EA]">
+          <button onClick={onCancel} disabled={aplicando} className="px-4 py-2 rounded-lg text-sm text-[#1D1D1F] hover:bg-[#F5F5F7] font-medium">Cancelar</button>
+          <button onClick={onConfirm} disabled={aplicando} className="px-4 py-2 rounded-lg text-sm bg-[#E8740E] text-white font-bold hover:bg-[#D06A0D] disabled:opacity-50">
+            {aplicando ? "Aplicando..." : "✅ Confirmar balanço"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/admin/usados/page.tsx
+++ b/app/admin/usados/page.tsx
@@ -922,7 +922,7 @@ function BalancoSeminovosSection({
     if (!password) return;
     setLoading(true);
     try {
-      const res = await fetch("/api/admin/recalc-balancos?categoria=SEMINOVOS", {
+      const res = await fetch("/api/admin/recalc-balancos", {
         headers: { "x-admin-password": password },
         cache: "no-store",
       });

--- a/app/api/admin/recalc-balancos/route.ts
+++ b/app/api/admin/recalc-balancos/route.ts
@@ -59,31 +59,27 @@ export async function POST(req: NextRequest) {
 
 /**
  * GET: Preview do balanço manual de seminovos.
- * Retorna lista de modelos em estoque da categoria SEMINOVOS, com quantidade,
- * valor total (custo_compra ponderado) e o balanço calculado (custo médio).
+ * Retorna lista de modelos em estoque com tipo=SEMINOVO, agrupados por
+ * categoria + modelo base (getModeloBase), com quantidade, valor total
+ * (custo_compra ponderado) e o balanço calculado (custo médio).
  * Usado pra UI de seleção antes de aplicar.
- *
- * ?categoria=SEMINOVOS (opcional, default SEMINOVOS)
  */
 export async function GET(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   try {
-    const url = new URL(req.url);
-    const categoria = (url.searchParams.get("categoria") || "SEMINOVOS").toUpperCase();
-
     const { supabase } = await import("@/lib/supabase");
     const { data: items, error } = await supabase
       .from("estoque")
-      .select("id, categoria, produto, cor, qnt, custo_compra, custo_unitario")
+      .select("id, categoria, produto, cor, tipo, qnt, custo_compra, custo_unitario")
       .eq("status", "EM ESTOQUE")
+      .eq("tipo", "SEMINOVO")
       .gt("qnt", 0)
-      .ilike("categoria", categoria)
       .range(0, 49999);
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-    type Row = { id: string; categoria: string; produto: string; cor: string | null; qnt: number; custo_compra: number; custo_unitario: number };
+    type Row = { id: string; categoria: string; produto: string; cor: string | null; tipo: string | null; qnt: number; custo_compra: number; custo_unitario: number };
     interface Grupo {
       categoria: string;
       modeloBase: string;

--- a/app/api/admin/simulacoes/route.ts
+++ b/app/api/admin/simulacoes/route.ts
@@ -46,6 +46,8 @@ export async function PATCH(request: Request) {
     "modelo_usado2", "storage_usado2", "cor_usado2", "avaliacao_usado2", "condicao_linhas2",
     "diferenca", "preco_novo", "vendedor", "forma_pagamento",
     "nome", "whatsapp",
+    "status", "motivo_invalido", "obs_invalido", "respondido_wa",
+    "marcado_invalido_em", "marcado_invalido_por",
   ];
   for (const k of editableFields) {
     if (k in patch) allowed[k] = patch[k];

--- a/lib/recalc-balancos.ts
+++ b/lib/recalc-balancos.ts
@@ -31,20 +31,23 @@ export async function recalcBalancos(opts?: {
 
   const { data: items, error } = await sb
     .from("estoque")
-    .select("id, categoria, produto, cor, qnt, custo_compra, custo_unitario")
+    .select("id, categoria, produto, cor, tipo, qnt, custo_compra, custo_unitario")
     .eq("status", "EM ESTOQUE")
     .gt("qnt", 0)
     .range(0, 49999);
 
   if (error || !items || items.length === 0) return { groups: 0, updated: 0 };
 
-  type Row = { id: string; categoria: string; produto: string; cor: string | null; qnt: number; custo_compra: number; custo_unitario: number };
+  type Row = { id: string; categoria: string; produto: string; cor: string | null; tipo: string | null; qnt: number; custo_compra: number; custo_unitario: number };
   const groups = new Map<string, Row[]>();
   for (const raw of items as unknown as Row[]) {
     const cc = Number(raw.custo_compra || 0);
     if (cc <= 0) continue;
-    // Pular SEMINOVOS no balanco automatico (feito manual via /admin/usados)
-    if (excludeSeminovos && String(raw.categoria || "").toUpperCase() === "SEMINOVOS") continue;
+    const isSeminovo = String(raw.tipo || "").toUpperCase() === "SEMINOVO";
+    // Pular SEMINOVO no balanco automatico (feito manual via /admin/usados)
+    if (excludeSeminovos && isSeminovo) continue;
+    // Modo manual (onlyModelos): so processa items de seminovo
+    if (onlySet && !isSeminovo) continue;
     // Usa getModeloBase para agrupar de forma consistente com o restante do sistema
     const modeloBase = getModeloBase(raw.produto, raw.categoria);
     const key = `${raw.categoria || ""}|${modeloBase}`;

--- a/supabase/migrations/20260417_simulacao_invalido.sql
+++ b/supabase/migrations/20260417_simulacao_invalido.sql
@@ -1,0 +1,13 @@
+-- Permite marcar simulacoes como INVALIDO (cliente nao elegivel pra troca)
+-- com motivo estruturado, observacao livre e flag de resposta no WhatsApp.
+
+-- Novas colunas (nao mexem em dados existentes)
+ALTER TABLE simulacoes
+  ADD COLUMN IF NOT EXISTS motivo_invalido TEXT,
+  ADD COLUMN IF NOT EXISTS obs_invalido TEXT,
+  ADD COLUMN IF NOT EXISTS respondido_wa BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS marcado_invalido_em TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS marcado_invalido_por TEXT;
+
+-- Index pra filtrar rapido por status/invalido
+CREATE INDEX IF NOT EXISTS idx_simulacoes_status_created ON simulacoes(status, created_at DESC);


### PR DESCRIPTION
## 1. Edit WhatsApp em modal (remove inline)

**Antes:** edit inline na tabela parecia gambiarra.

**Agora:** botao \u2702\ufe0f discreto abre modal profissional com:
- Cliente (readonly)
- WhatsApp atual (readonly)
- Campo novo com validacao DDD + 9 d\u00edgitos
- Enter salva, Esc cancela

## 2. Marcar simula\u00e7\u00e3o como INV\u00c1LIDO

Migra\u00e7\u00e3o adiciona colunas em \`simulacoes\`:
- \`motivo_invalido\`, \`obs_invalido\`, \`respondido_wa\`, \`marcado_invalido_em\`, \`marcado_invalido_por\`

**Bot\u00e3o '\ud83d\udeab Marcar inv\u00e1lido'** na coluna Status (s\u00f3 admin) abre modal:
- Select motivo: Aparelho n\u00e3o aceito / com defeito / j\u00e1 teve manuten\u00e7\u00e3o / tela paralela / cliente desistiu / Outro (campo aberto)
- Observa\u00e7\u00e3o interna (textarea opcional)
- \u2611\ufe0f Checkbox \"J\u00e1 respondido no WhatsApp\"

**Depois de salvar:**
- Linha cinza + opacity 60%
- Status badge vira \"\ud83d\udeab Inv\u00e1lido\" com tooltip do motivo
- Nova aba **Inv\u00e1lidos (X)** no topo da tabela
- Contato preservado (hist\u00f3rico de lead ruim)

## 3. Balan\u00e7o seminovos com preview

**Antes:** clicar \"Fazer balan\u00e7o\" abria um \`confirm()\` simples sem detalhes.

**Agora:** modal profissional com:

### Resumo
- Modelos selecionados: N
- Total de produtos: M
- Valor atual do estoque
- Valor ap\u00f3s balan\u00e7o
- **Impacto total** (verde se sobe, vermelho se desce)

### Tabela detalhada
Cada modelo selecionado com Qnt | Atual | Novo | Diferen\u00e7a

Bot\u00f5es **Cancelar / Confirmar balan\u00e7o**.

Agrupamento continua por **modelo + armazenamento** (todas cores juntas), autom\u00e1tico segue desligado pra SEMINOVOS (como PR anterior).

## A\u00e7\u00e3o p\u00f3s-merge

Rodar a migra\u00e7\u00e3o em \`/admin/migrations\`:
\`20260417_simulacao_invalido.sql\`

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)