### PR TITLE
fix(vendas): editar venda single e adicionar produtos novos

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -1390,9 +1390,13 @@ export default function VendasPage() {
     // MODO EDIÇÃO: atualizar venda(s) existente(s) via PATCH
     if (editandoVendaId) {
       try {
-        // Edição de grupo (múltiplas vendas)
+        // IDs das vendas originais: se entrou como grupo, usa editandoGrupoIds;
+        // se entrou como single, usa [editandoVendaId]. Isso garante que mesmo
+        // vendas single podem ser expandidas pra grupo ao editar.
+        const idsOriginais = editandoGrupoIds.length > 0 ? editandoGrupoIds : [editandoVendaId];
+        // Edicao de grupo: quando tem >1 produto no final OU mais de 1 venda original
         // Agora suporta adicionar/remover produtos: PATCH existentes, POST novos, DELETE removidos.
-        if (editandoGrupoIds.length > 1 || (editandoGrupoIds.length >= 1 && allProducts.length > editandoGrupoIds.length)) {
+        if (allProducts.length > 1 || idsOriginais.length > 1) {
           // Build payloads and redistribute valor_comprovante/preco_vendido proportionally
           const groupPayloads: Record<string, unknown>[] = allProducts.map(p => buildPayload(p));
           const comprovanteTotal = Number(groupPayloads[0]?.valor_comprovante || 0);
@@ -1434,28 +1438,35 @@ export default function VendasPage() {
             }
           }
 
-          // Descobrir grupo_id original (pra novos itens vincularem ao mesmo grupo)
-          const primeiraVenda = vendas.find(v => v.id === editandoGrupoIds[0]);
+          // Descobrir grupo_id original (pra novos itens vincularem ao mesmo grupo).
+          // Se era venda single sem grupo_id, usa o id da venda como grupo_id sintetico
+          // e garante que a venda original tambem fique com esse grupo_id.
+          const primeiraVenda = vendas.find(v => v.id === idsOriginais[0]);
           const grupoIdOriginal = (primeiraVenda as unknown as { grupo_id?: string })?.grupo_id
-            || editandoGrupoIds[0]; // fallback: usa id da primeira venda como grupo_id sintetico
+            || idsOriginais[0];
+          // Se expandindo de single pra group, propaga o grupo_id na venda original tambem
+          const precisaPropagar = !((primeiraVenda as unknown as { grupo_id?: string })?.grupo_id) && allProducts.length > idsOriginais.length;
 
           let allOk = true;
 
           // 1. PATCH nos produtos que casam com vendas existentes
-          const nPatch = Math.min(allProducts.length, editandoGrupoIds.length);
+          const nPatch = Math.min(allProducts.length, idsOriginais.length);
           for (let i = 0; i < nPatch; i++) {
+            const payload = precisaPropagar && i === 0
+              ? { ...groupPayloads[i], grupo_id: grupoIdOriginal }
+              : groupPayloads[i];
             const res = await fetch("/api/vendas", {
               method: "PATCH",
               headers: { "Content-Type": "application/json", "x-admin-password": password },
-              body: JSON.stringify({ id: editandoGrupoIds[i], ...groupPayloads[i] }),
+              body: JSON.stringify({ id: idsOriginais[i], ...payload }),
             });
             const json = await res.json();
             if (!json.ok && !json.data) { allOk = false; setMsg("Erro ao atualizar: " + (json.error || "erro desconhecido")); break; }
           }
 
-          // 2. POST novos produtos (se allProducts.length > editandoGrupoIds.length)
-          if (allOk && allProducts.length > editandoGrupoIds.length) {
-            for (let i = editandoGrupoIds.length; i < allProducts.length; i++) {
+          // 2. POST novos produtos (se allProducts.length > idsOriginais.length)
+          if (allOk && allProducts.length > idsOriginais.length) {
+            for (let i = idsOriginais.length; i < allProducts.length; i++) {
               const payload = { ...groupPayloads[i], grupo_id: grupoIdOriginal };
               const res = await fetch("/api/vendas", {
                 method: "POST",
@@ -1467,10 +1478,10 @@ export default function VendasPage() {
             }
           }
 
-          // 3. DELETE vendas removidas (se allProducts.length < editandoGrupoIds.length)
-          if (allOk && allProducts.length < editandoGrupoIds.length) {
-            for (let i = allProducts.length; i < editandoGrupoIds.length; i++) {
-              const res = await fetch(`/api/vendas?id=${editandoGrupoIds[i]}`, {
+          // 3. DELETE vendas removidas (se allProducts.length < idsOriginais.length)
+          if (allOk && allProducts.length < idsOriginais.length) {
+            for (let i = allProducts.length; i < idsOriginais.length; i++) {
+              const res = await fetch(`/api/vendas?id=${idsOriginais[i]}`, {
                 method: "DELETE",
                 headers: { "x-admin-password": password },
               });
@@ -1479,11 +1490,11 @@ export default function VendasPage() {
           }
 
           if (allOk) {
-            const msgFinal = allProducts.length === editandoGrupoIds.length
-              ? `${editandoGrupoIds.length} vendas atualizadas com sucesso!`
-              : allProducts.length > editandoGrupoIds.length
-                ? `${editandoGrupoIds.length} atualizadas + ${allProducts.length - editandoGrupoIds.length} novas criadas!`
-                : `${allProducts.length} atualizadas + ${editandoGrupoIds.length - allProducts.length} removidas!`;
+            const msgFinal = allProducts.length === idsOriginais.length
+              ? `${idsOriginais.length} venda${idsOriginais.length === 1 ? '' : 's'} atualizada${idsOriginais.length === 1 ? '' : 's'} com sucesso!`
+              : allProducts.length > idsOriginais.length
+                ? `${idsOriginais.length} atualizada${idsOriginais.length === 1 ? '' : 's'} + ${allProducts.length - idsOriginais.length} nova${allProducts.length - idsOriginais.length === 1 ? '' : 's'} criada${allProducts.length - idsOriginais.length === 1 ? '' : 's'}!`
+                : `${allProducts.length} atualizada${allProducts.length === 1 ? '' : 's'} + ${idsOriginais.length - allProducts.length} removida${idsOriginais.length - allProducts.length === 1 ? '' : 's'}!`;
             setEditandoVendaId(null);
             setEditandoGrupoIds([]);
             setDuplicadoInfo(null);


### PR DESCRIPTION
## Bug reportado

Nicolas: \"so vai se eu cancelar a venda e adicionar de novo\".

No caso do MARCINHO REVENDA (venda \u00fanica de 1 MacBook), ao editar e tentar adicionar outro produto, salvar nao incluia o novo. Tinha que cancelar a venda toda e recriar.

## Causa

A PR #476 corrigiu o caso de editar **grupo** (vendas com >1 item). Mas n\u00e3o cobriu o caso de **venda single expandindo pra grupo**:

- Venda single: \`editandoGrupoIds = []\`, \`editandoVendaId = id\`
- User adicionava produtos: \`allProducts.length = 2\`
- Condi\u00e7\u00e3o anterior: \`editandoGrupoIds.length >= 1\` → **false** (0 < 1)
- Ca\u00eda no fluxo de edi\u00e7\u00e3o simples, PATCH s\u00f3 no primeiro item, ignorava os novos

## Fix

1. Sintetiza \`idsOriginais\` que vale \`editandoGrupoIds\` ou \`[editandoVendaId]\` (fallback pra single).
2. Condi\u00e7\u00e3o nova: \`allProducts.length > 1 || idsOriginais.length > 1\` — qualquer expans\u00e3o pra >1 item cai no fluxo de grupo.
3. Quando venda single sem \`grupo_id\` expande pra grupo, gera \`grupo_id\` sint\u00e9tico (id da venda original) e propaga tanto no PATCH da original quanto nos POSTs dos novos. Assim ficam vinculados.

## Test plan

- [ ] Editar venda com 1 item, adicionar 2\u00ba produto → salvar → 2 vendas no banco com mesmo grupo_id
- [ ] Editar venda com 2 itens (j\u00e1 em grupo), adicionar 3\u00ba → 3 vendas
- [ ] Editar venda com 3 itens, remover 1 → 2 vendas
- [ ] Editar venda single sem adicionar nada → comportamento normal (s\u00f3 atualiza campos)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)