### PR TITLE
feat: vinculo venda<->entrega + entrada Pix visivel + anti-duplicidade

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -158,6 +158,29 @@ export default function EntregasPage() {
   const vendedoresList = useVendedores(password);
   const [entregas, setEntregas] = useState<Entrega[]>([]);
   const [loading, setLoading] = useState(true);
+  // ID pra destacar (vem de /admin/vendas?destacar=XXX ao clicar 'Ver entrega')
+  const [destacarId, setDestacarId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get("destacar");
+    if (id) setDestacarId(id);
+  }, []);
+
+  // Quando as entregas carregam E temos um destacarId, rola ate o card e
+  // destaca por 3 segundos. Util pra botao 'Ver entrega' em /admin/vendas.
+  useEffect(() => {
+    if (!destacarId || entregas.length === 0) return;
+    const el = document.getElementById(`entrega-${destacarId}`);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.classList.add("ring-4", "ring-[#E8740E]", "ring-offset-2");
+      setTimeout(() => {
+        el.classList.remove("ring-4", "ring-[#E8740E]", "ring-offset-2");
+      }, 3000);
+    }
+  }, [destacarId, entregas.length]);
   const [weekOffset, setWeekOffset] = useState(0);
   // Visualização: "dia" (default) mostra um único dia com divisão por motoboy;
   // "semana" mostra o calendário semanal completo (visão geral).
@@ -2231,6 +2254,7 @@ export default function EntregasPage() {
           return (
             <button
               key={e.id}
+              id={`entrega-${e.id}`}
               onClick={() => {
                 if (modoSelecao) {
                   const next = new Set(entregasSelecionadas);

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -5361,8 +5361,8 @@ export default function VendasPage() {
                                             ❌ Cancelar Venda
                                           </button>
                                         )}
-                                        {/* Botão Encaminhar Entrega — cria entrega com dados da venda */}
-                                        {(v.status_pagamento === "AGUARDANDO" || v.status_pagamento === "PROGRAMADA" || (v.status_pagamento === "FINALIZADO" && v.data_programada)) && (v.local === "ENTREGA" || v.local === "RETIRADA") && (
+                                        {/* Botão Encaminhar Entrega — SO aparece se ainda nao tem entrega vinculada */}
+                                        {!v.entrega_id && (v.status_pagamento === "AGUARDANDO" || v.status_pagamento === "PROGRAMADA" || (v.status_pagamento === "FINALIZADO" && v.data_programada)) && (v.local === "ENTREGA" || v.local === "RETIRADA") && (
                                           <button
                                             onClick={async (e) => {
                                               e.stopPropagation();
@@ -5383,6 +5383,13 @@ export default function VendasPage() {
                                                 const json = await res.json();
                                                 if (res.ok) {
                                                   setMsg("📦 Entrega criada com sucesso!");
+                                                  // Atualiza local pra esconder o botao imediatamente e mostrar 'Ver entrega'
+                                                  if (json.entrega?.id) {
+                                                    setVendas(prev => prev.map(x => x.id === v.id ? { ...x, entrega_id: json.entrega.id } : x));
+                                                  }
+                                                } else if (res.status === 409) {
+                                                  setMsg("⚠️ Esta venda já tem uma entrega vinculada.");
+                                                  fetchVendas();
                                                 } else {
                                                   setMsg(`Erro: ${json.error || "Falha ao criar entrega"}`);
                                                 }
@@ -5394,6 +5401,17 @@ export default function VendasPage() {
                                           >
                                             📦 {v.status_pagamento === "PROGRAMADA" || v.data_programada ? "Agendar Entrega" : "Encaminhar Entrega"}
                                           </button>
+                                        )}
+                                        {/* Botao 'Ver entrega' quando ja tem entrega vinculada */}
+                                        {v.entrega_id && (
+                                          <a
+                                            href={`/admin/entregas?destacar=${v.entrega_id}`}
+                                            onClick={(e) => e.stopPropagation()}
+                                            className="px-3 py-1.5 rounded-lg text-xs font-semibold text-green-700 border border-green-300 bg-green-50 hover:bg-green-100 transition-colors inline-flex items-center gap-1"
+                                            title="Abrir entrega vinculada"
+                                          >
+                                            🚚 Ver entrega
+                                          </a>
                                         )}
                                         {/* Botão Reajuste — só admin */}
                                         {podeVerHistorico && <button

--- a/app/api/admin/link-compras/encaminhar-entrega/route.ts
+++ b/app/api/admin/link-compras/encaminhar-entrega/route.ts
@@ -172,8 +172,21 @@ export async function POST(request: Request) {
       tipo: link.tipo === "TROCA" || trocaLinhas.length > 0 ? "TROCA" : null,
       forma_pagamento: (() => {
         if (!forma) return null;
-        if (isCartao && parcelasNum > 0) return `${parcelasNum}x no ${forma === "Link de Pagamento" ? "Link" : "Cartão"}`;
-        return forma;
+        // Monta a forma base do restante (pos-entrada)
+        const base = isCartao && parcelasNum > 0
+          ? `${parcelasNum}x no ${forma === "Link de Pagamento" ? "Link" : "Cartão"}`
+          : forma;
+        // Se tem entrada (Pix/Especie geralmente), mostra separadamente — motoboy
+        // e o resumo da entrega precisam ver a quebra (ex: "Entrada R$ 500 via Pix + 10x no Cartão")
+        if (entradaVal > 0) {
+          const bancoEntrada = String(link.banco_pix || preench.banco_pix || "ITAU").toUpperCase();
+          // Detecta se entrada eh Pix (default) ou dinheiro. Nos links de compra
+          // a entrada tipicamente e PIX, mas conferimos formaPagamento do preench.
+          const formaEntrada = String(preench.forma_entrada || "PIX").toUpperCase();
+          const labelForma = formaEntrada.includes("ESPEC") || formaEntrada.includes("DINHEIRO") ? "Dinheiro" : "Pix";
+          return `Entrada R$ ${entradaVal.toLocaleString("pt-BR")} via ${labelForma}${bancoEntrada && labelForma === "Pix" ? ` (${bancoEntrada})` : ""} + ${base}`;
+        }
+        return base;
       })(),
       valor: valorFinal > 0 ? valorFinal : (valorBase > 0 ? valorBase : null),
       entrada: entradaVal > 0 ? entradaVal : null,

--- a/app/api/admin/vendas/encaminhar-entrega/route.ts
+++ b/app/api/admin/vendas/encaminhar-entrega/route.ts
@@ -70,13 +70,16 @@ export async function POST(request: Request) {
   } else if (venda.forma) {
     formaPag = `${venda.forma}${venda.banco ? ` (${venda.banco})` : ""}`;
   }
-  // Adicionar entrada PIX se houver
+  // Adicionar entrada PIX/ESPECIE se houver (motoboy precisa saber separado)
   const entradaPix = Number(venda.entrada_pix || 0);
   const entradaEspecie = Number(venda.entrada_especie || 0);
   const totalEntrada = entradaPix + entradaEspecie;
-  if (totalEntrada > 0 && formaPag) {
-    const entradaLabel = entradaPix > 0 ? `PIX R$ ${entradaPix.toLocaleString("pt-BR")}` : `Espécie R$ ${entradaEspecie.toLocaleString("pt-BR")}`;
-    formaPag = `Entrada ${entradaLabel} + ${formaPag}`;
+  if (totalEntrada > 0) {
+    const entradaPartes: string[] = [];
+    if (entradaPix > 0) entradaPartes.push(`PIX R$ ${entradaPix.toLocaleString("pt-BR")}`);
+    if (entradaEspecie > 0) entradaPartes.push(`Espécie R$ ${entradaEspecie.toLocaleString("pt-BR")}`);
+    const entradaLabel = `Entrada ${entradaPartes.join(" + ")}`;
+    formaPag = formaPag ? `${entradaLabel} + ${formaPag}` : entradaLabel;
   }
 
   // Montar observação com detalhes úteis pro motoboy (incluindo 1º e 2º produto na troca)
@@ -148,6 +151,13 @@ export async function POST(request: Request) {
     .select()
     .single();
   if (e2) return NextResponse.json({ error: e2.message }, { status: 500 });
+
+  // Vincular a venda a entrega recem-criada (facilita UI: esconder botao
+  // Encaminhar, mostrar botao Ver Entrega, etc.)
+  await supabase
+    .from("vendas")
+    .update({ entrega_id: entrega.id })
+    .eq("id", venda_id);
 
   await logActivity(
     getUser(request),

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -95,6 +95,8 @@ export interface Venda {
   codigo_rastreio: string | null;
   // Histórico de pagamentos (vendas programadas com múltiplos pagamentos)
   pagamento_historia: { tipo: string; valor: number; data: string; forma: string; banco: string; obs?: string }[];
+  // Entrega vinculada (preenchido quando a venda e encaminhada pra entrega)
+  entrega_id: string | null;
 }
 
 export interface Reajuste {

--- a/supabase/migrations/20260417c_vendas_entrega_id.sql
+++ b/supabase/migrations/20260417c_vendas_entrega_id.sql
@@ -1,0 +1,17 @@
+-- Vincular venda a entrega (bidirecional):
+-- - entregas.venda_id ja existe
+-- - adicionar vendas.entrega_id pra facilitar a UI (esconder botao Encaminhar
+--   quando ja tem entrega, mostrar botao Ver Entrega, status sincronizado)
+
+ALTER TABLE vendas
+  ADD COLUMN IF NOT EXISTS entrega_id UUID;
+
+CREATE INDEX IF NOT EXISTS idx_vendas_entrega_id ON vendas(entrega_id);
+
+-- Backfill: preenche entrega_id em vendas que ja tem entrega vinculada via
+-- entregas.venda_id. Evita estado inconsistente pra vendas antigas.
+UPDATE vendas v
+SET entrega_id = e.id
+FROM entregas e
+WHERE e.venda_id = v.id
+  AND v.entrega_id IS NULL;


### PR DESCRIPTION
## Escopo do pedido original

Esta PR resolve **parte** dos ajustes reportados:

- \u2705 **1. Entrada Pix vis\u00edvel** no modal/motoboy/resumo
- \u23ed\ufe0f 2. Vendedor correto \u2014 j\u00e1 foi na PR #468
- \u2705 **3. V\u00ednculo Venda \u2194 Entrega**
- \u2705 **4. Bloquear duplicidade de entrega**
- \u2705 **5. Remover/esconder Encaminhar se j\u00e1 tem entrega + bot\u00e3o Ver Entrega**
- \u2705 **6. Navega\u00e7\u00e3o entre venda e entrega**
- \u23ed\ufe0f 7. Sincronizar status \u2014 pr\u00f3xima PR

## Migration

\`20260417c_vendas_entrega_id.sql\`:
- Adiciona \`vendas.entrega_id UUID\` + index
- Backfill: preenche pra vendas que j\u00e1 t\u00eam entrega via \`entregas.venda_id\`

## Backend

### \`/api/admin/vendas/encaminhar-entrega\`
- Ap\u00f3s criar entrega, faz UPDATE em \`vendas.entrega_id = entrega.id\` (v\u00ednculo bidirecional)
- Endpoint j\u00e1 rejeitava duplicidade com 409 (mantido)
- \`forma_pagamento\` agora suporta Entrada Pix + Entrada Esp\u00e9cie juntas

### \`/api/admin/link-compras/encaminhar-entrega\`
- \`forma_pagamento\` agora mostra \"Entrada R$ 500 via Pix (ITAU) + 10x no Cart\u00e3o\" quando h\u00e1 entrada
- Antes omitia a entrada, motoboy n\u00e3o sabia quanto cobrar

## Frontend

### \`/admin/vendas\`
- Bot\u00e3o **\ud83d\udce6 Encaminhar Entrega** s\u00f3 aparece se \`entrega_id\` \u00e9 null
- Quando j\u00e1 tem entrega \u2192 bot\u00e3o **\ud83d\ude9a Ver entrega** (verde)
- Ao criar entrega com sucesso, atualiza state local imediato (esconde o bot\u00e3o, mostra 'Ver entrega')
- Erro 409 (j\u00e1 tem entrega): mostra aviso + refetch

### \`/admin/entregas\`
- Suporta \`?destacar=<uuid>\` \u2014 scroll at\u00e9 o card + highlight laranja por 3s
- Cada card tem \`id=\"entrega-<uuid>\"\` pra permitir scroll direto

## A\u00e7\u00e3o p\u00f3s-merge

1. Rodar migration em \`/admin/migrations\`: \`20260417c_vendas_entrega_id.sql\`
2. Testar fluxo de criar entrega \u2192 bot\u00e3o \"Ver entrega\" aparece
3. Criar link com entrada \u2192 encaminhar entrega \u2192 conferir que texto mostra \"Entrada R$ X via Pix\"

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)