### PR TITLE
feat(entregas): modal de encaminhar com vendedor + banco no breakdown

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -116,35 +116,57 @@ function formatPagamentoDisplay(
   const fp = formaPagamento.trim();
   const total = Number(valorTotal || valor || 0);
   const entrada = Number(entradaCol || 0);
-  // Label da entrada (Pix / Espécie / Transferência)
+  // Detecta entrada Pix/Especie/Transferencia e o banco (se tiver)
+  // Formatos suportados:
+  //   'Entrada R$ X via Pix (ITAU) + 10x no Cartão'  <- novo (link-compras)
+  //   'Entrada PIX R$ X + 10x no Cartão'             <- antigo (vendas admin)
+  //   'Entrada Espécie R$ X + ...'
   let labelEntrada = "Entrada";
-  if (/\+\s*pix/i.test(fp)) labelEntrada = "Entrada PIX";
-  else if (/\+\s*esp[eé]cie/i.test(fp)) labelEntrada = "Entrada Espécie";
-  else if (/\+\s*transfer/i.test(fp)) labelEntrada = "Entrada Transferência";
+  let bancoEntrada: string | null = null;
+  const matchPixBanco = fp.match(/via\s+Pix\s*\(([^)]+)\)/i);
+  if (matchPixBanco) {
+    labelEntrada = "Entrada PIX";
+    bancoEntrada = matchPixBanco[1].trim().toUpperCase();
+  } else if (/via\s+Pix/i.test(fp) || /\+\s*pix/i.test(fp) || /Entrada\s+PIX/i.test(fp)) {
+    labelEntrada = "Entrada PIX";
+  } else if (/\+\s*esp[eé]cie/i.test(fp) || /via\s+Dinheiro/i.test(fp) || /Entrada\s+Esp[eé]cie/i.test(fp)) {
+    labelEntrada = "Entrada Espécie";
+  } else if (/\+\s*transfer/i.test(fp)) {
+    labelEntrada = "Entrada Transferência";
+  }
   // Extrai cartões "Nx no Cartão (MAQ)" — 1 ou 2 ocorrências
-  const cartaoRegex = /(\d+)x\s+no\s+(?:Cart[ãa]o|Link)(?:\s*\(([^)]*)\))?/gi;
-  const cartoes: { parcelas: number; maquina: string }[] = [];
+  const cartaoRegex = /(\d+)x\s+no\s+(Cart[ãa]o|Link)(?:\s*\(([^)]*)\))?/gi;
+  const cartoes: { parcelas: number; maquina: string; tipo: "Cartão" | "Link" }[] = [];
   let m;
   while ((m = cartaoRegex.exec(fp)) !== null) {
-    cartoes.push({ parcelas: parseInt(m[1]), maquina: (m[2] || "").trim() });
+    const tipo = /link/i.test(m[2]) ? "Link" : "Cartão" as const;
+    let maq = (m[3] || "").trim();
+    // Se eh Link, a maquina e Mercado Pago (implicito) — adiciona pra deixar claro no motoboy
+    if (!maq && tipo === "Link") maq = "Mercado Pago";
+    cartoes.push({ parcelas: parseInt(m[1]), maquina: maq, tipo });
   }
   const baseCartoes = Math.max(0, total - entrada);
   const linhas: string[] = [fp];
-  if (entrada > 0) linhas.push(`   • ${labelEntrada}: ${fmtBRL(entrada)}`);
+  if (entrada > 0) {
+    const bancoSuffix = bancoEntrada ? ` — ${bancoEntrada}` : "";
+    linhas.push(`   • ${labelEntrada}: ${fmtBRL(entrada)}${bancoSuffix}`);
+  }
   if (cartoes.length === 1 && cartoes[0].parcelas > 0) {
     const c = cartoes[0];
     const vParc = baseCartoes / c.parcelas;
+    const maqSuffix = c.maquina ? ` — ${c.maquina}` : "";
     if (c.parcelas > 1) {
-      linhas.push(`   • ${c.parcelas}x de ${fmtBRL(vParc)}${c.maquina ? ` (${c.maquina})` : ""} — total ${fmtBRL(baseCartoes)}`);
+      linhas.push(`   • ${c.parcelas}x de ${fmtBRL(vParc)} — total ${fmtBRL(baseCartoes)}${maqSuffix}`);
     } else {
-      linhas.push(`   • Cartão${c.maquina ? ` (${c.maquina})` : ""}: ${fmtBRL(baseCartoes)}`);
+      linhas.push(`   • ${c.tipo}: ${fmtBRL(baseCartoes)}${maqSuffix}`);
     }
   } else if (cartoes.length === 2) {
     // Sem granularidade de valores nos dois cartões — aproxima 50/50
     const metade = baseCartoes / 2;
     cartoes.forEach((c, i) => {
       const vParc = c.parcelas > 0 ? metade / c.parcelas : 0;
-      linhas.push(`   • Cartão ${i + 1}: ${c.parcelas}x de ${fmtBRL(vParc)}${c.maquina ? ` (${c.maquina})` : ""} — total ${fmtBRL(metade)}`);
+      const maqSuffix = c.maquina ? ` — ${c.maquina}` : "";
+      linhas.push(`   • ${c.tipo} ${i + 1}: ${c.parcelas}x de ${fmtBRL(vParc)} — total ${fmtBRL(metade)}${maqSuffix}`);
     });
   } else if (entrada === 0 && valor != null) {
     linhas.push(`   • ${fmtBRL(Number(valor))}`);

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -10,6 +10,7 @@ import { addToQueue, getQueue, removeFromQueue, getQueueCount } from "@/lib/offl
 import type { Venda } from "@/lib/admin-types";
 import { corParaPT, normalizarCoresNoTexto } from "@/lib/cor-pt";
 import { getModeloBase } from "@/lib/produto-display";
+import { useVendedores } from "@/lib/vendedores";
 import BarcodeScanner from "@/components/BarcodeScanner";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 
@@ -19,6 +20,7 @@ const VENDAS_PASSWORD = "tigrao$vendas";
 
 export default function VendasPage() {
   const { password, user, darkMode } = useAdmin();
+  const vendedoresList = useVendedores(password);
   const dm = darkMode;
   const [vendas, setVendas] = useState<Venda[]>([]);
   const [loading, setLoading] = useState(true);
@@ -28,6 +30,7 @@ export default function VendasPage() {
   const [uploadingId, setUploadingId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [reajusteId, setReajusteId] = useState<string | null>(null);
+  const [encaminharVenda, setEncaminharVenda] = useState<Venda | null>(null);
   const [reajForm, setReajForm] = useState({ valor: "", motivo: "", banco: "ITAU", forma: "PIX", observacao: "" });
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editandoVendaId, setEditandoVendaId] = useState<string | null>(null);
@@ -5364,38 +5367,9 @@ export default function VendasPage() {
                                         {/* Botão Encaminhar Entrega — SO aparece se ainda nao tem entrega vinculada */}
                                         {!v.entrega_id && (v.status_pagamento === "AGUARDANDO" || v.status_pagamento === "PROGRAMADA" || (v.status_pagamento === "FINALIZADO" && v.data_programada)) && (v.local === "ENTREGA" || v.local === "RETIRADA") && (
                                           <button
-                                            onClick={async (e) => {
+                                            onClick={(e) => {
                                               e.stopPropagation();
-                                              const defaultDate = v.data_programada
-                                                ? new Date(v.data_programada + "T12:00:00").toLocaleDateString("pt-BR")
-                                                : new Date().toLocaleDateString("pt-BR");
-                                              const dataEntrega = prompt("Data da entrega (DD/MM/AAAA):", defaultDate);
-                                              if (!dataEntrega) return;
-                                              // Converter DD/MM/AAAA para YYYY-MM-DD
-                                              const parts = dataEntrega.split("/");
-                                              const dataISO = parts.length === 3 ? `${parts[2]}-${parts[1].padStart(2, "0")}-${parts[0].padStart(2, "0")}` : dataEntrega;
-                                              try {
-                                                const res = await fetch("/api/admin/vendas/encaminhar-entrega", {
-                                                  method: "POST",
-                                                  headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
-                                                  body: JSON.stringify({ venda_id: v.id, data_entrega: dataISO }),
-                                                });
-                                                const json = await res.json();
-                                                if (res.ok) {
-                                                  setMsg("📦 Entrega criada com sucesso!");
-                                                  // Atualiza local pra esconder o botao imediatamente e mostrar 'Ver entrega'
-                                                  if (json.entrega?.id) {
-                                                    setVendas(prev => prev.map(x => x.id === v.id ? { ...x, entrega_id: json.entrega.id } : x));
-                                                  }
-                                                } else if (res.status === 409) {
-                                                  setMsg("⚠️ Esta venda já tem uma entrega vinculada.");
-                                                  fetchVendas();
-                                                } else {
-                                                  setMsg(`Erro: ${json.error || "Falha ao criar entrega"}`);
-                                                }
-                                              } catch {
-                                                setMsg("Erro ao encaminhar para entrega");
-                                              }
+                                              setEncaminharVenda(v);
                                             }}
                                             className="px-3 py-1.5 rounded-lg text-xs font-semibold text-purple-600 border border-purple-200 hover:bg-purple-50 transition-colors"
                                           >
@@ -6077,6 +6051,163 @@ export default function VendasPage() {
           </div>
         </div>
       )}
+
+      {/* Modal: Encaminhar Entrega (com select de vendedor) */}
+      {encaminharVenda && (
+        <EncaminharEntregaModal
+          venda={encaminharVenda}
+          vendedores={vendedoresList}
+          password={password}
+          userNome={user?.nome || "sistema"}
+          onClose={() => setEncaminharVenda(null)}
+          onSaved={(entregaId) => {
+            setVendas(prev => prev.map(x => x.id === encaminharVenda.id ? { ...x, entrega_id: entregaId } : x));
+            setMsg("📦 Entrega criada com sucesso!");
+            setEncaminharVenda(null);
+          }}
+          onConflito={() => {
+            setMsg("⚠️ Esta venda já tem uma entrega vinculada.");
+            fetchVendas();
+            setEncaminharVenda(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ====================================================================
+// Modal: Encaminhar Entrega (data + horario + vendedor + observacao)
+// ====================================================================
+
+function EncaminharEntregaModal({
+  venda,
+  vendedores,
+  password,
+  userNome,
+  onClose,
+  onSaved,
+  onConflito,
+}: {
+  venda: Venda;
+  vendedores: Array<{ nome: string; numero?: string; ativo?: boolean }>;
+  password: string;
+  userNome: string;
+  onClose: () => void;
+  onSaved: (entregaId: string) => void;
+  onConflito: () => void;
+}) {
+  // Data default: data_programada se houver, senao hoje
+  const defaultData = venda.data_programada || new Date().toLocaleDateString("en-CA", { timeZone: "America/Sao_Paulo" });
+  // Vendedor default: o vendedor atual da venda, senao o usuario logado
+  const defaultVendedor = venda.vendedor || userNome;
+  const [dataEntrega, setDataEntrega] = useState(defaultData);
+  const [horario, setHorario] = useState("");
+  const [vendedor, setVendedor] = useState(defaultVendedor);
+  const [observacao, setObservacao] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [erro, setErro] = useState<string | null>(null);
+
+  const vendedoresAtivos = vendedores.filter(v => v.ativo !== false).map(v => v.nome);
+  // Garantir que o default apareca na lista mesmo se for admin/sistema
+  const opcoesVendedor = Array.from(new Set([defaultVendedor, ...vendedoresAtivos].filter(Boolean)));
+
+  const salvar = async () => {
+    setErro(null);
+    if (!dataEntrega) { setErro("Informe a data"); return; }
+    setSaving(true);
+    try {
+      const res = await fetch("/api/admin/vendas/encaminhar-entrega", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(userNome) },
+        body: JSON.stringify({
+          venda_id: venda.id,
+          data_entrega: dataEntrega,
+          horario: horario || undefined,
+          vendedor: vendedor || undefined,
+          observacao: observacao || undefined,
+        }),
+      });
+      const json = await res.json();
+      if (res.status === 409) { onConflito(); return; }
+      if (!res.ok) { setErro(json.error || "Falha ao criar entrega"); setSaving(false); return; }
+      onSaved(json.entrega?.id || "");
+    } catch (e) {
+      setErro(String(e));
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50" onClick={onClose}>
+      <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6 max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold text-[#1D1D1F]">📦 Encaminhar Entrega</h2>
+          <button onClick={onClose} className="text-2xl text-[#86868B] hover:text-[#1D1D1F]">×</button>
+        </div>
+
+        <div className="bg-gray-50 rounded-lg p-3 mb-4">
+          <p className="text-sm font-medium text-[#1D1D1F]">{venda.cliente}</p>
+          <p className="text-xs text-[#6E6E73] mt-0.5">{venda.produto}</p>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wide block mb-1">Data da entrega</label>
+            <input
+              type="date"
+              value={dataEntrega}
+              onChange={(e) => setDataEntrega(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] focus:outline-none focus:border-[#E8740E] text-sm"
+            />
+          </div>
+
+          <div>
+            <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wide block mb-1">Horário (opcional)</label>
+            <input
+              type="text"
+              value={horario}
+              onChange={(e) => setHorario(e.target.value)}
+              placeholder="Ex: 14:00 ou 14h a 16h"
+              className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] focus:outline-none focus:border-[#E8740E] text-sm"
+            />
+          </div>
+
+          <div>
+            <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wide block mb-1">Vendedor responsável</label>
+            <select
+              value={vendedor}
+              onChange={(e) => setVendedor(e.target.value)}
+              className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] focus:outline-none focus:border-[#E8740E] text-sm"
+            >
+              {opcoesVendedor.map((nome) => (
+                <option key={nome} value={nome}>{nome}</option>
+              ))}
+            </select>
+            <p className="text-[10px] text-[#86868B] mt-1">Quem fechou a venda / quem recebe a comissão</p>
+          </div>
+
+          <div>
+            <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wide block mb-1">Observação (opcional)</label>
+            <textarea
+              value={observacao}
+              onChange={(e) => setObservacao(e.target.value)}
+              rows={2}
+              placeholder="Algo especial pro motoboy..."
+              className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] focus:outline-none focus:border-[#E8740E] text-sm resize-none"
+            />
+          </div>
+
+          {erro && <p className="text-sm text-red-600 bg-red-50 px-3 py-2 rounded-lg">{erro}</p>}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 mt-6 pt-4 border-t border-[#E5E5EA]">
+          <button onClick={onClose} disabled={saving} className="px-4 py-2 rounded-lg text-sm text-[#1D1D1F] hover:bg-[#F5F5F7] font-medium">Cancelar</button>
+          <button onClick={salvar} disabled={saving} className="px-4 py-2 rounded-lg text-sm bg-[#E8740E] text-white font-bold hover:bg-[#D06A0D] disabled:opacity-50">
+            {saving ? "Criando..." : "📦 Criar entrega"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/api/admin/vendas/encaminhar-entrega/route.ts
+++ b/app/api/admin/vendas/encaminhar-entrega/route.ts
@@ -15,7 +15,7 @@ function getUser(request: Request) {
 export async function POST(request: Request) {
   if (!auth(request)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const body = await request.json();
-  const { venda_id, data_entrega, horario, entregador, observacao } = body || {};
+  const { venda_id, data_entrega, horario, entregador, observacao, vendedor: vendedorOverride } = body || {};
   if (!venda_id || !data_entrega) {
     return NextResponse.json({ error: "venda_id e data_entrega obrigatórios" }, { status: 400 });
   }
@@ -146,7 +146,7 @@ export async function POST(request: Request) {
         if (comp > 0) return comp + totalEntrada;
         return Number(venda.preco_vendido || 0) || null;
       })(),
-      vendedor: venda.vendedor || null,
+      vendedor: (vendedorOverride && String(vendedorOverride).trim()) || venda.vendedor || null,
     })
     .select()
     .single();

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -97,6 +97,8 @@ export interface Venda {
   pagamento_historia: { tipo: string; valor: number; data: string; forma: string; banco: string; obs?: string }[];
   // Entrega vinculada (preenchido quando a venda e encaminhada pra entrega)
   entrega_id: string | null;
+  // Vendedor responsavel pela venda
+  vendedor: string | null;
 }
 
 export interface Reajuste {


### PR DESCRIPTION
Dois ajustes do Nicolas no fluxo de entrega:

## 1. Modal de encaminhar entrega com escolha de vendedor

Antes: clicar 'Encaminhar Entrega' abria um prompt() nativo pedindo so a data, e o vendedor era auto-atribuido pelo vendedor da venda original.

Agora: abre um modal profissional pedindo:
- Data da entrega (type=date, default: data_programada ou hoje)
- Horario (opcional, ex: '14:00' ou '14h a 16h')
- Vendedor responsavel (SELECT com lista dinamica de vendedores ativos, default = vendedor atual da venda ou usuario logado)
- Observacao (opcional, textarea)

Endpoint /api/admin/vendas/encaminhar-entrega agora aceita 'vendedor' no body e sobrescreve o da venda ao criar a entrega. A venda em si nao e alterada — so a entrega fica com o vendedor correto.

## 2. Banco do Pix/Cartao visivel no breakdown do motoboy

formatPagamentoDisplay agora detecta o novo formato 'Entrada R$ X via Pix (ITAU) + 10x no Cartao' (da PR #487), extrai o banco e mostra no breakdown. Exemplo:

Antes:
💵 PAGAMENTO: Entrada R$ 3.750 via Pix (ITAU) + 10x no Cartao
   • Entrada: R$ 3.750,00
   • 10x de R$ 560,30 — total R$ 5.603,00

Agora:
💵 PAGAMENTO: Entrada R$ 3.750 via Pix (ITAU) + 10x no Cartao
   • Entrada PIX: R$ 3.750,00 — ITAU
   • 10x de R$ 560,30 — total R$ 5.603,00

Link de Pagamento (sem maquina explicita) agora adiciona 'Mercado Pago' automaticamente no breakdown pra deixar claro pro motoboy.

## Bonus: tipo Venda ganhou 'vendedor' + 'entrega_id'

Campos que ja existiam no banco mas faltavam no type do frontend.