### PR TITLE
fix: remover banco do Pix no motoboy + select de vendedor em /admin/gerar-link

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -116,18 +116,14 @@ function formatPagamentoDisplay(
   const fp = formaPagamento.trim();
   const total = Number(valorTotal || valor || 0);
   const entrada = Number(entradaCol || 0);
-  // Detecta entrada Pix/Especie/Transferencia e o banco (se tiver)
+  // Detecta entrada Pix/Especie/Transferencia
   // Formatos suportados:
-  //   'Entrada R$ X via Pix (ITAU) + 10x no Cartão'  <- novo (link-compras)
-  //   'Entrada PIX R$ X + 10x no Cartão'             <- antigo (vendas admin)
+  //   'Entrada R$ X via Pix + 10x no Cartão'        <- novo (link-compras)
+  //   'Entrada PIX R$ X + 10x no Cartão'            <- antigo (vendas admin)
   //   'Entrada Espécie R$ X + ...'
+  // Banco do Pix nao interessa no texto do motoboy — info interna.
   let labelEntrada = "Entrada";
-  let bancoEntrada: string | null = null;
-  const matchPixBanco = fp.match(/via\s+Pix\s*\(([^)]+)\)/i);
-  if (matchPixBanco) {
-    labelEntrada = "Entrada PIX";
-    bancoEntrada = matchPixBanco[1].trim().toUpperCase();
-  } else if (/via\s+Pix/i.test(fp) || /\+\s*pix/i.test(fp) || /Entrada\s+PIX/i.test(fp)) {
+  if (/via\s+Pix/i.test(fp) || /\+\s*pix/i.test(fp) || /Entrada\s+PIX/i.test(fp)) {
     labelEntrada = "Entrada PIX";
   } else if (/\+\s*esp[eé]cie/i.test(fp) || /via\s+Dinheiro/i.test(fp) || /Entrada\s+Esp[eé]cie/i.test(fp)) {
     labelEntrada = "Entrada Espécie";
@@ -148,8 +144,7 @@ function formatPagamentoDisplay(
   const baseCartoes = Math.max(0, total - entrada);
   const linhas: string[] = [fp];
   if (entrada > 0) {
-    const bancoSuffix = bancoEntrada ? ` — ${bancoEntrada}` : "";
-    linhas.push(`   • ${labelEntrada}: ${fmtBRL(entrada)}${bancoSuffix}`);
+    linhas.push(`   • ${labelEntrada}: ${fmtBRL(entrada)}`);
   }
   if (cartoes.length === 1 && cartoes[0].parcelas > 0) {
     const c = cartoes[0];

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -581,6 +581,7 @@ export default function GerarLinkPage() {
   const [encaminharData, setEncaminharData] = useState("");
   const [encaminharHorario, setEncaminharHorario] = useState("");
   const [encaminharObs, setEncaminharObs] = useState("");
+  const [encaminharVendedor, setEncaminharVendedor] = useState("");
 
   function editarLink(l: LinkCompra) {
     reutilizarLink(l);
@@ -708,12 +709,13 @@ export default function GerarLinkPage() {
           data_entrega: encaminharData,
           horario: encaminharHorario || null,
           observacao: encaminharObs || null,
+          vendedor: encaminharVendedor || null,
         }),
       });
       const j = await res.json();
       if (!res.ok) { alert("Erro: " + (j.error || res.status)); return; }
       setEncaminharLink(null);
-      setEncaminharData(""); setEncaminharHorario(""); setEncaminharObs("");
+      setEncaminharData(""); setEncaminharHorario(""); setEncaminharObs(""); setEncaminharVendedor("");
       fetchHistorico();
       alert("✅ Entrega criada com sucesso!");
     } catch (e) { alert("Erro: " + String(e)); }
@@ -1770,10 +1772,29 @@ export default function GerarLinkPage() {
                 <input type="time" value={encaminharHorario} onChange={(e) => setEncaminharHorario(e.target.value)} className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm mt-1" />
               </div>
               <div>
+                <label className="text-[11px] text-[#86868B] font-semibold">Vendedor responsável *</label>
+                <select
+                  value={encaminharVendedor}
+                  onChange={(e) => setEncaminharVendedor(e.target.value)}
+                  className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm mt-1"
+                >
+                  <option value="">— Selecionar vendedor —</option>
+                  {(() => {
+                    const opcoes = new Set<string>();
+                    if (encaminharLink?.vendedor) opcoes.add(encaminharLink.vendedor);
+                    for (const v of vendedoresList) {
+                      if (v.ativo !== false && v.nome) opcoes.add(v.nome);
+                    }
+                    return [...opcoes].map(n => <option key={n} value={n}>{n}</option>);
+                  })()}
+                </select>
+                <p className="text-[10px] text-[#86868B] mt-1">Quem fecha a venda e recebe a comissão pela entrega</p>
+              </div>
+              <div>
                 <label className="text-[11px] text-[#86868B] font-semibold">Observação (opcional)</label>
                 <textarea value={encaminharObs} onChange={(e) => setEncaminharObs(e.target.value)} rows={2} className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm mt-1" />
               </div>
-              <button onClick={encaminharParaEntrega} disabled={!encaminharData} className="w-full py-2.5 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 disabled:opacity-50">
+              <button onClick={encaminharParaEntrega} disabled={!encaminharData || !encaminharVendedor} className="w-full py-2.5 rounded-lg bg-green-500 text-white text-sm font-semibold hover:bg-green-600 disabled:opacity-50">
                 Criar entrega
               </button>
             </div>
@@ -2006,7 +2027,7 @@ export default function GerarLinkPage() {
                   )}
                   {l.cliente_preencheu_em && !l.entrega_id && (
                     <button
-                      onClick={() => { setEncaminharLink(l); setEncaminharData(new Date().toISOString().slice(0, 10)); }}
+                      onClick={() => { setEncaminharLink(l); setEncaminharData(new Date().toISOString().slice(0, 10)); setEncaminharVendedor(l.vendedor || user?.nome || ""); }}
                       className="text-xs px-2.5 py-1 rounded-lg bg-green-500 text-white hover:bg-green-600 font-medium"
                     >
                       → Encaminhar entrega

--- a/app/api/admin/link-compras/encaminhar-entrega/route.ts
+++ b/app/api/admin/link-compras/encaminhar-entrega/route.ts
@@ -176,15 +176,13 @@ export async function POST(request: Request) {
         const base = isCartao && parcelasNum > 0
           ? `${parcelasNum}x no ${forma === "Link de Pagamento" ? "Link" : "Cartão"}`
           : forma;
-        // Se tem entrada (Pix/Especie geralmente), mostra separadamente — motoboy
-        // e o resumo da entrega precisam ver a quebra (ex: "Entrada R$ 500 via Pix + 10x no Cartão")
+        // Se tem entrada (Pix/Especie), mostra separadamente pro motoboy saber
+        // a quebra (ex: "Entrada R$ 500 via Pix + 10x no Cartão"). Banco do Pix
+        // nao interessa no texto do motoboy — e info interna.
         if (entradaVal > 0) {
-          const bancoEntrada = String(link.banco_pix || preench.banco_pix || "ITAU").toUpperCase();
-          // Detecta se entrada eh Pix (default) ou dinheiro. Nos links de compra
-          // a entrada tipicamente e PIX, mas conferimos formaPagamento do preench.
           const formaEntrada = String(preench.forma_entrada || "PIX").toUpperCase();
           const labelForma = formaEntrada.includes("ESPEC") || formaEntrada.includes("DINHEIRO") ? "Dinheiro" : "Pix";
-          return `Entrada R$ ${entradaVal.toLocaleString("pt-BR")} via ${labelForma}${bancoEntrada && labelForma === "Pix" ? ` (${bancoEntrada})` : ""} + ${base}`;
+          return `Entrada R$ ${entradaVal.toLocaleString("pt-BR")} via ${labelForma} + ${base}`;
         }
         return base;
       })(),

--- a/app/api/admin/link-compras/encaminhar-entrega/route.ts
+++ b/app/api/admin/link-compras/encaminhar-entrega/route.ts
@@ -16,7 +16,7 @@ function getUser(request: Request) {
 export async function POST(request: Request) {
   if (!auth(request)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const body = await request.json();
-  const { link_id, data_entrega, horario, entregador, observacao } = body || {};
+  const { link_id, data_entrega, horario, entregador, observacao, vendedor: vendedorOverride } = body || {};
   if (!link_id || !data_entrega) {
     return NextResponse.json({ error: "link_id e data_entrega obrigatórios" }, { status: 400 });
   }
@@ -130,30 +130,34 @@ export async function POST(request: Request) {
   obsParts.push(`Encaminhada do link ${link.short_code}`);
   const observacaoFinal = obsParts.filter(Boolean).join("\n");
 
-  // Vendedor da entrega: se quem esta encaminhando e um vendedor com
-  // recebe_links=true (ex: Bianca triando links da Paloma), ele vira o vendedor
-  // da entrega. Caso contrario (admin Nicolas, ou vendedor sem recebe_links),
-  // mantem o vendedor original do link.
+  // Vendedor da entrega:
+  //  1. Se operador escolheu explicitamente no modal (vendedorOverride) → usa esse
+  //  2. Senao, se quem esta encaminhando tem recebe_links=true (Bianca/André) → usa ele
+  //  3. Fallback: mantem o vendedor original do link
   let vendedorFinal: string | null = link.vendedor || null;
-  try {
-    const userLogado = getUser(request);
-    if (userLogado && userLogado !== "Sistema") {
-      const { data: cfg } = await supabase
-        .from("tradein_config")
-        .select("labels")
-        .limit(1)
-        .maybeSingle();
-      const labels = (cfg?.labels || {}) as Record<string, unknown>;
-      const recebeMap = (labels._whatsapp_vendedores_recebe_links || {}) as Record<string, boolean>;
-      const norm = (s: string) => s.trim().toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
-      const userKey = norm(userLogado);
-      // Procura match case-insensitive e sem acento
-      const recebe = Object.entries(recebeMap).some(([nome, flag]) => norm(nome) === userKey && flag === true);
-      if (recebe) {
-        vendedorFinal = userLogado;
+  if (vendedorOverride && String(vendedorOverride).trim()) {
+    vendedorFinal = String(vendedorOverride).trim();
+  } else {
+    try {
+      const userLogado = getUser(request);
+      if (userLogado && userLogado !== "Sistema") {
+        const { data: cfg } = await supabase
+          .from("tradein_config")
+          .select("labels")
+          .limit(1)
+          .maybeSingle();
+        const labels = (cfg?.labels || {}) as Record<string, unknown>;
+        const recebeMap = (labels._whatsapp_vendedores_recebe_links || {}) as Record<string, boolean>;
+        const norm = (s: string) => s.trim().toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+        const userKey = norm(userLogado);
+        // Procura match case-insensitive e sem acento
+        const recebe = Object.entries(recebeMap).some(([nome, flag]) => norm(nome) === userKey && flag === true);
+        if (recebe) {
+          vendedorFinal = userLogado;
+        }
       }
-    }
-  } catch { /* silent: fallback ja e link.vendedor */ }
+    } catch { /* silent: fallback ja e link.vendedor */ }
+  }
 
   const { data: entrega, error: e2 } = await supabase
     .from("entregas")


### PR DESCRIPTION
## Dois ajustes

### 1. Tirar banco do Pix no texto do motoboy

Nicolas: \"o valor no pix n\u00e3o tem que mostrar para qual banco seria, onde vai ser o pix n\u00e3o interessa\".

**Antes:**
\`\`\`
\ud83d\udcb5 PAGAMENTO: Entrada R$ 3.750 via Pix (ITAU) + 10x no Cart\u00e3o
   \u2022 Entrada PIX: R$ 3.750,00 \u2014 ITAU
\`\`\`

**Agora:**
\`\`\`
\ud83d\udcb5 PAGAMENTO: Entrada R$ 3.750 via Pix + 10x no Cart\u00e3o
   \u2022 Entrada PIX: R$ 3.750,00
\`\`\`

Banco onde cai o Pix eh info interna, n\u00e3o precisa ir pro motoboy.

### 2. Select de vendedor no modal de encaminhar entrega em /admin/gerar-link

Nicolas: \"e o que eu pedi de selecionar o vendedor na hora de gerar a entrega? pois ainda est\u00e1 bugando a parte de quem gerou o link\".

A PR anterior #488 adicionou o modal de sele\u00e7\u00e3o em \`/admin/vendas\`, mas n\u00e3o no fluxo principal (\`/admin/gerar-link\` \u2192 aba Hist\u00f3rico \u2192 Encaminhar entrega). Agora tem nos dois.

No modal existente de \`/admin/gerar-link\`, adicionei select **Vendedor respons\u00e1vel *** (obrigat\u00f3rio):
- Op\u00e7\u00f5es: vendedor do link + vendedores ativos cadastrados
- Default: vendedor do link (se tiver) ou usu\u00e1rio logado
- Bot\u00e3o bloqueado at\u00e9 selecionar

Endpoint \`/api/admin/link-compras/encaminhar-entrega\` tem nova l\u00f3gica:
1. \`body.vendedor\` preenchido \u2192 usa ele (override expl\u00edcito)
2. Sen\u00e3o, \`userLogado\` com \`recebe_links\` \u2192 usa ele (comportamento anterior)
3. Fallback: \`link.vendedor\`

Resolve o caso: Paloma vende, Bianca recebe formul\u00e1rio, e a entrega pode ficar pra qualquer um que a equipe decidir.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)