### PR TITLE
fix(vendedor): default Bianca + editar inline em /admin/entregas

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -2707,12 +2707,44 @@ export default function EntregasPage() {
                     })()}
                   </div>
                 )}
-                {e.vendedor && (
-                  <div className="text-sm">
-                    <span className="text-[#86868B]">Vendedor: </span>
-                    <span className="text-[#1D1D1F]">{e.vendedor}</span>
-                  </div>
-                )}
+                <div className="text-sm flex items-center gap-2 flex-wrap">
+                  <span className="text-[#86868B]">Vendedor: </span>
+                  <select
+                    value={e.vendedor || ""}
+                    onChange={async (ev) => {
+                      const novoVendedor = ev.target.value || null;
+                      // Otimista: atualiza local imediato
+                      setEntregas(prev => prev.map(x => x.id === e.id ? { ...x, vendedor: novoVendedor } : x));
+                      if (selectedEntrega?.id === e.id) setSelectedEntrega({ ...selectedEntrega, vendedor: novoVendedor });
+                      try {
+                        const res = await fetch("/api/admin/entregas", {
+                          method: "PATCH",
+                          headers: { "Content-Type": "application/json", ...apiHeaders() },
+                          body: JSON.stringify({ id: e.id, vendedor: novoVendedor }),
+                        });
+                        if (!res.ok) {
+                          // Reverte se deu erro
+                          setEntregas(prev => prev.map(x => x.id === e.id ? { ...x, vendedor: e.vendedor } : x));
+                          alert("Erro ao atualizar vendedor");
+                        }
+                      } catch {
+                        setEntregas(prev => prev.map(x => x.id === e.id ? { ...x, vendedor: e.vendedor } : x));
+                        alert("Erro de conexão");
+                      }
+                    }}
+                    className={`px-2 py-1 rounded-lg border text-sm ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"} hover:border-[#E8740E] focus:outline-none focus:border-[#E8740E]`}
+                  >
+                    <option value="">— Nenhum —</option>
+                    {(() => {
+                      const opcoes = new Set<string>();
+                      if (e.vendedor) opcoes.add(e.vendedor);
+                      for (const v of vendedoresList) {
+                        if (v.ativo !== false && v.nome) opcoes.add(v.nome);
+                      }
+                      return [...opcoes].map((n) => <option key={n} value={n}>{n}</option>);
+                    })()}
+                  </select>
+                </div>
                 {e.observacao && (
                   <div className="text-sm p-3 bg-[#F5F5F7] rounded-lg">
                     <span className="text-[#86868B]">Obs: </span>

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -1788,7 +1788,7 @@ export default function GerarLinkPage() {
                     return [...opcoes].map(n => <option key={n} value={n}>{n}</option>);
                   })()}
                 </select>
-                <p className="text-[10px] text-[#86868B] mt-1">Quem fecha a venda e recebe a comissão pela entrega</p>
+                <p className="text-[10px] text-[#86868B] mt-1">Vendedor responsável pelo contato com o cliente</p>
               </div>
               <div>
                 <label className="text-[11px] text-[#86868B] font-semibold">Observação (opcional)</label>
@@ -2027,7 +2027,7 @@ export default function GerarLinkPage() {
                   )}
                   {l.cliente_preencheu_em && !l.entrega_id && (
                     <button
-                      onClick={() => { setEncaminharLink(l); setEncaminharData(new Date().toISOString().slice(0, 10)); setEncaminharVendedor(l.vendedor || user?.nome || ""); }}
+                      onClick={() => { setEncaminharLink(l); setEncaminharData(new Date().toISOString().slice(0, 10)); setEncaminharVendedor("Bianca"); }}
                       className="text-xs px-2.5 py-1 rounded-lg bg-green-500 text-white hover:bg-green-600 font-medium"
                     >
                       → Encaminhar entrega

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -6099,8 +6099,9 @@ function EncaminharEntregaModal({
 }) {
   // Data default: data_programada se houver, senao hoje
   const defaultData = venda.data_programada || new Date().toLocaleDateString("en-CA", { timeZone: "America/Sao_Paulo" });
-  // Vendedor default: o vendedor atual da venda, senao o usuario logado
-  const defaultVendedor = venda.vendedor || userNome;
+  // Vendedor default: Bianca (principal responsavel pelos formularios).
+  // Operador pode sobrescrever pelo select se for outra pessoa atendendo.
+  const defaultVendedor = "Bianca";
   const [dataEntrega, setDataEntrega] = useState(defaultData);
   const [horario, setHorario] = useState("");
   const [vendedor, setVendedor] = useState(defaultVendedor);
@@ -6184,7 +6185,7 @@ function EncaminharEntregaModal({
                 <option key={nome} value={nome}>{nome}</option>
               ))}
             </select>
-            <p className="text-[10px] text-[#86868B] mt-1">Quem fechou a venda / quem recebe a comissão</p>
+            <p className="text-[10px] text-[#86868B] mt-1">Vendedor responsável pelo contato com o cliente</p>
           </div>
 
           <div>


### PR DESCRIPTION
## Tres ajustes

### 1. Default = Bianca no modal de encaminhar entrega

Nicolas: \"no caso por padr\u00e3o deve ficar marcado Bianca, e caso precise alterar o operador remarca\".

Antes o default era o vendedor do link (Paloma se foi ela que gerou). Agora sempre vem **Bianca** marcada por padr\u00e3o. Aplicado nos 2 fluxos: \`/admin/gerar-link\` e \`/admin/vendas\`.

### 2. Helper text sem coment\u00e1rio sobre comiss\u00e3o

Antes: *\"Quem fecha a venda e recebe a comiss\u00e3o pela entrega\"*

Agora: *\"Vendedor respons\u00e1vel pelo contato com o cliente\"*

### 3. Editar vendedor inline em \`/admin/entregas\`

Nicolas: \"essa parte deve poder ser editada na aba de entregas, por exemplo se j\u00e1 gerei uma entrega, e quero editar o vendedor respons\u00e1vel\".

No detalhe da entrega (modal), a linha \"Vendedor: Bianca\" virou um **select editavel**. Troca direto sem precisar abrir o form completo de edi\u00e7\u00e3o. Grava via PATCH em \`/api/admin/entregas\` com update otimista (reverte se der erro).

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)