### PR TITLE
feat(estoque): seminovo editavel por quem tem permissao Estoque (Paloma)

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -5337,7 +5337,10 @@ export default function EstoquePage() {
         // reset serial/imei edit mode when a different product opens
         // (tracked via editingDetailSerial / editingDetailImei in page state)
         const cpIco = <svg className="w-3 h-3 opacity-40 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>;
-        const canEdit = isAdmin || p.tipo === "PENDENCIA" || p.status === "PENDENTE" || p.status === "A CAMINHO";
+        // SEMINOVO em estoque pode ser editado por qualquer user com permissao
+        // 'Estoque' marcada (Paloma, etc). Produtos NOVOS/outros continuam so admin.
+        const isSeminovoEmEstoque = p.tipo === "SEMINOVO" && p.status === "EM ESTOQUE";
+        const canEdit = isAdmin || p.tipo === "PENDENCIA" || p.status === "PENDENTE" || p.status === "A CAMINHO" || isSeminovoEmEstoque;
         // IMEI/Serial editável para pendências (qualquer user) ou admin (qualquer status)
         const isPendente = p.tipo === "PENDENCIA" || p.status === "PENDENTE" || p.status === "A CAMINHO";
         const canEditImei = isPendente || isAdmin;


### PR DESCRIPTION
## O que muda

Antes: s\u00f3 admin conseguia editar os campos de seminovos (caixa, cabo, grade, bateria, garantia, etc) quando j\u00e1 estavam 'EM ESTOQUE'. A Paloma (marcada s\u00f3 com Estoque) via os dados mas n\u00e3o podia atualizar.

Agora: se o usu\u00e1rio tem permiss\u00e3o **Estoque** marcada E o item \u00e9 **tipo=SEMINOVO** + **status=EM ESTOQUE**, pode editar todos esses campos.

Produtos NOVOS continuam s\u00f3 admin.

## Por qu\u00ea

Seminovos s\u00e3o atualizados frequentemente ap\u00f3s chegarem das trocas (adicionar cabo, trocar grade, etc). Esse trabalho operacional n\u00e3o precisa passar sempre por admin.

## Scope

- Regra \`canEdit\` em \`app/admin/estoque/page.tsx\` (1 linha)
- Backend n\u00e3o precisou de mudan\u00e7a (PATCH j\u00e1 aceitava qualquer user com \`estoque.read\`)

## Pra Paloma

J\u00e1 tem **Estoque** marcado na tela de permiss\u00f5es (print). Basta mergear e ela passa a editar automaticamente.

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)