### PR TITLE
refactor(balanco): selecao por unidade (serial) + remover Balancear Precos antigo

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -1159,10 +1159,6 @@ export default function EstoquePage() {
   const [bulkDeleting, setBulkDeleting] = useState(false);
   const [showDiagnostico, setShowDiagnostico] = useState(false);
 
-  // Balance mode (seminovos)
-  const [balanceMode, setBalanceMode] = useState(false);
-  const [balanceSelected, setBalanceSelected] = useState<Set<string>>(new Set());
-  const [balanceApplying, setBalanceApplying] = useState(false);
 
   // IMEI search
   const [imeiSearch, setImeiSearch] = useState("");
@@ -2003,29 +1999,6 @@ export default function EstoquePage() {
     return res;
   };
 
-  const handleApplyBalance = async () => {
-    if (balanceSelected.size === 0) return;
-    const selectedItems = estoque.filter((p) => balanceSelected.has(p.id));
-    const totalCusto = selectedItems.reduce((s, p) => s + p.qnt * (p.custo_unitario || 0), 0);
-    const totalQnt = selectedItems.reduce((s, p) => s + p.qnt, 0);
-    if (totalQnt === 0) return;
-    const avgCusto = Math.round(totalCusto / totalQnt);
-    if (!confirm(`Aplicar custo médio de ${fmt(avgCusto)} a ${balanceSelected.size} item(ns)?`)) return;
-    setBalanceApplying(true);
-    try {
-      for (const item of selectedItems) {
-        await apiPatch(item.id, { custo_unitario: avgCusto });
-      }
-      setEstoque((prev) => prev.map((p) => balanceSelected.has(p.id) ? { ...p, custo_unitario: avgCusto } : p));
-      setMsg(`Balanço aplicado: ${balanceSelected.size} item(ns) com custo ${fmt(avgCusto)}`);
-      setBalanceSelected(new Set());
-      setBalanceMode(false);
-    } catch {
-      setMsg("Erro ao aplicar balanço");
-    } finally {
-      setBalanceApplying(false);
-    }
-  };
 
   const handleUpdateQnt = async (item: ProdutoEstoque, newQnt: number) => {
     const newStatus = newQnt === 0 ? "ESGOTADO" : item.status === "ESGOTADO" ? "EM ESTOQUE" : item.status;
@@ -3196,14 +3169,6 @@ export default function EstoquePage() {
               className={`px-4 py-2 rounded-xl text-[12px] font-semibold transition-all ${bgCard} border ${borderCard} text-[#E8740E] hover:bg-[#E8740E] hover:text-white hover:border-[#E8740E]`}
             >
               🏷️ Imprimir Todas Etiquetas
-            </button>
-          )}
-          {isAdmin && tab === "seminovos" && !selectMode && (
-            <button
-              onClick={() => { setBalanceMode(!balanceMode); if (balanceMode) setBalanceSelected(new Set()); }}
-              className={`px-4 py-2 rounded-xl text-[12px] font-semibold transition-all ${balanceMode ? "bg-blue-500 text-white" : `${bgCard} border ${borderCard} ${textSecondary} hover:border-blue-500 hover:text-blue-500`}`}
-            >
-              {balanceMode ? "Cancelar Balanço" : "Balancear Preços"}
             </button>
           )}
 
@@ -5307,33 +5272,6 @@ export default function EstoquePage() {
           </button>
         </div>
       )}
-
-      {/* Floating balance bar */}
-      {balanceMode && tab === "seminovos" && balanceSelected.size > 0 && (() => {
-        const selItems = estoque.filter((p) => balanceSelected.has(p.id));
-        const totalCusto = selItems.reduce((s, p) => s + p.qnt * (p.custo_unitario || 0), 0);
-        const totalQnt = selItems.reduce((s, p) => s + p.qnt, 0);
-        const avgCusto = totalQnt > 0 ? Math.round(totalCusto / totalQnt) : 0;
-        return (
-          <div className={`fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-4 px-6 py-3 rounded-2xl shadow-2xl border ${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-white border-[#D2D2D7]"}`}>
-            <span className={`text-sm font-semibold ${textPrimary}`}>{balanceSelected.size} selecionado(s)</span>
-            <span className={`text-sm ${textSecondary}`}>Custo medio: <span className="font-bold text-blue-500">{fmt(avgCusto)}</span></span>
-            <button
-              onClick={handleApplyBalance}
-              disabled={balanceApplying}
-              className="px-4 py-1.5 rounded-lg text-xs font-semibold bg-blue-500 text-white hover:bg-blue-600 transition-colors disabled:opacity-50"
-            >
-              {balanceApplying ? "Aplicando..." : "Aplicar Balanço"}
-            </button>
-            <button
-              onClick={() => { setBalanceSelected(new Set()); setBalanceMode(false); }}
-              className={`px-3 py-1.5 rounded-lg text-xs font-medium ${textSecondary} hover:${textPrimary} transition-colors`}
-            >
-              Cancelar
-            </button>
-          </div>
-        );
-      })()}
 
       {/* Modal de detalhes do produto */}
       {detailProduct && (() => {

--- a/app/api/admin/recalc-balancos/route.ts
+++ b/app/api/admin/recalc-balancos/route.ts
@@ -16,8 +16,13 @@ function getUsuario(req: NextRequest): string {
  * POST: Recalcula o balanço (preco medio ponderado).
  *
  * Body opcional:
- * - { modelos: [{ categoria, modeloBase }] } — recalcula APENAS os modelos listados.
- *   Usado pra balanco manual de seminovos na tela /admin/usados.
+ * - { ids: string[] } — aplica balanco MANUAL apenas nessas unidades especificas
+ *   (ids do estoque). Calcula o preco medio ponderado das unidades selecionadas
+ *   e atualiza o custo_unitario de cada uma pro mesmo valor.
+ *   Usado pra balanco manual na tela /admin/estoque > aba Seminovos — permite
+ *   excluir unidades avariadas do calculo.
+ * - { modelos: [{ categoria, modeloBase }] } — legacy, aplica em TODOS itens do
+ *   grupo (modo agrupado).
  * - { includeSeminovos: true } — inclui SEMINOVOS na passada geral (nao e default).
  *
  * Sem body ou vazio: recalcula tudo EXCETO seminovos (comportamento padrao).
@@ -26,13 +31,55 @@ export async function POST(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   try {
-    let body: { modelos?: Array<{ categoria: string; modeloBase: string }>; includeSeminovos?: boolean } = {};
+    let body: {
+      ids?: string[];
+      modelos?: Array<{ categoria: string; modeloBase: string }>;
+      includeSeminovos?: boolean;
+    } = {};
     try { body = await req.json(); } catch { /* no body = default */ }
 
+    // Modo por IDs especificos (novo, mais granular)
+    if (Array.isArray(body.ids) && body.ids.length > 0) {
+      const { supabase } = await import("@/lib/supabase");
+      const { data: itens, error } = await supabase
+        .from("estoque")
+        .select("id, qnt, custo_compra")
+        .in("id", body.ids);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+      if (!itens || itens.length === 0) return NextResponse.json({ error: "Nenhum item encontrado" }, { status: 404 });
+      // Calcula media ponderada pelas quantidades
+      let totalCusto = 0;
+      let totalQnt = 0;
+      for (const it of itens) {
+        const q = Number(it.qnt || 0);
+        const c = Number(it.custo_compra || 0);
+        if (c <= 0 || q <= 0) continue;
+        totalCusto += q * c;
+        totalQnt += q;
+      }
+      if (totalQnt === 0) return NextResponse.json({ error: "Itens sem quantidade ou custo valido" }, { status: 400 });
+      const novoCusto = Math.round((totalCusto / totalQnt) * 100) / 100;
+      // Atualiza todos pros mesmo custo_unitario
+      const { error: upErr } = await supabase
+        .from("estoque")
+        .update({ custo_unitario: novoCusto, updated_at: new Date().toISOString() })
+        .in("id", body.ids);
+      if (upErr) return NextResponse.json({ error: upErr.message }, { status: 500 });
+
+      await logActivity(
+        getUsuario(req),
+        "Balanco manual por unidades",
+        `${body.ids.length} unidade(s) com novo custo R$ ${novoCusto.toLocaleString("pt-BR")}`,
+        "estoque"
+      );
+
+      return NextResponse.json({ ok: true, updated: body.ids.length, novoCusto });
+    }
+
+    // Modo legacy por modelos
     const opts: Parameters<typeof recalcBalancos>[0] = {};
     if (Array.isArray(body.modelos) && body.modelos.length > 0) {
       opts.onlyModelos = body.modelos;
-      // Quando manual, permite incluir seminovos (padrão do manual)
       opts.excludeSeminovos = false;
     } else if (body.includeSeminovos) {
       opts.excludeSeminovos = false;
@@ -79,19 +126,54 @@ export async function GET(req: NextRequest) {
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-    type Row = { id: string; categoria: string; produto: string; cor: string | null; tipo: string | null; qnt: number; custo_compra: number; custo_unitario: number };
+    type Row = {
+      id: string;
+      categoria: string;
+      produto: string;
+      cor: string | null;
+      tipo: string | null;
+      qnt: number;
+      custo_compra: number;
+      custo_unitario: number;
+      serial_no?: string | null;
+      imei?: string | null;
+      observacao?: string | null;
+      fornecedor?: string | null;
+    };
+
+    // Reselect com colunas extras pra mostrar na UI
+    const { data: itemsDetalhados } = await supabase
+      .from("estoque")
+      .select("id, categoria, produto, cor, tipo, qnt, custo_compra, custo_unitario, serial_no, imei, observacao, fornecedor")
+      .eq("status", "EM ESTOQUE")
+      .eq("tipo", "SEMINOVO")
+      .gt("qnt", 0)
+      .range(0, 49999);
+
+    interface Unidade {
+      id: string;
+      produto: string;
+      cor: string | null;
+      qnt: number;
+      custo_compra: number;
+      custo_unitario: number;
+      serial_no: string | null;
+      imei: string | null;
+      observacao: string | null;
+      fornecedor: string | null;
+    }
     interface Grupo {
       categoria: string;
       modeloBase: string;
       qnt: number;
-      custoTotal: number; // soma(qnt * custo_compra)
-      custoAtual: number; // custo_unitario atual (de um dos itens)
-      balancoCalculado: number; // custoTotal / qnt
+      custoTotal: number;
+      custoAtual: number;
+      balancoCalculado: number;
       precisaAtualizar: boolean;
-      qntItens: number; // quantos registros na tabela estoque fazem parte
+      unidades: Unidade[];
     }
     const groups = new Map<string, Grupo>();
-    for (const raw of (items || []) as unknown as Row[]) {
+    for (const raw of (itemsDetalhados || []) as unknown as Row[]) {
       const cc = Number(raw.custo_compra || 0);
       if (cc <= 0) continue;
       const modeloBase = getModeloBase(raw.produto, raw.categoria);
@@ -104,18 +186,31 @@ export async function GET(req: NextRequest) {
         custoAtual: Number(raw.custo_unitario || 0),
         balancoCalculado: 0,
         precisaAtualizar: false,
-        qntItens: 0,
+        unidades: [] as Unidade[],
       };
       const q = Number(raw.qnt || 0);
       g.qnt += q;
       g.custoTotal += q * cc;
-      g.qntItens += 1;
+      g.unidades.push({
+        id: raw.id,
+        produto: raw.produto,
+        cor: raw.cor ?? null,
+        qnt: q,
+        custo_compra: cc,
+        custo_unitario: Number(raw.custo_unitario || 0),
+        serial_no: raw.serial_no ?? null,
+        imei: raw.imei ?? null,
+        observacao: raw.observacao ?? null,
+        fornecedor: raw.fornecedor ?? null,
+      });
       groups.set(key, g);
     }
 
     const result = [...groups.values()].map((g) => {
       g.balancoCalculado = g.qnt > 0 ? Math.round((g.custoTotal / g.qnt) * 100) / 100 : 0;
       g.precisaAtualizar = Math.abs(g.balancoCalculado - g.custoAtual) > 0.01;
+      // Ordena unidades por serial (ou custo se sem serial)
+      g.unidades.sort((a, b) => (a.serial_no || "").localeCompare(b.serial_no || ""));
       return g;
     }).sort((a, b) => a.modeloBase.localeCompare(b.modeloBase));
 

--- a/components/admin/BalancoSeminovosSection.tsx
+++ b/components/admin/BalancoSeminovosSection.tsx
@@ -3,6 +3,19 @@ import { useCallback, useEffect, useState } from "react";
 
 const fmt = (v: number) => `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
 
+interface Unidade {
+  id: string;
+  produto: string;
+  cor: string | null;
+  qnt: number;
+  custo_compra: number;
+  custo_unitario: number;
+  serial_no: string | null;
+  imei: string | null;
+  observacao: string | null;
+  fornecedor: string | null;
+}
+
 interface BalancoGrupo {
   categoria: string;
   modeloBase: string;
@@ -11,26 +24,31 @@ interface BalancoGrupo {
   custoAtual: number;
   balancoCalculado: number;
   precisaAtualizar: boolean;
-  qntItens: number;
+  unidades: Unidade[];
 }
 
 interface Props {
   password: string;
   userNome: string;
   onMsg: (m: string) => void;
-  /** Se true, a secao comeca aberta (sem toggle). Default: false (colapsada). */
-  sempreAberta?: boolean;
+}
+
+// Extrai a grade (A+, A, AB, B) da observacao se presente
+function extractGrade(obs: string | null): string | null {
+  if (!obs) return null;
+  const m = obs.match(/\[GRADE_([AB+]+)\]/);
+  return m ? m[1] : null;
 }
 
 export default function BalancoSeminovosSection({
   password,
   userNome,
   onMsg,
-  sempreAberta = false,
 }: Props) {
-  const [aberto, setAberto] = useState(sempreAberta);
+  const [aberto, setAberto] = useState(false);
   const [grupos, setGrupos] = useState<BalancoGrupo[]>([]);
-  const [selecionados, setSelecionados] = useState<Set<string>>(new Set());
+  const [gruposExpandidos, setGruposExpandidos] = useState<Set<string>>(new Set());
+  const [idsSelecionados, setIdsSelecionados] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(false);
   const [aplicando, setAplicando] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -55,39 +73,59 @@ export default function BalancoSeminovosSection({
     if (aberto) carregar();
   }, [aberto, carregar]);
 
-  const toggleTodos = () => {
-    if (selecionados.size === grupos.length) setSelecionados(new Set());
-    else setSelecionados(new Set(grupos.map(keyOf)));
-  };
-
-  const toggleUm = (g: BalancoGrupo) => {
-    const k = keyOf(g);
-    const next = new Set(selecionados);
+  const toggleGrupoExpandido = (k: string) => {
+    const next = new Set(gruposExpandidos);
     if (next.has(k)) next.delete(k);
     else next.add(k);
-    setSelecionados(next);
+    setGruposExpandidos(next);
   };
 
+  const toggleUnidade = (id: string) => {
+    const next = new Set(idsSelecionados);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setIdsSelecionados(next);
+  };
+
+  const toggleGrupoInteiro = (g: BalancoGrupo) => {
+    const next = new Set(idsSelecionados);
+    const todasMarcadas = g.unidades.every(u => next.has(u.id));
+    if (todasMarcadas) {
+      g.unidades.forEach(u => next.delete(u.id));
+    } else {
+      g.unidades.forEach(u => next.add(u.id));
+    }
+    setIdsSelecionados(next);
+  };
+
+  // Calcula preview do novo custo medio das unidades selecionadas
+  const unidadesSelecionadas = grupos.flatMap(g => g.unidades).filter(u => idsSelecionados.has(u.id));
+  const totalQntSel = unidadesSelecionadas.reduce((s, u) => s + u.qnt, 0);
+  const totalCustoSel = unidadesSelecionadas.reduce((s, u) => s + u.qnt * u.custo_compra, 0);
+  const novoCustoMedio = totalQntSel > 0 ? Math.round((totalCustoSel / totalQntSel) * 100) / 100 : 0;
+
   const abrirConfirmacao = () => {
-    if (selecionados.size === 0) { alert("Selecione ao menos 1 modelo."); return; }
+    if (idsSelecionados.size === 0) { alert("Selecione ao menos 1 unidade."); return; }
+    if (idsSelecionados.size === 1) {
+      alert("Selecione pelo menos 2 unidades pra calcular uma média. Pra editar 1 unidade só, use o Editar do produto.");
+      return;
+    }
     setConfirmOpen(true);
   };
 
   const aplicarBalanco = async () => {
-    const modelos = grupos.filter(g => selecionados.has(keyOf(g))).map(g => ({ categoria: g.categoria, modeloBase: g.modeloBase }));
-    const total = modelos.length;
     setConfirmOpen(false);
     setAplicando(true);
     try {
       const res = await fetch("/api/admin/recalc-balancos", {
         method: "POST",
         headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(userNome) },
-        body: JSON.stringify({ modelos }),
+        body: JSON.stringify({ ids: [...idsSelecionados] }),
       });
       const j = await res.json();
       if (!j.ok) { alert("Erro: " + (j.error || "falha")); setAplicando(false); return; }
-      onMsg(`✓ Balanço aplicado em ${total} modelo(s). ${j.updated} produto(s) atualizado(s).`);
-      setSelecionados(new Set());
+      onMsg(`✓ Balanço aplicado em ${j.updated} unidade(s). Novo custo: ${fmt(j.novoCusto || novoCustoMedio)}.`);
+      setIdsSelecionados(new Set());
       await carregar();
     } catch (e) {
       alert("Erro de conexão: " + String(e));
@@ -99,39 +137,22 @@ export default function BalancoSeminovosSection({
 
   return (
     <div className="bg-white border border-[#D2D2D7] rounded-2xl shadow-sm overflow-hidden">
-      {!sempreAberta && (
-        <button
-          onClick={() => setAberto(!aberto)}
-          className="w-full px-5 py-4 flex items-center justify-between hover:bg-[#F5F5F7] transition-colors"
-        >
-          <div className="flex items-center gap-3">
-            <span className="text-lg">📊</span>
-            <div className="text-left">
-              <p className="text-sm font-bold text-[#1D1D1F]">Balanço Manual (Preço Médio)</p>
-              <p className="text-[11px] text-[#86868B]">
-                Selecione modelos de seminovo (agrupados por modelo+armazenamento) e aplique o recálculo de preço médio ponderado
-                {aberto && precisam > 0 && <span className="ml-2 text-[#E8740E] font-semibold">· {precisam} modelo(s) com balanço desatualizado</span>}
-              </p>
-            </div>
-          </div>
-          <span className="text-[#86868B]">{aberto ? "▲" : "▼"}</span>
-        </button>
-      )}
-
-      {sempreAberta && (
-        <div className="px-5 py-4 border-b border-[#E5E5EA] bg-[#F5F5F7]">
-          <div className="flex items-center gap-3">
-            <span className="text-lg">📊</span>
-            <div>
-              <p className="text-sm font-bold text-[#1D1D1F]">Balanço Manual (Preço Médio)</p>
-              <p className="text-[11px] text-[#86868B]">
-                Agrupado por modelo+armazenamento. Aplica preço médio ponderado nos itens selecionados.
-                {precisam > 0 && <span className="ml-2 text-[#E8740E] font-semibold">· {precisam} modelo(s) com balanço desatualizado</span>}
-              </p>
-            </div>
+      <button
+        onClick={() => setAberto(!aberto)}
+        className="w-full px-5 py-4 flex items-center justify-between hover:bg-[#F5F5F7] transition-colors"
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-lg">📊</span>
+          <div className="text-left">
+            <p className="text-sm font-bold text-[#1D1D1F]">Balanço Manual (Preço Médio)</p>
+            <p className="text-[11px] text-[#86868B]">
+              Selecione as unidades específicas (por número de série) e aplique o recálculo de preço médio ponderado. Pula avariadas.
+              {aberto && precisam > 0 && <span className="ml-2 text-[#E8740E] font-semibold">· {precisam} modelo(s) com balanço desatualizado</span>}
+            </p>
           </div>
         </div>
-      )}
+        <span className="text-[#86868B]">{aberto ? "▲" : "▼"}</span>
+      </button>
 
       {aberto && (
         <div className="px-5 py-4 border-t border-[#E5E5EA] bg-[#FAFAFA]">
@@ -141,75 +162,141 @@ export default function BalancoSeminovosSection({
           )}
           {!loading && grupos.length > 0 && (
             <>
-              <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
-                <button
-                  onClick={toggleTodos}
-                  className="text-xs text-[#E8740E] hover:underline font-medium"
-                >
-                  {selecionados.size === grupos.length ? "Desmarcar todos" : "Selecionar todos"} ({selecionados.size}/{grupos.length})
-                </button>
+              {/* Barra topo com resumo e botao aplicar */}
+              <div className="flex items-center justify-between mb-3 flex-wrap gap-2 bg-white rounded-xl border border-[#E5E5EA] p-3">
+                <div className="flex items-center gap-3 flex-wrap">
+                  <span className="text-xs text-[#86868B]">Selecionadas:</span>
+                  <span className="text-sm font-bold text-[#1D1D1F]">{idsSelecionados.size} unidade(s)</span>
+                  {totalQntSel > 0 && (
+                    <>
+                      <span className="text-xs text-[#86868B]">· Novo custo médio:</span>
+                      <span className="text-sm font-bold text-[#E8740E] font-mono">{fmt(novoCustoMedio)}</span>
+                    </>
+                  )}
+                </div>
                 <button
                   onClick={abrirConfirmacao}
-                  disabled={aplicando || selecionados.size === 0}
+                  disabled={aplicando || idsSelecionados.size === 0}
                   className="px-4 py-2 rounded-lg text-sm font-bold bg-[#E8740E] text-white hover:bg-[#D06A0D] disabled:opacity-40 disabled:cursor-not-allowed"
                 >
-                  {aplicando ? "Aplicando..." : `🔄 Fazer balanço dos selecionados (${selecionados.size})`}
+                  {aplicando ? "Aplicando..." : `🔄 Aplicar balanço (${idsSelecionados.size})`}
                 </button>
               </div>
-              <div className="overflow-x-auto bg-white rounded-xl border border-[#E5E5EA]">
-                <table className="w-full text-sm">
-                  <thead className="bg-[#F5F5F7]">
-                    <tr>
-                      <th className="px-3 py-2 text-left text-[10px] font-bold text-[#86868B] uppercase"></th>
-                      <th className="px-3 py-2 text-left text-[10px] font-bold text-[#86868B] uppercase">Modelo + Armazenamento</th>
-                      <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Qnt</th>
-                      <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Custo Atual</th>
-                      <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Novo Balanço</th>
-                      <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Diferença</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {grupos.map((g) => {
-                      const k = keyOf(g);
-                      const sel = selecionados.has(k);
-                      const diff = g.balancoCalculado - g.custoAtual;
-                      return (
-                        <tr
-                          key={k}
-                          className={`border-t border-[#F5F5F7] hover:bg-[#FAFAFA] cursor-pointer ${sel ? "bg-orange-50" : ""}`}
-                          onClick={() => toggleUm(g)}
+
+              {/* Grupos expansiveis */}
+              <div className="space-y-2">
+                {grupos.map((g) => {
+                  const k = keyOf(g);
+                  const expandido = gruposExpandidos.has(k);
+                  const marcadasNoGrupo = g.unidades.filter(u => idsSelecionados.has(u.id)).length;
+                  const todasMarcadas = g.unidades.length > 0 && marcadasNoGrupo === g.unidades.length;
+                  const algumaMarcada = marcadasNoGrupo > 0 && !todasMarcadas;
+                  return (
+                    <div key={k} className="bg-white rounded-xl border border-[#E5E5EA] overflow-hidden">
+                      <div className="flex items-center gap-3 px-3 py-2 hover:bg-[#FAFAFA]">
+                        <input
+                          type="checkbox"
+                          checked={todasMarcadas}
+                          ref={(el) => { if (el) el.indeterminate = algumaMarcada; }}
+                          onChange={() => toggleGrupoInteiro(g)}
+                          className="w-4 h-4 accent-[#E8740E] cursor-pointer"
+                          title="Selecionar todas unidades deste modelo"
+                        />
+                        <button
+                          onClick={() => toggleGrupoExpandido(k)}
+                          className="flex-1 flex items-center justify-between text-left"
                         >
-                          <td className="px-3 py-2">
-                            <input
-                              type="checkbox"
-                              checked={sel}
-                              onChange={() => toggleUm(g)}
-                              onClick={(e) => e.stopPropagation()}
-                              className="w-4 h-4 accent-[#E8740E]"
-                            />
-                          </td>
-                          <td className="px-3 py-2 text-[#1D1D1F] font-medium">{g.modeloBase}</td>
-                          <td className="px-3 py-2 text-right text-[#1D1D1F] font-mono">{g.qnt}</td>
-                          <td className="px-3 py-2 text-right text-[#86868B] font-mono">{fmt(g.custoAtual)}</td>
-                          <td className={`px-3 py-2 text-right font-mono font-semibold ${g.precisaAtualizar ? "text-[#E8740E]" : "text-[#86868B]"}`}>{fmt(g.balancoCalculado)}</td>
-                          <td className={`px-3 py-2 text-right font-mono ${Math.abs(diff) < 0.01 ? "text-[#86868B]" : diff > 0 ? "text-green-600" : "text-red-600"}`}>
-                            {Math.abs(diff) < 0.01 ? "—" : `${diff > 0 ? "+" : ""}${fmt(diff)}`}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
+                          <div className="flex items-center gap-2">
+                            <span className="text-xs text-[#86868B]">{expandido ? "▼" : "▶"}</span>
+                            <span className="text-sm font-semibold text-[#1D1D1F]">{g.modeloBase}</span>
+                            <span className="text-[10px] text-[#86868B]">· {g.qnt} unidade(s)</span>
+                            {marcadasNoGrupo > 0 && (
+                              <span className="text-[10px] bg-orange-100 text-[#E8740E] px-2 py-0.5 rounded-full font-semibold">
+                                {marcadasNoGrupo} selecionada(s)
+                              </span>
+                            )}
+                            {g.precisaAtualizar && (
+                              <span className="text-[10px] bg-yellow-100 text-yellow-700 px-2 py-0.5 rounded-full font-medium">
+                                ⚠ balanço desatualizado
+                              </span>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-3 text-xs">
+                            <span className="text-[#86868B]">Atual: <span className="font-mono text-[#1D1D1F]">{fmt(g.custoAtual)}</span></span>
+                            <span className="text-[#86868B]">Sugerido: <span className={`font-mono ${g.precisaAtualizar ? "text-[#E8740E]" : "text-[#86868B]"}`}>{fmt(g.balancoCalculado)}</span></span>
+                          </div>
+                        </button>
+                      </div>
+                      {expandido && (
+                        <div className="border-t border-[#E5E5EA] bg-[#FAFAFA]">
+                          <table className="w-full text-xs">
+                            <thead>
+                              <tr className="border-b border-[#E5E5EA]">
+                                <th className="px-3 py-2 text-left text-[10px] font-bold text-[#86868B] uppercase w-[50px]"></th>
+                                <th className="px-3 py-2 text-left text-[10px] font-bold text-[#86868B] uppercase">Serial / IMEI</th>
+                                <th className="px-3 py-2 text-left text-[10px] font-bold text-[#86868B] uppercase">Cor</th>
+                                <th className="px-3 py-2 text-left text-[10px] font-bold text-[#86868B] uppercase">Grade</th>
+                                <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Qnt</th>
+                                <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Custo Compra</th>
+                                <th className="px-3 py-2 text-right text-[10px] font-bold text-[#86868B] uppercase">Custo Atual</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {g.unidades.map((u) => {
+                                const selecionada = idsSelecionados.has(u.id);
+                                const grade = extractGrade(u.observacao);
+                                return (
+                                  <tr
+                                    key={u.id}
+                                    className={`border-b border-[#F5F5F7] hover:bg-white cursor-pointer ${selecionada ? "bg-orange-50" : ""}`}
+                                    onClick={() => toggleUnidade(u.id)}
+                                  >
+                                    <td className="px-3 py-2">
+                                      <input
+                                        type="checkbox"
+                                        checked={selecionada}
+                                        onChange={() => toggleUnidade(u.id)}
+                                        onClick={(e) => e.stopPropagation()}
+                                        className="w-4 h-4 accent-[#E8740E]"
+                                      />
+                                    </td>
+                                    <td className="px-3 py-2 font-mono text-[11px] text-[#1D1D1F]">
+                                      {u.serial_no || u.imei || <span className="text-[#86868B]">—</span>}
+                                    </td>
+                                    <td className="px-3 py-2 text-[#6E6E73]">{u.cor || "—"}</td>
+                                    <td className="px-3 py-2">
+                                      {grade ? (
+                                        <span className={`text-[10px] px-1.5 py-0.5 rounded font-bold ${
+                                          grade === "A+" ? "bg-green-100 text-green-700" :
+                                          grade === "A" ? "bg-blue-100 text-blue-700" :
+                                          grade === "AB" ? "bg-yellow-100 text-yellow-700" :
+                                          "bg-red-100 text-red-700"
+                                        }`}>{grade}</span>
+                                      ) : <span className="text-[#86868B]">—</span>}
+                                    </td>
+                                    <td className="px-3 py-2 text-right font-mono text-[#1D1D1F]">{u.qnt}</td>
+                                    <td className="px-3 py-2 text-right font-mono text-[#1D1D1F]">{fmt(u.custo_compra)}</td>
+                                    <td className="px-3 py-2 text-right font-mono text-[#86868B]">{fmt(u.custo_unitario)}</td>
+                                  </tr>
+                                );
+                              })}
+                            </tbody>
+                          </table>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </>
           )}
         </div>
       )}
 
-      {/* Modal de confirmacao com preview */}
       {confirmOpen && (
         <ConfirmarBalancoModal
-          gruposSelecionados={grupos.filter(g => selecionados.has(keyOf(g)))}
+          unidades={unidadesSelecionadas}
+          novoCustoMedio={novoCustoMedio}
           onCancel={() => setConfirmOpen(false)}
           onConfirm={aplicarBalanco}
           aplicando={aplicando}
@@ -220,20 +307,22 @@ export default function BalancoSeminovosSection({
 }
 
 function ConfirmarBalancoModal({
-  gruposSelecionados,
+  unidades,
+  novoCustoMedio,
   onCancel,
   onConfirm,
   aplicando,
 }: {
-  gruposSelecionados: BalancoGrupo[];
+  unidades: Unidade[];
+  novoCustoMedio: number;
   onCancel: () => void;
   onConfirm: () => void;
   aplicando: boolean;
 }) {
-  const qntTotalProdutos = gruposSelecionados.reduce((s, g) => s + g.qnt, 0);
-  const valorTotalAtual = gruposSelecionados.reduce((s, g) => s + g.qnt * g.custoAtual, 0);
-  const valorTotalNovo = gruposSelecionados.reduce((s, g) => s + g.custoTotal, 0);
-  const impactoValor = valorTotalNovo - valorTotalAtual;
+  const totalQnt = unidades.reduce((s, u) => s + u.qnt, 0);
+  const valorAtualTotal = unidades.reduce((s, u) => s + u.qnt * u.custo_unitario, 0);
+  const valorNovoTotal = totalQnt * novoCustoMedio;
+  const impacto = valorNovoTotal - valorAtualTotal;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50" onClick={onCancel}>
@@ -244,60 +333,58 @@ function ConfirmarBalancoModal({
         </div>
 
         <p className="text-sm text-[#6E6E73] mb-4">
-          Revise os modelos antes de aplicar o balanço. Os valores de <strong>custo_unitario</strong> de cada produto em estoque serão atualizados para o preço médio ponderado.
+          Todas as <strong>{unidades.length} unidades selecionadas</strong> vão ficar com o mesmo <strong>custo_unitario = {fmt(novoCustoMedio)}</strong> (preço médio ponderado).
         </p>
 
         <div className="bg-gradient-to-br from-[#F5F5F7] to-white border border-[#D2D2D7] rounded-xl p-4 mb-4 grid grid-cols-2 gap-3">
           <div>
-            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Modelos selecionados</p>
-            <p className="text-xl font-bold text-[#1D1D1F]">{gruposSelecionados.length}</p>
+            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Unidades</p>
+            <p className="text-xl font-bold text-[#1D1D1F]">{unidades.length}</p>
           </div>
           <div>
-            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Total de produtos</p>
-            <p className="text-xl font-bold text-[#1D1D1F]">{qntTotalProdutos}</p>
+            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Novo custo médio</p>
+            <p className="text-xl font-bold text-[#E8740E] font-mono">{fmt(novoCustoMedio)}</p>
           </div>
           <div>
-            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Valor atual do estoque</p>
-            <p className="text-sm font-mono font-semibold text-[#1D1D1F]">{fmt(valorTotalAtual)}</p>
+            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Valor atual</p>
+            <p className="text-sm font-mono text-[#1D1D1F]">{fmt(valorAtualTotal)}</p>
           </div>
           <div>
             <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Valor após balanço</p>
-            <p className="text-sm font-mono font-semibold text-[#1D1D1F]">{fmt(valorTotalNovo)}</p>
+            <p className="text-sm font-mono text-[#1D1D1F]">{fmt(valorNovoTotal)}</p>
           </div>
           <div className="col-span-full pt-2 border-t border-[#E5E5EA]">
-            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Impacto total</p>
-            <p className={`text-lg font-mono font-bold ${Math.abs(impactoValor) < 1 ? "text-[#86868B]" : impactoValor > 0 ? "text-green-600" : "text-red-600"}`}>
-              {impactoValor > 0 ? "+" : ""}{fmt(impactoValor)}
+            <p className="text-[10px] text-[#86868B] uppercase tracking-wider">Impacto</p>
+            <p className={`text-lg font-mono font-bold ${Math.abs(impacto) < 1 ? "text-[#86868B]" : impacto > 0 ? "text-green-600" : "text-red-600"}`}>
+              {impacto > 0 ? "+" : ""}{fmt(impacto)}
             </p>
           </div>
         </div>
 
         <div className="border border-[#E5E5EA] rounded-xl overflow-hidden mb-4">
           <div className="bg-[#F5F5F7] px-4 py-2 border-b border-[#E5E5EA]">
-            <p className="text-[10px] font-bold text-[#86868B] uppercase tracking-wider">Detalhe por modelo</p>
+            <p className="text-[10px] font-bold text-[#86868B] uppercase tracking-wider">Unidades</p>
           </div>
           <div className="max-h-64 overflow-y-auto">
             <table className="w-full text-xs">
               <thead className="sticky top-0 bg-white">
                 <tr className="border-b border-[#E5E5EA]">
-                  <th className="px-3 py-2 text-left text-[10px] text-[#86868B]">Modelo</th>
-                  <th className="px-3 py-2 text-right text-[10px] text-[#86868B]">Qnt</th>
+                  <th className="px-3 py-2 text-left text-[10px] text-[#86868B]">Produto</th>
+                  <th className="px-3 py-2 text-left text-[10px] text-[#86868B]">Serial</th>
                   <th className="px-3 py-2 text-right text-[10px] text-[#86868B]">Atual</th>
                   <th className="px-3 py-2 text-right text-[10px] text-[#86868B]">Novo</th>
-                  <th className="px-3 py-2 text-right text-[10px] text-[#86868B]">Dif</th>
                 </tr>
               </thead>
               <tbody>
-                {gruposSelecionados.map((g) => {
-                  const diff = g.balancoCalculado - g.custoAtual;
+                {unidades.map((u) => {
+                  const diff = novoCustoMedio - u.custo_unitario;
                   return (
-                    <tr key={`${g.categoria}|${g.modeloBase}`} className="border-b border-[#F5F5F7]">
-                      <td className="px-3 py-2 text-[#1D1D1F] font-medium">{g.modeloBase}</td>
-                      <td className="px-3 py-2 text-right text-[#1D1D1F] font-mono">{g.qnt}</td>
-                      <td className="px-3 py-2 text-right text-[#86868B] font-mono">{fmt(g.custoAtual)}</td>
-                      <td className="px-3 py-2 text-right text-[#E8740E] font-mono font-semibold">{fmt(g.balancoCalculado)}</td>
-                      <td className={`px-3 py-2 text-right font-mono ${Math.abs(diff) < 0.01 ? "text-[#86868B]" : diff > 0 ? "text-green-600" : "text-red-600"}`}>
-                        {Math.abs(diff) < 0.01 ? "—" : `${diff > 0 ? "+" : ""}${fmt(diff)}`}
+                    <tr key={u.id} className="border-b border-[#F5F5F7]">
+                      <td className="px-3 py-2 text-[#1D1D1F]">{u.produto} {u.cor ? `(${u.cor})` : ""}</td>
+                      <td className="px-3 py-2 font-mono text-[10px] text-[#6E6E73]">{u.serial_no || u.imei || "—"}</td>
+                      <td className="px-3 py-2 text-right text-[#86868B] font-mono">{fmt(u.custo_unitario)}</td>
+                      <td className={`px-3 py-2 text-right font-mono font-semibold ${Math.abs(diff) < 1 ? "text-[#86868B]" : diff > 0 ? "text-green-600" : "text-red-600"}`}>
+                        {fmt(novoCustoMedio)}
                       </td>
                     </tr>
                   );


### PR DESCRIPTION
## Summary
- Balanço Manual de seminovos agora permite selecionar **unidades específicas por número de série** (não mais o modelo inteiro). Útil quando tem unidade avariada que não deve entrar na média.
- Removido o botão antigo **Balancear Preços** (item-a-item) da aba Seminovos — ficava confuso ter 3 lugares diferentes falando de balanço.
- Grupos colapsáveis por modelo+armazenamento; dentro de cada grupo lista as unidades com serial/IMEI, cor, grade (A+/A/AB/B), qnt, custo_compra e custo_unitario atual.
- Checkbox por unidade + checkbox do grupo com indeterminate. Preview ao vivo do novo custo médio ponderado.
- Mínimo 2 unidades selecionadas. Modal de confirmação com detalhamento.

## Test plan
- [ ] /admin/estoque > aba Seminovos → expandir um grupo → selecionar 2+ unidades → ver preview "Novo custo médio: R$ X"
- [ ] Confirmar balanço → unidades selecionadas ficam com mesmo custo_unitario
- [ ] Unidade deselecionada NÃO entra no cálculo
- [ ] Botão "Balancear Preços" antigo não aparece mais
- [ ] Fecha PR #498 (obsoleta, com conflito)

🤖 Generated with [Claude Code](https://claude.com/claude-code)