### PR TITLE
fix(balanco): modelos faltando + custo_compra editavel no modal

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -6537,15 +6537,20 @@ export default function EstoquePage() {
                         <span className={`text-[13px] ${mS}`}>R$</span>
                         <input
                           type="text" inputMode="numeric"
-                          defaultValue={p.custo_unitario ? String(p.custo_unitario) : ""}
+                          // Mostra custo_compra (valor que entrou em estoque).
+                          // Fallback pro custo_unitario em itens legados sem custo_compra.
+                          defaultValue={(p.custo_compra ?? p.custo_unitario) ? String(p.custo_compra ?? p.custo_unitario) : ""}
                           placeholder="0"
                           onBlur={async (e) => {
                             const val = e.target.value.replace(/\D/g, "");
                             const num = val ? parseInt(val) : null;
-                            if (num !== p.custo_unitario) {
-                              await apiPatch(p.id, { custo_unitario: num });
-                              setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, custo_unitario: num ?? 0 } : x));
-                              setDetailProduct({ ...p, custo_unitario: num ?? 0 });
+                            const atual = p.custo_compra ?? p.custo_unitario;
+                            if (num !== atual) {
+                              // Atualiza custo_compra (o que entrou em estoque). NAO mexe em custo_unitario
+                              // pra nao alterar balancos ja aplicados — isso e feito via Balanco Manual.
+                              await apiPatch(p.id, { custo_compra: num });
+                              setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, custo_compra: num } : x));
+                              setDetailProduct({ ...p, custo_compra: num });
                               showSaved("custo");
                             }
                           }}
@@ -6554,7 +6559,12 @@ export default function EstoquePage() {
                         />
                       </div>
                     ) : (
-                      <p className={`text-[14px] font-bold ${mP} mt-0.5`}>{p.custo_unitario ? fmt(p.custo_unitario) : "—"}</p>
+                      <p className={`text-[14px] font-bold ${mP} mt-0.5`}>{(p.custo_compra ?? p.custo_unitario) ? fmt(p.custo_compra ?? p.custo_unitario!) : "—"}</p>
+                    )}
+                    {p.custo_compra != null && p.custo_unitario && Math.abs(p.custo_compra - p.custo_unitario) > 0.5 && (
+                      <p className={`text-[10px] ${mS} mt-0.5`} title="Custo medio apos balanco ponderado">
+                        Balanço: <span className="font-mono text-[#E8740E]">{fmt(p.custo_unitario)}</span>
+                      </p>
                     )}
                   </div>
                   <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Categoria</p><p className={`text-[13px] ${mP} mt-0.5`}>{p.categoria}</p></div>

--- a/app/api/admin/recalc-balancos/route.ts
+++ b/app/api/admin/recalc-balancos/route.ts
@@ -175,7 +175,8 @@ export async function GET(req: NextRequest) {
     const groups = new Map<string, Grupo>();
     for (const raw of (itemsDetalhados || []) as unknown as Row[]) {
       const cc = Number(raw.custo_compra || 0);
-      if (cc <= 0) continue;
+      // Nao pulamos mais unidades sem custo_compra — mostramos elas pro user ver.
+      // Elas so nao entram no calculo de media ponderada (q/cc=0 nao altera).
       const modeloBase = getModeloBase(raw.produto, raw.categoria);
       const key = `${raw.categoria}|${modeloBase}`;
       const g = groups.get(key) || {
@@ -189,8 +190,11 @@ export async function GET(req: NextRequest) {
         unidades: [] as Unidade[],
       };
       const q = Number(raw.qnt || 0);
-      g.qnt += q;
-      g.custoTotal += q * cc;
+      // So soma quando tem custo_compra valido (unidades sem custo ficam listadas mas nao contam).
+      if (cc > 0) {
+        g.qnt += q;
+        g.custoTotal += q * cc;
+      }
       g.unidades.push({
         id: raw.id,
         produto: raw.produto,

--- a/app/api/estoque/route.ts
+++ b/app/api/estoque/route.ts
@@ -506,11 +506,18 @@ export async function PATCH(req: NextRequest) {
   // Buscar estado anterior para o log
   const { data: antes } = await supabase.from("estoque").select("*").eq("id", id).single();
 
-  // custo_compra é IMUTÁVEL após cadastro (custo real da compra).
-  // custo_unitario = balanço (média ponderada) só muda via endpoint /api/admin/recalc-balancos.
-  // Se o cliente tentar alterar custo_compra, preservamos o valor original.
-  if (antes && fields.custo_compra !== undefined && antes.custo_compra != null && Number(antes.custo_compra) > 0) {
-    delete fields.custo_compra;
+  // custo_compra = valor real que entrou em estoque. Admin pode corrigir (erro de digitacao, etc).
+  // custo_unitario = balanço (média ponderada) só muda via endpoint /api/admin/recalc-balancos
+  // ou por edicao manual explicita.
+  // Se custo_compra for editado e ainda nao ha balanco aplicado, mantem custo_unitario sincronizado.
+  if (antes && fields.custo_compra !== undefined) {
+    const ccAnt = Number(antes.custo_compra || 0);
+    const cuAnt = Number(antes.custo_unitario || 0);
+    const ccNovo = fields.custo_compra == null ? 0 : Number(fields.custo_compra);
+    // Se custo_unitario == custo_compra antigo (nao houve balanco), atualiza ambos pro novo custo_compra.
+    if (cuAnt === ccAnt && fields.custo_unitario === undefined) {
+      fields.custo_unitario = ccNovo;
+    }
   }
 
   // Forçar serial_no e imei em caixa alta

--- a/components/admin/BalancoSeminovosSection.tsx
+++ b/components/admin/BalancoSeminovosSection.tsx
@@ -89,19 +89,23 @@ export default function BalancoSeminovosSection({
 
   const toggleGrupoInteiro = (g: BalancoGrupo) => {
     const next = new Set(idsSelecionados);
-    const todasMarcadas = g.unidades.every(u => next.has(u.id));
+    // Ignora unidades sem custo_compra no toggle do grupo
+    const elegiveis = g.unidades.filter(u => Number(u.custo_compra) > 0);
+    const todasMarcadas = elegiveis.length > 0 && elegiveis.every(u => next.has(u.id));
     if (todasMarcadas) {
-      g.unidades.forEach(u => next.delete(u.id));
+      elegiveis.forEach(u => next.delete(u.id));
     } else {
-      g.unidades.forEach(u => next.add(u.id));
+      elegiveis.forEach(u => next.add(u.id));
     }
     setIdsSelecionados(next);
   };
 
-  // Calcula preview do novo custo medio das unidades selecionadas
+  // Calcula preview do novo custo medio das unidades selecionadas.
+  // Unidades sem custo_compra (cc<=0) nao entram no calculo — espelha o backend.
   const unidadesSelecionadas = grupos.flatMap(g => g.unidades).filter(u => idsSelecionados.has(u.id));
-  const totalQntSel = unidadesSelecionadas.reduce((s, u) => s + u.qnt, 0);
-  const totalCustoSel = unidadesSelecionadas.reduce((s, u) => s + u.qnt * u.custo_compra, 0);
+  const unidadesValidas = unidadesSelecionadas.filter(u => Number(u.custo_compra) > 0 && Number(u.qnt) > 0);
+  const totalQntSel = unidadesValidas.reduce((s, u) => s + u.qnt, 0);
+  const totalCustoSel = unidadesValidas.reduce((s, u) => s + u.qnt * u.custo_compra, 0);
   const novoCustoMedio = totalQntSel > 0 ? Math.round((totalCustoSel / totalQntSel) * 100) / 100 : 0;
 
   const abrirConfirmacao = () => {
@@ -245,19 +249,22 @@ export default function BalancoSeminovosSection({
                               {g.unidades.map((u) => {
                                 const selecionada = idsSelecionados.has(u.id);
                                 const grade = extractGrade(u.observacao);
+                                const semCusto = !(Number(u.custo_compra) > 0);
                                 return (
                                   <tr
                                     key={u.id}
-                                    className={`border-b border-[#F5F5F7] hover:bg-white cursor-pointer ${selecionada ? "bg-orange-50" : ""}`}
-                                    onClick={() => toggleUnidade(u.id)}
+                                    className={`border-b border-[#F5F5F7] ${semCusto ? "opacity-60 bg-yellow-50" : "hover:bg-white cursor-pointer"} ${selecionada ? "bg-orange-50" : ""}`}
+                                    onClick={() => { if (!semCusto) toggleUnidade(u.id); }}
+                                    title={semCusto ? "Sem custo_compra — não pode entrar no cálculo de média" : ""}
                                   >
                                     <td className="px-3 py-2">
                                       <input
                                         type="checkbox"
                                         checked={selecionada}
+                                        disabled={semCusto}
                                         onChange={() => toggleUnidade(u.id)}
                                         onClick={(e) => e.stopPropagation()}
-                                        className="w-4 h-4 accent-[#E8740E]"
+                                        className="w-4 h-4 accent-[#E8740E] disabled:cursor-not-allowed"
                                       />
                                     </td>
                                     <td className="px-3 py-2 font-mono text-[11px] text-[#1D1D1F]">
@@ -275,7 +282,9 @@ export default function BalancoSeminovosSection({
                                       ) : <span className="text-[#86868B]">—</span>}
                                     </td>
                                     <td className="px-3 py-2 text-right font-mono text-[#1D1D1F]">{u.qnt}</td>
-                                    <td className="px-3 py-2 text-right font-mono text-[#1D1D1F]">{fmt(u.custo_compra)}</td>
+                                    <td className="px-3 py-2 text-right font-mono text-[#1D1D1F]">
+                                      {semCusto ? <span className="text-yellow-700 text-[11px]">sem custo</span> : fmt(u.custo_compra)}
+                                    </td>
                                     <td className="px-3 py-2 text-right font-mono text-[#86868B]">{fmt(u.custo_unitario)}</td>
                                   </tr>
                                 );


### PR DESCRIPTION
## Summary
- Balanço Manual agora inclui modelos mesmo com unidades sem custo_compra (antes o grupo inteiro sumia). Unidades sem custo aparecem com badge 'sem custo' e checkbox disabled.
- Modal do produto mostra **Preço de Compra** = `custo_compra` (valor que entrou em estoque), não mais custo_unitario (média após balanço).
- Quando há divergência (balanço aplicado), mostra linha extra "Balanço: R$ X".
- API permite editar custo_compra (corrigir erro de digitação). Mantém sincronia com custo_unitario se ainda não há balanço.

## Test plan
- [ ] /admin/estoque > aba Seminovos > Balanço Manual → iPhone 16 Pro Max 256GB aparece
- [ ] Abrir produto com unidade sem custo_compra → badge amarelo "sem custo"
- [ ] Abrir modal de produto → "Preço de Compra" mostra custo_compra
- [ ] Editar preço de compra → salva e atualiza

🤖 Generated with [Claude Code](https://claude.com/claude-code)