### PR TITLE
feat(balanco): Preco de Compra + Balanco separados + fallback legacy

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -6537,8 +6537,6 @@ export default function EstoquePage() {
                         <span className={`text-[13px] ${mS}`}>R$</span>
                         <input
                           type="text" inputMode="numeric"
-                          // Mostra custo_compra (valor que entrou em estoque).
-                          // Fallback pro custo_unitario em itens legados sem custo_compra.
                           defaultValue={(p.custo_compra ?? p.custo_unitario) ? String(p.custo_compra ?? p.custo_unitario) : ""}
                           placeholder="0"
                           onBlur={async (e) => {
@@ -6546,8 +6544,6 @@ export default function EstoquePage() {
                             const num = val ? parseInt(val) : null;
                             const atual = p.custo_compra ?? p.custo_unitario;
                             if (num !== atual) {
-                              // Atualiza custo_compra (o que entrou em estoque). NAO mexe em custo_unitario
-                              // pra nao alterar balancos ja aplicados — isso e feito via Balanco Manual.
                               await apiPatch(p.id, { custo_compra: num });
                               setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, custo_compra: num } : x));
                               setDetailProduct({ ...p, custo_compra: num });
@@ -6561,11 +6557,35 @@ export default function EstoquePage() {
                     ) : (
                       <p className={`text-[14px] font-bold ${mP} mt-0.5`}>{(p.custo_compra ?? p.custo_unitario) ? fmt(p.custo_compra ?? p.custo_unitario!) : "—"}</p>
                     )}
-                    {p.custo_compra != null && p.custo_unitario && Math.abs(p.custo_compra - p.custo_unitario) > 0.5 && (
-                      <p className={`text-[10px] ${mS} mt-0.5`} title="Custo medio apos balanco ponderado">
-                        Balanço: <span className="font-mono text-[#E8740E]">{fmt(p.custo_unitario)}</span>
-                      </p>
+                    <p className={`text-[9px] ${mS} mt-0.5`}>O valor que entrou em estoque</p>
+                  </div>
+                  <div>
+                    <p className={`text-[10px] uppercase tracking-wider ${mS}`}>Balanço (Preço Médio)</p>
+                    {canEdit && isAdmin ? (
+                      <div className="flex items-center gap-1 mt-0.5">
+                        <span className={`text-[13px] ${mS}`}>R$</span>
+                        <input
+                          type="text" inputMode="numeric"
+                          defaultValue={p.custo_unitario ? String(p.custo_unitario) : ""}
+                          placeholder="0"
+                          onBlur={async (e) => {
+                            const val = e.target.value.replace(/\D/g, "");
+                            const num = val ? parseInt(val) : null;
+                            if (num !== p.custo_unitario) {
+                              await apiPatch(p.id, { custo_unitario: num });
+                              setEstoque(prev => prev.map(x => x.id === p.id ? { ...x, custo_unitario: num ?? 0 } : x));
+                              setDetailProduct({ ...p, custo_unitario: num ?? 0 });
+                              showSaved("balanco");
+                            }
+                          }}
+                          onKeyDown={(e) => { if (e.key === "Enter") (e.target as HTMLInputElement).blur(); }}
+                          className={`flex-1 text-[14px] font-bold px-2 py-1 rounded-lg border ${dm ? "bg-[#1C1C1E] border-[#3A3A3C] text-[#E8740E]" : "bg-white border-[#D2D2D7] text-[#E8740E]"} focus:border-[#E8740E] focus:outline-none`}
+                        />
+                      </div>
+                    ) : (
+                      <p className={`text-[14px] font-bold text-[#E8740E] mt-0.5`}>{p.custo_unitario ? fmt(p.custo_unitario) : "—"}</p>
                     )}
+                    <p className={`text-[9px] ${mS} mt-0.5`}>Média após balanço</p>
                   </div>
                   <div><p className={`text-[10px] uppercase tracking-wider ${mS}`}>Categoria</p><p className={`text-[13px] ${mP} mt-0.5`}>{p.categoria}</p></div>
                 </div>

--- a/app/api/admin/recalc-balancos/route.ts
+++ b/app/api/admin/recalc-balancos/route.ts
@@ -43,16 +43,19 @@ export async function POST(req: NextRequest) {
       const { supabase } = await import("@/lib/supabase");
       const { data: itens, error } = await supabase
         .from("estoque")
-        .select("id, qnt, custo_compra")
+        .select("id, qnt, custo_compra, custo_unitario")
         .in("id", body.ids);
       if (error) return NextResponse.json({ error: error.message }, { status: 500 });
       if (!itens || itens.length === 0) return NextResponse.json({ error: "Nenhum item encontrado" }, { status: 404 });
-      // Calcula media ponderada pelas quantidades
+      // Calcula media ponderada pelas quantidades.
+      // Fallback: usa custo_unitario quando custo_compra estiver vazio (itens legados).
       let totalCusto = 0;
       let totalQnt = 0;
       for (const it of itens) {
         const q = Number(it.qnt || 0);
-        const c = Number(it.custo_compra || 0);
+        const ccRaw = Number(it.custo_compra || 0);
+        const cuRaw = Number(it.custo_unitario || 0);
+        const c = ccRaw > 0 ? ccRaw : cuRaw;
         if (c <= 0 || q <= 0) continue;
         totalCusto += q * c;
         totalQnt += q;
@@ -174,9 +177,11 @@ export async function GET(req: NextRequest) {
     }
     const groups = new Map<string, Grupo>();
     for (const raw of (itemsDetalhados || []) as unknown as Row[]) {
-      const cc = Number(raw.custo_compra || 0);
-      // Nao pulamos mais unidades sem custo_compra — mostramos elas pro user ver.
-      // Elas so nao entram no calculo de media ponderada (q/cc=0 nao altera).
+      // Fallback: itens legados so tinham custo_unitario (era o valor de compra no cadastro).
+      // Se custo_compra esta vazio mas custo_unitario existe, usa custo_unitario como cc efetivo.
+      const ccRaw = Number(raw.custo_compra || 0);
+      const cuRaw = Number(raw.custo_unitario || 0);
+      const cc = ccRaw > 0 ? ccRaw : cuRaw;
       const modeloBase = getModeloBase(raw.produto, raw.categoria);
       const key = `${raw.categoria}|${modeloBase}`;
       const g = groups.get(key) || {


### PR DESCRIPTION
## Summary
- Modal do produto mostra **2 campos separados**: 'Preço de Compra' (custo_compra) e 'Balanço (Preço Médio)' (custo_unitario). Ambos editáveis.
- Fallback pra itens legados: quando custo_compra está vazio, usa custo_unitario como valor efetivo no Balanço Manual. Isso resolve o caso dos produtos que apareciam como 'sem custo' mesmo tendo preço salvo.

## Test plan
- [ ] Abrir modal de produto → ver 2 campos (Preço de Compra + Balanço)
- [ ] /admin/estoque > Seminovos > Balanço Manual → todos os produtos com preço aparecem (nenhum 'sem custo' se tem custo_unitario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)