### PR TITLE
fix(reservas): limpar reserva ao esgotar + ocultar ESGOTADOS

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -2633,8 +2633,10 @@ export default function EstoquePage() {
     setImportingInitial(false);
   };
 
-  // Reservados: produtos movidos para a aba Reservas (ficam escondidos das outras listas)
-  const isReservado = (p: ProdutoEstoque) => !!p.reserva_cliente;
+  // Reservados: produtos movidos para a aba Reservas (ficam escondidos das outras listas).
+  // Exclui ESGOTADOS — se foi vendido, a reserva cumpriu o papel (mesmo que os campos ainda
+  // estejam preenchidos em itens legados antes do fix do endpoint de venda).
+  const isReservado = (p: ProdutoEstoque) => !!p.reserva_cliente && p.status !== "ESGOTADO" && p.qnt > 0;
   const reservados = estoque.filter(isReservado);
 
   // Filtrar por tipo (sempre excluindo reservados)

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -356,16 +356,24 @@ export async function POST(req: NextRequest) {
 
   // Descontar do estoque se veio de um produto cadastrado
   if (estoqueId) {
-    const { data: item } = await supabase.from("estoque").select("qnt,produto,tipo").eq("id", estoqueId).single();
+    const { data: item } = await supabase.from("estoque").select("qnt,produto,tipo,reserva_cliente").eq("id", estoqueId).single();
     if (item) {
       const novaQnt = Math.max(0, Number(item.qnt) - 1);
       // Seminovos e Novos: marcar como ESGOTADO ao chegar em qnt=0 (nunca deletar)
       // Isso preserva o ID do item e permite rastreabilidade completa (retorno ao estoque na devolução)
-      await supabase.from("estoque").update({
+      // Quando esgota, limpa a reserva (venda concretizada → reserva cumpriu seu papel).
+      const updatePayload: Record<string, unknown> = {
         qnt: novaQnt,
         status: novaQnt === 0 ? "ESGOTADO" : "EM ESTOQUE",
         updated_at: new Date().toISOString(),
-      }).eq("id", estoqueId);
+      };
+      if (novaQnt === 0 && item.reserva_cliente) {
+        updatePayload.reserva_cliente = null;
+        updatePayload.reserva_data = null;
+        updatePayload.reserva_para = null;
+        updatePayload.reserva_operador = null;
+      }
+      await supabase.from("estoque").update(updatePayload).eq("id", estoqueId);
       await logActivity(
         usuario,
         novaQnt === 0 ? "Esgotou do estoque (auto)" : "Removeu do estoque (auto)",


### PR DESCRIPTION
## Problema
Produtos vendidos continuavam aparecendo na aba Reservas (Laisa/Wagner no print do Nicolas) mesmo com status 'Esgotado' e 0 un. O endpoint de venda não limpava os campos de reserva quando o item chegava em qnt=0.

## Fix
1. **API de venda** limpa `reserva_cliente`, `reserva_data`, `reserva_para`, `reserva_operador` quando item esgota.
2. **Aba Reservas** filtra também por `status !== ESGOTADO && qnt > 0` — esconde os órfãos já no banco.

## Test plan
- [ ] Aba Reservas não mostra mais os iPhones do Laisa/Wagner (esgotados)
- [ ] Reservar produto → vender → some da aba Reservas

🤖 Generated with [Claude Code](https://claude.com/claude-code)