### PR TITLE
feat(vendas): resumo de pagamento em multiplas linhas, uma por metodo

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -3193,25 +3193,55 @@ export default function VendasPage() {
                           }
                         }
                       }} placeholder="Valor da maquina" className={inputCls} /></div>
-                      <div className={`col-span-2 md:col-span-3 rounded-lg px-3 py-2 text-xs flex flex-wrap gap-3 ${dm ? "bg-[#2C2C2E] text-[#98989D]" : "bg-[#F5F5F7] text-[#86868B]"}`}>
-                        <span>Taxa: <strong className="text-[#E8740E]">{taxa.toFixed(2)}%</strong></span>
-                        {(parseFloat(form.valor_comprovante_input) || 0) > 0 && (() => {
-                          const liqPrincDisp = calcularLiquido(parseFloat(form.valor_comprovante_input) || 0, taxa);
-                          const compAltDisp = parseFloat(form.comp_alt) || 0;
-                          const taxaAltDisp = compAltDisp > 0 ? getTaxa(form.banco_alt || "ITAU", form.band_alt || null, parseInt(form.parc_alt) || 0, (form.forma_alt || form.forma || "CARTAO") as "CARTAO" | "LINK") : 0;
-                          const liqAltDisp = compAltDisp > 0 ? (taxaAltDisp > 0 ? calcularLiquido(compAltDisp, taxaAltDisp) : compAltDisp) : 0;
-                          return (
-                          <>
-                            <span>Liquido cartao: <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{fmt(liqPrincDisp)}</strong></span>
-                            {liqAltDisp > 0 && <span>+ 2o cartao: <strong>{fmt(liqAltDisp)}</strong></span>}
-                            {entradaPix > 0 && <span>+ PIX: <strong>{fmt(entradaPix)}</strong></span>}
-                            {entradaEspecie > 0 && <span>+ Especie: <strong>{fmt(entradaEspecie)}</strong></span>}
-                            {valorTroca > 0 && <span>+ Troca: <strong>{fmt(valorTroca)}</strong></span>}
-                            <span>= Vendido: <strong className="text-green-600">{fmt(Math.round(liqPrincDisp + liqAltDisp + entradaPix + entradaEspecie + valorTroca))}</strong></span>
-                          </>
-                          );
-                        })()}
-                      </div>
+                      {(() => {
+                        const compPrincDisp = parseFloat(form.valor_comprovante_input) || 0;
+                        const liqPrincDisp = compPrincDisp > 0 ? calcularLiquido(compPrincDisp, taxa) : 0;
+                        const compAltDisp = parseFloat(form.comp_alt) || 0;
+                        const formaAlt = (form.forma_alt || form.forma || "CARTAO") as "CARTAO" | "LINK";
+                        const bancoAlt = formaAlt === "LINK" ? "MERCADO_PAGO" : (form.banco_alt || "ITAU");
+                        const taxaAltDisp = compAltDisp > 0 ? getTaxa(bancoAlt, form.band_alt || null, parseInt(form.parc_alt) || 0, formaAlt) : 0;
+                        const liqAltDisp = compAltDisp > 0 ? (taxaAltDisp > 0 ? calcularLiquido(compAltDisp, taxaAltDisp) : compAltDisp) : 0;
+                        const bancoPrincLabel = (form.banco || "ITAU").replace("_", " ");
+                        const parcPrinc = parseInt(form.qnt_parcelas) || 1;
+                        const parcAlt = parseInt(form.parc_alt) || 1;
+                        const bancoAltLabel = formaAlt === "LINK" ? "Mercado Pago" : (form.banco_alt || "ITAU").replace("_", " ");
+                        const totalVendido = Math.round(liqPrincDisp + liqAltDisp + entradaPix + entradaEspecie + valorTroca);
+                        return (
+                          <div className={`col-span-2 md:col-span-3 rounded-lg px-3 py-2.5 text-xs ${dm ? "bg-[#2C2C2E] text-[#98989D]" : "bg-[#F5F5F7] text-[#86868B]"}`}>
+                            <div className="space-y-1.5">
+                              <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                                <span>💳 <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{bancoPrincLabel} {form.bandeira ? `(${form.bandeira})` : ""} {parcPrinc}x</strong></span>
+                                <span>• Taxa <strong className="text-[#E8740E]">{taxa.toFixed(2)}%</strong></span>
+                                {compPrincDisp > 0 && <span>• Bruto {fmt(compPrincDisp)}</span>}
+                                {compPrincDisp > 0 && <span>→ Líquido <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{fmt(liqPrincDisp)}</strong></span>}
+                              </div>
+                              {compAltDisp > 0 && (
+                                <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                                  <span>{formaAlt === "LINK" ? "🔗" : "💳"} <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{formaAlt === "LINK" ? "Link Mercado Pago" : bancoAltLabel} {form.band_alt && formaAlt !== "LINK" ? `(${form.band_alt})` : ""} {parcAlt}x</strong></span>
+                                  {taxaAltDisp > 0 && <span>• Taxa <strong className="text-[#E8740E]">{taxaAltDisp.toFixed(2)}%</strong></span>}
+                                  <span>• Bruto {fmt(compAltDisp)}</span>
+                                  <span>→ Líquido <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{fmt(liqAltDisp)}</strong></span>
+                                </div>
+                              )}
+                              {entradaPix > 0 && (
+                                <div className="flex flex-wrap items-center gap-x-2"><span>💸 <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>Pix</strong></span><span>• Valor {fmt(entradaPix)}</span></div>
+                              )}
+                              {entradaEspecie > 0 && (
+                                <div className="flex flex-wrap items-center gap-x-2"><span>💵 <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>Espécie</strong></span><span>• Valor {fmt(entradaEspecie)}</span></div>
+                              )}
+                              {valorTroca > 0 && (
+                                <div className="flex flex-wrap items-center gap-x-2"><span>🔄 <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>Troca</strong></span><span>• Valor {fmt(valorTroca)}</span></div>
+                              )}
+                              {compPrincDisp > 0 && (
+                                <div className={`pt-1.5 border-t ${dm ? "border-[#3A3A3C]" : "border-[#E5E5EA]"} flex items-center gap-2`}>
+                                  <span>✅ <strong>Total Vendido:</strong></span>
+                                  <strong className="text-green-600 text-sm">{fmt(totalVendido)}</strong>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })()}
                     </>
                   )}
                 </>
@@ -3234,25 +3264,54 @@ export default function VendasPage() {
                           }
                         }
                       }} placeholder="Valor total do link" className={inputCls} /></div>
-                      <div className={`col-span-2 md:col-span-3 rounded-lg px-3 py-2 text-xs flex flex-wrap gap-3 ${dm ? "bg-[#2C2C2E] text-[#98989D]" : "bg-[#F5F5F7] text-[#86868B]"}`}>
-                        <span>Taxa MP: <strong className="text-[#E8740E]">{taxa.toFixed(2)}%</strong></span>
-                        {(parseFloat(form.valor_comprovante_input) || 0) > 0 && (() => {
-                          const liqPrincDisp = calcularLiquido(parseFloat(form.valor_comprovante_input) || 0, taxa);
-                          const compAltDisp = parseFloat(form.comp_alt) || 0;
-                          const taxaAltDisp = compAltDisp > 0 ? getTaxa(form.banco_alt || "ITAU", form.band_alt || null, parseInt(form.parc_alt) || 0, (form.forma_alt || "CARTAO") as "CARTAO" | "LINK") : 0;
-                          const liqAltDisp = compAltDisp > 0 ? (taxaAltDisp > 0 ? calcularLiquido(compAltDisp, taxaAltDisp) : compAltDisp) : 0;
-                          return (
-                          <>
-                            <span>Liquido: <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{fmt(liqPrincDisp)}</strong></span>
-                            {liqAltDisp > 0 && <span>+ 2o cartao: <strong>{fmt(liqAltDisp)}</strong></span>}
-                            {entradaPix > 0 && <span>+ PIX: <strong>{fmt(entradaPix)}</strong></span>}
-                            {entradaEspecie > 0 && <span>+ Especie: <strong>{fmt(entradaEspecie)}</strong></span>}
-                            {valorTroca > 0 && <span>+ Troca: <strong>{fmt(valorTroca)}</strong></span>}
-                            <span>= Vendido: <strong className="text-green-600">{fmt(Math.round(liqPrincDisp + liqAltDisp + entradaPix + entradaEspecie + valorTroca))}</strong></span>
-                          </>
-                          );
-                        })()}
-                      </div>
+                      {(() => {
+                        const compPrincDisp = parseFloat(form.valor_comprovante_input) || 0;
+                        const liqPrincDisp = compPrincDisp > 0 ? calcularLiquido(compPrincDisp, taxa) : 0;
+                        const compAltDisp = parseFloat(form.comp_alt) || 0;
+                        const formaAlt = (form.forma_alt || "CARTAO") as "CARTAO" | "LINK";
+                        const bancoAlt = formaAlt === "LINK" ? "MERCADO_PAGO" : (form.banco_alt || "ITAU");
+                        const taxaAltDisp = compAltDisp > 0 ? getTaxa(bancoAlt, form.band_alt || null, parseInt(form.parc_alt) || 0, formaAlt) : 0;
+                        const liqAltDisp = compAltDisp > 0 ? (taxaAltDisp > 0 ? calcularLiquido(compAltDisp, taxaAltDisp) : compAltDisp) : 0;
+                        const parcPrinc = parseInt(form.qnt_parcelas) || 1;
+                        const parcAlt = parseInt(form.parc_alt) || 1;
+                        const bancoAltLabel = formaAlt === "LINK" ? "Mercado Pago" : (form.banco_alt || "ITAU").replace("_", " ");
+                        const totalVendido = Math.round(liqPrincDisp + liqAltDisp + entradaPix + entradaEspecie + valorTroca);
+                        return (
+                          <div className={`col-span-2 md:col-span-3 rounded-lg px-3 py-2.5 text-xs ${dm ? "bg-[#2C2C2E] text-[#98989D]" : "bg-[#F5F5F7] text-[#86868B]"}`}>
+                            <div className="space-y-1.5">
+                              <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                                <span>🔗 <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>Link Mercado Pago {parcPrinc}x</strong></span>
+                                <span>• Taxa <strong className="text-[#E8740E]">{taxa.toFixed(2)}%</strong></span>
+                                {compPrincDisp > 0 && <span>• Bruto {fmt(compPrincDisp)}</span>}
+                                {compPrincDisp > 0 && <span>→ Líquido <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{fmt(liqPrincDisp)}</strong></span>}
+                              </div>
+                              {compAltDisp > 0 && (
+                                <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5">
+                                  <span>{formaAlt === "LINK" ? "🔗" : "💳"} <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{formaAlt === "LINK" ? "Link Mercado Pago" : bancoAltLabel} {form.band_alt && formaAlt !== "LINK" ? `(${form.band_alt})` : ""} {parcAlt}x</strong></span>
+                                  {taxaAltDisp > 0 && <span>• Taxa <strong className="text-[#E8740E]">{taxaAltDisp.toFixed(2)}%</strong></span>}
+                                  <span>• Bruto {fmt(compAltDisp)}</span>
+                                  <span>→ Líquido <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{fmt(liqAltDisp)}</strong></span>
+                                </div>
+                              )}
+                              {entradaPix > 0 && (
+                                <div className="flex flex-wrap items-center gap-x-2"><span>💸 <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>Pix</strong></span><span>• Valor {fmt(entradaPix)}</span></div>
+                              )}
+                              {entradaEspecie > 0 && (
+                                <div className="flex flex-wrap items-center gap-x-2"><span>💵 <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>Espécie</strong></span><span>• Valor {fmt(entradaEspecie)}</span></div>
+                              )}
+                              {valorTroca > 0 && (
+                                <div className="flex flex-wrap items-center gap-x-2"><span>🔄 <strong className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>Troca</strong></span><span>• Valor {fmt(valorTroca)}</span></div>
+                              )}
+                              {compPrincDisp > 0 && (
+                                <div className={`pt-1.5 border-t ${dm ? "border-[#3A3A3C]" : "border-[#E5E5EA]"} flex items-center gap-2`}>
+                                  <span>✅ <strong>Total Vendido:</strong></span>
+                                  <strong className="text-green-600 text-sm">{fmt(totalVendido)}</strong>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })()}
                     </>
                   )}
                 </>


### PR DESCRIPTION
## Antes
\`Taxa: 8.99% • Líquido: R\$ 4.551 • + 2o cartão: R\$ 4.388 • = Vendido: R\$ 8.938\` — tudo numa linha só, difícil identificar qual taxa é de qual forma.

## Depois
Uma linha por método, com label explícito:
- 💳 Máquina ITAU (Visa, 12x) • Taxa 8.99% • Bruto R\$ 5.000 → Líquido R\$ 4.551
- 🔗 Link Mercado Pago 12x • Taxa 11.35% • Bruto R\$ 4.949 → Líquido R\$ 4.388
- 💸 Pix • Valor R\$ 2.000
- ─────────────
- ✅ Total Vendido: R\$ 10.939

## Test plan
- [ ] CARTAO + 2a forma LINK → duas linhas com taxas corretas
- [ ] LINK + 2a forma CARTAO → duas linhas
- [ ] Sozinho (sem 2a forma) → apenas 1 linha + total

🤖 Generated with [Claude Code](https://claude.com/claude-code)