### PR TITLE
fix(funcionarios): grants RLS + manter patrimonio da empresa ao vincular

### DIFF
--- a/app/api/admin/produtos-funcionarios/route.ts
+++ b/app/api/admin/produtos-funcionarios/route.ts
@@ -92,10 +92,13 @@ export async function POST(req: NextRequest) {
       imei = item.imei;
       valorTotal = Number(item.custo_compra || item.custo_unitario || 0);
 
-      // Marca item como COM_FUNCIONARIO (sai do estoque disponivel)
+      // Marca item como COM_FUNCIONARIO — MANTEM qnt=1 porque o produto ainda
+      // eh patrimonio da empresa (nao foi vendido, apenas cedido/emprestado).
+      // Status 'COM_FUNCIONARIO' garante que ele nao aparece em listas de
+      // 'estoque disponivel' (/admin/estoque filtra por status='EM ESTOQUE'),
+      // mas continua contando no patrimonio total (qnt * custo_unitario).
       await supabase.from("estoque").update({
         status: "COM_FUNCIONARIO",
-        qnt: 0,
         updated_at: new Date().toISOString(),
       }).eq("id", estoque_id);
     }
@@ -182,11 +185,10 @@ export async function PATCH(req: NextRequest) {
     if (!antes) return NextResponse.json({ error: "Não encontrado" }, { status: 404 });
 
     if (devolver) {
-      // Retorna ao estoque se tinha origem
+      // Retorna ao estoque se tinha origem — so precisa trocar o status (qnt nunca foi zerado).
       if (antes.estoque_id) {
         await supabase.from("estoque").update({
           status: "EM ESTOQUE",
-          qnt: 1,
           updated_at: new Date().toISOString(),
         }).eq("id", antes.estoque_id);
       }
@@ -254,11 +256,10 @@ export async function DELETE(req: NextRequest) {
       .from("produtos_funcionarios").select("*").eq("id", id).single();
     if (!antes) return NextResponse.json({ error: "Não encontrado" }, { status: 404 });
 
-    // Retorna ao estoque
+    // Retorna ao estoque — so troca o status (qnt sempre se manteve).
     if (antes.estoque_id) {
       await supabase.from("estoque").update({
         status: "EM ESTOQUE",
-        qnt: 1,
         updated_at: new Date().toISOString(),
       }).eq("id", antes.estoque_id);
     }

--- a/supabase/migrations/20260417i_produtos_funcionarios_grants.sql
+++ b/supabase/migrations/20260417i_produtos_funcionarios_grants.sql
@@ -1,0 +1,10 @@
+-- Concede privilegios nas tabelas de produtos_funcionarios
+-- (a primeira migration criou as tabelas mas nao liberou acesso via API)
+
+GRANT ALL ON produtos_funcionarios TO anon, authenticated, service_role;
+GRANT ALL ON produtos_funcionarios_pagamentos TO anon, authenticated, service_role;
+
+-- Desabilita RLS (tabelas admin-only — o acesso ja eh controlado pela API
+-- que valida o x-admin-password antes de qualquer operacao).
+ALTER TABLE produtos_funcionarios DISABLE ROW LEVEL SECURITY;
+ALTER TABLE produtos_funcionarios_pagamentos DISABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Problemas reportados
1. Erro \"permission denied for table produtos_funcionarios\" ao vincular.
2. \"Esse produto tem que continuar marcado como patrimônio da empresa\" — ao vincular, valor do produto sumia do total de estoque porque qnt virava 0.

## Fixes

### 1. Grants/RLS
Nova migration \`20260417i_produtos_funcionarios_grants.sql\`:
- GRANT ALL pra anon/authenticated/service_role
- DISABLE ROW LEVEL SECURITY (acesso controlado pela API via x-admin-password)

### 2. Preservar patrimônio
Antes: vincular zerava \`estoque.qnt=0\` → produto sumia do cálculo de \`qnt * custo_unitario\`.
Agora: mantém \`qnt=1\`, só muda \`status=COM_FUNCIONARIO\`. Produto continua contando como patrimônio da empresa, só não aparece em listas de estoque disponível (que filtram por \`status='EM ESTOQUE'\`).

## ⚠️ Após merge
Rodar migration \`20260417i_produtos_funcionarios_grants.sql\` em \`/admin/migrations\`.

## Test plan
- [ ] Rodar migration
- [ ] Vincular produto → sem erro
- [ ] /admin/estoque → produto some da aba de disponível
- [ ] Total de patrimônio/valor do estoque continua incluindo esse item
- [ ] Devolver → volta a aparecer na aba disponível

🤖 Generated with [Claude Code](https://claude.com/claude-code)