### PR TITLE
fix(funcionarios): backfill de produtos orfaos no estoque

### DIFF
--- a/supabase/migrations/20260417j_backfill_com_funcionario.sql
+++ b/supabase/migrations/20260417j_backfill_com_funcionario.sql
@@ -1,0 +1,12 @@
+-- Backfill: produtos que foram vinculados a funcionarios ANTES do fix ficaram
+-- orfaos no estoque (qnt=1, status variado). Esse script corrige:
+-- pra cada vinculo ativo (nao DEVOLVIDO) com estoque_id, forca o item do estoque
+-- pra qnt=0 + status=COM_FUNCIONARIO.
+
+UPDATE estoque e
+SET status = 'COM_FUNCIONARIO',
+    qnt = 0,
+    updated_at = NOW()
+FROM produtos_funcionarios pf
+WHERE pf.estoque_id = e.id
+  AND pf.status NOT IN ('DEVOLVIDO');


### PR DESCRIPTION
## Problema
Produto vinculado à Paloma (iPhone 15 Pro Max) ainda aparece no estoque mesmo depois do fix. Vínculos antigos (criados antes das PRs #522/#524) não tiveram o estoque atualizado corretamente.

## Fix
Migration de backfill `20260417j_backfill_com_funcionario.sql` que força `qnt=0 + status=COM_FUNCIONARIO` em todos os itens de estoque que estão em vínculos ativos (não DEVOLVIDO) com funcionários.

## ⚠️ Após merge
Rodar migration em `/admin/migrations` → produto some do estoque imediatamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)