### PR TITLE
fix(funcionarios): CHECK constraint de estoque.status aceita COM_FUNCIONARIO

### DIFF
--- a/supabase/migrations/20260417k_estoque_status_com_funcionario.sql
+++ b/supabase/migrations/20260417k_estoque_status_com_funcionario.sql
@@ -1,0 +1,23 @@
+-- O CHECK constraint existente em estoque.status nao aceita 'COM_FUNCIONARIO'.
+-- Recria aceitando todos os status conhecidos + COM_FUNCIONARIO.
+
+ALTER TABLE estoque DROP CONSTRAINT IF EXISTS estoque_status_check;
+ALTER TABLE estoque ADD CONSTRAINT estoque_status_check
+  CHECK (status IN (
+    'EM ESTOQUE',
+    'ESGOTADO',
+    'A CAMINHO',
+    'PENDENTE',
+    'RESERVADO',
+    'DEVOLVIDO',
+    'COM_FUNCIONARIO'
+  ));
+
+-- Agora roda o backfill (igual ao 20260417j que falhou)
+UPDATE estoque e
+SET status = 'COM_FUNCIONARIO',
+    qnt = 0,
+    updated_at = NOW()
+FROM produtos_funcionarios pf
+WHERE pf.estoque_id = e.id
+  AND pf.status NOT IN ('DEVOLVIDO');


### PR DESCRIPTION
## Problema
Migration 20260417j falhou com `violates check constraint 'estoque_status_check'`. Esse era o motivo do produto da Paloma continuar em estoque — todos os updates pra `status='COM_FUNCIONARIO'` eram rejeitados pelo banco (inclusive os do código normal de vincular).

## Fix
Migration `20260417k`:
1. DROP + recria o CHECK incluindo COM_FUNCIONARIO
2. Executa o backfill (igual 20260417j)

## ⚠️ Após merge
Rodar `20260417k_estoque_status_com_funcionario.sql` em /admin/migrations. Produto da Paloma vai sumir do estoque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)