### PR TITLE
feat(estoque): seminovo usa layout card do Lacrado + vincular funcionario

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -1720,6 +1720,9 @@ export default function EstoquePage() {
   type BancoValores = Record<Banco, string>;
   const emptyBancoValores = (): BancoValores => ({ ITAU: "", INFINITE: "", MERCADO_PAGO: "", ESPECIE: "" });
   const [pedidoProdutos, setPedidoProdutos] = useState<ProdutoRowState[]>([createEmptyProdutoRow()]);
+  // Vincular a funcionario ao cadastrar (opcional)
+  const [vincularFuncionario, setVincularFuncionario] = useState(false);
+  const [funcForm, setFuncForm] = useState({ funcionario: "", tipoAcordo: "CEDIDO" as "CEDIDO" | "PARCIAL" | "TOTAL" | "SUBSIDIADO" | "OUTRO", percentual: 50, observacao: "" });
   const [bancoValores, setBancoValores] = useState<BancoValores>(emptyBancoValores());
   const [descricaoGasto, setDescricaoGasto] = useState("");
   const totalPagamento = BANCOS.reduce((s, b) => s + (parseFloat(bancoValores[b]) || 0), 0);
@@ -2439,12 +2442,25 @@ export default function EstoquePage() {
     let successCount = 0;
     let errorMsg = "";
     const mergeMessages: string[] = [];
+    const savedIds: string[] = [];
 
     for (const p of pedidoProdutos) {
       // Para categorias estruturadas, SEMPRE usar buildProdutoName (ignora p.produto livre)
       const isStructured = STRUCTURED_CATS_LIST.includes(getBaseCat(p.categoria));
       const nome = (isStructured ? buildProdutoNameFromSpec(p.categoria, p.spec, p.cor) : p.produto || "").toUpperCase();
       if (!nome) continue;
+
+      // Monta observacao com tags (grade/caixa/cabo/fonte) + texto livre
+      const obsParts: string[] = [];
+      if (p.observacao?.trim()) obsParts.push(p.observacao.trim());
+      if (p.grade) obsParts.push(`[GRADE_${p.grade}]`);
+      if (p.caixa) obsParts.push("[COM_CAIXA]");
+      if (p.cabo) obsParts.push("[COM_CABO]");
+      if (p.fonte) obsParts.push("[COM_FONTE]");
+      // tipo=A_CAMINHO com condicao diferente de NOVO: prefixa
+      if (form.tipo === "A_CAMINHO" && p.condicao && p.condicao !== "NOVO") obsParts.unshift(`[${p.condicao}]`);
+      const obsFinal = obsParts.length > 0 ? obsParts.join(" ") : null;
+
       const res = await fetch("/api/estoque", {
         method: "POST",
         headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(userName) },
@@ -2453,32 +2469,59 @@ export default function EstoquePage() {
           categoria: p.categoria,
           qnt: parseInt(p.qnt) || 1,
           custo_unitario: parseFloat(p.custo_unitario) || 0,
+          custo_compra: parseFloat(p.custo_unitario) || 0,
           status,
           cor: p.cor || null,
           tipo,
           fornecedor: p.fornecedor || null,
+          cliente: p.cliente || null,
           imei: p.imei || null,
           serial_no: p.serial_no || null,
           origem_compra: form.origem_compra || null,
           data_entrada: hojeBR(),
-          observacao: (form.tipo === "A_CAMINHO" && p.condicao && p.condicao !== "NOVO")
-            ? `[${p.condicao}]`
-            : null,
+          bateria: p.bateria ? parseInt(p.bateria) : null,
+          garantia: p.garantia || null,
+          observacao: obsFinal,
         }),
       });
       const json = await res.json();
       if (json.ok) {
         successCount++;
+        if (json.data?.[0]?.id) savedIds.push(json.data[0].id);
         if (json.merged && json.mergeDetails) {
           mergeMessages.push(`🔄 ${p.produto || nome}: ${json.mergeDetails.log}`);
         }
       } else { errorMsg = json.error; }
     }
 
+    // Vincular a funcionário se marcado
+    if (vincularFuncionario && funcForm.funcionario.trim() && savedIds.length > 0) {
+      const pct = Math.max(0, Math.min(100, Number(funcForm.percentual)));
+      for (const estoqueId of savedIds) {
+        try {
+          await fetch("/api/admin/produtos-funcionarios", {
+            method: "POST",
+            headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(userName) },
+            body: JSON.stringify({
+              estoque_id: estoqueId,
+              funcionario: funcForm.funcionario.trim(),
+              tipo_acordo: funcForm.tipoAcordo,
+              percentual_funcionario: pct,
+              observacao: funcForm.observacao.trim() || "Vinculado ao cadastrar no estoque",
+              data_saida: hojeBR(),
+            }),
+          });
+        } catch { /* silent */ }
+      }
+    }
+
     if (successCount > 0) {
       const mergeInfo = mergeMessages.length > 0 ? ` | ${mergeMessages.join(" | ")}` : "";
-      setMsg(`${successCount} produto(s) adicionados${status === "A CAMINHO" ? " como A Caminho" : " ao estoque"}!${mergeInfo}${errorMsg ? ` (${errorMsg})` : ""}`);
+      const funcInfo = vincularFuncionario && funcForm.funcionario.trim() ? ` + vinculado a ${funcForm.funcionario.trim()}` : "";
+      setMsg(`${successCount} produto(s) adicionados${status === "A CAMINHO" ? " como A Caminho" : " ao estoque"}${funcInfo}!${mergeInfo}${errorMsg ? ` (${errorMsg})` : ""}`);
       setPedidoProdutos([createEmptyProdutoRow()]);
+      setVincularFuncionario(false);
+      setFuncForm({ funcionario: "", tipoAcordo: "CEDIDO", percentual: 50, observacao: "" });
       fetchEstoque();
       setFilterCat(pedidoProdutos[0]?.categoria || "");
     } else {
@@ -3764,7 +3807,13 @@ export default function EstoquePage() {
                 <option value="ACESSORIOS">Acessórios Seminovo</option>
               </select></div>
             ) : (
-              <div><p className={labelCls}>Tipo</p><select value={form.tipo} onChange={(e) => set("tipo", e.target.value)} className={inputCls}>
+              <div><p className={labelCls}>Tipo</p><select value={form.tipo} onChange={(e) => {
+                const novoTipo = e.target.value;
+                set("tipo", novoTipo);
+                // Sincroniza condicao dos produtos do carrinho com o tipo selecionado
+                const condicao = novoTipo === "NAO_ATIVADO" ? "NAO_ATIVADO" : novoTipo === "SEMINOVO" ? "SEMINOVO" : "NOVO";
+                setPedidoProdutos(prev => prev.map(p => ({ ...p, condicao })));
+              }} className={inputCls}>
                 <option value="NOVO">Novo (Lacrado)</option>
                 <option value="NAO_ATIVADO">Não Ativado</option>
                 <option value="SEMINOVO">Seminovo</option>
@@ -3773,8 +3822,8 @@ export default function EstoquePage() {
             )}
           </div>
 
-          {/* MODO MULTI-PRODUTO (NOVO e A_CAMINHO) */}
-          {(form.tipo === "NOVO" || form.tipo === "A_CAMINHO") && form.categoria !== "SEMINOVOS" ? (
+          {/* MODO MULTI-PRODUTO (NOVO, SEMINOVO, NAO_ATIVADO e A_CAMINHO) */}
+          {(form.tipo === "NOVO" || form.tipo === "A_CAMINHO" || form.tipo === "SEMINOVO" || form.tipo === "NAO_ATIVADO") && form.categoria !== "SEMINOVOS" ? (
             <div className="space-y-4">
               {form.tipo === "A_CAMINHO" && (
                 <div className={`p-3 rounded-xl border ${dm ? "bg-[#2C2C2E] border-[#3A3A3C]" : "bg-[#FFF8F0] border-[#E8740E]/20"}`}>
@@ -3826,8 +3875,62 @@ export default function EstoquePage() {
                 </button>
               </div>
 
+              {/* Vincular a funcionário (opcional) — aparece pra NOVO, SEMINOVO e NAO_ATIVADO */}
+              {form.tipo !== "A_CAMINHO" && (
+                <div className={`p-4 rounded-xl border ${dm ? "border-[#3A3A3C] bg-[#1C1C1E]" : "border-[#E8E8ED] bg-[#FAFAFA]"}`}>
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input type="checkbox" checked={vincularFuncionario} onChange={e => setVincularFuncionario(e.target.checked)} className="w-4 h-4 accent-[#E8740E]" />
+                    <span className={`text-sm font-semibold ${textPrimary}`}>👥 Já vincular a um funcionário?</span>
+                  </label>
+                  <p className={`text-[11px] ${textSecondary} mt-1 ml-6`}>
+                    Marque se o produto vai direto pra um colaborador (cedido/parcial/etc). Sai do estoque disponível e entra em /admin/produtos-funcionarios.
+                  </p>
+                  {vincularFuncionario && (
+                    <div className="mt-3 pl-6 space-y-3">
+                      <div className="grid grid-cols-2 gap-3">
+                        <div>
+                          <p className={labelCls}>Funcionário</p>
+                          <input type="text" value={funcForm.funcionario} onChange={e => setFuncForm(f => ({ ...f, funcionario: e.target.value }))} placeholder="Ex: Paloma" className={inputCls} />
+                        </div>
+                        <div>
+                          <p className={labelCls}>Tipo de acordo</p>
+                          <select value={funcForm.tipoAcordo} onChange={e => setFuncForm(f => ({ ...f, tipoAcordo: e.target.value as typeof f.tipoAcordo }))} className={inputCls}>
+                            <option value="CEDIDO">Cedido (empresa paga 100%)</option>
+                            <option value="PARCIAL">Pagamento parcial</option>
+                            <option value="TOTAL">Pagamento total</option>
+                            <option value="SUBSIDIADO">Subsidiado pela empresa</option>
+                            <option value="OUTRO">Outro</option>
+                          </select>
+                        </div>
+                      </div>
+                      {(funcForm.tipoAcordo === "PARCIAL" || funcForm.tipoAcordo === "SUBSIDIADO") && (
+                        <div>
+                          <div className="flex items-center justify-between mb-1">
+                            <span className={`text-[11px] uppercase ${textSecondary} font-bold`}>Funcionário paga</span>
+                            <span className="text-sm font-bold text-[#E8740E]">{funcForm.percentual}%</span>
+                          </div>
+                          <input type="range" min={10} max={100} step={5} value={funcForm.percentual} onChange={e => setFuncForm(f => ({ ...f, percentual: Number(e.target.value) }))} className="w-full accent-[#E8740E]" />
+                        </div>
+                      )}
+                      <div>
+                        <p className={labelCls}>Observação do acordo</p>
+                        <textarea rows={2} value={funcForm.observacao} onChange={e => setFuncForm(f => ({ ...f, observacao: e.target.value }))} placeholder="Ex: Empresa cedeu pra uso no trabalho. Funcionário devolve ao sair." className={inputCls} />
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
               <button onClick={handleSubmitMulti} className="w-full py-4 rounded-2xl bg-[#E8740E] text-white text-[15px] font-semibold hover:bg-[#D06A0D] transition-colors shadow-sm active:scale-[0.99]">
-                {form.tipo === "A_CAMINHO" ? `Adicionar ${pedidoProdutos.length} como A Caminho` : `Adicionar ${pedidoProdutos.length} ao Estoque`}
+                {form.tipo === "A_CAMINHO"
+                  ? `Adicionar ${pedidoProdutos.length} como A Caminho`
+                  : vincularFuncionario && funcForm.funcionario.trim()
+                    ? `Adicionar ${pedidoProdutos.length} e vincular a ${funcForm.funcionario.trim()}`
+                    : form.tipo === "SEMINOVO"
+                      ? `Adicionar ${pedidoProdutos.length} Seminovo${pedidoProdutos.length > 1 ? "s" : ""}`
+                      : form.tipo === "NAO_ATIVADO"
+                        ? `Adicionar ${pedidoProdutos.length} Não Ativado${pedidoProdutos.length > 1 ? "s" : ""}`
+                        : `Adicionar ${pedidoProdutos.length} ao Estoque`}
               </button>
             </div>
           ) : (

--- a/app/admin/gastos/page.tsx
+++ b/app/admin/gastos/page.tsx
@@ -179,7 +179,12 @@ function produtoToRowState(p: any, fornecedoresList: { id: string; nome: string 
     serial_no: p.serial_no || "",
     condicao: condicaoInicial,
     caixa: caixaInicial,
+    cabo: !!(p.observacao && p.observacao.includes("[COM_CABO]")),
+    fonte: !!(p.observacao && p.observacao.includes("[COM_FONTE]")),
     grade: gradeInicial,
+    bateria: p.bateria ? String(p.bateria) : "",
+    garantia: p.garantia || "",
+    observacao: (p.observacao || "").replace(/\[GRADE_[^\]]+\]|\[COM_CAIXA\]|\[COM_CABO\]|\[COM_FONTE\]|\[NAO_ATIVADO\]|\[SEMINOVO\]/g, "").trim(),
   };
 }
 

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -180,7 +180,12 @@ export interface ProdutoRowState {
   serial_no: string;
   condicao: string; // "NOVO" | "NAO_ATIVADO" | "SEMINOVO"
   caixa: boolean;   // tem caixa original?
+  cabo: boolean;    // (SEMINOVO) tem cabo original?
+  fonte: boolean;   // (SEMINOVO) tem fonte original?
   grade: string;    // grade de qualidade: "A+" | "A" | "AB" | "B" | ""
+  bateria: string;  // (SEMINOVO) saude da bateria em %
+  garantia: string; // (SEMINOVO) data ou validade da garantia
+  observacao: string; // (SEMINOVO) detalhes adicionais
 }
 
 export function createEmptyProdutoRow(): ProdutoRowState {
@@ -199,7 +204,12 @@ export function createEmptyProdutoRow(): ProdutoRowState {
     serial_no: "",
     condicao: "NOVO",
     caixa: false,
+    cabo: false,
+    fonte: false,
     grade: "",
+    bateria: "",
+    garantia: "",
+    observacao: "",
   };
 }
 
@@ -503,41 +513,69 @@ export default function ProdutoSpecFields({
         </div>}
       </div>
 
-      {/* Caixa + Grade — só aparece quando não é Lacrado e não é modo compacto */}
+      {/* Seminovo/NaoAtivado extras: Caixa + Cabo + Fonte + Grade + Bateria + Garantia + Observacao */}
       {!compactMode && row.condicao !== "NOVO" && (
-        <div className="flex items-center gap-3">
-          {/* Caixa toggle */}
-          <button
-            type="button"
-            onClick={() => set("caixa", !row.caixa)}
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-semibold transition-colors ${
-              row.caixa
-                ? "bg-green-500/15 border-green-500/40 text-green-600"
+        <div className="space-y-3">
+          {/* Toggles: Caixa / Cabo / Fonte */}
+          <div className="flex items-center gap-2 flex-wrap">
+            <button type="button" onClick={() => set("caixa", !row.caixa)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-semibold transition-colors ${
+                row.caixa ? "bg-green-500/15 border-green-500/40 text-green-600"
                 : dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#98989D]" : "bg-[#F5F5F7] border-[#D2D2D7] text-[#86868B]"
-            }`}
-          >
-            📦 {row.caixa ? "Com caixa" : "Sem caixa"}
-          </button>
-          {/* Grade select */}
-          <div className="flex items-center gap-1.5">
-            <span className={`text-xs font-semibold ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Grade</span>
-            {(["A+", "A", "AB", "B"] as const).map((g) => (
-              <button
-                key={g}
-                type="button"
-                onClick={() => set("grade", row.grade === g ? "" : g)}
-                className={`px-2 h-7 min-w-[28px] rounded-lg text-xs font-bold border transition-colors ${
-                  row.grade === g
-                    ? g === "A+" ? "bg-amber-500/15 border-amber-500/40 text-amber-600"
-                      : g === "A" ? "bg-green-500/15 border-green-500/40 text-green-600"
-                      : g === "AB" ? "bg-yellow-500/15 border-yellow-500/40 text-yellow-600"
-                      : "bg-orange-500/15 border-orange-500/40 text-orange-600"
-                    : dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#98989D]" : "bg-[#F5F5F7] border-[#D2D2D7] text-[#86868B]"
-                }`}
-              >
-                {g}
-              </button>
-            ))}
+              }`}>
+              📦 {row.caixa ? "Com caixa" : "Sem caixa"}
+            </button>
+            <button type="button" onClick={() => set("cabo", !row.cabo)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-semibold transition-colors ${
+                row.cabo ? "bg-blue-500/15 border-blue-500/40 text-blue-600"
+                : dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#98989D]" : "bg-[#F5F5F7] border-[#D2D2D7] text-[#86868B]"
+              }`}>
+              🔌 {row.cabo ? "Com cabo" : "Sem cabo"}
+            </button>
+            <button type="button" onClick={() => set("fonte", !row.fonte)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-xs font-semibold transition-colors ${
+                row.fonte ? "bg-purple-500/15 border-purple-500/40 text-purple-600"
+                : dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#98989D]" : "bg-[#F5F5F7] border-[#D2D2D7] text-[#86868B]"
+              }`}>
+              🔋 {row.fonte ? "Com fonte" : "Sem fonte"}
+            </button>
+            {/* Grade */}
+            <div className="flex items-center gap-1.5 ml-2">
+              <span className={`text-xs font-semibold ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Grade</span>
+              {(["A+", "A", "AB", "B"] as const).map((g) => (
+                <button key={g} type="button" onClick={() => set("grade", row.grade === g ? "" : g)}
+                  className={`px-2 h-7 min-w-[28px] rounded-lg text-xs font-bold border transition-colors ${
+                    row.grade === g
+                      ? g === "A+" ? "bg-amber-500/15 border-amber-500/40 text-amber-600"
+                        : g === "A" ? "bg-green-500/15 border-green-500/40 text-green-600"
+                        : g === "AB" ? "bg-yellow-500/15 border-yellow-500/40 text-yellow-600"
+                        : "bg-orange-500/15 border-orange-500/40 text-orange-600"
+                      : dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#98989D]" : "bg-[#F5F5F7] border-[#D2D2D7] text-[#86868B]"
+                  }`}>
+                  {g}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Bateria + Garantia (bateria apenas pra iPhones/iPads/Watch) */}
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+            {(row.categoria === "IPHONES" || row.categoria === "IPADS" || row.categoria === "APPLE_WATCH") && (
+              <div>
+                <p className={labelCls}>Bateria %</p>
+                <input type="number" min={0} max={100} value={row.bateria} onChange={(e) => set("bateria", e.target.value)} placeholder="Ex: 91" className={inputCls} />
+              </div>
+            )}
+            <div>
+              <p className={labelCls}>Garantia</p>
+              <input type="text" value={row.garantia} onChange={(e) => set("garantia", e.target.value)} placeholder="DD/MM/AAAA ou MM/AAAA" className={inputCls} />
+            </div>
+          </div>
+
+          {/* Observacao */}
+          <div>
+            <p className={labelCls}>Observação</p>
+            <input type="text" value={row.observacao} onChange={(e) => set("observacao", e.target.value)} placeholder="Detalhes adicionais..." className={inputCls} />
           </div>
         </div>
       )}


### PR DESCRIPTION
## Mudancas
1. **Seminovo no mesmo layout do Lacrado**: cards multi-produto (ProdutoSpecFields), com Caixa/Cabo/Fonte, Grade A+/A/AB/B, Bateria %, Garantia e Observação por card. Permite cadastrar vários seminovos de uma vez.
2. **Vincular a funcionário ao cadastrar**: checkbox no final. Se marcado, captura funcionário + tipo de acordo (Cedido/Parcial/Total/Subsidiado/Outro) + slider % pra PARCIAL + observação. Ao adicionar, já vincula automaticamente — produto sai do estoque e vai pra /admin/produtos-funcionarios.

## Test plan
- [ ] Tipo=Seminovo → layout em cards
- [ ] Toggles Caixa/Cabo/Fonte funcionam
- [ ] Grade + Bateria + Garantia salvam
- [ ] Marcar "Vincular a funcionário" → campo funcionário, tipo acordo, slider, observação
- [ ] Adicionar → produto some do estoque, aparece em /admin/produtos-funcionarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)