### PR TITLE
feat(funcionarios): vincular SALARIO + busca com tag TIGRAO no estoque

### DIFF
--- a/app/admin/gastos/page.tsx
+++ b/app/admin/gastos/page.tsx
@@ -39,6 +39,7 @@ interface GastoGrupo {
   hora: string | null;
   is_dep_esp: boolean;
   bancos: string;
+  funcionario: string | null;
 }
 
 function agruparGastos(gastos: Gasto[]): GastoGrupo[] {
@@ -73,6 +74,7 @@ function agruparGastos(gastos: Gasto[]): GastoGrupo[] {
       hora: first.hora,
       is_dep_esp: first.is_dep_esp,
       bancos: items.map((i) => `${i.banco}: ${fmt(i.valor)}`).join(" | "),
+      funcionario: first.funcionario || null,
     });
   }
 
@@ -91,6 +93,7 @@ function agruparGastos(gastos: Gasto[]): GastoGrupo[] {
       hora: g.hora,
       is_dep_esp: g.is_dep_esp,
       bancos: g.banco || "—",
+      funcionario: g.funcionario || null,
     });
   }
 
@@ -625,6 +628,8 @@ export default function GastosPage() {
 
   // Fornecedores
   const [fornecedores, setFornecedores] = useState<{ id: string; nome: string }[]>([]);
+  // Funcionarios (para SALARIO)
+  const [funcionariosLista, setFuncionariosLista] = useState<{ nome: string; tag: string }[]>([]);
 
   // Form state
   const [form, setForm] = useState({
@@ -634,6 +639,7 @@ export default function GastosPage() {
     descricao: "",
     observacao: "",
     is_dep_esp: false,
+    funcionario: "",
     // Estorno
     contato_tipo: "cliente" as "cliente" | "fornecedor" | "atacado",
     contato_nome: "",
@@ -656,6 +662,7 @@ export default function GastosPage() {
     descricao: "",
     observacao: "",
     is_dep_esp: false,
+    funcionario: "",
   });
   const [editBancoValores, setEditBancoValores] = useState<BancoValores>(emptyBancoValores());
 
@@ -740,6 +747,13 @@ export default function GastosPage() {
           setAtacados(json.clientes ?? json.data ?? []);
         }
       } catch { /* ignore */ }
+      try {
+        const res = await fetch("/api/admin/funcionarios-list", { headers: { "x-admin-password": password } });
+        if (res.ok) {
+          const json = await res.json();
+          setFuncionariosLista(json.funcionarios ?? []);
+        }
+      } catch { /* ignore */ }
     })();
   }, [password]);
 
@@ -756,6 +770,7 @@ export default function GastosPage() {
   const isFornecedor = form.categoria === "FORNECEDOR";
   const isEstorno = form.categoria === "ESTORNO";
   const isReembolso = form.categoria === "REEMBOLSO";
+  const isSalario = form.categoria === "SALARIO";
 
   // Carrega vendas do contato selecionado para popular o dropdown de venda relacionada
   useEffect(() => {
@@ -797,6 +812,12 @@ export default function GastosPage() {
       }
     }
 
+    if (isSalario && !form.funcionario.trim()) {
+      setMsg("Selecione o funcionário");
+      setSaving(false);
+      return;
+    }
+
     const base = {
       data: form.data,
       hora: form.horario || null,
@@ -805,6 +826,7 @@ export default function GastosPage() {
       descricao: form.descricao || null,
       observacao: form.observacao || null,
       is_dep_esp: form.is_dep_esp,
+      funcionario: isSalario ? form.funcionario.trim().toUpperCase() : null,
       contato_nome: isEstorno ? form.contato_nome.trim().toUpperCase() : null,
       contato_tipo: isEstorno ? form.contato_tipo : null,
       venda_id: isEstorno && form.venda_id.trim() ? form.venda_id.trim() : null,
@@ -873,7 +895,7 @@ export default function GastosPage() {
         ? ` + ${pedidoProdutos.length} produto(s) adicionados como A Caminho`
         : "";
       setMsg(`Gasto registrado!${prodMsg}`);
-      setForm((f) => ({ ...f, descricao: "", observacao: "", is_dep_esp: false, horario: new Date().toTimeString().slice(0, 5), contato_nome: "", venda_id: "" }));
+      setForm((f) => ({ ...f, descricao: "", observacao: "", is_dep_esp: false, horario: new Date().toTimeString().slice(0, 5), contato_nome: "", venda_id: "", funcionario: "" }));
       setBancoValores(emptyBancoValores());
       setPedidoProdutos([]);
       fetchGastos();
@@ -893,6 +915,7 @@ export default function GastosPage() {
       categoria: g.categoria,
       observacao: g.observacao || "",
       is_dep_esp: g.is_dep_esp,
+      funcionario: g.funcionario || "",
     });
     const bv = emptyBancoValores();
     for (const item of g.items) {
@@ -922,6 +945,7 @@ export default function GastosPage() {
       descricao: editForm.descricao || null,
       observacao: editForm.observacao || null,
       is_dep_esp: editForm.is_dep_esp,
+      funcionario: editForm.categoria === "SALARIO" ? (editForm.funcionario || "").trim().toUpperCase() || null : null,
     };
 
     let payload;
@@ -1062,6 +1086,33 @@ export default function GastosPage() {
             <div><p className={labelCls}>Descricao</p><input value={form.descricao} onChange={(e) => set("descricao", e.target.value.toUpperCase())} className={`${inputCls} uppercase`} /></div>
             <div><p className={labelCls}>Observacao</p><input value={form.observacao} onChange={(e) => set("observacao", e.target.value.toUpperCase())} className={`${inputCls} uppercase`} /></div>
           </div>
+
+          {/* Bloco SALARIO — vincula ao funcionário */}
+          {isSalario && (
+            <div className={`p-4 rounded-xl border-2 border-dashed ${dm ? "border-[#E8740E]/40 bg-[#E8740E]/5" : "border-[#E8740E]/30 bg-[#FFF8F0]"} space-y-2`}>
+              <div>
+                <p className={`text-sm font-bold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>👤 Salário — vincular ao funcionário</p>
+                <p className={`text-xs ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
+                  O gasto fica vinculado ao funcionário selecionado. Use a observação pra registrar o motivo.
+                </p>
+              </div>
+              <div>
+                <p className={labelCls}>Funcionário <span className="text-red-500">*</span></p>
+                <input
+                  list="salario-funcionarios"
+                  value={form.funcionario}
+                  onChange={(e) => set("funcionario", e.target.value.toUpperCase())}
+                  placeholder="Comece a digitar para buscar..."
+                  className={`${inputCls} uppercase`}
+                />
+                <datalist id="salario-funcionarios">
+                  {funcionariosLista.map((f) => (
+                    <option key={f.nome} value={f.nome}>{f.tag}</option>
+                  ))}
+                </datalist>
+              </div>
+            </div>
+          )}
 
           {/* Bloco de Estorno — vínculo com contato */}
           {isEstorno && (
@@ -1411,6 +1462,15 @@ export default function GastosPage() {
                                 <p className={`text-xs font-semibold uppercase tracking-wider mb-1 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Observação</p>
                                 <p className={dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}>{g.observacao || "—"}</p>
                               </div>
+                              {g.categoria === "SALARIO" && g.funcionario && (
+                                <div className="col-span-2 md:col-span-3">
+                                  <p className={`text-xs font-semibold uppercase tracking-wider mb-1 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Funcionário</p>
+                                  <span className="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-semibold bg-[#E8740E]/10 text-[#E8740E]">
+                                    👤 {g.funcionario}
+                                    <span className="text-[9px] bg-[#E8740E] text-white px-1.5 py-0.5 rounded">TIGRAO</span>
+                                  </span>
+                                </div>
+                              )}
                               {g.is_dep_esp && (
                                 <div className="col-span-2 md:col-span-3">
                                   <span className="inline-block px-3 py-1 rounded-full text-xs font-semibold bg-[#E8740E]/10 text-[#E8740E]">
@@ -1441,6 +1501,23 @@ export default function GastosPage() {
                                 <div><p className={labelCls}>Descricao</p><input value={editForm.descricao} onChange={(e) => editSet("descricao", e.target.value.toUpperCase())} className={`${inputCls} uppercase`} /></div>
                                 <div><p className={labelCls}>Observacao</p><input value={editForm.observacao} onChange={(e) => editSet("observacao", e.target.value.toUpperCase())} className={`${inputCls} uppercase`} /></div>
                               </div>
+                              {editForm.categoria === "SALARIO" && (
+                                <div>
+                                  <p className={labelCls}>Funcionário</p>
+                                  <input
+                                    list="salario-funcionarios-edit"
+                                    value={editForm.funcionario}
+                                    onChange={(e) => editSet("funcionario", e.target.value.toUpperCase())}
+                                    placeholder="Comece a digitar para buscar..."
+                                    className={`${inputCls} uppercase`}
+                                  />
+                                  <datalist id="salario-funcionarios-edit">
+                                    {funcionariosLista.map((f) => (
+                                      <option key={f.nome} value={f.nome}>{f.tag}</option>
+                                    ))}
+                                  </datalist>
+                                </div>
+                              )}
                               <div className={`p-3 rounded-xl border ${dm ? "bg-[#2C2C2E] border-[#3A3A3C]" : "bg-[#FAFAFA] border-[#E8E8ED]"}`}>
                                 <p className={`text-xs font-semibold uppercase tracking-wider mb-2 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Valor por banco</p>
                                 {bancoInputGrid(editBancoValores, editSetBanco, inputCls)}

--- a/app/api/admin/funcionarios-list/route.ts
+++ b/app/api/admin/funcionarios-list/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+/**
+ * GET /api/admin/funcionarios-list
+ * Retorna lista de funcionarios (nomes distintos) baseada nos vinculos
+ * ja registrados em produtos_funcionarios. Usado pra autocomplete em
+ * Gastos (SALARIO) e Cadastro de Produto.
+ */
+export async function GET(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase
+    .from("produtos_funcionarios")
+    .select("funcionario")
+    .not("funcionario", "is", null);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const set = new Set<string>();
+  for (const r of data ?? []) {
+    const n = (r.funcionario || "").trim();
+    if (n) set.add(n.toUpperCase());
+  }
+  const funcionarios = [...set].sort().map((nome) => ({ nome, tag: "TIGRAO" }));
+
+  return NextResponse.json({ funcionarios });
+}

--- a/app/api/admin/search/route.ts
+++ b/app/api/admin/search/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: NextRequest) {
   const q = searchParams.get("q")?.trim();
   const includeHistory = searchParams.get("history") === "true";
 
-  if (!q || q.length < 2) return NextResponse.json({ operacoes: [], contatos: [], estoque: [], vendas: [] });
+  if (!q || q.length < 2) return NextResponse.json({ operacoes: [], contatos: [], estoque: [], vendas: [], funcionarios: [] });
 
   const searchTerm = `%${q}%`;
 
@@ -59,6 +59,23 @@ export async function GET(req: NextRequest) {
   const contatos = [...contatosMap.values()].filter(c => c.nome.includes(q.toUpperCase())).slice(0, 15);
 
   const qUpper = q.toUpperCase();
+
+  // ── 3b. Buscar funcionarios (produtos_funcionarios.funcionario distinct) ──
+  const { data: funcResults } = await supabase
+    .from("produtos_funcionarios")
+    .select("funcionario")
+    .ilike("funcionario", searchTerm)
+    .limit(50);
+  const funcSet = new Set<string>();
+  for (const r of funcResults ?? []) {
+    const n = (r.funcionario || "").trim().toUpperCase();
+    if (n && n.includes(qUpper)) funcSet.add(n);
+  }
+  const funcionarios = [...funcSet].sort().slice(0, 10).map((nome) => ({
+    nome,
+    tag: "TIGRAO",
+    isTigrao: true,
+  }));
 
   // ── 4. Montar operações (vendas agrupadas por cliente+data) ──
   const opMap = new Map<string, {
@@ -200,5 +217,5 @@ export async function GET(req: NextRequest) {
     };
   });
 
-  return NextResponse.json({ operacoes, contatos, estoque, vendas });
+  return NextResponse.json({ operacoes, contatos, estoque, vendas, funcionarios });
 }

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -238,9 +238,10 @@ export default function ProdutoSpecFields({
 
   // Client search state
   const [clienteQuery, setClienteQuery] = useState(row.cliente || "");
-  const [clienteSuggestions, setClienteSuggestions] = useState<string[]>([]);
+  const [clienteSuggestions, setClienteSuggestions] = useState<Array<{ nome: string; isTigrao?: boolean }>>([]);
   const [clienteLoading, setClienteLoading] = useState(false);
   const [showClienteSugg, setShowClienteSugg] = useState(false);
+  const [clienteIsTigrao, setClienteIsTigrao] = useState(false);
   const [linhaFiltro, setLinhaFiltro] = useState<string>("");
   const clienteDebounceRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -387,9 +388,11 @@ export default function ProdutoSpecFields({
   const hasStructured = STRUCTURED_CATS.includes(row.categoria);
 
   // Client search handler
+  // Nao seta row.cliente enquanto digita — so quando o usuario confirma via
+  // sugestao ou Enter. Assim o input nao some (bug anterior: digitar 1 letra
+  // ja colocava em "modo cliente selecionado" e escondia o campo).
   const handleClienteChange = (q: string) => {
     setClienteQuery(q);
-    set("cliente", q);
     setShowClienteSugg(true);
     if (clienteDebounceRef.current) clearTimeout(clienteDebounceRef.current);
     if (q.length < 2) { setClienteSuggestions([]); return; }
@@ -401,12 +404,29 @@ export default function ProdutoSpecFields({
         });
         if (res.ok) {
           const json = await res.json();
-          const names: string[] = (json.contatos || []).map((c: { nome: string }) => c.nome);
-          setClienteSuggestions(names.slice(0, 8));
+          const funcs = (json.funcionarios || []).map((f: { nome: string }) => ({ nome: f.nome, isTigrao: true }));
+          const contatos = (json.contatos || []).map((c: { nome: string }) => ({ nome: c.nome, isTigrao: false }));
+          // Dedupe (funcionarios tem precedencia pra mostrar tag TIGRAO)
+          const seen = new Set<string>();
+          const merged: Array<{ nome: string; isTigrao?: boolean }> = [];
+          for (const item of [...funcs, ...contatos]) {
+            const key = item.nome.toUpperCase();
+            if (seen.has(key)) continue;
+            seen.add(key);
+            merged.push(item);
+          }
+          setClienteSuggestions(merged.slice(0, 10));
         }
       } catch { /* ignore */ }
       setClienteLoading(false);
     }, 350);
+  };
+
+  const commitCliente = (nome: string, isTigrao = false) => {
+    setClienteQuery(nome);
+    set("cliente", nome);
+    setShowClienteSugg(false);
+    setClienteIsTigrao(isTigrao);
   };
 
   // ── Render ────────────────────────────────────────────────────────────────────
@@ -549,7 +569,7 @@ export default function ProdutoSpecFields({
           <div className={`flex rounded-lg overflow-hidden border text-[11px] font-semibold ${dm ? "border-[#3A3A3C]" : "border-[#D2D2D7]"}`}>
             <button
               type="button"
-              onClick={() => { set("cliente", ""); setClienteQuery(""); }}
+              onClick={() => { set("cliente", ""); setClienteQuery(""); setClienteIsTigrao(false); }}
               className={`px-3 py-1 transition-colors ${!row.cliente ? "bg-[#E8740E] text-white" : dm ? "text-[#98989D] hover:text-[#F5F5F7]" : "text-[#86868B] hover:text-[#1D1D1F]"}`}
             >
               Fornecedor
@@ -572,12 +592,15 @@ export default function ProdutoSpecFields({
           </select>
         ) : (
           /* Modo Cliente — mostra cliente selecionado com botão de limpar */
-          <div className={`flex items-center gap-2 px-3 py-2 rounded-lg ${dm ? "bg-[#0071E3]/20 border border-[#0071E3]/40" : "bg-blue-50 border border-blue-200"}`}>
-            <span className="text-blue-500 text-sm">👤</span>
-            <span className={`flex-1 text-sm font-semibold ${dm ? "text-blue-300" : "text-blue-700"}`}>{row.cliente}</span>
+          <div className={`flex items-center gap-2 px-3 py-2 rounded-lg ${clienteIsTigrao ? (dm ? "bg-[#E8740E]/20 border border-[#E8740E]/40" : "bg-orange-50 border border-orange-200") : (dm ? "bg-[#0071E3]/20 border border-[#0071E3]/40" : "bg-blue-50 border border-blue-200")}`}>
+            <span className="text-sm">{clienteIsTigrao ? "👷" : "👤"}</span>
+            <span className={`flex-1 text-sm font-semibold ${clienteIsTigrao ? (dm ? "text-orange-300" : "text-orange-700") : (dm ? "text-blue-300" : "text-blue-700")}`}>{row.cliente}</span>
+            {clienteIsTigrao && (
+              <span className="text-[9px] bg-[#E8740E] text-white px-1.5 py-0.5 rounded font-bold">TIGRAO</span>
+            )}
             <button
               type="button"
-              onClick={() => { set("cliente", ""); setClienteQuery(""); }}
+              onClick={() => { set("cliente", ""); setClienteQuery(""); setClienteIsTigrao(false); }}
               className="text-[10px] text-red-400 hover:text-red-600 font-bold"
             >
               ✕
@@ -590,11 +613,17 @@ export default function ProdutoSpecFields({
           <div className="relative">
             <input
               value={clienteQuery}
-              onChange={(e) => handleClienteChange(e.target.value)}
+              onChange={(e) => handleClienteChange(e.target.value.toUpperCase())}
               onFocus={() => clienteQuery.length >= 2 && setShowClienteSugg(true)}
               onBlur={() => setTimeout(() => setShowClienteSugg(false), 200)}
-              placeholder="🔍 Buscar cliente cadastrado pelo nome..."
-              className={`${inputCls} text-xs`}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && clienteQuery.trim()) {
+                  e.preventDefault();
+                  commitCliente(clienteQuery.trim());
+                }
+              }}
+              placeholder="🔍 Buscar cliente ou funcionário pelo nome..."
+              className={`${inputCls} text-xs uppercase`}
               autoComplete="off"
             />
             {showClienteSugg && (clienteSuggestions.length > 0 || clienteLoading) && (
@@ -602,20 +631,24 @@ export default function ProdutoSpecFields({
                 {clienteLoading && (
                   <p className={`px-3 py-2 text-xs ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Buscando...</p>
                 )}
-                {clienteSuggestions.map((nome) => (
+                {clienteSuggestions.map((sug) => (
                   <button
-                    key={nome}
+                    key={sug.nome}
                     type="button"
-                    onMouseDown={() => {
-                      setClienteQuery(nome);
-                      set("cliente", nome);
-                      setShowClienteSugg(false);
-                    }}
-                    className={`w-full text-left px-3 py-2 text-xs transition-colors ${dm ? "hover:bg-[#3A3A3C] text-[#F5F5F7]" : "hover:bg-[#F5F5F7] text-[#1D1D1F]"}`}
+                    onMouseDown={() => commitCliente(sug.nome, !!sug.isTigrao)}
+                    className={`w-full text-left px-3 py-2 text-xs transition-colors flex items-center justify-between gap-2 ${dm ? "hover:bg-[#3A3A3C] text-[#F5F5F7]" : "hover:bg-[#F5F5F7] text-[#1D1D1F]"}`}
                   >
-                    👤 {nome}
+                    <span>{sug.isTigrao ? "👷" : "👤"} {sug.nome}</span>
+                    {sug.isTigrao && (
+                      <span className="text-[9px] bg-[#E8740E] text-white px-1.5 py-0.5 rounded font-bold">TIGRAO</span>
+                    )}
                   </button>
                 ))}
+                {!clienteLoading && clienteSuggestions.length === 0 && clienteQuery.length >= 2 && (
+                  <p className={`px-3 py-2 text-xs ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
+                    Nenhum resultado. Pressione Enter para usar &quot;{clienteQuery}&quot; mesmo assim.
+                  </p>
+                )}
               </div>
             )}
           </div>

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -127,6 +127,7 @@ export interface Gasto {
   is_dep_esp: boolean;
   grupo_id: string | null;
   pedido_fornecedor_id: string | null;
+  funcionario: string | null;
 }
 
 export interface PedidoFornecedorItem {

--- a/supabase/migrations/20260417l_gastos_funcionario.sql
+++ b/supabase/migrations/20260417l_gastos_funcionario.sql
@@ -1,0 +1,8 @@
+-- Adiciona coluna `funcionario` na tabela gastos para vincular
+-- pagamentos (ex: SALARIO) a um funcionario especifico.
+-- Segue o mesmo padrao de `produtos_funcionarios.funcionario` (TEXT livre),
+-- ja que nao existe tabela dedicada de funcionarios.
+
+ALTER TABLE gastos ADD COLUMN IF NOT EXISTS funcionario TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_gastos_funcionario ON gastos(funcionario);


### PR DESCRIPTION
## Summary
- **Gastos SALARIO**: novo campo opcional "Funcionário vinculado" com autocomplete que aparece só quando categoria = SALARIO. Persiste em `gastos.funcionario` e aparece no histórico com chip `👤 NOME [TIGRAO]`, também editável.
- **Cadastro de produto (estoque)**: busca de cliente agora inclui funcionários (distintos de `produtos_funcionarios`) com badge `TIGRAO` laranja nas sugestões.
- **Fix do bug da busca de cliente** em `ProdutoSpecFields`: o input sumia ao digitar 1 letra porque `set("cliente", q)` rodava no onChange — agora só confirma via clique em sugestão ou Enter.

## Alterações
- Migration: `supabase/migrations/20260417l_gastos_funcionario.sql` — adiciona `gastos.funcionario TEXT` + índice
- API nova: `/api/admin/funcionarios-list` (nomes distintos pra datalist)
- API estendida: `/api/admin/search` agora retorna `funcionarios` com flag `isTigrao`
- UI: `app/admin/gastos/page.tsx`, `components/admin/ProdutoSpecFields.tsx`, `lib/admin-types.ts`

## Test plan
- [ ] Gastos → Novo → trocar categoria para SALARIO → bloco laranja "Salário — vincular ao funcionário" aparece
- [ ] Digitar nome no campo → autocomplete mostra funcionários já cadastrados
- [ ] Registrar → conferir que aparece no histórico com chip `👤 NOME [TIGRAO]`
- [ ] Editar gasto de salário → campo aparece no modal de edição, persiste ao salvar
- [ ] Estoque → Adicionar produto → Origem da compra → Cliente → digitar nome → conferir que input NÃO some ao digitar e que funcionários aparecem com tag TIGRAO
- [ ] Selecionar um funcionário → chip laranja com 👷 e badge TIGRAO
- [ ] Rodar migration `20260417l_gastos_funcionario.sql` em `/admin/migrations` antes de testar SALARIO

🤖 Generated with [Claude Code](https://claude.com/claude-code)