### PR TITLE
fix(vendas): backfill v2 trocas março — UPDATE por ID (venda fonte)

### DIFF
--- a/supabase/migrations/20260418_backfill_trocas_marco_v2.sql
+++ b/supabase/migrations/20260418_backfill_trocas_marco_v2.sql
@@ -1,0 +1,94 @@
+-- Backfill v2: vincula produtos de trade-in as vendas de upgrade de marco/2026.
+--
+-- Versao anterior (20260417o_) nao afetou nada porque tentou buscar os
+-- produtos no `estoque` — mas esses trade-ins ja foram revendidos como ATACADO,
+-- entao os serials aparecem na tabela `vendas` (nao `estoque`).
+--
+-- Esta versao usa os IDs das vendas diretamente (ja confirmados via diagnostico),
+-- e busca o produto/imei do trade-in na tabela `vendas` (onde o mesmo serial foi
+-- registrado como produto vendido pra atacado depois do upgrade).
+--
+-- Escopo: SO preenche troca_produto/troca_serial/troca_imei/troca_categoria em
+-- 6 vendas especificas. Nao mexe em valor, cliente, pagamento, status.
+-- Idempotente (COALESCE, so preenche se estiver NULL).
+
+------------------------------------------------------------
+-- 02/03 — Alexandra Ferrari (venda id aee80b50-...) — trade-in D396PWWHNJ
+------------------------------------------------------------
+UPDATE vendas
+SET
+  troca_produto   = COALESCE(troca_produto,   'IPHONE 14 PRO MAX 128GB SPACE BLACK ZP (HK/MO)- E-SIM'),
+  troca_serial    = COALESCE(troca_serial,    'D396PWWHNJ'),
+  troca_imei      = COALESCE(troca_imei,      '352632921341685'),
+  troca_categoria = COALESCE(troca_categoria, 'IPHONES')
+WHERE id = 'aee80b50-f6af-4a33-beef-bfa924a46cbe';
+
+------------------------------------------------------------
+-- 02/03 — Roberto Soares (venda id 512ea8ae-...) — trade-in FWDX7347KL
+------------------------------------------------------------
+UPDATE vendas
+SET
+  troca_produto   = COALESCE(troca_produto,   'IPHONE 16 PRO MAX 256GB BLACK TITANIUM LL (EUA)- E-SIM'),
+  troca_serial    = COALESCE(troca_serial,    'FWDX7347KL'),
+  troca_imei      = COALESCE(troca_imei,      '354331128040806'),
+  troca_categoria = COALESCE(troca_categoria, 'IPHONES')
+WHERE id = '512ea8ae-5396-432b-b635-19ebdd701073';
+
+------------------------------------------------------------
+-- 03/03 — Andréa Cota Freitas Bastos (venda iPhone 17 Pro) — trade-in F17F2PCW0D91
+-- Obs: Andrea tem 2 vendas nesse dia (iPhone + Apple Watch). O trade-in vai na
+-- venda do iPhone (upgrade natural). Se for pra vincular ao Apple Watch, mudar id.
+------------------------------------------------------------
+UPDATE vendas
+SET
+  troca_produto   = COALESCE(troca_produto,   'IPHONE 12 PRO 128GB AZUL SEMINOVO'),
+  troca_serial    = COALESCE(troca_serial,    'F17F2PCW0D91'),
+  troca_imei      = COALESCE(troca_imei,      '35279829208483'),
+  troca_categoria = COALESCE(troca_categoria, 'IPHONES')
+WHERE id = '48841074-eefe-417b-9b56-1b6af03652be';
+
+------------------------------------------------------------
+-- 03/03 — Carolina Penades Lima (venda id c4318c32-...) — 2 trade-ins
+-- 1º: KN4924074V (IPHONE 14 PRO MAX 256GB ROXO SEMINOVO)
+-- 2º: L7LQC9NTJR (modelo desconhecido — so preenche serial)
+------------------------------------------------------------
+UPDATE vendas
+SET
+  troca_produto   = COALESCE(troca_produto,   'IPHONE 14 PRO MAX 256GB ROXO SEMINOVO'),
+  troca_serial    = COALESCE(troca_serial,    'KN4924074V'),
+  troca_imei      = COALESCE(troca_imei,      '359451591954021'),
+  troca_categoria = COALESCE(troca_categoria, 'IPHONES'),
+  troca_serial2   = COALESCE(troca_serial2,   'L7LQC9NTJR')  -- modelo a preencher manualmente
+WHERE id = 'c4318c32-aebe-437d-aa3c-c9ee0ee066b4';
+
+------------------------------------------------------------
+-- 03/03 — Inconnect Marketing LTDA (venda id 7bd80e28-...) — trade-in DVPX4104JT
+-- Obs: CNPJ esta no campo `cpf` pra PJ nessa venda (nao no `cnpj`).
+------------------------------------------------------------
+UPDATE vendas
+SET
+  troca_produto   = COALESCE(troca_produto,   'IPHONE 17 PRO MAX 256GB LARANJA CHIP FÍSICO'),
+  troca_serial    = COALESCE(troca_serial,    'DVPX4104JT'),
+  troca_imei      = COALESCE(troca_imei,      '355292135329518'),
+  troca_categoria = COALESCE(troca_categoria, 'IPHONES')
+WHERE id = '7bd80e28-42a9-4063-a85f-4c4a3234ff2a';
+
+------------------------------------------------------------
+-- 03/03 — Jéssica Jorge de Freitas (venda id bde664d6-...) — trade-in M52N70FHPG
+------------------------------------------------------------
+UPDATE vendas
+SET
+  troca_produto   = COALESCE(troca_produto,   'IPHONE 16 PRO 256GB DESERT TITANIUM LL (EUA)- E-SIM'),
+  troca_serial    = COALESCE(troca_serial,    'M52N70FHPG'),
+  troca_imei      = COALESCE(troca_imei,      '357234292324112'),
+  troca_categoria = COALESCE(troca_categoria, 'IPHONES')
+WHERE id = 'bde664d6-7164-4312-bf6a-076a41a72ce8';
+
+------------------------------------------------------------
+-- 03/03 — Vanessa Rodrigues Santos (venda id 78b83742-...) — trade-in H4T5253763
+-- Obs: Serial H4T5253763 nao existe no sistema — so registra o serial, sem produto.
+------------------------------------------------------------
+UPDATE vendas
+SET
+  troca_serial    = COALESCE(troca_serial,    'H4T5253763')  -- modelo a preencher manualmente
+WHERE id = '78b83742-9c83-4437-b595-4236ad67ee06';


### PR DESCRIPTION
## Por que a v1 não funcionou

A migration anterior ([#534](https://github.com/tigraoimports-a11y/tigrao-tradein/pull/534)) buscava os produtos em `estoque` — mas esses trade-ins **já tinham sido revendidos como ATACADO**, então os serials só aparecem em `vendas` (com `fornecedor="UPGRADE"`), não em `estoque`.

Diagnóstico via `/api/admin/audit-trocas-marco`:
- 8/8 seriais NÃO encontrados em `estoque` ❌
- 6/8 seriais encontrados em `vendas` ✅
- 2 vendas não casavam por CPF/CNPJ (ex: CNPJ da Inconnect Marketing está no campo `cpf`, não `cnpj`)

## O que esse PR faz

`UPDATE` direto por ID de cada venda, com produto/IMEI já confirmado via chrome/audit. Só mexe em `troca_produto`, `troca_serial`, `troca_imei`, `troca_categoria`. Nada de valor, cliente, pagamento.

### 6 casos completos

| Venda | Trade-in |
|-------|----------|
| Alexandra Ferrari (02/03) | iPhone 14 Pro Max 128GB Space Black — `D396PWWHNJ` |
| Roberto Soares (02/03) | iPhone 16 Pro Max 256GB Black Titanium — `FWDX7347KL` |
| Andréa Cota (03/03, venda iPhone 17 Pro) | iPhone 12 Pro 128GB Azul Seminovo — `F17F2PCW0D91` |
| Carolina Penades (03/03) | iPhone 14 Pro Max 256GB Roxo Seminovo — `KN4924074V` |
| Inconnect Marketing (03/03) | iPhone 17 Pro Max 256GB Laranja — `DVPX4104JT` |
| Jéssica Jorge (03/03) | iPhone 16 Pro 256GB Desert Titanium — `M52N70FHPG` |

### 2 casos parciais (só serial, sem produto)

Esses dois serials não existem em nenhum lugar do sistema:
- **Carolina Penades (2º produto)**: `L7LQC9NTJR`
- **Vanessa Rodrigues Santos**: `H4T5253763`

A migration preenche o `troca_serial` (pra ter rastreabilidade) mas deixa `troca_produto` NULL — você edita manualmente no admin depois quando souber o modelo. 

Se quiser, me diz os modelos desses 2 e eu abro outro PR pra completar.

## Test plan
- [ ] Mergear e rodar `20260418_backfill_trocas_marco_v2.sql` em `/admin/migrations`
- [ ] Rodar `/api/admin/audit-trocas-marco` de novo → `ok` deve virar 6 ou 8 (dependendo da interpretação — os 2 parciais contam como "vinculados" porque `troca_serial` foi preenchido)
- [ ] Abrir `/admin/vendas` filtrando 02/03 e 03/03 → ver 🔄 preview do trade-in em cada uma

🤖 Generated with [Claude Code](https://claude.com/claude-code)