### PR TITLE
fix(vendas): corrige venda 2L IMPORTS 20/03 + completa trocas pendentes

### DIFF
--- a/supabase/migrations/20260418b_corrige_venda_2l_imports_e_completa_trocas.sql
+++ b/supabase/migrations/20260418b_corrige_venda_2l_imports_e_completa_trocas.sql
@@ -1,0 +1,49 @@
+-- Complemento do backfill v2 + correcao de venda com serial errado.
+--
+-- 1) Venda pra 2L IMPORTS de 20/03 (id 48a2c885-...) ficou com serial/imei/produto
+--    errados — duplicou os dados do iPhone 17 Pro que foi vendido pra JF IMPORTS
+--    em 21/03 (mesmo serial CNWVKD64JF). O produto REAL vendido em 20/03 era o
+--    H4T5253763 (iPhone 15 Pro Natural Titanium), que veio do trade-in da Vanessa.
+--
+-- 2) Completa o backfill v2: preenche troca_produto2/troca_imei2 da Carolina
+--    (L7LQC9NTJR) e troca_produto/troca_imei da Vanessa (H4T5253763), cujos
+--    modelos nao existiam na v2.
+
+------------------------------------------------------------
+-- 1. Corrige a venda pra 2L IMPORTS (20/03) — serial estava trocado
+-- AND serial_no = 'CNWVKD64JF' eh guard contra reexecucao (idempotente).
+------------------------------------------------------------
+UPDATE vendas
+SET
+  produto    = 'IPHONE 15 PRO 128GB NATURAL TITANIUM SEMINOVO',
+  serial_no  = 'H4T5253763',
+  imei       = '353884191494301',
+  fornecedor = 'UPGRADE'
+WHERE id = '48a2c885-0db9-4d44-80bb-660655084b1d'
+  AND serial_no = 'CNWVKD64JF';
+
+------------------------------------------------------------
+-- 2a. Carolina Penades — 2º trade-in (L7LQC9NTJR) — modelo agora conhecido
+------------------------------------------------------------
+UPDATE vendas
+SET
+  troca_produto2   = COALESCE(troca_produto2,   'IPHONE 14 PRO MAX 256GB DEEP PURPLE SEMINOVO'),
+  troca_serial2    = COALESCE(troca_serial2,    'L7LQC9NTJR'),
+  troca_imei2      = COALESCE(troca_imei2,      '359451591687845'),
+  troca_categoria2 = COALESCE(troca_categoria2, 'IPHONES'),
+  troca_cor2       = COALESCE(troca_cor2,       'DEEP PURPLE'),
+  troca_bateria2   = COALESCE(troca_bateria2,   '84')
+WHERE id = 'c4318c32-aebe-437d-aa3c-c9ee0ee066b4';
+
+------------------------------------------------------------
+-- 2b. Vanessa Rodrigues Santos — trade-in (H4T5253763) — modelo agora conhecido
+------------------------------------------------------------
+UPDATE vendas
+SET
+  troca_produto   = COALESCE(troca_produto,   'IPHONE 15 PRO 128GB NATURAL TITANIUM SEMINOVO'),
+  troca_serial    = COALESCE(troca_serial,    'H4T5253763'),
+  troca_imei      = COALESCE(troca_imei,      '353884191494301'),
+  troca_categoria = COALESCE(troca_categoria, 'IPHONES'),
+  troca_cor       = COALESCE(troca_cor,       'NATURAL TITANIUM'),
+  troca_bateria   = COALESCE(troca_bateria,   '87')
+WHERE id = '78b83742-9c83-4437-b595-4236ad67ee06';


### PR DESCRIPTION
## Contexto

### 1. Venda duplicada (serial errado)
O serial `CNWVKD64JF` aparece em **2 vendas**:

| Venda | Data | Cliente | Produto | Valor |
|-------|------|---------|---------|-------|
| `0a9ac5a5-...` | 21/03 | JF IMPORTS | iPhone 17 Pro 512GB Silver | R$ 9.650 ← **correta** |
| `48a2c885-...` | 20/03 | 2L IMPORTS | iPhone 15 Pro 128GB Azul Seminovo | R$ 3.390 ← **errada** |

O produto **real** vendido em 20/03 pra 2L IMPORTS era o `H4T5253763` (iPhone 15 Pro 128GB Natural Titanium Seminovo), trade-in recebido da Vanessa Rodrigues. Alguém colou o serial errado por engano.

### 2. Trade-ins incompletos
O backfill v2 ([#536](https://github.com/tigraoimports-a11y/tigrao-tradein/pull/536)) deixou 2 trade-ins com só o serial preenchido porque o modelo não estava no sistema:
- **Carolina Penades (2º)** — serial `L7LQC9NTJR`
- **Vanessa Rodrigues** — serial `H4T5253763`

Agora sei os modelos completos.

## Mudanças

### 1. Corrige venda 2L IMPORTS 20/03 (`48a2c885-...`)
`UPDATE vendas SET produto, serial_no, imei, fornecedor` com os dados corretos do H4T5253763. Não mexe em valor, cliente, data, pagamento. Guard `AND serial_no = 'CNWVKD64JF'` garante idempotência.

### 2. Completa trade-ins
- **Carolina 2º** (`L7LQC9NTJR`): iPhone 14 Pro Max 256GB Deep Purple Seminovo, IMEI 359451591687845, bateria 84%
- **Vanessa** (`H4T5253763`): iPhone 15 Pro 128GB Natural Titanium Seminovo, IMEI 353884191494301, bateria 87%

## Test plan
- [ ] Mergear e rodar `20260418b_corrige_venda_2l_imports_e_completa_trocas.sql` em `/admin/migrations`
- [ ] Verificar que a venda pra **2L IMPORTS (20/03)** agora mostra `IPHONE 15 PRO 128GB NATURAL TITANIUM SEMINOVO` com serial `H4T5253763`
- [ ] Verificar que a venda pra **JF IMPORTS (21/03)** continua intocada (iPhone 17 Pro 512GB Silver, serial `CNWVKD64JF`)
- [ ] Abrir venda da **Carolina Penades** → 🔄 mostra trade-in 1 (KN4924074V) e 🔄 trade-in 2 (L7LQC9NTJR) com modelos completos
- [ ] Abrir venda da **Vanessa Rodrigues** → 🔄 mostra trade-in com iPhone 15 Pro Natural

🤖 Generated with [Claude Code](https://claude.com/claude-code)