### PR TITLE
fix(vendas): 'Datas diferentes' bloqueava submit por causa de validação de comprovante

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -1311,8 +1311,10 @@ export default function VendasPage() {
     // Forma de pagamento é opcional — se não preenchida, venda vai como "Em Andamento" (AGUARDANDO)
     // e o pagamento pode ser registrado depois na aba "Em Andamento"
 
-    // Validação: comprovante obrigatório para vendas no CARTÃO (só se tem permissão de ver histórico)
-    if (podeVerHistorico && (form.forma === "CARTAO" || form.forma === "LINK" || form.forma === "DEBITO") && !(parseFloat(form.valor_comprovante_input) > 0)) {
+    // Validação: comprovante obrigatório para vendas no CARTÃO (só se tem permissão de ver histórico).
+    // No modo "Datas diferentes" cada pagamento em pagEntries tem sua propria forma/valor — nao
+    // existe um campo unico `valor_comprovante_input`, entao essa validacao nao se aplica.
+    if (!multiDatePagamento && podeVerHistorico && (form.forma === "CARTAO" || form.forma === "LINK" || form.forma === "DEBITO") && !(parseFloat(form.valor_comprovante_input) > 0)) {
       setMsg("⚠️ Preencha o VALOR DO COMPROVANTE para vendas no cartão/débito");
       return;
     }


### PR DESCRIPTION
## Bug
Ao registrar venda com **"Datas diferentes"** marcado (ex: 2 pagamentos PIX em dias diferentes), o botão Registrar não funciona.

## Causa
A validação de "valor do comprovante" em vendas com cartão/débito usa apenas `form.forma` e `form.valor_comprovante_input` — que são do **modo single-date**.

No modo "Datas diferentes" cada pagamento em `pagEntries` tem sua própria forma/valor. Não existe um campo único de comprovante — então a validação nunca pode passar.

**Cenário do bug**:
1. Usuário marca "Datas diferentes"
2. Preenche 2 pagamentos PIX em dias diferentes (17/04 R$4.897 + 18/04 R$3.100)
3. Se `form.forma` acidentalmente ainda tem valor antigo `CARTAO`/`LINK`/`DEBITO` (de uma edição anterior no modo single-date) e `form.valor_comprovante_input` está vazio, a validação bloqueia o submit

`app/admin/vendas/page.tsx:1315`

## Fix
Pular a validação de `valor_comprovante_input` quando `multiDatePagamento === true`. No modo multi-date, cada pagamento já tem sua própria validação via `pagEntries`.

```diff
-if (podeVerHistorico && (form.forma === "CARTAO" || form.forma === "LINK" || form.forma === "DEBITO") && !(parseFloat(form.valor_comprovante_input) > 0)) {
+if (!multiDatePagamento && podeVerHistorico && (form.forma === "CARTAO" || form.forma === "LINK" || form.forma === "DEBITO") && !(parseFloat(form.valor_comprovante_input) > 0)) {
```

## Test plan
- [ ] Nova venda → marcar "Datas diferentes" → adicionar 2 pagamentos PIX em datas diferentes → Registrar
- [ ] Confirmar que a venda cria com `status_pagamento = FINALIZADO` (quando total cobre preço) ou `PROGRAMADA`
- [ ] Confirmar que `pagamento_historia` foi gravado corretamente com ambos os pagamentos
- [ ] Regressão: nova venda no modo single-date com CARTÃO sem comprovante continua mostrando "⚠️ Preencha o VALOR DO COMPROVANTE"

🤖 Generated with [Claude Code](https://claude.com/claude-code)