### PR TITLE
fix(vendas): preco_vendido zerado no modo 'Datas diferentes' + validação

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -755,6 +755,31 @@ export default function VendasPage() {
     syncQueue();
   }, [isOnline, password, fetchVendas, fetchEstoque]);
 
+  // Recalcular preco_vendido automaticamente no modo "Datas diferentes".
+  // Sem isso, preco_vendido fica 0 e a venda grava com lucro negativo (custo - 0).
+  // Soma valor liquido de cada pagEntry respeitando a forma (taxa de cartao/link/debito).
+  useEffect(() => {
+    if (!multiDatePagamento) return;
+    const pTroca1 = parseFloat(form.produto_na_troca) || 0;
+    const pTroca2 = parseFloat(form.produto_na_troca2) || 0;
+    const totalTroca = pTroca1 + pTroca2;
+    const totalPagEntries = pagEntries.reduce((sum, e) => {
+      const bruto = parseFloat(String(e.valor).replace(/\./g, "").replace(",", ".")) || 0;
+      if (bruto <= 0) return sum;
+      // preco_vendido = valor BRUTO (o que o cliente pagou) — sem descontar taxa
+      return sum + bruto;
+    }, 0);
+    const newVendido = String(Math.round(totalPagEntries + totalTroca));
+    if (newVendido === "0") return;
+    if (produtosCarrinho.length === 0) {
+      setForm(f => f.preco_vendido === newVendido ? f : { ...f, preco_vendido: newVendido });
+    } else if (produtosCarrinho.length === 1) {
+      setProdutosCarrinho(prev => prev.length === 1 && prev[0].preco_vendido !== newVendido
+        ? [{ ...prev[0], preco_vendido: newVendido }]
+        : prev);
+    }
+  }, [multiDatePagamento, pagEntries, form.produto_na_troca, form.produto_na_troca2, produtosCarrinho.length]);
+
   // Recalcular preco_vendido automaticamente quando 2o cartão (ou qualquer parte do pagamento) mudar
   // IMPORTANTE: precisa estar ANTES do early return abaixo (regras dos hooks)
   useEffect(() => {
@@ -1311,8 +1336,9 @@ export default function VendasPage() {
     // Forma de pagamento é opcional — se não preenchida, venda vai como "Em Andamento" (AGUARDANDO)
     // e o pagamento pode ser registrado depois na aba "Em Andamento"
 
-    // Validação: comprovante obrigatório para vendas no CARTÃO (só se tem permissão de ver histórico)
-    if (podeVerHistorico && (form.forma === "CARTAO" || form.forma === "LINK" || form.forma === "DEBITO") && !(parseFloat(form.valor_comprovante_input) > 0)) {
+    // Validação: comprovante obrigatório para vendas no CARTÃO (só se tem permissão de ver histórico).
+    // No modo "Datas diferentes" cada pagamento em pagEntries tem sua propria forma/valor/comprovante.
+    if (!multiDatePagamento && podeVerHistorico && (form.forma === "CARTAO" || form.forma === "LINK" || form.forma === "DEBITO") && !(parseFloat(form.valor_comprovante_input) > 0)) {
       setMsg("⚠️ Preencha o VALOR DO COMPROVANTE para vendas no cartão/débito");
       return;
     }


### PR DESCRIPTION
## Contexto
Venda do Henrique Rego Soares (17/04) foi registrada com **"Datas diferentes"** (2 PIX: R$4.897 em 17/04 + R$3.100 em 18/04). A venda gravou como **FINALIZADO** mas:
- **Total: R$ 0** (deveria ser ~R$7.997)
- **Pago: R$ 7.997** (correto)
- **Lucro: R$ -7.171** (= -custo, porque preco_vendido=0)

## Bug 1: `preco_vendido` não é recalculado no modo multi-date
O `useEffect` em `page.tsx:760` que recalcula `form.preco_vendido` só monitora os campos do modo **single-date**:
- `valor_comprovante_input`, `entrada_pix`, `entrada_especie`, `comp_alt`, etc.

No modo multi-date, os valores ficam em `pagEntries[]`. Esse array **não está nas dependências do useEffect** e não há outro useEffect pra esse caso. Resultado: `preco_vendido` fica com o valor inicial `""`, vira 0 no payload, e a venda grava com lucro negativo.

**Fix**: novo `useEffect` que, quando `multiDatePagamento === true`, soma:
- Valores brutos de cada `pagEntries[i].valor`
- Trocas (`produto_na_troca` + `produto_na_troca2`)

E atualiza `form.preco_vendido` (ou o item do carrinho se tiver 1).

## Bug 2: Validação de comprovante bloqueava submit
A validação "Preencha VALOR DO COMPROVANTE" rodava mesmo no modo multi-date. Se `form.forma` acidentalmente tivesse valor antigo `CARTAO`/`LINK`/`DEBITO`, a venda nem tentava salvar.

**Fix**: pular essa validação quando `multiDatePagamento === true`.

## Test plan
- [ ] Nova venda com "Datas diferentes" → 2 PIX em datas diferentes
- [ ] Painel "Lucro" deve mostrar valor positivo (preço − custo), não R$ -custo
- [ ] Total mostrado no card da venda finalizada deve bater com soma dos pagamentos
- [ ] Regressão: venda single-date continua funcionando igual

## Venda que já foi gravada errada
A venda do Henrique (17/04) está com `preco_vendido=0` no banco. Pra corrigir:
- Opção A: abrir a venda e editar o preço manualmente
- Opção B: posso abrir outra PR com migration pra dar `UPDATE` na venda específica — me avisa o ID/valor correto se preferir

🤖 Generated with [Claude Code](https://claude.com/claude-code)