### PR TITLE
fix(simulador): seminovo respeita config WhatsApp do admin (ignorava Bianca)

### DIFF
--- a/components/StepNewDevice.tsx
+++ b/components/StepNewDevice.tsx
@@ -419,7 +419,12 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
                       website: getHoneypotValue(),
                     }),
                   }).catch(() => {});
-                  const waNum = WHATSAPP_SEMINOVO;
+                  // whatsappNumber eh passado pelo TradeInCalculator ja com a
+                  // logica correta pra seminovos (prefere vendedor selecionado;
+                  // senao tradeinConfig.whatsapp_formularios_seminovos; senao
+                  // principal). O fallback WHATSAPP_SEMINOVO so entra se o prop
+                  // nao foi passado (componente usado standalone).
+                  const waNum = whatsappNumber || WHATSAPP_SEMINOVO;
                   const msg = encodeURIComponent(buildWhatsAppMsg());
                   window.location.href = `https://wa.me/${waNum}?text=${msg}`;
                 }}


### PR DESCRIPTION
## Bug
Admin escolhe **Bianca** em `/admin/configuracoes` → "WhatsApp Troca — Seminovos" e coloca o número dela (`5521972461357`). Mas cliente que faz simulação de trade-in **SEMINOVO** é redirecionado pro **Nicolas** (`5521995618747`).

## Causa
`components/StepNewDevice.tsx:422` tinha:
```js
const waNum = WHATSAPP_SEMINOVO;  // → sempre Nicolas (hardcoded em lib/whatsapp-config.ts)
```

A prop `whatsappNumber` que o componente recebe **já vem com a lógica correta** de `TradeInCalculator.tsx:402`:
```js
whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormulariosSeminovos}
```

Que lê de `tradeinConfig?.whatsapp_formularios_seminovos` (a config que você salva no admin). Só que a linha 422 ignorava essa prop.

## Fix
Uma linha:
```diff
-const waNum = WHATSAPP_SEMINOVO;
+const waNum = whatsappNumber || WHATSAPP_SEMINOVO;
```

Prop tem prioridade; hardcoded vira fallback (só importa se o componente for usado standalone sem o calculator em volta).

## Test plan
- [ ] Em `/admin/configuracoes` → WhatsApp Troca — Seminovos → marcar **Bianca**, colocar número dela, salvar
- [ ] Abrir o simulador público → selecionar um iPhone → escolher opção **Seminovo** → clicar em "Consultar no WhatsApp"
- [ ] Confirmar que abre WhatsApp do número da Bianca, não do Nicolas
- [ ] Regressão: fluxo lacrado continua indo pro destinatário certo

🤖 Generated with [Claude Code](https://claude.com/claude-code)