### PR TITLE
fix(vendas+estoque): edicao multi-produto + NF nao reenvia + Ultra 3 milanes

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -5066,7 +5066,13 @@ export default function EstoquePage() {
                 allItems.forEach(p => {
                   const base = getModeloBase(p.produto, p.categoria, p.observacao).toUpperCase();
                   const cor = p.cor ? corParaPT(p.cor).toUpperCase() : "";
-                  const key = `${base}|||${cor}`;
+                  // Apple Watch: separa variantes com pulseira estilo milanês em card
+                  // proprio — produto/preco diferem do Ultra "normal" com pulseira ocean.
+                  const isMilanes = p.categoria === "APPLE_WATCH"
+                    && (/MILAN[EÊÉ]S/i.test(p.produto || "")
+                        || /MILAN[EÊÉ]S/i.test(p.observacao || ""));
+                  const variante = isMilanes ? "|||MILANES" : "";
+                  const key = `${base}|||${cor}${variante}`;
                   if (!grouped[key]) grouped[key] = [];
                   grouped[key].push(p);
                 });
@@ -5148,6 +5154,19 @@ export default function EstoquePage() {
                           <div className="flex-1 min-w-0">
                             <p className={`font-bold text-xs sm:text-sm ${textPrimary} leading-tight`}>{formatProdutoDisplay(rep)}</p>
                             {corPt && <p className={`text-[10px] sm:text-xs ${textSecondary} mt-0.5`}>{corPt}</p>}
+                            {(() => {
+                              // Badge Milanês: formatProdutoDisplay remove "PULSEIRA ..." do nome,
+                              // entao marca cards com pulseira estilo milanes pra diferenciar do Ultra normal.
+                              const isMilanes = rep.categoria === "APPLE_WATCH"
+                                && (/MILAN[EÊÉ]S/i.test(rep.produto || "")
+                                    || /MILAN[EÊÉ]S/i.test(rep.observacao || ""));
+                              if (!isMilanes) return null;
+                              return (
+                                <span className={`inline-block mt-1 px-1.5 py-0.5 rounded text-[9px] font-semibold ${dm ? "bg-[#3A3A3C] text-[#98989D]" : "bg-[#F2F2F7] text-[#636366]"}`}>
+                                  Pulseira Milanês
+                                </span>
+                              );
+                            })()}
                           </div>
                           <span className={`shrink-0 text-[10px] cursor-grab active:cursor-grabbing select-none ${textMuted} opacity-40 hover:opacity-100 transition-opacity`} title="Arrastar para reordenar">⠿</span>
                         </div>

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -1543,20 +1543,28 @@ export default function VendasPage() {
             }
           }
 
-          // Descobrir grupo_id original (pra novos itens vincularem ao mesmo grupo)
+          // Descobrir grupo_id original (pra novos itens vincularem ao mesmo grupo).
+          // Se a venda original nao tem grupo_id (era venda unica) e estamos adicionando
+          // novos produtos, gera um UUID real pra agrupar todos.
           const primeiraVenda = vendas.find(v => v.id === editandoGrupoIds[0]);
-          const grupoIdOriginal = (primeiraVenda as unknown as { grupo_id?: string })?.grupo_id
-            || editandoGrupoIds[0]; // fallback: usa id da primeira venda como grupo_id sintetico
+          const grupoIdExistente = (primeiraVenda as unknown as { grupo_id?: string })?.grupo_id;
+          const precisaCriarGrupo = !grupoIdExistente && allProducts.length > editandoGrupoIds.length;
+          const grupoIdOriginal = grupoIdExistente
+            || (precisaCriarGrupo ? crypto.randomUUID() : editandoGrupoIds[0]);
 
           let allOk = true;
 
-          // 1. PATCH nos produtos que casam com vendas existentes
+          // 1. PATCH nos produtos que casam com vendas existentes.
+          // Se estamos criando grupo novo (venda unica virando multi), propaga grupo_id
+          // pro PATCH pra original tambem entrar no mesmo grupo.
           const nPatch = Math.min(allProducts.length, editandoGrupoIds.length);
           for (let i = 0; i < nPatch; i++) {
+            const patchBody: Record<string, unknown> = { id: editandoGrupoIds[i], ...groupPayloads[i] };
+            if (precisaCriarGrupo) patchBody.grupo_id = grupoIdOriginal;
             const res = await fetch("/api/vendas", {
               method: "PATCH",
               headers: { "Content-Type": "application/json", "x-admin-password": password },
-              body: JSON.stringify({ id: editandoGrupoIds[i], ...groupPayloads[i] }),
+              body: JSON.stringify(patchBody),
             });
             const json = await res.json();
             if (!json.ok && !json.data) { allOk = false; setMsg("Erro ao atualizar: " + (json.error || "erro desconhecido")); break; }
@@ -5249,7 +5257,11 @@ export default function VendasPage() {
                                               // Campos de produto/troca já foram limpos no setForm acima (grupoVendas.length > 1 ? "" : ...)
                                             } else {
                                               setProdutosCarrinho([]);
-                                              setEditandoGrupoIds([]);
+                                              // Venda unica: registra o id em editandoGrupoIds pra
+                                              // habilitar o ramo multi-produto caso o admin adicione
+                                              // um 2o produto durante a edicao (antes era [] e o
+                                              // 2o produto era silenciosamente descartado).
+                                              setEditandoGrupoIds([v.id]);
                                               setEditandoVendaId(v.id);
                                             }
                                             // Guarda o estoque_id ORIGINAL da venda (pra detectar se trocou produto no submit)

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -675,8 +675,10 @@ export async function PATCH(req: NextRequest) {
   }
 
   // Buscar venda anterior para comparar estoque_id (devolver produto se trocou)
-  const { data: vendaAnterior } = await supabase.from("vendas").select("estoque_id, serial_no, produto").eq("id", id).single();
+  // e status_pagamento (evitar reenvio de NF/Telegram em edicoes posteriores).
+  const { data: vendaAnterior } = await supabase.from("vendas").select("estoque_id, serial_no, produto, status_pagamento").eq("id", id).single();
   const estoqueIdAnterior = vendaAnterior?.estoque_id || null;
+  const statusPagamentoAnterior = (vendaAnterior as unknown as { status_pagamento?: string } | null)?.status_pagamento || null;
 
   // Se o admin enviou _estoque_id (mesmo null), atualizar o vinculo na venda
   if (estoqueIdFoiEnviado) {
@@ -797,8 +799,12 @@ export async function PATCH(req: NextRequest) {
     }
   }
 
-  // Enviar notificação no Telegram quando venda é FINALIZADA
-  if (fields.status_pagamento === "FINALIZADO" && data && data.length > 0) {
+  // Enviar notificacao Telegram + NF por email APENAS na transicao para FINALIZADO.
+  // Se a venda ja estava FINALIZADA antes do PATCH, nao reenviar (bug: edicao
+  // de venda finalizada reenviava NF/Telegram toda vez).
+  const transicionouParaFinalizado = fields.status_pagamento === "FINALIZADO"
+    && statusPagamentoAnterior !== "FINALIZADO";
+  if (transicionouParaFinalizado && data && data.length > 0) {
     const venda = data[0];
     const lucroCalc = Number(venda.preco_vendido || 0) - Number(venda.custo || 0);
     console.log("[Vendas] Enviando notificação Telegram para venda finalizada:", venda.cliente, venda.produto);


### PR DESCRIPTION
## Resumo

Tres correcoes combinadas:

### 1. Editar venda unica descartava 2o produto adicionado
- Ao editar uma venda sem grupo_id, adicionar novo produto no carrinho e salvar, o codigo caia no ramo "Edicao simples" e salvava apenas o primeiro item; pagamento tambem nao era redistribuido.
- `setEditandoGrupoIds([v.id])` em vez de `[]` pra venda unica habilitar o ramo multi-produto quando um 2o produto aparece.
- Quando a venda original nao tem `grupo_id`, gera UUID real e propaga no PATCH da original pra ambas ficarem no mesmo grupo.

### 2. NF/Telegram reenviados a cada edicao de venda finalizada
- PATCH disparava email de NF e notificacao Telegram sempre que `status_pagamento === "FINALIZADO"`, mesmo quando a venda ja estava finalizada antes.
- Agora busca `status_pagamento` anterior e so dispara na transicao `!= FINALIZADO -> FINALIZADO`.

### 3. Ultra 3 com pulseira milanes misturado com Ultra 3 normal
- Chave de agrupamento de Apple Watch no estoque nao considerava variante de pulseira.
- Chave ganha sufixo `|||MILANES` quando produto/observacao contem "milanes"; card mostra pill "Pulseira Milanes" abaixo da cor.

## Test plan

### Edicao multi-produto
- [ ] Abrir uma venda unica (sem badge de grupo), clicar Editar
- [ ] Clicar "Adicionar ao carrinho" pra mover produto atual pro carrinho
- [ ] Preencher um 2o produto no formulario e ajustar comprovante
- [ ] Salvar e confirmar: aparecem DOIS produtos agrupados (borda laranja), comprovante redistribuido por custo

### NF nao reenvia
- [ ] Abrir uma venda ja FINALIZADA com email + NF anexada
- [ ] Editar qualquer campo (ex: corrigir telefone) e salvar
- [ ] Confirmar nos logs do servidor que \`[Vendas] NF enviada por email\` NAO dispara
- [ ] Criar/finalizar uma venda do zero: NF ainda eh enviada normalmente na 1a vez

### Ultra 3 milanes
- [ ] Na aba Estoque, verificar se Ultra 3 Titanio Natural com "Pulseira natural estilo milanes" aparece em card separado do normal
- [ ] Idem para Titanio Preto com "Pulseira preta estilo milanes"
- [ ] Card mostra pill "Pulseira Milanes" abaixo da cor

🤖 Generated with [Claude Code](https://claude.com/claude-code)