### PR TITLE
feat(instagram): PR 1 — geração de carrossel com pesquisa + fact-check

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useAdmin } from "@/components/admin/AdminShell";
+
+interface Slide {
+  titulo: string;
+  texto: string;
+  destaque?: string;
+}
+
+interface Pesquisa {
+  fontes?: string[];
+  fatos_verificados?: string[];
+}
+
+interface Post {
+  id: string;
+  tema: string;
+  tipo: "DICA" | "COMPARATIVO" | "NOTICIA";
+  numero_slides: number;
+  status: "RASCUNHO" | "GERANDO" | "GERADO" | "APROVADO" | "AGENDADO" | "POSTADO" | "ERRO";
+  slides_json: Slide[] | null;
+  legenda: string | null;
+  hashtags: string[] | null;
+  pesquisa_json: Pesquisa | null;
+  erro: string | null;
+  criado_por: string | null;
+  created_at: string;
+}
+
+const STATUS_LABEL: Record<Post["status"], string> = {
+  RASCUNHO: "📝 Rascunho",
+  GERANDO: "⏳ Gerando...",
+  GERADO: "✨ Gerado",
+  APROVADO: "👍 Aprovado",
+  AGENDADO: "📅 Agendado",
+  POSTADO: "✅ Postado",
+  ERRO: "❌ Erro",
+};
+
+const TIPO_LABEL: Record<Post["tipo"], string> = {
+  DICA: "💡 Dica",
+  COMPARATIVO: "⚖️ Comparativo",
+  NOTICIA: "📰 Notícia",
+};
+
+export default function InstagramPostPage() {
+  const { id } = useParams<{ id: string }>();
+  const { password, apiHeaders } = useAdmin();
+  const [post, setPost] = useState<Post | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [gerando, setGerando] = useState(false);
+  const [salvando, setSalvando] = useState(false);
+  const [msg, setMsg] = useState("");
+  const [slidesEdit, setSlidesEdit] = useState<Slide[]>([]);
+  const [legendaEdit, setLegendaEdit] = useState("");
+  const [hashtagsEdit, setHashtagsEdit] = useState("");
+
+  const fetchPost = useCallback(async () => {
+    if (!password || !id) return;
+    try {
+      const res = await fetch(`/api/admin/instagram-posts?id=${id}`, { headers: apiHeaders() });
+      if (res.ok) {
+        const j = await res.json();
+        setPost(j.data);
+        if (j.data?.slides_json) setSlidesEdit(j.data.slides_json);
+        if (j.data?.legenda) setLegendaEdit(j.data.legenda);
+        if (j.data?.hashtags) setHashtagsEdit(j.data.hashtags.join(" "));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [password, id, apiHeaders]);
+
+  useEffect(() => { fetchPost(); }, [fetchPost]);
+
+  const gerar = async () => {
+    setGerando(true);
+    setMsg("Gerando... isso pode levar até 2 minutos (pesquisa + fact-check).");
+    try {
+      const res = await fetch("/api/instagram/gerar", {
+        method: "POST",
+        headers: apiHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ postId: id }),
+      });
+      const j = await res.json();
+      if (!res.ok || !j.ok) {
+        setMsg("Erro: " + (j.detalhe || j.error || "falha ao gerar"));
+        await fetchPost();
+        return;
+      }
+      setPost(j.data);
+      if (j.data.slides_json) setSlidesEdit(j.data.slides_json);
+      if (j.data.legenda) setLegendaEdit(j.data.legenda);
+      if (j.data.hashtags) setHashtagsEdit(j.data.hashtags.join(" "));
+      setMsg("Gerado com sucesso.");
+    } catch (e) {
+      setMsg("Erro de rede: " + (e instanceof Error ? e.message : String(e)));
+    } finally {
+      setGerando(false);
+    }
+  };
+
+  const salvarEdicao = async (novoStatus?: Post["status"]) => {
+    setSalvando(true);
+    setMsg("");
+    try {
+      const hashtags = hashtagsEdit
+        .split(/\s+/)
+        .map(h => h.replace(/^#+/, "").trim())
+        .filter(Boolean);
+
+      const body: Record<string, unknown> = {
+        id,
+        slides_json: slidesEdit,
+        legenda: legendaEdit,
+        hashtags,
+      };
+      if (novoStatus) body.status = novoStatus;
+
+      const res = await fetch("/api/admin/instagram-posts", {
+        method: "PATCH",
+        headers: apiHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify(body),
+      });
+      const j = await res.json();
+      if (!res.ok || !j.ok) {
+        setMsg("Erro: " + (j.error || "falha ao salvar"));
+        return;
+      }
+      setMsg(novoStatus === "APROVADO" ? "Aprovado!" : "Salvo.");
+      fetchPost();
+    } finally {
+      setSalvando(false);
+    }
+  };
+
+  const atualizarSlide = (idx: number, campo: keyof Slide, valor: string) => {
+    setSlidesEdit(prev => prev.map((s, i) => i === idx ? { ...s, [campo]: valor } : s));
+  };
+
+  if (loading) return <div className="max-w-5xl mx-auto p-6 text-[#86868B]">Carregando...</div>;
+  if (!post) return <div className="max-w-5xl mx-auto p-6 text-[#E74C3C]">Post não encontrado.</div>;
+
+  const jaTemConteudo = post.status !== "RASCUNHO" && post.status !== "GERANDO" && slidesEdit.length > 0;
+  const podeEditar = ["GERADO", "ERRO"].includes(post.status);
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      {/* Header */}
+      <div className="mb-4">
+        <Link href="/admin/instagram" className="text-sm text-[#E8740E] hover:underline">← Voltar</Link>
+      </div>
+
+      <div className="flex items-start justify-between mb-6 flex-wrap gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap mb-2">
+            <span className="text-xs px-2 py-1 rounded-lg bg-[#F5F5F7] text-[#6E6E73]">{TIPO_LABEL[post.tipo]}</span>
+            <span className="text-xs px-2 py-1 rounded-lg bg-[#F5F5F7] text-[#6E6E73]">{post.numero_slides} slides</span>
+            <span className="text-xs px-2 py-1 rounded-lg bg-[#FFF5EB] text-[#E8740E]">{STATUS_LABEL[post.status]}</span>
+          </div>
+          <h1 className="text-2xl font-bold text-[#1D1D1F]">{post.tema}</h1>
+          <p className="text-xs text-[#86868B] mt-1">
+            Criado em {new Date(post.created_at).toLocaleString("pt-BR")}
+            {post.criado_por && ` · por ${post.criado_por}`}
+          </p>
+        </div>
+      </div>
+
+      {msg && (
+        <div className={`mb-4 px-4 py-3 rounded-xl text-sm ${
+          msg.startsWith("Erro") ? "bg-[#FFF0F0] text-[#E74C3C] border border-[#E74C3C]/20" : "bg-[#F0FFF4] text-[#2ECC71] border border-[#2ECC71]/20"
+        }`}>
+          {msg}
+        </div>
+      )}
+
+      {post.erro && (
+        <div className="mb-4 px-4 py-3 rounded-xl bg-[#FFF0F0] text-[#E74C3C] border border-[#E74C3C]/20 text-sm">
+          <strong>Último erro:</strong> {post.erro}
+        </div>
+      )}
+
+      {/* Ação principal: gerar */}
+      {(post.status === "RASCUNHO" || post.status === "ERRO") && (
+        <div className="bg-white border border-[#D2D2D7] rounded-2xl p-6 mb-6 text-center">
+          <p className="text-sm text-[#6E6E73] mb-4">
+            Clique pra a IA pesquisar o tema, verificar os fatos em múltiplas fontes e montar os {post.numero_slides} slides do carrossel.
+          </p>
+          <button
+            onClick={gerar}
+            disabled={gerando}
+            className="px-5 py-2.5 rounded-xl bg-[#E8740E] text-white font-semibold hover:bg-[#F5A623] transition-colors disabled:opacity-50"
+          >
+            {gerando ? "⏳ Gerando..." : post.status === "ERRO" ? "🔄 Tentar de novo" : "✨ Gerar conteúdo"}
+          </button>
+        </div>
+      )}
+
+      {post.status === "GERANDO" && (
+        <div className="bg-white border border-[#D2D2D7] rounded-2xl p-8 mb-6 text-center text-[#86868B]">
+          ⏳ Gerando... (pesquisando, verificando fatos, montando slides)
+        </div>
+      )}
+
+      {/* Slides */}
+      {jaTemConteudo && (
+        <>
+          <div className="mb-4 flex items-center justify-between flex-wrap gap-2">
+            <h2 className="text-lg font-semibold text-[#1D1D1F]">Slides</h2>
+            {podeEditar && (
+              <div className="flex gap-2">
+                <button
+                  onClick={gerar}
+                  disabled={gerando}
+                  className="px-3 py-1.5 rounded-xl border border-[#D2D2D7] text-xs text-[#6E6E73] hover:bg-[#F5F5F7] disabled:opacity-50"
+                >
+                  {gerando ? "Gerando..." : "🔄 Re-gerar"}
+                </button>
+                <button
+                  onClick={() => salvarEdicao()}
+                  disabled={salvando}
+                  className="px-3 py-1.5 rounded-xl border border-[#D2D2D7] text-xs text-[#6E6E73] hover:bg-[#F5F5F7] disabled:opacity-50"
+                >
+                  {salvando ? "Salvando..." : "💾 Salvar edição"}
+                </button>
+                <button
+                  onClick={() => salvarEdicao("APROVADO")}
+                  disabled={salvando}
+                  className="px-3 py-1.5 rounded-xl bg-[#2ECC71] text-white text-xs font-semibold hover:bg-[#27AE60] disabled:opacity-50"
+                >
+                  👍 Aprovar
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div className="grid gap-3 mb-6">
+            {slidesEdit.map((slide, idx) => (
+              <div key={idx} className="bg-white border border-[#D2D2D7] rounded-2xl p-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <span className="text-xs px-2 py-1 rounded bg-[#1D1D1F] text-white font-mono">{idx + 1}</span>
+                  <span className="text-xs text-[#86868B]">
+                    {idx === 0 ? "Capa" : idx === slidesEdit.length - 1 ? "CTA" : "Slide"}
+                  </span>
+                  {slide.destaque && (
+                    <span className="text-xs px-2 py-1 rounded bg-[#FFF5EB] text-[#E8740E] font-bold">
+                      💥 {slide.destaque}
+                    </span>
+                  )}
+                </div>
+                <input
+                  value={slide.titulo}
+                  onChange={e => atualizarSlide(idx, "titulo", e.target.value)}
+                  disabled={!podeEditar}
+                  placeholder="Título"
+                  className="w-full mb-2 px-3 py-2 rounded-lg border border-[#E8E8ED] text-base font-semibold focus:outline-none focus:border-[#E8740E]"
+                />
+                <textarea
+                  value={slide.texto}
+                  onChange={e => atualizarSlide(idx, "texto", e.target.value)}
+                  disabled={!podeEditar}
+                  placeholder="Texto"
+                  rows={3}
+                  className="w-full px-3 py-2 rounded-lg border border-[#E8E8ED] text-sm focus:outline-none focus:border-[#E8740E]"
+                />
+                <div className="text-xs text-[#86868B] mt-1 flex gap-4">
+                  <span>Título: {slide.titulo.length} chars</span>
+                  <span>Texto: {slide.texto.length} chars</span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Legenda + hashtags */}
+          <div className="bg-white border border-[#D2D2D7] rounded-2xl p-4 mb-6">
+            <h3 className="text-sm font-semibold text-[#1D1D1F] mb-3">Legenda</h3>
+            <textarea
+              value={legendaEdit}
+              onChange={e => setLegendaEdit(e.target.value)}
+              disabled={!podeEditar}
+              rows={4}
+              className="w-full px-3 py-2 rounded-lg border border-[#E8E8ED] text-sm mb-3 focus:outline-none focus:border-[#E8740E]"
+            />
+            <h3 className="text-sm font-semibold text-[#1D1D1F] mb-2">Hashtags</h3>
+            <input
+              value={hashtagsEdit}
+              onChange={e => setHashtagsEdit(e.target.value)}
+              disabled={!podeEditar}
+              placeholder="separadas por espaço"
+              className="w-full px-3 py-2 rounded-lg border border-[#E8E8ED] text-sm focus:outline-none focus:border-[#E8740E]"
+            />
+            <div className="text-xs text-[#86868B] mt-2">
+              {hashtagsEdit.split(/\s+/).filter(Boolean).length} hashtags
+            </div>
+          </div>
+
+          {/* Fact-check */}
+          {post.pesquisa_json && (
+            <details className="bg-[#F5F5F7] border border-[#E8E8ED] rounded-2xl p-4 mb-6">
+              <summary className="cursor-pointer text-sm font-semibold text-[#1D1D1F]">
+                🔍 Pesquisa e fact-check
+              </summary>
+              <div className="mt-3 space-y-3">
+                {post.pesquisa_json.fatos_verificados && post.pesquisa_json.fatos_verificados.length > 0 && (
+                  <div>
+                    <h4 className="text-xs font-medium text-[#6E6E73] mb-2">Fatos verificados</h4>
+                    <ul className="text-sm text-[#1D1D1F] space-y-1 list-disc list-inside">
+                      {post.pesquisa_json.fatos_verificados.map((f, i) => (
+                        <li key={i}>{f}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+                {post.pesquisa_json.fontes && post.pesquisa_json.fontes.length > 0 && (
+                  <div>
+                    <h4 className="text-xs font-medium text-[#6E6E73] mb-2">Fontes consultadas</h4>
+                    <ul className="text-sm space-y-1">
+                      {post.pesquisa_json.fontes.map((url, i) => (
+                        <li key={i}>
+                          <a href={url} target="_blank" rel="noreferrer" className="text-[#E8740E] hover:underline break-all">
+                            {url}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            </details>
+          )}
+        </>
+      )}
+
+      <div className="text-xs text-[#86868B] text-center py-4">
+        Após aprovar: próximo PR adiciona renderização de imagem + postagem automática.
+      </div>
+    </div>
+  );
+}

--- a/app/admin/instagram/page.tsx
+++ b/app/admin/instagram/page.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAdmin } from "@/components/admin/AdminShell";
+
+interface Post {
+  id: string;
+  tema: string;
+  tipo: "DICA" | "COMPARATIVO" | "NOTICIA";
+  numero_slides: number;
+  status: "RASCUNHO" | "GERANDO" | "GERADO" | "APROVADO" | "AGENDADO" | "POSTADO" | "ERRO";
+  erro: string | null;
+  criado_por: string | null;
+  created_at: string;
+  agendado_para: string | null;
+  postado_em: string | null;
+}
+
+const STATUS_LABEL: Record<Post["status"], string> = {
+  RASCUNHO: "📝 Rascunho",
+  GERANDO: "⏳ Gerando...",
+  GERADO: "✨ Gerado",
+  APROVADO: "👍 Aprovado",
+  AGENDADO: "📅 Agendado",
+  POSTADO: "✅ Postado",
+  ERRO: "❌ Erro",
+};
+
+const TIPO_LABEL: Record<Post["tipo"], string> = {
+  DICA: "💡 Dica",
+  COMPARATIVO: "⚖️ Comparativo",
+  NOTICIA: "📰 Notícia",
+};
+
+export default function InstagramListPage() {
+  const { password, apiHeaders } = useAdmin();
+  const router = useRouter();
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filtro, setFiltro] = useState<"TODOS" | Post["status"]>("TODOS");
+  const [novoOpen, setNovoOpen] = useState(false);
+  const [form, setForm] = useState({ tema: "", tipo: "DICA" as Post["tipo"], numero_slides: 7 });
+  const [saving, setSaving] = useState(false);
+  const [msg, setMsg] = useState("");
+
+  const fetchPosts = useCallback(async () => {
+    if (!password) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/instagram-posts", { headers: apiHeaders() });
+      if (res.ok) {
+        const j = await res.json();
+        setPosts(j.data || []);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [password, apiHeaders]);
+
+  useEffect(() => { fetchPosts(); }, [fetchPosts]);
+
+  const criar = async () => {
+    if (!form.tema.trim()) {
+      setMsg("Preencha o tema");
+      return;
+    }
+    setSaving(true);
+    setMsg("");
+    try {
+      const res = await fetch("/api/admin/instagram-posts", {
+        method: "POST",
+        headers: apiHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify(form),
+      });
+      const j = await res.json();
+      if (!res.ok || !j.ok) {
+        setMsg("Erro: " + (j.error || "falha ao criar"));
+        return;
+      }
+      router.push(`/admin/instagram/${j.data.id}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remover = async (id: string, tema: string) => {
+    if (!confirm(`Remover o post "${tema}"?`)) return;
+    await fetch(`/api/admin/instagram-posts?id=${id}`, { method: "DELETE", headers: apiHeaders() });
+    fetchPosts();
+  };
+
+  const filtrados = filtro === "TODOS" ? posts : posts.filter(p => p.status === filtro);
+  const contagem: Record<string, number> = {
+    TODOS: posts.length,
+    RASCUNHO: posts.filter(p => p.status === "RASCUNHO").length,
+    GERADO: posts.filter(p => p.status === "GERADO").length,
+    APROVADO: posts.filter(p => p.status === "APROVADO").length,
+    AGENDADO: posts.filter(p => p.status === "AGENDADO").length,
+    POSTADO: posts.filter(p => p.status === "POSTADO").length,
+    ERRO: posts.filter(p => p.status === "ERRO").length,
+  };
+
+  return (
+    <div className="max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-6 flex-wrap gap-3">
+        <div>
+          <h1 className="text-2xl font-bold text-[#1D1D1F]">📸 Instagram</h1>
+          <p className="text-sm text-[#86868B] mt-1">Posts automatizados em carrossel com pesquisa + fact-check</p>
+        </div>
+        <button
+          onClick={() => setNovoOpen(true)}
+          className="px-4 py-2 rounded-xl bg-[#E8740E] text-white font-semibold hover:bg-[#F5A623] transition-colors"
+        >
+          + Novo post
+        </button>
+      </div>
+
+      {/* Filtros */}
+      <div className="flex gap-2 mb-4 flex-wrap">
+        {(["TODOS", "RASCUNHO", "GERADO", "APROVADO", "AGENDADO", "POSTADO", "ERRO"] as const).map(s => (
+          <button
+            key={s}
+            onClick={() => setFiltro(s)}
+            className={`px-3 py-1.5 rounded-xl text-xs font-medium border transition-colors ${
+              filtro === s
+                ? "bg-[#FFF5EB] text-[#E8740E] border-[#E8740E]/30"
+                : "bg-white text-[#6E6E73] border-[#D2D2D7] hover:bg-[#F5F5F7]"
+            }`}
+          >
+            {s === "TODOS" ? "Todos" : STATUS_LABEL[s as Post["status"]]} <span className="opacity-60">({contagem[s] ?? 0})</span>
+          </button>
+        ))}
+      </div>
+
+      {/* Modal novo post */}
+      {novoOpen && (
+        <div className="fixed inset-0 bg-black/40 z-40 flex items-center justify-center p-4" onClick={() => setNovoOpen(false)}>
+          <div className="bg-white rounded-2xl p-6 max-w-md w-full shadow-xl" onClick={e => e.stopPropagation()}>
+            <h2 className="text-lg font-semibold mb-4 text-[#1D1D1F]">Novo post</h2>
+            <div className="space-y-3">
+              <div>
+                <label className="text-xs font-medium text-[#6E6E73] mb-1 block">Tema</label>
+                <textarea
+                  value={form.tema}
+                  onChange={e => setForm({ ...form, tema: e.target.value })}
+                  placeholder='ex: "5 dicas pra economizar bateria no iPhone 15"'
+                  rows={3}
+                  className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-[#6E6E73] mb-1 block">Tipo</label>
+                <select
+                  value={form.tipo}
+                  onChange={e => setForm({ ...form, tipo: e.target.value as Post["tipo"] })}
+                  className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                >
+                  <option value="DICA">💡 Dica prática</option>
+                  <option value="COMPARATIVO">⚖️ Comparativo</option>
+                  <option value="NOTICIA">📰 Notícia / lançamento</option>
+                </select>
+              </div>
+              <div>
+                <label className="text-xs font-medium text-[#6E6E73] mb-1 block">Nº de slides</label>
+                <select
+                  value={form.numero_slides}
+                  onChange={e => setForm({ ...form, numero_slides: Number(e.target.value) })}
+                  className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                >
+                  <option value={5}>5 slides</option>
+                  <option value={6}>6 slides</option>
+                  <option value={7}>7 slides</option>
+                </select>
+              </div>
+              {msg && <p className="text-sm text-[#E74C3C]">{msg}</p>}
+              <div className="flex gap-2 pt-2">
+                <button
+                  onClick={() => { setNovoOpen(false); setMsg(""); }}
+                  className="flex-1 px-4 py-2 rounded-xl border border-[#D2D2D7] text-sm text-[#6E6E73] hover:bg-[#F5F5F7]"
+                >
+                  Cancelar
+                </button>
+                <button
+                  onClick={criar}
+                  disabled={saving}
+                  className="flex-1 px-4 py-2 rounded-xl bg-[#E8740E] text-white text-sm font-semibold hover:bg-[#F5A623] disabled:opacity-50"
+                >
+                  {saving ? "Criando..." : "Criar e gerar"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Lista */}
+      <div className="bg-white rounded-2xl border border-[#D2D2D7] overflow-hidden">
+        {loading ? (
+          <div className="p-8 text-center text-[#86868B] text-sm">Carregando...</div>
+        ) : filtrados.length === 0 ? (
+          <div className="p-8 text-center text-[#86868B] text-sm">
+            {filtro === "TODOS" ? "Nenhum post ainda. Clique em \"+ Novo post\" pra começar." : "Nenhum post nesse status."}
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-[#F5F5F7] text-[#6E6E73] text-xs uppercase">
+              <tr>
+                <th className="text-left px-4 py-3">Tipo</th>
+                <th className="text-left px-4 py-3">Tema</th>
+                <th className="text-left px-4 py-3">Status</th>
+                <th className="text-left px-4 py-3">Criado</th>
+                <th className="text-right px-4 py-3"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtrados.map(p => (
+                <tr key={p.id} className="border-t border-[#E8E8ED] hover:bg-[#FAFAFA]">
+                  <td className="px-4 py-3 whitespace-nowrap">{TIPO_LABEL[p.tipo]}</td>
+                  <td className="px-4 py-3">
+                    <Link href={`/admin/instagram/${p.id}`} className="text-[#E8740E] hover:underline">
+                      {p.tema}
+                    </Link>
+                    {p.erro && <div className="text-xs text-[#E74C3C] mt-1 truncate max-w-md" title={p.erro}>{p.erro}</div>}
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap text-xs">{STATUS_LABEL[p.status]}</td>
+                  <td className="px-4 py-3 whitespace-nowrap text-xs text-[#86868B]">
+                    {new Date(p.created_at).toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" })}
+                    {p.criado_por && <span className="ml-1">· {p.criado_por}</span>}
+                  </td>
+                  <td className="px-4 py-3 text-right whitespace-nowrap">
+                    <Link href={`/admin/instagram/${p.id}`} className="text-xs text-[#E8740E] hover:underline mr-3">Abrir</Link>
+                    <button onClick={() => remover(p.id, p.tema)} className="text-xs text-[#E74C3C] hover:underline">Remover</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="mt-6 p-4 rounded-xl bg-[#FFF5EB] border border-[#E8740E]/20 text-xs text-[#6E6E73]">
+        <strong className="text-[#1D1D1F]">Fase 1 de 3:</strong> geração de texto com pesquisa + fact-check.
+        Renderização de imagem e postagem automática vêm nos próximos PRs.
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/instagram-posts/route.ts
+++ b/app/api/admin/instagram-posts/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { logActivity } from "@/lib/activity-log";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+const noCache = { "Cache-Control": "no-store, no-cache, must-revalidate", "Pragma": "no-cache" };
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+function getUsuario(req: NextRequest) {
+  return decodeURIComponent(req.headers.get("x-admin-user") || "sistema");
+}
+
+export async function GET(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: noCache });
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  const status = searchParams.get("status");
+
+  if (id) {
+    const { data, error } = await supabase.from("instagram_posts").select("*").eq("id", id).single();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCache });
+    return NextResponse.json({ data }, { headers: noCache });
+  }
+
+  let q = supabase.from("instagram_posts").select("*").order("created_at", { ascending: false }).limit(200);
+  if (status) q = q.eq("status", status);
+  const { data, error } = await q;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCache });
+  return NextResponse.json({ data: data || [] }, { headers: noCache });
+}
+
+export async function POST(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: noCache });
+  const usuario = getUsuario(req);
+  const body = await req.json();
+  const { tema, tipo = "DICA", numero_slides = 7 } = body;
+
+  if (!tema?.trim()) return NextResponse.json({ error: "tema obrigatório" }, { status: 400, headers: noCache });
+  if (!["DICA", "COMPARATIVO", "NOTICIA"].includes(tipo)) {
+    return NextResponse.json({ error: "tipo inválido" }, { status: 400, headers: noCache });
+  }
+  const n = Number(numero_slides);
+  if (!Number.isInteger(n) || n < 5 || n > 7) {
+    return NextResponse.json({ error: "numero_slides deve estar entre 5 e 7" }, { status: 400, headers: noCache });
+  }
+
+  const { data, error } = await supabase
+    .from("instagram_posts")
+    .insert({ tema: tema.trim(), tipo, numero_slides: n, criado_por: usuario })
+    .select("*")
+    .single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCache });
+
+  await logActivity(usuario, "Post Instagram criado", `${tipo}: ${tema}`, "instagram", data.id);
+  return NextResponse.json({ ok: true, data }, { headers: noCache });
+}
+
+export async function PATCH(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: noCache });
+  const usuario = getUsuario(req);
+  const body = await req.json();
+  const { id, ...campos } = body;
+  if (!id) return NextResponse.json({ error: "id obrigatório" }, { status: 400, headers: noCache });
+
+  const editaveis = [
+    "tema", "tipo", "numero_slides", "status",
+    "pesquisa_json", "slides_json", "legenda", "hashtags",
+    "agendado_para", "erro",
+  ] as const;
+
+  const upd: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  for (const k of editaveis) {
+    if (campos[k] !== undefined) upd[k] = campos[k];
+  }
+
+  const { error } = await supabase.from("instagram_posts").update(upd).eq("id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCache });
+  await logActivity(usuario, "Post Instagram atualizado", `id=${id}`, "instagram", id);
+  return NextResponse.json({ ok: true }, { headers: noCache });
+}
+
+export async function DELETE(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: noCache });
+  const usuario = getUsuario(req);
+  const { searchParams } = new URL(req.url);
+  const id = searchParams.get("id");
+  if (!id) return NextResponse.json({ error: "id obrigatório" }, { status: 400, headers: noCache });
+
+  const { error } = await supabase.from("instagram_posts").delete().eq("id", id);
+  if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCache });
+  await logActivity(usuario, "Post Instagram removido", `id=${id}`, "instagram", id);
+  return NextResponse.json({ ok: true }, { headers: noCache });
+}

--- a/app/api/instagram/gerar/route.ts
+++ b/app/api/instagram/gerar/route.ts
@@ -49,6 +49,27 @@ REGRA DE OURO — FACT-CHECK
 4. Preços em reais: só inclua se for preço oficial Apple Brasil. Nunca invente.
 5. Data de lançamento: só inclua se for confirmada (Apple Newsroom, site oficial ou 2 veículos grandes).
 
+HIERARQUIA DE FONTES — consulte nesta ordem
+PRIMÁRIA (sempre tentar primeiro):
+- apple.com (apple.com/br, newsroom.apple.com, support.apple.com, developer.apple.com)
+- Página oficial do produto (ex: apple.com/br/iphone-16-pro/specs/) e a tabela de comparação (apple.com/br/iphone/compare/) — obrigatória pra posts do tipo COMPARATIVO.
+
+SECUNDÁRIA (use pra contexto, opinião e "no mundo real"):
+- 9to5mac.com, macrumors.com, theverge.com, arstechnica.com, wired.com
+- Em português: tecnoblog.net, techtudo.com.br, canaltech.com.br, olhardigital.com.br, meiobit.com
+
+EVITAR:
+- Blogs pessoais sem autoria, sites de afiliado/cupom, fóruns do Reddit como fonte única, páginas de "top 10" agregadoras sem fonte primária.
+- Rumores não confirmados por 2+ veículos grandes (ex: só um tweet ou só um leaker).
+
+YOUTUBE:
+- web_search pode trazer vídeos do YouTube. Você pode usar o TÍTULO + DESCRIÇÃO + TRANSCRIÇÃO (quando disponível) como fonte secundária, mas NÃO presuma o conteúdo do vídeo só pelo thumbnail ou título. Se a informação só existe em vídeo sem transcrição acessível, considere não confirmada.
+
+PROTOCOLO DE BUSCA POR TIPO DE POST:
+- DICA: 1 busca em apple.com/support + 1 em fonte secundária pt-BR pra linguagem do dia a dia.
+- COMPARATIVO: SEMPRE abra apple.com/compare ou as páginas /specs/ dos dois modelos ANTES de qualquer review. Depois confirma impressões práticas em 2 fontes secundárias.
+- NOTICIA: 1 busca em newsroom.apple.com + 1 em 9to5mac/MacRumors/Verge. Data e número de modelo só do site oficial.
+
 LEGENDA
 - 2-4 frases. Começa com um gancho (pergunta, observação ou contraste). Termina com um CTA coerente com o último slide.
 - Hashtags separadas no campo próprio. Retorne 10-15 hashtags em português/inglês relevantes ao nicho Apple + loja (ex: iphone, apple, rio, tradein, tigraoimports). Sem '#' — o sistema adiciona.

--- a/app/api/instagram/gerar/route.ts
+++ b/app/api/instagram/gerar/route.ts
@@ -1,0 +1,231 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { createClient } from "@supabase/supabase-js";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 300;
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || "";
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const TIPO_GUIA: Record<string, string> = {
+  DICA: "dica prática pra dono de iPhone/Mac/Apple Watch (ex: '5 ajustes pra economizar bateria'). Foco em utilidade imediata.",
+  COMPARATIVO: "comparativo entre modelos ou features (ex: 'iPhone 15 vs 16 — vale a pena trocar?'). Traga números concretos (chip, bateria, tela) e veredito honesto.",
+  NOTICIA: "novidade, lançamento ou rumor do ecossistema Apple. Data, fonte e o que muda na prática pro consumidor.",
+};
+
+function buildSystemPrompt(tipo: string, numeroSlides: number): string {
+  return `Você é o editor de conteúdo do Instagram da @tigraoimports, loja de eletrônicos Apple no Rio de Janeiro. Nicho: iPhone, Mac, Apple Watch, AirPods — novos, seminovos e trade-in.
+
+TAREFA
+Criar um carrossel de ${numeroSlides} slides sobre o tema solicitado. Tipo: ${tipo} — ${TIPO_GUIA[tipo] || ""}.
+
+TOM DE VOZ (misto descontraído + técnico + formal)
+- Descontraído sem ser coloquial demais. Nada de "mano", "brother", "tá ligado". Nada de "ademais", "outrossim", "cumpre ressaltar".
+- Técnico quando ajuda: pode falar "chip A17 Pro", "ProMotion 120Hz", "USB-C 2.0", "câmera de 48MP" sem explicar se for óbvio. Se for detalhe menos conhecido, explica em 1 linha.
+- Formal no sentido de correção gramatical e precisão. Nunca clickbait ("você não vai acreditar", "descubra agora").
+- Português brasileiro. Você pode usar "você" / "seu".
+
+ESTRUTURA DO CARROSSEL
+- Slide 1 (capa): título curto e impactante (máx 50 caracteres) + uma linha de chamada (máx 80 caracteres). Sem emoji na capa.
+- Slides do meio: 1 ideia central por slide. Título curto (máx 40 caracteres) + texto corrido (máx 220 caracteres).
+- Último slide: CTA suave. Ex: "Salva pra consultar depois", "Comenta sua dúvida", "Compartilha com quem vai comprar iPhone".
+- Campo 'destaque' (opcional): 1 número/dado que merece virar tipografia grande no slide. Ex: "48MP", "30%", "R$ 6.999". Só usa se for realmente impactante.
+
+REGRA DE OURO — FACT-CHECK
+1. Use web_search pra pesquisar o tema. Mínimo 2 buscas com ângulos diferentes.
+2. Para CADA fato que for parar no carrossel (número, data, specs, preço, nome de chip, etc), confirme em pelo menos 2 fontes independentes.
+3. Se um fato relevante não pôde ser confirmado em 2+ fontes, NÃO coloque no post. Prefira silêncio a erro.
+4. Preços em reais: só inclua se for preço oficial Apple Brasil. Nunca invente.
+5. Data de lançamento: só inclua se for confirmada (Apple Newsroom, site oficial ou 2 veículos grandes).
+
+LEGENDA
+- 2-4 frases. Começa com um gancho (pergunta, observação ou contraste). Termina com um CTA coerente com o último slide.
+- Hashtags separadas no campo próprio. Retorne 10-15 hashtags em português/inglês relevantes ao nicho Apple + loja (ex: iphone, apple, rio, tradein, tigraoimports). Sem '#' — o sistema adiciona.
+
+SAÍDA
+Quando tiver a pesquisa completa e o conteúdo pronto, chame a ferramenta 'salvar_post' UMA vez com o JSON final. Não escreva texto narrativo — só a chamada da ferramenta.`;
+}
+
+const TOOLS: Anthropic.Tool[] = [
+  {
+    name: "salvar_post",
+    description: "Salva o post finalizado após pesquisa e verificação de fatos. Chame UMA única vez quando tiver tudo pronto.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        slides: {
+          type: "array",
+          description: "Array ordenado de slides do carrossel (capa no índice 0, CTA no último).",
+          items: {
+            type: "object",
+            properties: {
+              titulo: { type: "string", description: "Título do slide. Capa: máx 50 caracteres; outros: máx 40." },
+              texto: { type: "string", description: "Corpo do slide. Capa: máx 80 caracteres; outros: máx 220." },
+              destaque: { type: "string", description: "Opcional. Número/dado curto que vira tipografia grande. Ex: '48MP', 'R$ 6.999'." },
+            },
+            required: ["titulo", "texto"],
+          },
+        },
+        legenda: { type: "string", description: "Legenda do post (2-4 frases, com CTA no final). Sem hashtags." },
+        hashtags: {
+          type: "array",
+          items: { type: "string" },
+          description: "10-15 hashtags sem '#'. Ex: ['iphone', 'apple', 'rio'].",
+        },
+        fontes: {
+          type: "array",
+          items: { type: "string" },
+          description: "URLs das fontes consultadas no fact-check.",
+        },
+        fatos_verificados: {
+          type: "array",
+          items: { type: "string" },
+          description: "Lista dos principais fatos que foram confirmados em 2+ fontes (um por linha).",
+        },
+      },
+      required: ["slides", "legenda", "hashtags", "fontes", "fatos_verificados"],
+    },
+  },
+];
+
+// Server-side web_search tool do Anthropic
+const WEB_SEARCH_TOOL = {
+  type: "web_search_20250305",
+  name: "web_search",
+  max_uses: 5,
+} as unknown as Anthropic.Tool;
+
+interface SlideOutput {
+  titulo: string;
+  texto: string;
+  destaque?: string;
+}
+
+interface PostOutput {
+  slides: SlideOutput[];
+  legenda: string;
+  hashtags: string[];
+  fontes: string[];
+  fatos_verificados: string[];
+}
+
+export async function POST(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const supabase = getSupabase();
+  try {
+    const body = await req.json();
+    const { postId } = body;
+    if (!postId) return NextResponse.json({ error: "postId obrigatório" }, { status: 400 });
+
+    const { data: post, error: fetchErr } = await supabase
+      .from("instagram_posts")
+      .select("*")
+      .eq("id", postId)
+      .single();
+    if (fetchErr || !post) {
+      return NextResponse.json({ error: fetchErr?.message || "post não encontrado" }, { status: 404 });
+    }
+
+    await supabase.from("instagram_posts").update({ status: "GERANDO", erro: null, updated_at: new Date().toISOString() }).eq("id", postId);
+
+    const systemPrompt = buildSystemPrompt(post.tipo, post.numero_slides);
+    const userPrompt = `Tema do post: "${post.tema}"\n\nPesquise, verifique os fatos e monte o carrossel. Chame salvar_post no final.`;
+
+    const messages: Anthropic.MessageParam[] = [{ role: "user", content: userPrompt }];
+
+    const MAX_ITER = 12;
+    let iter = 0;
+    let resultado: PostOutput | null = null;
+
+    let response = await client.messages.create({
+      model: "claude-opus-4-7",
+      max_tokens: 6000,
+      system: systemPrompt,
+      tools: [WEB_SEARCH_TOOL, ...TOOLS],
+      messages,
+    });
+
+    while (response.stop_reason === "tool_use" && iter < MAX_ITER && !resultado) {
+      iter++;
+      const toolUses = response.content.filter((b): b is Anthropic.ToolUseBlock => b.type === "tool_use");
+
+      const toolResults: Anthropic.ToolResultBlockParam[] = [];
+      for (const tu of toolUses) {
+        if (tu.name === "salvar_post") {
+          resultado = tu.input as unknown as PostOutput;
+          toolResults.push({
+            type: "tool_result",
+            tool_use_id: tu.id,
+            content: "Post salvo. Não chame mais nenhuma ferramenta.",
+          });
+        }
+        // web_search é server-side: respostas vêm automaticamente no próximo turno, não precisa responder aqui.
+      }
+
+      if (resultado) break;
+
+      // Se não houve salvar_post, deixa o loop continuar — web_search já foi processado pelo servidor.
+      // Mas se não há tool_results (só web_search), o loop para — Claude vai voltar com texto ou outra tool_use.
+      messages.push({ role: "assistant", content: response.content });
+      if (toolResults.length > 0) {
+        messages.push({ role: "user", content: toolResults });
+      }
+
+      response = await client.messages.create({
+        model: "claude-opus-4-7",
+        max_tokens: 6000,
+        system: systemPrompt,
+        tools: [WEB_SEARCH_TOOL, ...TOOLS],
+        messages,
+      });
+    }
+
+    if (!resultado) {
+      const msg = "Claude não chamou salvar_post após " + iter + " iterações";
+      await supabase.from("instagram_posts").update({ status: "ERRO", erro: msg, updated_at: new Date().toISOString() }).eq("id", postId);
+      return NextResponse.json({ error: msg }, { status: 500 });
+    }
+
+    const { error: updErr } = await supabase.from("instagram_posts").update({
+      status: "GERADO",
+      slides_json: resultado.slides,
+      legenda: resultado.legenda,
+      hashtags: resultado.hashtags,
+      pesquisa_json: {
+        fontes: resultado.fontes,
+        fatos_verificados: resultado.fatos_verificados,
+      },
+      erro: null,
+      updated_at: new Date().toISOString(),
+    }).eq("id", postId);
+
+    if (updErr) {
+      return NextResponse.json({ error: updErr.message }, { status: 500 });
+    }
+
+    const { data: atualizado } = await supabase.from("instagram_posts").select("*").eq("id", postId).single();
+    return NextResponse.json({ ok: true, data: atualizado });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error("[instagram/gerar]", msg);
+    try {
+      const body = await req.clone().json().catch(() => ({}));
+      if (body?.postId) {
+        await supabase.from("instagram_posts").update({ status: "ERRO", erro: msg, updated_at: new Date().toISOString() }).eq("id", body.postId);
+      }
+    } catch { /* noop */ }
+    return NextResponse.json({ error: "Erro ao gerar post", detalhe: msg }, { status: 500 });
+  }
+}

--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -8,11 +8,21 @@ import { NAV, isGroup, type NavGroup, type NavItem } from "./nav-config";
 
 interface AdminNavProps {
   userRole: string;
+  userNome?: string;
   userPermissoes?: string[];
   abasOcultas?: string[];
 }
 
-export default function AdminNav({ userRole, userPermissoes, abasOcultas }: AdminNavProps) {
+function normalizarNome(s: string): string {
+  return (s || "")
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .split(/\s+/)[0] || "";
+}
+
+export default function AdminNav({ userRole, userNome, userPermissoes, abasOcultas }: AdminNavProps) {
   const pathname = usePathname();
   const { sidebarCollapsed: collapsed, setSidebarCollapsed: setCollapsed } = useAdmin();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -28,6 +38,7 @@ export default function AdminNav({ userRole, userPermissoes, abasOcultas }: Admi
 
   const isAdmin = userRole === "admin";
   const perms = userPermissoes ?? [];
+  const primeiroNome = normalizarNome(userNome ?? "");
 
   // Páginas visíveis pra todos os usuários (não precisa de permissão)
   const PUBLIC_PAGES = ["gerar_link", "calculadora_taxas", "entregas"];
@@ -51,6 +62,12 @@ export default function AdminNav({ userRole, userPermissoes, abasOcultas }: Admi
     return !ocultas.has(item.href);
   }
 
+  // Feature em beta: se o item tem 'betaPara', só mostra pros nomes listados.
+  function liberadoEmBeta(item: NavItem): boolean {
+    if (!item.betaPara || item.betaPara.length === 0) return true;
+    return item.betaPara.map(normalizarNome).includes(primeiroNome);
+  }
+
   function toggleGroup(label: string) {
     setOpenGroups((prev) => {
       const next = new Set(prev);
@@ -64,6 +81,7 @@ export default function AdminNav({ userRole, userPermissoes, abasOcultas }: Admi
     const isActive = pathname === item.href || (item.href !== "/admin" && pathname?.startsWith(item.href + "/"));
     if (!canSee(item.pageKey)) return null;
     if (!naoOculta(item)) return null;
+    if (!liberadoEmBeta(item)) return null;
     return (
       <Link
         key={item.href}
@@ -83,7 +101,7 @@ export default function AdminNav({ userRole, userPermissoes, abasOcultas }: Admi
   }
 
   function renderGroup(group: NavGroup) {
-    const visibleItems = group.items.filter((i) => canSee(i.pageKey) && naoOculta(i));
+    const visibleItems = group.items.filter((i) => canSee(i.pageKey) && naoOculta(i) && liberadoEmBeta(i));
     if (visibleItems.length === 0) return null;
 
     const isOpen = openGroups.has(group.label);

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -320,7 +320,7 @@ export default function AdminShell({ children }: { children: ReactNode }) {
         }}
       >
         {/* Sidebar Navigation */}
-        <AdminNav userRole={user.role} userPermissoes={user.permissoes} abasOcultas={user.abas_ocultas} />
+        <AdminNav userRole={user.role} userNome={user.nome} userPermissoes={user.permissoes} abasOcultas={user.abas_ocultas} />
 
         {/* Main content area — offset by sidebar width */}
         <div className={`${sidebarCollapsed ? "lg:ml-[60px]" : "lg:ml-[220px]"} print:ml-0 min-h-screen flex flex-col transition-all duration-200`}>

--- a/components/admin/nav-config.ts
+++ b/components/admin/nav-config.ts
@@ -74,6 +74,7 @@ export const NAV: NavEntry[] = [
     items: [
       { href: "/admin/mostruario", label: "Mostruario", icon: "\u{1F5BC}\uFE0F", pageKey: "mostruario" },
       { href: "/admin/simulacoes", label: "Simulacoes", icon: "\u{1F4F1}", pageKey: "simulacoes" },
+      { href: "/admin/instagram", label: "Instagram", icon: "\u{1F4F8}", pageKey: "instagram" },
       { href: "/admin/precos", label: "Alteração de Preços", icon: "\u{1F3F7}\uFE0F", pageKey: "precos" },
       { href: "/admin/usados", label: "Precos Trade-In", icon: "\u{1F4B0}", pageKey: "tradein_precos" },
       { href: "/admin/analytics", label: "Funil Trade-In", icon: "\u{1F4C8}", pageKey: "funil_tradein" },

--- a/components/admin/nav-config.ts
+++ b/components/admin/nav-config.ts
@@ -6,6 +6,12 @@ export interface NavItem {
   label: string;
   icon: string;
   pageKey: string; // granular permission key
+  /**
+   * Se preenchido, o item só aparece pros usuários listados (match por primeiro
+   * nome, case-insensitive, sem acento). Usado pra features em teste que só o
+   * dono/beta tester vê antes de liberar pra todo o admin.
+   */
+  betaPara?: string[];
 }
 
 export interface NavGroup {
@@ -74,7 +80,7 @@ export const NAV: NavEntry[] = [
     items: [
       { href: "/admin/mostruario", label: "Mostruario", icon: "\u{1F5BC}\uFE0F", pageKey: "mostruario" },
       { href: "/admin/simulacoes", label: "Simulacoes", icon: "\u{1F4F1}", pageKey: "simulacoes" },
-      { href: "/admin/instagram", label: "Instagram", icon: "\u{1F4F8}", pageKey: "instagram" },
+      { href: "/admin/instagram", label: "Instagram", icon: "\u{1F4F8}", pageKey: "instagram", betaPara: ["andre"] },
       { href: "/admin/precos", label: "Alteração de Preços", icon: "\u{1F3F7}\uFE0F", pageKey: "precos" },
       { href: "/admin/usados", label: "Precos Trade-In", icon: "\u{1F4B0}", pageKey: "tradein_precos" },
       { href: "/admin/analytics", label: "Funil Trade-In", icon: "\u{1F4C8}", pageKey: "funil_tradein" },

--- a/supabase/migrations/20260419c_instagram_posts.sql
+++ b/supabase/migrations/20260419c_instagram_posts.sql
@@ -1,0 +1,49 @@
+-- Tabela de posts automatizados para Instagram (carrossel).
+-- PR 1: fundação + geração de texto. Campos de imagem e postagem ficam prontos
+-- mas só são usados nos PRs seguintes.
+
+create table if not exists instagram_posts (
+  id uuid primary key default gen_random_uuid(),
+
+  -- Input do usuário
+  tema text not null,
+  tipo text not null default 'DICA', -- DICA | COMPARATIVO | NOTICIA
+  numero_slides int not null default 7, -- entre 5 e 7
+
+  -- Fluxo: RASCUNHO → GERANDO → GERADO → APROVADO → AGENDADO → POSTADO
+  -- ERRO em qualquer ponto marca falha; mensagem fica em "erro".
+  status text not null default 'RASCUNHO',
+
+  -- Resultado da pesquisa/geração (Claude)
+  pesquisa_json jsonb,  -- { fontes: [...], fatos_verificados: [...] }
+  slides_json jsonb,    -- [{ titulo, texto, destaque? }]
+  legenda text,
+  hashtags text[],
+
+  -- Fase 2 (renderização de imagens) — preenchido no próximo PR
+  imagens_urls text[],
+
+  -- Fase 3 (postagem automática) — preenchido no próximo PR
+  agendado_para timestamptz,
+  postado_em timestamptz,
+  instagram_post_id text,
+
+  erro text,
+  criado_por text,
+
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+
+  constraint instagram_posts_tipo_check check (tipo in ('DICA', 'COMPARATIVO', 'NOTICIA')),
+  constraint instagram_posts_status_check check (status in ('RASCUNHO', 'GERANDO', 'GERADO', 'APROVADO', 'AGENDADO', 'POSTADO', 'ERRO')),
+  constraint instagram_posts_numero_slides_check check (numero_slides between 3 and 10)
+);
+
+create index if not exists idx_instagram_posts_status on instagram_posts(status);
+create index if not exists idx_instagram_posts_agendado on instagram_posts(agendado_para) where agendado_para is not null;
+create index if not exists idx_instagram_posts_created on instagram_posts(created_at desc);
+
+grant all on table instagram_posts to service_role;
+grant all on table instagram_posts to postgres;
+grant all on table instagram_posts to authenticated;
+alter table instagram_posts disable row level security;


### PR DESCRIPTION
## Summary

Primeira fase (de 3) do sistema automatizado de postagem no Instagram. Esta PR entrega **geração de texto com pesquisa e fact-check** — ainda sem renderização de imagem nem postagem automática.

- Migration `instagram_posts` (`20260419c`): tabela com os campos de todas as 3 fases (os não-usados ficam vazios por ora)
- CRUD admin em `/api/admin/instagram-posts`
- Endpoint `/api/instagram/gerar`: Claude Opus 4.7 com `web_search` server-side + tool estruturada `salvar_post`. Força verificação em 2+ fontes antes de aceitar cada fato
- UI `/admin/instagram`: lista com filtros por status + editor que mostra slides, legenda, hashtags e fontes consultadas; permite editar e aprovar
- Tom de voz: **descontraído + técnico + formal**. 5–7 slides. Tipos: Dica / Comparativo / Notícia

## Fluxo atual
1. Admin cria post (tema + tipo + nº slides)
2. Clica "Gerar" → IA pesquisa, verifica fatos, monta slides
3. Admin revisa texto, edita se quiser, aprova
4. *(próximos PRs: renderizar imagens → agendar → postar)*

## Variáveis de ambiente necessárias
Já existentes no projeto:
- `ANTHROPIC_API_KEY` (já usada em `/api/ia`)
- `ADMIN_PASSWORD`, `SUPABASE_SERVICE_ROLE_KEY`

## Migration
Após deploy: `/admin/migrations` → achar `20260419c_instagram_posts` pendente → **▶ Rodar**.

## Próximos PRs
- **PR 2**: renderização HTML/CSS → PNG dos slides (aguardando design de referência)
- **PR 3**: integração Instagram Graph API + cron de publicação

## Test plan
- [ ] Migration rodou sem erro em `/admin/migrations`
- [ ] Link "📸 Instagram" aparece no menu lateral (grupo Site)
- [ ] Criar post de teste ("5 dicas pra economizar bateria no iPhone 15") funciona
- [ ] Botão "Gerar" retorna 5-7 slides coerentes (pode levar até 2 min)
- [ ] Seção "Pesquisa e fact-check" mostra fontes consultadas
- [ ] Edição dos slides + legenda salva corretamente
- [ ] Botão "Aprovar" move status para APROVADO
- [ ] Remover post funciona

🤖 Generated with [Claude Code](https://claude.com/claude-code)