### PR TITLE
fix(instagram): resize client-side pro upload evitar erro 413

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { resizeImageFile } from "@/lib/instagram/image-resize";
 
 interface Slide {
   titulo: string;
@@ -153,8 +154,14 @@ export default function InstagramPostPage() {
   const uploadImagemSlide = async (idx: number, file: File) => {
     setUploadingSlide(idx);
     try {
+      setMsg(`Preparando imagem do slide ${idx + 1}...`);
+      // Imagens de slide: 1600px eh suficiente pro render em 1080x1350.
+      const resized = await resizeImageFile(file, { maxWidth: 1600, maxHeight: 1600, quality: 0.85 });
+      const sizeKB = Math.round(resized.size / 1024);
+      setMsg(`Enviando slide ${idx + 1} (${sizeKB} KB)...`);
+
       const form = new FormData();
-      form.append("file", file);
+      form.append("file", resized);
       form.append("kind", "slide");
       form.append("postId", String(id));
       const up = await fetch("/api/admin/instagram-upload", {
@@ -162,12 +169,20 @@ export default function InstagramPostPage() {
         headers: apiHeaders(),
         body: form,
       });
-      const uj = await up.json();
-      if (!up.ok || !uj.ok) {
-        setMsg("Erro no upload: " + (uj.error || "falha"));
+      let uj: { ok?: boolean; url?: string; error?: string };
+      try {
+        uj = await up.json();
+      } catch {
+        setMsg(`Erro no upload (HTTP ${up.status}): resposta invalida. Use uma imagem menor.`);
         return;
       }
-      atribuirImagem(idx, uj.url);
+      if (!up.ok || !uj.ok) {
+        setMsg("Erro no upload: " + (uj.error || `HTTP ${up.status}`));
+        return;
+      }
+      atribuirImagem(idx, uj.url ?? null);
+    } catch (err) {
+      setMsg("Erro: " + (err instanceof Error ? err.message : String(err)));
     } finally {
       setUploadingSlide(null);
     }

--- a/app/admin/instagram/configuracoes/page.tsx
+++ b/app/admin/instagram/configuracoes/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { resizeImageFile } from "@/lib/instagram/image-resize";
 
 interface Config {
   id: number;
@@ -43,19 +44,30 @@ export default function InstagramConfigPage() {
       return;
     }
     setUploading(true);
-    setMsg("Enviando foto...");
     try {
+      setMsg("Preparando imagem...");
+      // Foto de perfil: quadrada 800x800 eh mais que suficiente no rodape circular.
+      const resized = await resizeImageFile(file, { maxWidth: 800, maxHeight: 800, quality: 0.9 });
+      const sizeKB = Math.round(resized.size / 1024);
+      setMsg(`Enviando foto (${sizeKB} KB)...`);
+
       const form = new FormData();
-      form.append("file", file);
+      form.append("file", resized);
       form.append("kind", "perfil");
       const up = await fetch("/api/admin/instagram-upload", {
         method: "POST",
         headers: apiHeaders(),
         body: form,
       });
-      const uj = await up.json();
+      let uj: { ok?: boolean; url?: string; error?: string };
+      try {
+        uj = await up.json();
+      } catch {
+        setMsg(`Erro no upload (HTTP ${up.status}): resposta invalida do servidor. Tente uma imagem menor.`);
+        return;
+      }
       if (!up.ok || !uj.ok) {
-        setMsg("Erro no upload: " + (uj.error || "falha"));
+        setMsg("Erro no upload: " + (uj.error || `HTTP ${up.status}`));
         return;
       }
       const patch = await fetch("/api/admin/instagram-config", {
@@ -70,6 +82,8 @@ export default function InstagramConfigPage() {
       }
       setMsg("Foto atualizada!");
       fetchConfig();
+    } catch (err) {
+      setMsg("Erro: " + (err instanceof Error ? err.message : String(err)));
     } finally {
       setUploading(false);
     }

--- a/app/api/admin/instagram-upload/route.ts
+++ b/app/api/admin/instagram-upload/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@supabase/supabase-js";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+export const maxDuration = 60;
 const noCache = { "Cache-Control": "no-store, no-cache, must-revalidate", "Pragma": "no-cache" };
 
 function auth(req: NextRequest) {

--- a/lib/instagram/image-resize.ts
+++ b/lib/instagram/image-resize.ts
@@ -1,0 +1,59 @@
+// Redimensiona e comprime imagem no cliente antes do upload.
+// Evita estourar o limite do Vercel (4.5 MB por request em funcoes Node).
+
+export interface ResizeOptions {
+  maxWidth?: number;
+  maxHeight?: number;
+  quality?: number; // 0..1 pro JPEG/WEBP
+  mimeType?: "image/jpeg" | "image/webp" | "image/png";
+}
+
+export async function resizeImageFile(
+  file: File,
+  options: ResizeOptions = {}
+): Promise<File> {
+  const {
+    maxWidth = 1600,
+    maxHeight = 1600,
+    quality = 0.85,
+    mimeType = "image/jpeg",
+  } = options;
+
+  // Formatos que sao so passthrough (nao da pra re-encodar pro canvas sem perder transparencia)
+  if (file.type === "image/gif" || file.type === "image/svg+xml") {
+    return file;
+  }
+
+  // Se ja e pequeno, nao mexe.
+  if (file.size < 800 * 1024) {
+    return file;
+  }
+
+  const bitmap = await createImageBitmap(file);
+  const scale = Math.min(1, maxWidth / bitmap.width, maxHeight / bitmap.height);
+  const w = Math.round(bitmap.width * scale);
+  const h = Math.round(bitmap.height * scale);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    bitmap.close?.();
+    return file;
+  }
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  bitmap.close?.();
+
+  const blob: Blob = await new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error("toBlob retornou null"))),
+      mimeType,
+      quality
+    );
+  });
+
+  const ext = mimeType === "image/jpeg" ? "jpg" : mimeType === "image/webp" ? "webp" : "png";
+  const baseName = file.name.replace(/\.[^.]+$/, "");
+  return new File([blob], `${baseName}.${ext}`, { type: mimeType });
+}


### PR DESCRIPTION
## Bug

Ao subir foto de perfil em \`/admin/instagram/configuracoes\`, o upload ficava travado em "Enviando foto..." pra sempre.

**Causa**: arquivos > ~4.5 MB estouram o limite de body do Vercel e voltam \`HTTP 413\`. O cliente tentava \`res.json()\` na resposta de erro (que vem como texto/HTML) e caía em SyntaxError silencioso, sem tirar o estado \`uploading\`.

## Fix

1. \`lib/instagram/image-resize.ts\` — helper client-side que usa canvas pra redimensionar e re-encodar pra JPEG antes do FormData:
   - Foto de perfil: 800×800, quality 0.9 (~200 KB)
   - Imagens de slide: 1600×1600, quality 0.85 (~500 KB)
   - Passa direto quando arquivo já é < 800 KB
2. Cliente agora faz \`try/catch\` no \`res.json()\` e mostra o HTTP status explicitamente quando resposta não é JSON.
3. \`maxDuration=60\` no endpoint de upload pra dar folga.

## Test
- [ ] Subir uma foto de 5+ MB em \`/admin/instagram/configuracoes\` — deve mostrar "Preparando imagem..." → "Enviando foto (XXX KB)..." → "Foto atualizada!"
- [ ] Upload manual por slide no editor também deve funcionar
- [ ] Foto no círculo de preview carrega sem pixelar

🤖 Generated with [Claude Code](https://claude.com/claude-code)