### PR TITLE
feat(instagram): comparativos cobrem o quadro completo, não só a dimensão do tema

### DIFF
--- a/app/admin/instagram/page.tsx
+++ b/app/admin/instagram/page.tsx
@@ -153,10 +153,21 @@ export default function InstagramListPage() {
                 <textarea
                   value={form.tema}
                   onChange={e => setForm({ ...form, tema: e.target.value })}
-                  placeholder='ex: "5 dicas pra economizar bateria no iPhone 15"'
+                  placeholder={
+                    form.tipo === "COMPARATIVO"
+                      ? 'ex: "iPhone 17 vs 17 Pro — vale pagar mais pelo Pro?"'
+                      : form.tipo === "NOTICIA"
+                      ? 'ex: "Lançamento do Apple Watch Ultra 3 — o que mudou?"'
+                      : 'ex: "5 dicas pra economizar bateria no iPhone 15"'
+                  }
                   rows={3}
                   className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
                 />
+                {form.tipo === "COMPARATIVO" && (
+                  <p className="text-xs text-[#86868B] mt-1">
+                    Dica: comparativos cobrem câmera + tela + chip + bateria + design + preço + revenda. Prefira o tema amplo (&quot;X vs Y&quot;) a estreito (&quot;câmera X vs Y&quot;).
+                  </p>
+                )}
               </div>
               <div>
                 <label className="text-xs font-medium text-[#6E6E73] mb-1 block">Tipo</label>

--- a/app/api/instagram/gerar/route.ts
+++ b/app/api/instagram/gerar/route.ts
@@ -20,7 +20,21 @@ const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
 const TIPO_GUIA: Record<string, string> = {
   DICA: "dica prática pra dono de iPhone/Mac/Apple Watch (ex: '5 ajustes pra economizar bateria'). Foco em utilidade imediata.",
-  COMPARATIVO: "comparativo entre modelos ou features (ex: 'iPhone 15 vs 16 — vale a pena trocar?'). Traga números concretos (chip, bateria, tela) e veredito honesto.",
+  COMPARATIVO: `comparativo entre modelos (ex: 'iPhone 17 vs 17 Pro — vale pagar mais?').
+
+REGRA IMPORTANTE de comparativo entre 2 modelos Apple:
+Mesmo que o tema enfatize UMA dimensão (ex: 'câmera iPhone 17 vs 17 Pro'), SEMPRE cubra o quadro completo pra dono de loja ajudar o cliente a decidir. Dedique slides a:
+1. Câmera (sensores, lentes, zoom, vídeo)
+2. Tela (ProMotion 120Hz, Always-On, brilho nits)
+3. Chip / performance (A-Pro vs A-base, Neural Engine, GPU cores)
+4. Bateria (horas vídeo, carga rápida)
+5. Design e materiais (titânio vs alumínio, peso, botões Action/Camera Control)
+6. Preço oficial Apple BR + valor de revenda / trade-in (quem trocar em 1-2 anos o Pro segura mais valor?)
+7. Veredito honesto: "pro vale se você usa X; 17 base entrega Y pra maioria".
+
+Se o tema for estreito (só câmera), ainda distribua slides: 2 ou 3 aprofundando a dimensão do tema + 1 "além da câmera, o Pro também tem..." cobrindo as outras dimensões em 1 slide de resumo.
+
+Não romantize o Pro sem motivo. Se pro base cobre a maioria dos casos, diga.`,
   NOTICIA: "novidade, lançamento ou rumor do ecossistema Apple. Data, fonte e o que muda na prática pro consumidor.",
 };
 


### PR DESCRIPTION
## Problema

O post \"Câmera iPhone 17 vs 17 Pro — qual vale a pena?\" saiu focado só em câmera e deixou de fora os outros diferenciais que pesam na decisão de pagar mais pelo Pro (tela ProMotion, chip A-Pro, bateria, titânio, valor de revenda).

Pra dono de loja, o post ideal ajuda o cliente a decidir olhando o **quadro completo**, não uma dimensão isolada.

## Fix

1. **Prompt COMPARATIVO** agora lista 6 dimensões que sempre devem aparecer num comparativo entre 2 modelos Apple:
   - Câmera
   - Tela (ProMotion, Always-On, nits)
   - Chip e performance
   - Bateria
   - Design e materiais (titânio vs alumínio, peso, Action/Camera Control)
   - Preço Apple BR + valor de revenda/trade-in
   - Veredito honesto

   Quando o tema é estreito (\"câmera iPhone 17 vs 17 Pro\"), o Claude aprofunda na câmera (2-3 slides) + 1 slide \"além disso, o Pro também tem...\" cobrindo o resto.

2. Instrução explícita **\"não romantize o Pro sem motivo\"** — se o base entrega pra maioria, dizer.

3. **Placeholder e hint no formulário** de novo post variam por tipo. Comparativo sugere tema amplo (\"X vs Y\") e avisa sobre as 6 dimensões.

## Test
- [ ] Mergear PR
- [ ] Criar post comparativo com tema \"iPhone 17 vs 17 Pro — vale pagar mais pelo Pro?\"
- [ ] Gerar → conferir se os slides cobrem câmera + tela + chip + bateria + design + revenda
- [ ] Veredito do último slide não deve ser clickbait nem defender Pro cegamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)