### PR TITLE
fix(encomendas): vincular sincroniza nome do produto com estoque

### DIFF
--- a/app/admin/encomendas/page.tsx
+++ b/app/admin/encomendas/page.tsx
@@ -683,22 +683,37 @@ export default function EncomendasPage() {
 
   const confirmVincular = async (estoqueId: string) => {
     if (!vinculandoId) return;
-    await fetch("/api/encomendas", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json", ...hdrs() },
-      body: JSON.stringify({
-        id: vinculandoId,
-        estoque_id: estoqueId,
-        status: "A CAMINHO",
-      }),
-    });
-    setEncomendas((prev) =>
-      prev.map((e) =>
-        e.id === vinculandoId
-          ? { ...e, estoque_id: estoqueId, status: "A CAMINHO" }
-          : e
-      )
-    );
+    try {
+      const res = await fetch("/api/encomendas", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", ...hdrs() },
+        body: JSON.stringify({
+          id: vinculandoId,
+          estoque_id: estoqueId,
+          status: "A CAMINHO",
+        }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        setMsg(`Erro ao vincular: ${j.error || res.status}`);
+        setTimeout(() => setMsg(""), 5000);
+        setVinculandoId(null);
+        return;
+      }
+      // Refetch — backend sincroniza produto/cor/custo/fornecedor da encomenda
+      // com o item de estoque, entao precisa puxar dados novos pra UI mostrar
+      // o nome correto (ex: M5 em vez do snapshot velho M4).
+      const ref = await fetch("/api/encomendas", { headers: hdrs() });
+      if (ref.ok) {
+        const json = await ref.json();
+        setEncomendas(json.data ?? []);
+      }
+      setMsg("Produto vinculado — dados sincronizados com o estoque.");
+      setTimeout(() => setMsg(""), 3500);
+    } catch (err) {
+      setMsg(`Erro ao vincular: ${String(err)}`);
+      setTimeout(() => setMsg(""), 5000);
+    }
     setVinculandoId(null);
   };
 

--- a/app/api/encomendas/route.ts
+++ b/app/api/encomendas/route.ts
@@ -36,13 +36,40 @@ export async function PATCH(req: NextRequest) {
   const { id, ...fields } = await req.json();
   if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });
   if (fields.cliente) fields.cliente = String(fields.cliente).toUpperCase();
+
+  // Vincular: se estoque_id foi passado, sincroniza produto/cor/custo/fornecedor
+  // da encomenda com o item de estoque. Senao admin corrige nome no estoque,
+  // re-vincula, e a encomenda continua com o snapshot velho (ex: M4 no lugar
+  // de M5 depois da correcao do modelo).
+  if ("estoque_id" in fields && fields.estoque_id) {
+    const { data: estItem } = await supabase
+      .from("estoque")
+      .select("produto, cor, categoria, custo_compra, custo_unitario, fornecedor")
+      .eq("id", fields.estoque_id)
+      .single();
+    if (estItem) {
+      fields.produto = estItem.produto;
+      if (estItem.cor) fields.cor = estItem.cor;
+      if (estItem.categoria) fields.categoria = estItem.categoria;
+      if (estItem.fornecedor) fields.fornecedor = estItem.fornecedor;
+      const custoEst = Number(estItem.custo_compra || estItem.custo_unitario || 0);
+      if (custoEst > 0) fields.custo = custoEst;
+    }
+  }
+
   const { error } = await supabase.from("encomendas").update({ ...fields, updated_at: new Date().toISOString() }).eq("id", id);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
   // Vincular/desvincular estoque ↔ encomenda
   if ("estoque_id" in fields) {
     if (fields.estoque_id) {
-      // Vincular: seta encomenda_id no item do estoque
+      // Limpa encomenda_id de item ANTERIOR (se admin estiver trocando pra
+      // outro item). Senao o antigo fica com referencia stale.
+      await supabase.from("estoque")
+        .update({ encomenda_id: null })
+        .eq("encomenda_id", id)
+        .neq("id", fields.estoque_id);
+      // Vincular: seta encomenda_id no NOVO item do estoque
       await supabase.from("estoque").update({ encomenda_id: id }).eq("id", fields.estoque_id);
     }
     // Se desvinculando (estoque_id = null), limpar encomenda_id do estoque antigo


### PR DESCRIPTION
## Resumo

Admin corrigia modelo no estoque (ex: MacBook Air **M4** → **M5**) mas a encomenda continuava mostrando \"M4\" porque \`encomendas.produto\` é snapshot copiado na criação. Re-vincular pelo botão \"Vincular Produto A Caminho\" não atualizava. Sem feedback de erro no frontend também — admin achava que não estava indo.

## Fix

### Backend (\`app/api/encomendas\` PATCH)
- Ao receber \`estoque_id\`, busca \`produto\`/\`cor\`/\`categoria\`/\`custo\`/\`fornecedor\` do item no estoque e sobrescreve os campos da encomenda antes do update.
- Limpa \`encomenda_id\` de qualquer item **anterior** vinculado quando troca pra um novo (senão antigo fica com referência stale).

### Frontend (\`app/admin/encomendas\` \`confirmVincular\`)
- Checa \`res.ok\` e mostra mensagem de erro se PATCH falhar.
- Refetch das encomendas após sucesso pra UI pegar os dados sincronizados.
- Mensagem \"Produto vinculado — dados sincronizados com o estoque.\"

## Test plan

- [ ] Criar encomenda com produto M4
- [ ] Editar o item no estoque mudando produto pra M5
- [ ] Abrir encomenda e clicar \"Vincular Produto A Caminho\"
- [ ] Selecionar o mesmo item (agora M5)
- [ ] Confirmar que o nome na encomenda atualizou pra M5
- [ ] Se falhar, mensagem de erro aparece (antes desaparecia silenciosamente)
- [ ] Vincular pra um item diferente → item anterior perde \`encomenda_id\` (sem referência stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)