### PR TITLE
feat(instagram): Claude ilustra cada slide pelo contexto do texto

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -34,12 +34,6 @@ interface Post {
   created_at: string;
 }
 
-interface ImagemCandidata {
-  url: string;
-  source: string;
-  sourceUrl: string;
-}
-
 const STATUS_LABEL: Record<Post["status"], string> = {
   RASCUNHO: "📝 Rascunho",
   GERANDO: "⏳ Gerando...",
@@ -69,11 +63,9 @@ export default function InstagramPostPage() {
   const [hashtagsEdit, setHashtagsEdit] = useState("");
 
   // PR 2: imagens
-  const [buscandoImgs, setBuscandoImgs] = useState(false);
-  const [atribuindo, setAtribuindo] = useState(false);
+  const [ilustrando, setIlustrando] = useState(false);
+  const [reIlustrandoSlide, setReIlustrandoSlide] = useState<number | null>(null);
   const [renderizando, setRenderizando] = useState(false);
-  const [galeria, setGaleria] = useState<ImagemCandidata[]>([]);
-  const [slideAlvo, setSlideAlvo] = useState<number | null>(null);
   const [uploadingSlide, setUploadingSlide] = useState<number | null>(null);
   const uploadRefs = useRef<Record<number, HTMLInputElement | null>>({});
 
@@ -122,54 +114,46 @@ export default function InstagramPostPage() {
     }
   };
 
-  const buscarImagens = async () => {
-    setBuscandoImgs(true);
-    setMsg("Buscando imagens nas fontes consultadas...");
+  const ilustrarSlides = async () => {
+    setIlustrando(true);
+    setMsg("Claude buscando imagem pra cada slide na web... (~1-2 min)");
     try {
-      const res = await fetch("/api/instagram/buscar-imagem", {
+      const res = await fetch("/api/instagram/ilustrar-slides", {
         method: "POST",
         headers: apiHeaders({ "Content-Type": "application/json" }),
         body: JSON.stringify({ postId: id }),
       });
       const j = await res.json();
       if (!res.ok || !j.ok) {
-        setMsg("Erro: " + (j.error || "falha na busca"));
-        return;
-      }
-      setGaleria(j.imagens || []);
-      if ((j.imagens || []).length === 0) {
-        setMsg("Nenhuma imagem encontrada nas fontes. Use upload manual por slide.");
-      } else {
-        setMsg(`${j.imagens.length} imagens encontradas. Clique em "Atribuir automaticamente" ou escolha manual.`);
-      }
-    } finally {
-      setBuscandoImgs(false);
-    }
-  };
-
-  const atribuirAutomaticamente = async () => {
-    if (galeria.length === 0) {
-      setMsg("Busque as imagens primeiro.");
-      return;
-    }
-    setAtribuindo(true);
-    setMsg("Claude Vision analisando slides vs imagens... (~15s)");
-    try {
-      const res = await fetch("/api/instagram/atribuir-imagens", {
-        method: "POST",
-        headers: apiHeaders({ "Content-Type": "application/json" }),
-        body: JSON.stringify({ postId: id, imagens: galeria }),
-      });
-      const j = await res.json();
-      if (!res.ok || !j.ok) {
-        setMsg("Erro: " + (j.error || "falha na atribuição"));
+        setMsg("Erro: " + (j.error || "falha ao ilustrar"));
         return;
       }
       if (Array.isArray(j.slides)) setSlidesEdit(j.slides);
       const comImg = (j.slides || []).filter((s: Slide) => s.imagem_url).length;
-      setMsg(`${comImg} de ${(j.slides || []).length} slides receberam imagem. Ajuste manual se quiser e depois renderize.`);
+      setMsg(`${comImg} de ${(j.slides || []).length} slides receberam imagem. Clique "🔄" em algum slide pra trocar.`);
     } finally {
-      setAtribuindo(false);
+      setIlustrando(false);
+    }
+  };
+
+  const reIlustrarSlide = async (idx: number) => {
+    setReIlustrandoSlide(idx);
+    setMsg(`Buscando nova imagem pro slide ${idx + 1}...`);
+    try {
+      const res = await fetch("/api/instagram/ilustrar-slides", {
+        method: "POST",
+        headers: apiHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ postId: id, slideIndex: idx }),
+      });
+      const j = await res.json();
+      if (!res.ok || !j.ok) {
+        setMsg("Erro: " + (j.error || "falha"));
+        return;
+      }
+      if (Array.isArray(j.slides)) setSlidesEdit(j.slides);
+      setMsg(`Slide ${idx + 1} re-ilustrado.`);
+    } finally {
+      setReIlustrandoSlide(null);
     }
   };
 
@@ -282,7 +266,6 @@ export default function InstagramPostPage() {
 
   const jaTemConteudo = post.status !== "RASCUNHO" && post.status !== "GERANDO" && slidesEdit.length > 0;
   const podeEditar = ["GERADO", "ERRO"].includes(post.status);
-  const temFontes = Array.isArray(post.pesquisa_json?.fontes) && (post.pesquisa_json?.fontes?.length ?? 0) > 0;
   const temImagensRenderizadas = Array.isArray(post.imagens_urls) && post.imagens_urls.length > 0;
 
   return (
@@ -375,75 +358,31 @@ export default function InstagramPostPage() {
             )}
           </div>
 
-          {/* Galeria de imagens */}
+          {/* Ilustrar slides */}
           {podeEditar && (
             <div className="bg-white border border-[#D2D2D7] rounded-2xl p-4 mb-6">
-              <div className="flex items-center justify-between flex-wrap gap-2 mb-3">
+              <div className="flex items-center justify-between flex-wrap gap-2">
                 <div>
-                  <h3 className="text-sm font-semibold text-[#1D1D1F]">Imagens dos slides</h3>
+                  <h3 className="text-sm font-semibold text-[#1D1D1F]">Ilustrar slides</h3>
                   <p className="text-xs text-[#86868B] mt-1">
-                    Busca nas fontes do fact-check (Apple oficial primeiro). Se a imagem não for ideal, faça upload manual em cada slide.
+                    Claude busca na web uma imagem que ilustre o texto de cada slide (Apple oficial quando faz sentido, reviews e fontes tech caso contrário). Use &quot;🔄&quot; num slide pra trocar só aquela imagem. Upload manual também vale.
                   </p>
                 </div>
-                <div className="flex gap-2 flex-wrap">
-                  {galeria.length > 0 && (
-                    <button
-                      onClick={atribuirAutomaticamente}
-                      disabled={atribuindo || buscandoImgs}
-                      className="px-3 py-1.5 rounded-xl bg-[#E8740E] text-white text-xs font-semibold hover:bg-[#F5A623] disabled:opacity-50"
-                      title="Claude Vision lê os slides e as imagens, escolhe a melhor pra cada um"
-                    >
-                      {atribuindo ? "Analisando..." : "✨ Atribuir automaticamente"}
-                    </button>
-                  )}
-                  {temFontes && (
-                    <button
-                      onClick={buscarImagens}
-                      disabled={buscandoImgs || atribuindo}
-                      className="px-3 py-1.5 rounded-xl bg-[#1D1D1F] text-white text-xs font-semibold hover:bg-[#333] disabled:opacity-50"
-                    >
-                      {buscandoImgs ? "Buscando..." : galeria.length > 0 ? "🔍 Re-buscar" : "🔍 Buscar nas fontes"}
-                    </button>
-                  )}
-                </div>
+                <button
+                  onClick={ilustrarSlides}
+                  disabled={ilustrando}
+                  className="px-4 py-2 rounded-xl bg-[#E8740E] text-white text-sm font-semibold hover:bg-[#F5A623] disabled:opacity-50"
+                >
+                  {ilustrando ? "⏳ Ilustrando..." : "✨ Ilustrar slides"}
+                </button>
               </div>
-
-              {galeria.length > 0 && (
-                <>
-                  <div className="text-xs text-[#6E6E73] mb-2">
-                    {slideAlvo === null
-                      ? "Clique em um slide abaixo (ícone 🖼️) e depois na imagem que quiser atribuir."
-                      : <>Slide <strong>{slideAlvo + 1}</strong> selecionado. Clique numa imagem pra atribuir · <button onClick={() => setSlideAlvo(null)} className="text-[#E8740E] hover:underline">cancelar</button></>
-                    }
-                  </div>
-                  <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-5 gap-2 max-h-64 overflow-y-auto pr-1">
-                    {galeria.map((img, i) => (
-                      <button
-                        key={i}
-                        disabled={slideAlvo === null}
-                        onClick={() => { if (slideAlvo !== null) { atribuirImagem(slideAlvo, img.url); setSlideAlvo(null); } }}
-                        title={`${img.source} · ${img.sourceUrl}`}
-                        className={`relative aspect-square rounded-lg overflow-hidden border-2 ${
-                          slideAlvo !== null ? "border-[#E8740E]/30 hover:border-[#E8740E] cursor-pointer" : "border-[#E8E8ED] cursor-default"
-                        } bg-[#F5F5F7]`}
-                      >
-                        {/* eslint-disable-next-line @next/next/no-img-element */}
-                        <img src={img.url} alt={img.source} className="w-full h-full object-cover" loading="lazy" />
-                        <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white text-[9px] px-1 py-0.5 truncate">
-                          {img.source}
-                        </div>
-                      </button>
-                    ))}
-                  </div>
-                </>
-              )}
             </div>
           )}
 
           {/* Cards de edição de slide */}
           <div className="grid gap-3 mb-6">
             {slidesEdit.map((slide, idx) => (
-              <div key={idx} className={`bg-white border rounded-2xl p-4 ${slideAlvo === idx ? "border-[#E8740E] ring-2 ring-[#E8740E]/20" : "border-[#D2D2D7]"}`}>
+              <div key={idx} className="bg-white border border-[#D2D2D7] rounded-2xl p-4">
                 <div className="flex items-center gap-2 mb-3 flex-wrap">
                   <span className="text-xs px-2 py-1 rounded bg-[#1D1D1F] text-white font-mono">{idx + 1}</span>
                   <span className="text-xs text-[#86868B]">
@@ -457,16 +396,12 @@ export default function InstagramPostPage() {
                   {podeEditar && (
                     <div className="ml-auto flex items-center gap-2">
                       <button
-                        onClick={() => setSlideAlvo(slideAlvo === idx ? null : idx)}
-                        disabled={galeria.length === 0}
-                        title={galeria.length === 0 ? "Busque imagens primeiro" : "Atribuir imagem da galeria"}
-                        className={`text-xs px-2 py-1 rounded ${
-                          slideAlvo === idx
-                            ? "bg-[#E8740E] text-white"
-                            : "bg-[#F5F5F7] text-[#6E6E73] hover:bg-[#E8E8ED]"
-                        } disabled:opacity-40`}
+                        onClick={() => reIlustrarSlide(idx)}
+                        disabled={reIlustrandoSlide !== null || ilustrando}
+                        title="Claude busca nova imagem só pra esse slide"
+                        className="text-xs px-2 py-1 rounded bg-[#F5F5F7] text-[#6E6E73] hover:bg-[#E8E8ED] disabled:opacity-40"
                       >
-                        🖼️ Galeria
+                        {reIlustrandoSlide === idx ? "Buscando..." : "🔄 Trocar imagem"}
                       </button>
                       <button
                         onClick={() => uploadRefs.current[idx]?.click()}
@@ -540,7 +475,7 @@ export default function InstagramPostPage() {
                   {(() => {
                     const comImg = slidesEdit.filter(s => s.imagem_url).length;
                     if (comImg === 0) {
-                      return <p className="text-xs text-[#E74C3C] mt-1">⚠️ Nenhum slide com imagem atribuída. Use &quot;✨ Atribuir automaticamente&quot; antes de renderizar.</p>;
+                      return <p className="text-xs text-[#E74C3C] mt-1">⚠️ Nenhum slide com imagem. Use &quot;✨ Ilustrar slides&quot; antes de renderizar.</p>;
                     }
                     if (comImg < slidesEdit.length) {
                       return <p className="text-xs text-[#E8740E] mt-1">{comImg} de {slidesEdit.length} slides com imagem. Os outros vão renderizar só com texto.</p>;

--- a/app/api/instagram/ilustrar-slides/route.ts
+++ b/app/api/instagram/ilustrar-slides/route.ts
@@ -1,0 +1,259 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { createClient } from "@supabase/supabase-js";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 180;
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || "";
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+interface SlideData {
+  titulo: string;
+  texto: string;
+  destaque?: string;
+  imagem_url?: string | null;
+}
+
+interface AtribuicaoClaude {
+  slide_index: number;
+  image_url?: string | null;
+  page_url?: string | null;
+  motivo: string;
+}
+
+const SYSTEM_PROMPT = `Você é editor visual do Instagram da @tigraoimports, loja Apple no Rio de Janeiro.
+
+TAREFA
+Pra cada slide do carrossel, use web_search pra achar a MELHOR imagem que ilustre o conceito do texto. Depois chame a ferramenta 'definir_imagens' uma única vez com as atribuições de todos os slides.
+
+REGRAS
+1. Busca orientada ao CONCEITO do slide, não só ao produto.
+   - Slide "Command é o novo Ctrl" → buscar imagem de teclado Mac mostrando tecla ⌘, atalho ⌘+C em uso, etc.
+   - Slide "Configure Time Machine" → buscar screenshot/foto de Time Machine em Mac, backup para HD externo.
+   - Slide "Câmera iPhone 17 Pro" → buscar foto do módulo de câmera traseira do iPhone 17 Pro.
+
+2. Priorize:
+   - Páginas oficiais Apple (apple.com/br, newsroom) pra produtos específicos.
+   - 9to5Mac, MacRumors, The Verge, Tecnoblog, TechTudo pra reviews / imagens conceituais.
+   - Wikipedia, blogs tech confiáveis pra imagens com licença aberta.
+
+3. NÃO use:
+   - Ícones pequenos, sprites, logos.
+   - Imagens de site de afiliado/cupom.
+   - Screenshots de apresentação/slide (meta).
+   - Foto que aparece em 2 slides (nunca repita).
+
+4. Formato da URL:
+   - Prefira URL DIRETA de imagem (.jpg/.png/.webp) quando conseguir.
+   - Se só tiver URL de página, passe em \`page_url\` — eu extraio o og:image no backend.
+   - Se não encontrar imagem decente depois de 2 buscas, use null com motivo claro.
+
+5. Faça buscas específicas. Use o título + texto do slide pra montar o query, não termos genéricos.
+
+6. Slide CTA (último) normalmente não precisa imagem. Marque null.
+
+SAÍDA
+Só chame 'definir_imagens'. Não escreva texto narrativo.`;
+
+const TOOLS: Anthropic.Tool[] = [
+  {
+    name: "definir_imagens",
+    description: "Retorna o mapping final de slide → imagem. Chame UMA vez com todos os slides.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        atribuicoes: {
+          type: "array",
+          description: "Uma atribuição por slide (na ordem 0..N-1).",
+          items: {
+            type: "object",
+            properties: {
+              slide_index: { type: "integer", description: "Índice do slide (0-based)." },
+              image_url: { type: "string", description: "URL direta da imagem (.jpg/.png/.webp). Opcional — use page_url se só tiver link de página." },
+              page_url: { type: "string", description: "URL da página web. O backend extrai og:image dela." },
+              motivo: { type: "string", description: "Linha curta explicando a escolha." },
+            },
+            required: ["slide_index", "motivo"],
+          },
+        },
+      },
+      required: ["atribuicoes"],
+    },
+  },
+];
+
+const WEB_SEARCH_TOOL = {
+  type: "web_search_20250305",
+  name: "web_search",
+  max_uses: 15,
+} as unknown as Anthropic.Tool;
+
+function buildUserMessage(
+  slides: SlideData[],
+  tema: string,
+  tipo: string,
+  slideAlvo?: number
+): string {
+  const slidesTxt = slides
+    .map((s, i) => {
+      if (slideAlvo !== undefined && i !== slideAlvo) return null;
+      const tag = i === 0 ? "CAPA" : i === slides.length - 1 ? "CTA" : `SLIDE ${i + 1}`;
+      const dest = s.destaque ? ` [destaque: "${s.destaque}"]` : "";
+      return `${i}. ${tag}${dest}\n   Título: ${s.titulo}\n   Texto: ${s.texto}`;
+    })
+    .filter(Boolean)
+    .join("\n\n");
+
+  const contexto = slideAlvo !== undefined
+    ? `Re-ilustre APENAS o slide ${slideAlvo}. Ignore os outros.`
+    : `Ilustre todos os ${slides.length} slides. Faça 1-2 web_searches por slide (max_uses=15 total).`;
+
+  return `Tema do post: "${tema}" (tipo: ${tipo})
+
+${contexto}
+
+SLIDES:
+${slidesTxt}
+
+Busque a melhor imagem pra cada slide e chame 'definir_imagens' no final.`;
+}
+
+async function extrairOgImage(pageUrl: string): Promise<string | null> {
+  try {
+    const res = await fetch(pageUrl, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        Accept: "text/html,application/xhtml+xml",
+      },
+      signal: AbortSignal.timeout(8000),
+      redirect: "follow",
+    });
+    if (!res.ok) return null;
+    const html = await res.text();
+    const og = html.match(
+      /<meta[^>]+(?:property|name)=["']og:image(?::secure_url)?["'][^>]+content=["']([^"']+)["']/i
+    )?.[1];
+    if (og) return new URL(og, pageUrl).toString();
+    const tw = html.match(/<meta[^>]+name=["']twitter:image["'][^>]+content=["']([^"']+)/i)?.[1];
+    if (tw) return new URL(tw, pageUrl).toString();
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function ehImagemValida(url: string): boolean {
+  if (!/^https?:\/\//i.test(url)) return false;
+  if (/\/favicon/i.test(url)) return false;
+  if (/\/logo(-|_|\.)/i.test(url)) return false;
+  if (/sprite/i.test(url)) return false;
+  if (/\/(icons?|glyph)\//i.test(url)) return false;
+  if (/knowledge_graph/i.test(url)) return false;
+  if (/help\.apple\.com\/assets/i.test(url)) return false;
+  return true;
+}
+
+async function resolverImagem(
+  image_url?: string | null,
+  page_url?: string | null
+): Promise<string | null> {
+  if (image_url && ehImagemValida(image_url)) return image_url;
+  if (page_url) {
+    const og = await extrairOgImage(page_url);
+    if (og && ehImagemValida(og)) return og;
+  }
+  return null;
+}
+
+export async function POST(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json().catch(() => ({}));
+  const { postId, slideIndex } = body || {};
+  if (!postId) return NextResponse.json({ error: "postId obrigatório" }, { status: 400 });
+
+  const supabase = getSupabase();
+  const { data: post, error: postErr } = await supabase
+    .from("instagram_posts")
+    .select("*")
+    .eq("id", postId)
+    .single();
+  if (postErr || !post) {
+    return NextResponse.json({ error: postErr?.message || "post não encontrado" }, { status: 404 });
+  }
+
+  const slides: SlideData[] = Array.isArray(post.slides_json) ? post.slides_json : [];
+  if (slides.length === 0) {
+    return NextResponse.json({ error: "post sem slides" }, { status: 400 });
+  }
+  if (slideIndex !== undefined && (slideIndex < 0 || slideIndex >= slides.length)) {
+    return NextResponse.json({ error: "slideIndex fora do range" }, { status: 400 });
+  }
+
+  const userMsg = buildUserMessage(slides, post.tema, post.tipo, slideIndex);
+
+  let atribuicoes: AtribuicaoClaude[] = [];
+  try {
+    const response = await client.messages.create({
+      model: "claude-opus-4-7",
+      max_tokens: 6000,
+      system: SYSTEM_PROMPT,
+      tools: [WEB_SEARCH_TOOL, ...TOOLS],
+      messages: [{ role: "user", content: userMsg }],
+    });
+    const toolUse = response.content.find(
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use" && b.name === "definir_imagens"
+    );
+    if (!toolUse) {
+      return NextResponse.json(
+        { error: "Claude não chamou 'definir_imagens'. Tente novamente." },
+        { status: 500 }
+      );
+    }
+    const input = toolUse.input as { atribuicoes: AtribuicaoClaude[] };
+    atribuicoes = input.atribuicoes || [];
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: "Falha na chamada ao Claude: " + msg }, { status: 500 });
+  }
+
+  // Resolve cada atribuição → URL final de imagem.
+  const resolvidas = await Promise.all(
+    atribuicoes.map(async (a) => ({
+      slide_index: a.slide_index,
+      imagem_final: await resolverImagem(a.image_url, a.page_url),
+      motivo: a.motivo,
+    }))
+  );
+
+  // Aplica: se slideIndex foi especificado, só mexe naquele slide.
+  const slidesNovos = slides.map((s, i) => {
+    if (slideIndex !== undefined && i !== slideIndex) return s;
+    const r = resolvidas.find((x) => x.slide_index === i);
+    if (!r) return s;
+    return { ...s, imagem_url: r.imagem_final };
+  });
+
+  const { error: updErr } = await supabase
+    .from("instagram_posts")
+    .update({ slides_json: slidesNovos, updated_at: new Date().toISOString() })
+    .eq("id", postId);
+  if (updErr) return NextResponse.json({ error: updErr.message }, { status: 500 });
+
+  return NextResponse.json({
+    ok: true,
+    slides: slidesNovos,
+    atribuicoes: resolvidas,
+  });
+}


### PR DESCRIPTION
## O que muda

Antes a busca de imagem era em 2 etapas:
1. **🔍 Buscar nas fontes** → og:images globais das URLs do fact-check.
2. **✨ Atribuir automaticamente** → Claude Vision escolhia entre elas.
3. **Galeria manual** pra ajustar.

O problema: a imagem ideal pra um slide \"Command+Espaço abre Spotlight\" raramente está nas fontes gerais do post. Ela merece uma imagem próxima do **conceito** do texto, não do produto inteiro.

## Agora

**✨ Ilustrar slides** — botão único. Pra cada slide, Claude Opus faz um web_search específico com o título + texto, e retorna a melhor imagem. Usa Apple oficial quando faz sentido, mas não está preso a isso: pode vir de 9to5Mac, The Verge, Wikipedia, blog tech — o que ilustrar melhor.

**🔄 Trocar imagem** em cada slide → refaz a busca só pra aquele slide se você não gostou.

**📤 Upload manual** por slide continua funcionando como fallback.

## Backend

Novo endpoint \`/api/instagram/ilustrar-slides\`:
- Aceita \`{ postId }\` ou \`{ postId, slideIndex }\` (re-ilustrar só 1).
- Claude Opus 4.7 + web_search (max 15 usos) + tool \`definir_imagens\`.
- Claude pode retornar \`image_url\` direto OU \`page_url\` (backend extrai og:image automaticamente).
- Filtros de lixo aplicados antes de salvar.

## Frontend

- Removido: botões \"Buscar nas fontes\" + \"Atribuir automaticamente\" + galeria clicável + estado \`slideAlvo\`.
- Adicionado: \"✨ Ilustrar slides\" no card principal + \"🔄 Trocar imagem\" por slide.

## Test plan
- [ ] Mergear
- [ ] Abrir post gerado → \"✨ Ilustrar slides\" → esperar ~1-2 min → conferir imagens
- [ ] Trocar 1 imagem específica com \"🔄\"
- [ ] Renderizar PNGs e verificar que cada slide tem imagem coerente com o texto
- [ ] Testar num post de DICA (onde imagem por conceito faz mais diferença)

🤖 Generated with [Claude Code](https://claude.com/claude-code)