### PR TITLE
feat(instagram): botão Refinar com IA expande ideia curta em tema completo

### DIFF
--- a/app/admin/instagram/page.tsx
+++ b/app/admin/instagram/page.tsx
@@ -43,6 +43,8 @@ export default function InstagramListPage() {
   const [novoOpen, setNovoOpen] = useState(false);
   const [form, setForm] = useState({ tema: "", tipo: "DICA" as Post["tipo"], numero_slides: 7 });
   const [saving, setSaving] = useState(false);
+  const [refinando, setRefinando] = useState(false);
+  const [motivoRefino, setMotivoRefino] = useState("");
   const [msg, setMsg] = useState("");
 
   const fetchPosts = useCallback(async () => {
@@ -82,6 +84,32 @@ export default function InstagramListPage() {
       router.push(`/admin/instagram/${j.data.id}`);
     } finally {
       setSaving(false);
+    }
+  };
+
+  const refinarTema = async () => {
+    if (!form.tema.trim()) {
+      setMsg("Escreve uma ideia (pode ser curta) antes de refinar.");
+      return;
+    }
+    setRefinando(true);
+    setMsg("");
+    setMotivoRefino("");
+    try {
+      const res = await fetch("/api/instagram/refinar-tema", {
+        method: "POST",
+        headers: apiHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify({ ideia: form.tema }),
+      });
+      const j = await res.json();
+      if (!res.ok || !j.ok) {
+        setMsg("Erro ao refinar: " + (j.error || "falha"));
+        return;
+      }
+      setForm({ tema: j.tema, tipo: j.tipo, numero_slides: j.numero_slides });
+      setMotivoRefino(j.motivo || "");
+    } finally {
+      setRefinando(false);
     }
   };
 
@@ -149,23 +177,37 @@ export default function InstagramListPage() {
             <h2 className="text-lg font-semibold mb-4 text-[#1D1D1F]">Novo post</h2>
             <div className="space-y-3">
               <div>
-                <label className="text-xs font-medium text-[#6E6E73] mb-1 block">Tema</label>
+                <div className="flex items-center justify-between mb-1">
+                  <label className="text-xs font-medium text-[#6E6E73]">Tema</label>
+                  <button
+                    type="button"
+                    onClick={refinarTema}
+                    disabled={refinando || !form.tema.trim()}
+                    className="text-xs px-2 py-1 rounded bg-[#E8740E] text-white font-semibold hover:bg-[#F5A623] disabled:opacity-40"
+                    title="IA expande sua ideia curta pra tema completo + sugere tipo e nº de slides"
+                  >
+                    {refinando ? "Refinando..." : "✨ Refinar com IA"}
+                  </button>
+                </div>
                 <textarea
                   value={form.tema}
-                  onChange={e => setForm({ ...form, tema: e.target.value })}
+                  onChange={e => { setForm({ ...form, tema: e.target.value }); if (motivoRefino) setMotivoRefino(""); }}
                   placeholder={
                     form.tipo === "COMPARATIVO"
-                      ? 'ex: "iPhone 17 vs 17 Pro — vale pagar mais pelo Pro?"'
+                      ? 'ex: "iPhone 17 vs 17 Pro — vale pagar mais pelo Pro?" ou só "comparativo iPad" + Refinar'
                       : form.tipo === "NOTICIA"
-                      ? 'ex: "Lançamento do Apple Watch Ultra 3 — o que mudou?"'
-                      : 'ex: "5 dicas pra economizar bateria no iPhone 15"'
+                      ? 'ex: "Lançamento do Apple Watch Ultra 3 — o que mudou?" ou só "watch novo" + Refinar'
+                      : 'ex: "5 dicas pra economizar bateria no iPhone 15" ou só "dica MacBook" + Refinar'
                   }
                   rows={3}
                   className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
                 />
-                {form.tipo === "COMPARATIVO" && (
+                {motivoRefino && (
+                  <p className="text-xs text-[#2ECC71] mt-1">✨ IA: {motivoRefino}</p>
+                )}
+                {!motivoRefino && form.tipo === "COMPARATIVO" && (
                   <p className="text-xs text-[#86868B] mt-1">
-                    Dica: comparativos cobrem câmera + tela + chip + bateria + design + preço + revenda. Prefira o tema amplo (&quot;X vs Y&quot;) a estreito (&quot;câmera X vs Y&quot;).
+                    Dica: comparativos cobrem câmera + tela + chip + bateria + design + preço + revenda.
                   </p>
                 )}
               </div>

--- a/app/api/instagram/refinar-tema/route.ts
+++ b/app/api/instagram/refinar-tema/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const SYSTEM_PROMPT = `Você é o editor de pauta do Instagram da @tigraoimports, loja Apple no Rio de Janeiro. Nicho: iPhone, Mac, Apple Watch, AirPods, iPad — novos, seminovos e trade-in.
+
+TAREFA
+O admin mandou uma ideia curta ou vaga pra post (ex: "comparativo pra iPad", "dica de bateria", "notícia iPhone novo"). Expanda pra um TEMA específico, acionável, com ângulo claro — o suficiente pra um editor de conteúdo saber o que pesquisar.
+
+REGRAS
+- Escolha UMA pergunta ou ângulo concreto. Nada de genérico ("tudo sobre iPad").
+- Se a ideia é comparativo, escolha 2 modelos específicos atuais (ex: iPad Air M3 vs iPad Pro M4). Evite comparar modelo novo com um descontinuado há muito.
+- Se é dica, pegue um cenário de uso real (ex: "5 ajustes pra dar sobrevida de bateria em iPhone 13 que já não segura o dia inteiro").
+- Se é notícia, foque no fato específico e no que muda pro consumidor (ex: "Lançamento do Apple Watch Ultra 3 — o que mudou vs Ultra 2?").
+- Tom: descontraído mas técnico. Faça perguntas / contraste. Nada de clickbait.
+- Considere o público Rio de Janeiro, Brasil (preço em reais se relevante, sem viés gringo).
+
+SAÍDA
+Chame a ferramenta 'refinar' UMA vez com:
+- tema: o tema expandido (1 frase, <120 caracteres, pronto pra ser título do post).
+- tipo: DICA | COMPARATIVO | NOTICIA (o que melhor encaixa).
+- numero_slides: 5, 6 ou 7 (padrão 7; use menos se tema é simples).
+- motivo: 1 linha explicando por que escolheu esse ângulo.`;
+
+const TOOLS: Anthropic.Tool[] = [
+  {
+    name: "refinar",
+    description: "Retorna o tema expandido, tipo e número de slides sugeridos.",
+    input_schema: {
+      type: "object" as const,
+      properties: {
+        tema: { type: "string", description: "Tema expandido. 1 frase, <120 caracteres, pronto pra usar como título." },
+        tipo: { type: "string", enum: ["DICA", "COMPARATIVO", "NOTICIA"] },
+        numero_slides: { type: "integer", enum: [5, 6, 7] },
+        motivo: { type: "string", description: "Linha curta sobre por que escolheu esse ângulo." },
+      },
+      required: ["tema", "tipo", "numero_slides", "motivo"],
+    },
+  },
+];
+
+export async function POST(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json().catch(() => ({}));
+  const ideia = typeof body?.ideia === "string" ? body.ideia.trim() : "";
+  if (!ideia) return NextResponse.json({ error: "ideia obrigatória" }, { status: 400 });
+  if (ideia.length > 500) return NextResponse.json({ error: "ideia muito longa (máx 500)" }, { status: 400 });
+
+  try {
+    const response = await client.messages.create({
+      model: "claude-opus-4-7",
+      max_tokens: 800,
+      system: SYSTEM_PROMPT,
+      tools: TOOLS,
+      tool_choice: { type: "tool", name: "refinar" },
+      messages: [{ role: "user", content: `Ideia do admin: "${ideia}"\n\nExpande pra tema completo e chama 'refinar'.` }],
+    });
+    const toolUse = response.content.find(
+      (b): b is Anthropic.ToolUseBlock => b.type === "tool_use" && b.name === "refinar"
+    );
+    if (!toolUse) {
+      return NextResponse.json({ error: "Claude não retornou a ferramenta 'refinar'" }, { status: 500 });
+    }
+    const input = toolUse.input as {
+      tema: string;
+      tipo: "DICA" | "COMPARATIVO" | "NOTICIA";
+      numero_slides: number;
+      motivo: string;
+    };
+    return NextResponse.json({
+      ok: true,
+      tema: input.tema,
+      tipo: input.tipo,
+      numero_slides: input.numero_slides,
+      motivo: input.motivo,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: "Falha Claude: " + msg }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## O que muda

No modal \"Novo post\" tem agora o botão **✨ Refinar com IA** ao lado do label \"Tema\".

Você escreve uma ideia curta tipo \"comparativo pra iPad\" → clica Refinar → Claude Opus 4.7 expande pra tema completo, escolhe modelos atuais específicos, define o ângulo e sugere tipo + nº de slides. Você ainda edita antes de criar.

## Exemplo testado

- Input: \`\"preciso fazer um post comparativo pra ipad\"\`
- Output:
  - **Tema**: \"iPad Air M3 vs iPad Pro M4: qual vale mais a pena em 2025?\"
  - **Tipo**: COMPARATIVO
  - **Slides**: 7
  - **Motivo** (mostrado em verde): \"Dúvida recorrente de quem quer iPad premium sem pagar caro no Pro — contraste direto entre os dois atuais top de linha.\"

## Backend

\`/api/instagram/refinar-tema\`:
- Recebe \`{ ideia }\` (max 500 chars)
- Claude Opus + tool \`refinar\` com \`tool_choice\` forçado
- Retorna tema/tipo/slides/motivo em ~3s
- Sem web_search — Opus 4.7 conhece produtos Apple (cutoff Jan/2026)

## UI

- Label \"Tema\" com botão laranja \"✨ Refinar com IA\" do lado direito
- Após refino, textarea + select tipo + slides atualizam, e motivo aparece em verde abaixo
- Editar o texto limpa o motivo (indica que já não é mais a sugestão do Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)