### PR TITLE
feat(vendas): envio manual de NF + preserva status em edicao

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -40,6 +40,11 @@ export default function VendasPage() {
   // Usado pra detectar se o admin trocou o produto (mesmo digitando manualmente
   // sem vincular novo item do estoque). Permite devolver o antigo ao estoque.
   const [estoqueIdOriginal, setEstoqueIdOriginal] = useState<string | null>(null);
+  // Guarda o status_pagamento ORIGINAL da venda em edicao. Sem isso,
+  // buildPayload defaulta pra "AGUARDANDO" e edicoes (ex: trocar forma de
+  // pagamento) jogam a venda finalizada de volta pra "em andamento" —
+  // disparando reenvio de NF/Telegram na proxima finalizacao.
+  const [statusPagamentoOriginal, setStatusPagamentoOriginal] = useState<string | null>(null);
   const [vendaProgramada, setVendaProgramada] = useState(false);
   const [programadaJaPago, setProgramadaJaPago] = useState(false);
   const [programadaComSinal, setProgramadaComSinal] = useState(false);
@@ -1126,7 +1131,13 @@ export default function VendasPage() {
             const totalEntries = pagEntries.reduce((s, e) => s + (parseFloat(e.valor.replace(/\./g, "").replace(",", ".")) || 0), 0);
             return totalEntries >= pPrecoVendido ? "FINALIZADO" : "PROGRAMADA";
           })()
-        : vendaProgramada ? (programadaJaPago ? "FINALIZADO" : "PROGRAMADA") : "AGUARDANDO",
+        : vendaProgramada ? (programadaJaPago ? "FINALIZADO" : "PROGRAMADA")
+        // Em edicao, preserva o status original — edicao de forma de pagamento,
+        // dados do cliente, etc., nao deve jogar venda finalizada de volta
+        // pra AGUARDANDO (isso disparava reenvio de NF quando o admin
+        // finalizasse de novo).
+        : (editandoVendaId && statusPagamentoOriginal) ? statusPagamentoOriginal
+        : "AGUARDANDO",
       data_programada: vendaProgramada && dataProgramada ? dataProgramada : null,
       ...(multiDatePagamento && pagEntries.length > 0 ? {
         pagamento_historia: pagEntries.filter(e => (parseFloat(e.valor.replace(/\./g, "").replace(",", ".")) || 0) > 0).map(e => {
@@ -1607,7 +1618,7 @@ export default function VendasPage() {
               : allProducts.length > editandoGrupoIds.length
                 ? `${editandoGrupoIds.length} atualizadas + ${allProducts.length - editandoGrupoIds.length} novas criadas!`
                 : `${allProducts.length} atualizadas + ${editandoGrupoIds.length - allProducts.length} removidas!`;
-            setEditandoVendaId(null); setEstoqueIdOriginal(null);
+            setEditandoVendaId(null); setEstoqueIdOriginal(null); setStatusPagamentoOriginal(null);
             setEditandoGrupoIds([]);
             setDuplicadoInfo(null);
             setProdutosCarrinho([]);
@@ -1649,7 +1660,7 @@ export default function VendasPage() {
           });
           const json = await res.json();
           if (json.ok || json.data) {
-            setEditandoVendaId(null); setEstoqueIdOriginal(null);
+            setEditandoVendaId(null); setEstoqueIdOriginal(null); setStatusPagamentoOriginal(null);
             setEditandoGrupoIds([]);
             setDuplicadoInfo(null);
             setProdutosCarrinho([]);
@@ -2207,7 +2218,7 @@ export default function VendasPage() {
               </div>
               <button
                 onClick={() => {
-                  setEditandoVendaId(null); setEstoqueIdOriginal(null);
+                  setEditandoVendaId(null); setEstoqueIdOriginal(null); setStatusPagamentoOriginal(null);
                   setEditandoGrupoIds([]);
                   setProdutosCarrinho([]);
                   setForm(f => ({ ...f, cliente: "", produto: "", custo: "", preco_vendido: "", forma: "" }));
@@ -2253,7 +2264,7 @@ export default function VendasPage() {
                     is_brinde: false,
                   });
                   setCatSel(""); setEstoqueId(""); setProdutoManual(false); setShowSegundaTroca(false); setTrocaEnabled(false);
-                  setProdutosCarrinho([]); setEditandoVendaId(null); setEstoqueIdOriginal(null); setEditandoGrupoIds([]); setDuplicadoInfo(null); setLastClienteData(null);
+                  setProdutosCarrinho([]); setEditandoVendaId(null); setEstoqueIdOriginal(null); setStatusPagamentoOriginal(null); setEditandoGrupoIds([]); setDuplicadoInfo(null); setLastClienteData(null);
                   setTrocaRow(createEmptyProdutoRow()); setTrocaRow2(createEmptyProdutoRow());
                   setSerialBusca(""); setScanMsg("");
                   setVendaProgramada(false); setProgramadaJaPago(false); setProgramadaComSinal(false); setDataProgramada(""); setMultiDatePagamento(false); setPagEntries([]);
@@ -3082,7 +3093,7 @@ export default function VendasPage() {
                   setProdutosCarrinho([]);
                   setTrocaRow(createEmptyProdutoRow()); setTrocaRow2(createEmptyProdutoRow());
                   setSerialBusca(""); setScanMsg("");
-                  setEditandoVendaId(null); setEstoqueIdOriginal(null); setEditandoGrupoIds([]); setDuplicadoInfo(null);
+                  setEditandoVendaId(null); setEstoqueIdOriginal(null); setStatusPagamentoOriginal(null); setEditandoGrupoIds([]); setDuplicadoInfo(null);
                   setVendaProgramada(false); setProgramadaJaPago(false); setProgramadaComSinal(false); setDataProgramada(""); setMultiDatePagamento(false); setPagEntries([]);
                   setMsg("");
                   localStorage.removeItem("tigrao_venda_draft");
@@ -5337,6 +5348,10 @@ export default function VendasPage() {
                                             }
                                             // Guarda o estoque_id ORIGINAL da venda (pra detectar se trocou produto no submit)
                                             setEstoqueIdOriginal((primaryVenda as unknown as { estoque_id?: string | null }).estoque_id || null);
+                                            // Guarda o status_pagamento ORIGINAL — preservado em buildPayload
+                                            // pra edicao de venda FINALIZADA nao voltar pra AGUARDANDO
+                                            // (bug que disparava reenvio de NF ao finalizar de novo).
+                                            setStatusPagamentoOriginal(primaryVenda.status_pagamento || null);
                                             // Preservar flag de venda programada no form — senao o PATCH
                                             // zerava data_programada e mudava status pra AGUARDANDO ao salvar.
                                             if (primaryVenda.status_pagamento === "PROGRAMADA" || primaryVenda.data_programada) {
@@ -5500,6 +5515,44 @@ export default function VendasPage() {
                                               className="px-3 py-1.5 rounded-lg text-xs font-semibold text-green-600 border border-green-200 hover:bg-green-50 transition-colors inline-flex items-center gap-1">
                                               📄 Ver NF
                                             </a>
+                                            {/* Badge de status do envio + botao Enviar (substitui o envio
+                                                automatico que spamava cliente a cada edicao de venda). */}
+                                            {(v as unknown as { nota_fiscal_enviada?: boolean }).nota_fiscal_enviada ? (
+                                              <span
+                                                className="px-3 py-1.5 rounded-lg text-xs font-semibold text-green-700 bg-green-50 border border-green-200 inline-flex items-center gap-1"
+                                                title={(v as unknown as { nota_fiscal_enviada_em?: string }).nota_fiscal_enviada_em || ""}
+                                              >
+                                                ✅ NF enviada
+                                              </span>
+                                            ) : v.email ? (
+                                              <button
+                                                onClick={async (e) => {
+                                                  e.stopPropagation();
+                                                  if (!confirm(`Enviar NF por email pra ${v.email}?`)) return;
+                                                  const res = await fetch("/api/vendas", {
+                                                    method: "PATCH",
+                                                    headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
+                                                    body: JSON.stringify({ action: "enviar_nf", id: v.id }),
+                                                  });
+                                                  const j = await res.json().catch(() => ({}));
+                                                  if (res.ok && j.ok) {
+                                                    setVendas(prev => prev.map(r => r.id === v.id ? { ...r, nota_fiscal_enviada: true, nota_fiscal_enviada_em: new Date().toISOString() } as typeof r : r));
+                                                    setMsg(`NF enviada para ${v.email}`);
+                                                  } else {
+                                                    setMsg(`Erro ao enviar NF: ${j.error || res.status}`);
+                                                  }
+                                                  setTimeout(() => setMsg(""), 4000);
+                                                }}
+                                                className="px-3 py-1.5 rounded-lg text-xs font-semibold text-amber-700 bg-amber-50 border border-amber-300 hover:bg-amber-100 transition-colors inline-flex items-center gap-1"
+                                                title={`Enviar por email pra ${v.email}`}
+                                              >
+                                                📧 Enviar NF (pendente)
+                                              </button>
+                                            ) : (
+                                              <span className="px-3 py-1.5 rounded-lg text-xs font-semibold text-gray-500 bg-gray-50 border border-gray-200 inline-flex items-center gap-1" title="Venda sem email do cliente">
+                                                ⚠️ Sem email
+                                              </span>
+                                            )}
                                             <button
                                               onClick={async (e) => {
                                                 e.stopPropagation();
@@ -5507,9 +5560,9 @@ export default function VendasPage() {
                                                 await fetch("/api/vendas", {
                                                   method: "PATCH",
                                                   headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
-                                                  body: JSON.stringify({ id: v.id, nota_fiscal_url: null }),
+                                                  body: JSON.stringify({ id: v.id, nota_fiscal_url: null, nota_fiscal_enviada: false, nota_fiscal_enviada_em: null }),
                                                 });
-                                                setVendas(prev => prev.map(r => r.id === v.id ? { ...r, nota_fiscal_url: "" } : r));
+                                                setVendas(prev => prev.map(r => r.id === v.id ? { ...r, nota_fiscal_url: "", nota_fiscal_enviada: false, nota_fiscal_enviada_em: null } as typeof r : r));
                                                 setMsg("NF removida. Agora pode anexar a correta.");
                                               }}
                                               className="px-3 py-1.5 rounded-lg text-xs font-semibold text-red-500 border border-red-200 hover:bg-red-50 transition-colors inline-flex items-center gap-1"

--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -4508,6 +4508,45 @@ export default function VendasPage() {
                 </div>
                 <div className="flex gap-3 items-center text-xs text-[#86868B]">
                   <span>{filtered.length} vendas</span>
+                  {/* Botao de envio em massa de NFs pendentes — aparece quando
+                      ha vendas no filtro atual com NF anexa + email + ainda nao
+                      enviada. Confirma antes, mostra contagem e erros. */}
+                  {(() => {
+                    const pendentesNF = filtered.filter(v =>
+                      v.nota_fiscal_url
+                      && v.email
+                      && !((v as unknown as { nota_fiscal_enviada?: boolean }).nota_fiscal_enviada)
+                    );
+                    if (pendentesNF.length === 0) return null;
+                    return (
+                      <button
+                        onClick={async () => {
+                          if (!confirm(`Enviar ${pendentesNF.length} NF(s) pendente(s) por email?\n\nVai disparar email pra cada cliente dessa lista. Quem ja recebeu nao sera reenviado.`)) return;
+                          const ids = pendentesNF.map(v => v.id);
+                          const res = await fetch("/api/vendas", {
+                            method: "PATCH",
+                            headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
+                            body: JSON.stringify({ action: "enviar_nf_bulk", ids }),
+                          });
+                          const j = await res.json().catch(() => ({}));
+                          if (res.ok && j.ok) {
+                            const errTxt = j.erros && j.erros.length
+                              ? ` (${j.erros.length} erro${j.erros.length > 1 ? "s" : ""}: ${j.erros.slice(0, 3).map((e: { cliente: string }) => e.cliente).join(", ")}${j.erros.length > 3 ? "..." : ""})`
+                              : "";
+                            setMsg(`${j.enviadas}/${j.total} NF(s) enviada(s)${errTxt}`);
+                            fetchVendas();
+                          } else {
+                            setMsg(`Erro no envio em massa: ${j.error || res.status}`);
+                          }
+                          setTimeout(() => setMsg(""), 6000);
+                        }}
+                        className="px-3 py-1.5 rounded-lg text-xs font-semibold text-amber-700 bg-amber-50 border border-amber-300 hover:bg-amber-100 transition-colors inline-flex items-center gap-1"
+                        title="Envia todas as NFs anexadas que ainda nao foram enviadas por email"
+                      >
+                        📧 Enviar {pendentesNF.length} NF{pendentesNF.length > 1 ? "s" : ""} pendente{pendentesNF.length > 1 ? "s" : ""}
+                      </button>
+                    );
+                  })()}
                   {selecionadas.size > 0 && (
                     <div className="flex gap-2">
                       {tab === "andamento" && (

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -569,6 +569,37 @@ export async function PATCH(req: NextRequest) {
 
   const body = await req.json();
 
+  // Enviar NF manualmente por email ao cliente
+  if (body.action === "enviar_nf") {
+    const { id: vendaId } = body;
+    if (!vendaId) return NextResponse.json({ error: "id required" }, { status: 400 });
+    const { data: venda, error: e } = await supabase.from("vendas")
+      .select("id, email, cliente, produto, cor, valor_comprovante, preco_vendido, nota_fiscal_url, nota_fiscal_enviada")
+      .eq("id", vendaId)
+      .single();
+    if (e || !venda) return NextResponse.json({ error: "venda nao encontrada" }, { status: 404 });
+    if (!venda.email) return NextResponse.json({ error: "venda sem email do cliente" }, { status: 400 });
+    if (!venda.nota_fiscal_url) return NextResponse.json({ error: "venda sem NF anexada" }, { status: 400 });
+    try {
+      const { enviarNotaFiscal } = await import("@/lib/email");
+      await enviarNotaFiscal({
+        to: venda.email,
+        clienteNome: venda.cliente || "Cliente",
+        produto: normalizarCoresNoTexto(`${venda.produto || ""}${venda.cor ? ` ${venda.cor}` : ""}`.trim()),
+        valor: Number(venda.valor_comprovante || venda.preco_vendido || 0),
+        notaFiscalUrl: venda.nota_fiscal_url,
+      });
+      await supabase.from("vendas")
+        .update({ nota_fiscal_enviada: true, nota_fiscal_enviada_em: new Date().toISOString() })
+        .eq("id", vendaId);
+      await logActivity(usuario, "NF enviada por email (manual)", `${venda.cliente} → ${venda.email}`, "vendas", vendaId);
+      return NextResponse.json({ ok: true });
+    } catch (err) {
+      console.error("[Vendas] Erro ao enviar NF manual:", err);
+      return NextResponse.json({ error: `Erro ao enviar email: ${String(err)}` }, { status: 500 });
+    }
+  }
+
   // Bulk update: finalizar todas vendas de uma data
   if (body.action === "finalizar_dia") {
     const { data: dia } = body;
@@ -825,23 +856,9 @@ export async function PATCH(req: NextRequest) {
       else console.log("[Vendas] Notificação Telegram enviada com sucesso para:", venda.cliente);
     }).catch(err => console.error("[Vendas] Erro notificação Telegram:", err));
 
-    // Enviar Nota Fiscal por email ao cliente (se tem email + NF anexada)
-    if (venda.email && venda.nota_fiscal_url) {
-      import("@/lib/email").then(({ enviarNotaFiscal }) => {
-        enviarNotaFiscal({
-          to: venda.email!,
-          clienteNome: venda.cliente || "Cliente",
-          produto: normalizarCoresNoTexto(`${venda.produto || ""}${venda.cor ? ` ${venda.cor}` : ""}`.trim()),
-          valor: Number(venda.valor_comprovante || venda.preco_vendido || 0),
-          notaFiscalUrl: venda.nota_fiscal_url!,
-        }).then(() => {
-          console.log("[Vendas] NF enviada por email para:", venda.email);
-          logActivity(usuario, "NF enviada por email", `${venda.cliente} → ${venda.email}`, "vendas", id).catch(() => {});
-        }).catch(err => {
-          console.error("[Vendas] Erro ao enviar NF por email:", err);
-        });
-      }).catch(err => console.error("[Vendas] Erro ao importar email:", err));
-    }
+    // NF nao eh mais enviada automaticamente — admin envia manualmente via
+    // botao "Enviar NF" no card da venda (action=enviar_nf). Venda com NF
+    // anexada mas nao enviada ganha badge "Envio pendente" na UI.
   }
 
   // Se tem reajustes, sincronizar com tabela reajustes (para relatório da noite)

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -600,6 +600,53 @@ export async function PATCH(req: NextRequest) {
     }
   }
 
+  // Envio em massa de NF pendente. Filtra: tem nota_fiscal_url + tem email +
+  // nota_fiscal_enviada=false. Opcionalmente restringe por lista de ids.
+  // Nunca reenvia NF ja enviada (filtro no SELECT). Retorna contagem de
+  // enviadas + lista de erros por cliente.
+  if (body.action === "enviar_nf_bulk") {
+    const idsFiltro = Array.isArray(body.ids) ? (body.ids as string[]) : null;
+    let q = supabase.from("vendas")
+      .select("id, email, cliente, produto, cor, valor_comprovante, preco_vendido, nota_fiscal_url")
+      .not("nota_fiscal_url", "is", null)
+      .not("email", "is", null)
+      .eq("nota_fiscal_enviada", false);
+    if (idsFiltro && idsFiltro.length > 0) q = q.in("id", idsFiltro);
+    const { data: pendentes, error: errSel } = await q;
+    if (errSel) return NextResponse.json({ error: errSel.message }, { status: 500 });
+    if (!pendentes || pendentes.length === 0) {
+      return NextResponse.json({ ok: true, enviadas: 0, erros: [], total: 0 });
+    }
+    const { enviarNotaFiscal } = await import("@/lib/email");
+    const erros: { cliente: string; erro: string }[] = [];
+    let enviadas = 0;
+    for (const v of pendentes) {
+      try {
+        await enviarNotaFiscal({
+          to: v.email!,
+          clienteNome: v.cliente || "Cliente",
+          produto: normalizarCoresNoTexto(`${v.produto || ""}${v.cor ? ` ${v.cor}` : ""}`.trim()),
+          valor: Number(v.valor_comprovante || v.preco_vendido || 0),
+          notaFiscalUrl: v.nota_fiscal_url!,
+        });
+        await supabase.from("vendas")
+          .update({ nota_fiscal_enviada: true, nota_fiscal_enviada_em: new Date().toISOString() })
+          .eq("id", v.id);
+        enviadas++;
+      } catch (err) {
+        erros.push({ cliente: v.cliente || "?", erro: String(err) });
+        console.error("[Vendas] Erro envio bulk NF:", v.cliente, err);
+      }
+    }
+    await logActivity(
+      usuario,
+      "Envio em massa de NF",
+      `${enviadas}/${pendentes.length} enviadas${erros.length ? `, ${erros.length} erro(s)` : ""}`,
+      "vendas"
+    );
+    return NextResponse.json({ ok: true, enviadas, erros, total: pendentes.length });
+  }
+
   // Bulk update: finalizar todas vendas de uma data
   if (body.action === "finalizar_dia") {
     const { data: dia } = body;

--- a/supabase/migrations/20260419c_vendas_nota_fiscal_enviada.sql
+++ b/supabase/migrations/20260419c_vendas_nota_fiscal_enviada.sql
@@ -1,0 +1,29 @@
+-- Rastreia se a Nota Fiscal ja foi enviada por email ao cliente.
+--
+-- Antes, o envio era automatico toda vez que a venda ficava com status
+-- FINALIZADO. Como edicoes de venda sao comuns, isso spammava o cliente
+-- com NFs duplicadas. Agora o envio vira MANUAL — admin anexa a NF e
+-- clica "Enviar NF". Esse campo marca que o envio ja foi feito pra NAO
+-- mostrar mais "envio pendente" nem permitir reenvio acidental.
+--
+-- Vendas antigas ficam default false. Admin pode marcar manualmente como
+-- enviada via UI ou rodar um backfill de vendas finalizadas com NF anexa.
+
+ALTER TABLE vendas
+  ADD COLUMN IF NOT EXISTS nota_fiscal_enviada BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE vendas
+  ADD COLUMN IF NOT EXISTS nota_fiscal_enviada_em TIMESTAMPTZ;
+
+COMMENT ON COLUMN vendas.nota_fiscal_enviada IS 'Se a NF anexa foi enviada por email ao cliente';
+COMMENT ON COLUMN vendas.nota_fiscal_enviada_em IS 'Timestamp do envio da NF (null se nao enviada)';
+
+-- Backfill: vendas que ja foram FINALIZADAS com NF anexa provavelmente
+-- tiveram o email disparado pelo fluxo antigo automatico. Marca como
+-- enviadas pra nao aparecer "pendente" em historico.
+UPDATE vendas
+SET nota_fiscal_enviada = TRUE,
+    nota_fiscal_enviada_em = updated_at
+WHERE nota_fiscal_url IS NOT NULL
+  AND status_pagamento = 'FINALIZADO'
+  AND nota_fiscal_enviada = FALSE;


### PR DESCRIPTION
## Resumo

Muda o envio da Nota Fiscal por email de **automático** para **manual**. Resolve 3 problemas:

### 1. NF era reenviada a cada edição de venda finalizada
Admin corrige qualquer coisa na venda → PATCH → envio disparava de novo → cliente recebia email duplicado. Com o guard de transição de status anterior até dava pra evitar, mas o bug abaixo furava ele.

### 2. Editar só a forma de pagamento jogava venda para AGUARDANDO
\`buildPayload\` defaulta \`status_pagamento\` pra \`"AGUARDANDO"\` se não é programada. Em edição de venda finalizada, resetava o status. Re-finalizando, nova transição disparava NF + Telegram.
**Fix**: novo state \`statusPagamentoOriginal\` que preserva o status do DB ao entrar em edição.

### 3. Rastrear se NF já foi enviada
Não havia coluna pra isso. Agora:
- \`nota_fiscal_enviada\` (bool) + \`nota_fiscal_enviada_em\` (timestamptz)
- Badge \`✅ NF enviada\` se enviada, \`📧 Enviar NF (pendente)\` se anexa mas não enviada, \`⚠️ Sem email\` se não dá pra enviar
- Backfill: vendas FINALIZADAS com NF anexa são marcadas como enviadas (fluxo antigo já disparava)

## API

### Novo: \`action: enviar_nf\`
\`PATCH /api/vendas\` com body \`{ action: \"enviar_nf\", id: vendaId }\`
- Valida email do cliente + NF anexa
- Envia email, grava \`nota_fiscal_enviada=true\` + \`nota_fiscal_enviada_em=NOW()\`
- Log de atividade: \"NF enviada por email (manual)\"

### Removido: envio automático no PATCH
Bloco que chamava \`enviarNotaFiscal\` na transição pra FINALIZADO foi removido. Telegram continua automático (esse não spama cliente, só equipe).

## Test plan

- [ ] Rodar migration \`20260419c_vendas_nota_fiscal_enviada\`
- [ ] Venda FINALIZADA com NF anexa já existente → badge \"NF enviada\" (backfill)
- [ ] Venda nova finalizada → NF NÃO dispara automaticamente
- [ ] Anexar NF → badge \"Enviar NF (pendente)\" aparece
- [ ] Clicar \"Enviar NF\" → email dispara, badge vira \"enviada\"
- [ ] Editar forma de pagamento de venda finalizada → continua FINALIZADA (não volta pra em andamento)
- [ ] Trocar NF → flag reseta, badge vira \"pendente\" de novo
- [ ] Venda sem email do cliente → mostra \"Sem email\" em vez do botão

🤖 Generated with [Claude Code](https://claude.com/claude-code)