### PR TITLE
feat(calc-importacao): editar lista de produtos via UI + banco

### DIFF
--- a/components/admin/CalculadoraImportacao.tsx
+++ b/components/admin/CalculadoraImportacao.tsx
@@ -17,7 +17,15 @@ const TAXAS_PARCELA: Record<number, number> = {
 function getTaxa(n: number) { return TAXAS_PARCELA[n] ?? 0; }
 const fmtBRL = (v: number) => `R$ ${Math.ceil(v).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
 
-interface ProdutoPeso { cat: string; nome: string; peso: number }
+interface ProdutoPeso {
+  cat: string;
+  nome: string;
+  peso: number;
+  // Configuracoes (storage/RAM/chip) e cores opcionais — admin preenche via
+  // aba Editar produtos. Se vazio, calculadora nao mostra os seletores.
+  configs?: string[];
+  cores?: string[];
+}
 
 // Fallback caso a API falhe ou o seed ainda nao tenha rodado.
 // Admin edita a lista via aba "Editar produtos" e salva no app_settings
@@ -62,7 +70,17 @@ export default function CalculadoraImportacao() {
   const [result, setResult] = useState<CalcResult | null>(null);
   const [showProdutos, setShowProdutos] = useState(false);
   const [buscaProduto, setBuscaProduto] = useState("");
-  const [produtoSelecionado, setProdutoSelecionado] = useState("");
+  // produtoBaseNome = nome do row do catalogo (sem config/cor) que foi
+  // clicado. Usado pra buscar configs/cores disponiveis no array produtos.
+  const [produtoBaseNome, setProdutoBaseNome] = useState("");
+  const [configSelecionada, setConfigSelecionada] = useState("");
+  const [corSelecionada, setCorSelecionada] = useState("");
+  // produtoSelecionado = string composta (base + config + cor) mostrada na
+  // pill e usada no texto do orcamento.
+  const produtoBase = produtos.find(p => p.nome === produtoBaseNome) || null;
+  const produtoSelecionado = produtoBaseNome
+    ? [produtoBaseNome, configSelecionada, corSelecionada].filter(Boolean).join(" ")
+    : "";
 
   // Gerador de orçamento
   const [precoVenda, setPrecoVenda] = useState("");
@@ -149,9 +167,11 @@ export default function CalculadoraImportacao() {
           produtos={produtos}
           onSaved={(novaLista) => {
             setProdutos(novaLista);
-            // Se o produto selecionado na calculadora foi removido, limpa.
-            if (produtoSelecionado && !novaLista.some(p => p.nome === produtoSelecionado)) {
-              setProdutoSelecionado("");
+            // Se o produto base selecionado na calculadora foi removido, limpa.
+            if (produtoBaseNome && !novaLista.some(p => p.nome === produtoBaseNome)) {
+              setProdutoBaseNome("");
+              setConfigSelecionada("");
+              setCorSelecionada("");
             }
           }}
         />
@@ -178,6 +198,45 @@ export default function CalculadoraImportacao() {
           </span>
           <span className="text-[#86868B]">{showProdutos ? "▲" : "▼"}</span>
         </button>
+
+        {produtoBase && (produtoBase.configs?.length || produtoBase.cores?.length) && (
+          <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {produtoBase.configs && produtoBase.configs.length > 0 && (
+              <div>
+                <label className="block text-xs font-semibold text-[#86868B] mb-1.5 uppercase tracking-wider">
+                  Configuração
+                </label>
+                <select
+                  value={configSelecionada}
+                  onChange={(e) => setConfigSelecionada(e.target.value)}
+                  className="w-full px-3 py-2.5 rounded-xl border border-[#D2D2D7] bg-white text-sm outline-none focus:border-[#E8740E]"
+                >
+                  <option value="">— Selecionar —</option>
+                  {produtoBase.configs.map(c => (
+                    <option key={c} value={c}>{c}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+            {produtoBase.cores && produtoBase.cores.length > 0 && (
+              <div>
+                <label className="block text-xs font-semibold text-[#86868B] mb-1.5 uppercase tracking-wider">
+                  Cor
+                </label>
+                <select
+                  value={corSelecionada}
+                  onChange={(e) => setCorSelecionada(e.target.value)}
+                  className="w-full px-3 py-2.5 rounded-xl border border-[#D2D2D7] bg-white text-sm outline-none focus:border-[#E8740E]"
+                >
+                  <option value="">— Selecionar —</option>
+                  {produtoBase.cores.map(c => (
+                    <option key={c} value={c}>{c}</option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+        )}
 
         {showProdutos && (
           <div className="absolute z-50 mt-1 w-full bg-white border border-[#D2D2D7] rounded-xl shadow-xl max-h-[400px] overflow-hidden">
@@ -218,7 +277,10 @@ export default function CalculadoraImportacao() {
                       <button
                         onClick={() => {
                           setPeso(String(p.peso));
-                          setProdutoSelecionado(p.nome);
+                          setProdutoBaseNome(p.nome);
+                          // Pre-seleciona primeira config/cor se houver apenas uma
+                          setConfigSelecionada((p.configs && p.configs.length === 1) ? p.configs[0] : "");
+                          setCorSelecionada((p.cores && p.cores.length === 1) ? p.cores[0] : "");
                           setShowProdutos(false);
                           setBuscaProduto("");
                         }}
@@ -249,7 +311,13 @@ export default function CalculadoraImportacao() {
           label="Peso do produto"
           suffix="kg"
           value={peso}
-          onChange={(v) => { setPeso(v); setProdutoSelecionado(""); }}
+          onChange={(v) => {
+            setPeso(v);
+            // Se admin mexer no peso manualmente, desvincula do produto selecionado.
+            setProdutoBaseNome("");
+            setConfigSelecionada("");
+            setCorSelecionada("");
+          }}
           placeholder="3.0"
         />
         <InputField
@@ -412,6 +480,13 @@ function EditorProdutos({
     setLista(prev => prev.map((p, idx) => idx === i ? { ...p, [campo]: valor } : p));
   };
 
+  // Helper pra campos array (configs, cores): admin digita "256GB, 512GB, 1TB"
+  // e salva como ["256GB", "512GB", "1TB"]. Vazio/espacos ignorados.
+  const atualizarArray = (i: number, campo: "configs" | "cores", csv: string) => {
+    const arr = csv.split(",").map(s => s.trim()).filter(Boolean);
+    setLista(prev => prev.map((p, idx) => idx === i ? { ...p, [campo]: arr.length > 0 ? arr : undefined } : p));
+  };
+
   const adicionar = () => {
     setLista(prev => [...prev, { cat: "MacBook", nome: "", peso: 1.0 }]);
   };
@@ -496,13 +571,20 @@ function EditorProdutos({
       </datalist>
 
       <div className="overflow-x-auto">
+        <p className="text-[11px] text-[#86868B] mb-2">
+          💡 <strong>Configurações</strong> e <strong>Cores</strong> sao opcionais —
+          separe por virgula (ex: &quot;256GB, 512GB, 1TB&quot; ou &quot;Prata, Grafite&quot;).
+          Se preenchidos, viram seletores na tela de calcular.
+        </p>
         <table className="w-full text-sm">
           <thead>
             <tr className="text-[10px] font-bold text-[#86868B] uppercase tracking-wider border-b border-[#E5E5EA]">
-              <th className="text-left py-2 pr-3">Categoria</th>
+              <th className="text-left py-2 pr-3 w-28">Categoria</th>
               <th className="text-left py-2 pr-3">Nome</th>
-              <th className="text-left py-2 pr-3 w-24">Peso (kg)</th>
-              <th className="text-right py-2 w-16"></th>
+              <th className="text-left py-2 pr-3 w-20">Peso (kg)</th>
+              <th className="text-left py-2 pr-3">Configurações</th>
+              <th className="text-left py-2 pr-3">Cores</th>
+              <th className="text-right py-2 w-12"></th>
             </tr>
           </thead>
           <tbody>
@@ -538,6 +620,24 @@ function EditorProdutos({
                     className="w-full px-2 py-1.5 rounded-lg border border-[#D2D2D7] text-sm outline-none focus:border-[#E8740E]"
                   />
                 </td>
+                <td className="py-2 pr-3">
+                  <input
+                    type="text"
+                    value={(p.configs || []).join(", ")}
+                    onChange={(e) => atualizarArray(i, "configs", e.target.value)}
+                    placeholder="256GB, 512GB, 1TB"
+                    className="w-full px-2 py-1.5 rounded-lg border border-[#D2D2D7] text-sm outline-none focus:border-[#E8740E]"
+                  />
+                </td>
+                <td className="py-2 pr-3">
+                  <input
+                    type="text"
+                    value={(p.cores || []).join(", ")}
+                    onChange={(e) => atualizarArray(i, "cores", e.target.value)}
+                    placeholder="Prata, Grafite, Preto"
+                    className="w-full px-2 py-1.5 rounded-lg border border-[#D2D2D7] text-sm outline-none focus:border-[#E8740E]"
+                  />
+                </td>
                 <td className="py-2 text-right">
                   <button
                     onClick={() => remover(i)}
@@ -551,7 +651,7 @@ function EditorProdutos({
             ))}
             {lista.length === 0 && (
               <tr>
-                <td colSpan={4} className="py-8 text-center text-sm text-[#86868B]">
+                <td colSpan={6} className="py-8 text-center text-sm text-[#86868B]">
                   Nenhum produto. Clica em <strong>+ Adicionar produto</strong>.
                 </td>
               </tr>

--- a/components/admin/CalculadoraImportacao.tsx
+++ b/components/admin/CalculadoraImportacao.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 const formatBRL = (v: number) =>
   v.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
@@ -17,23 +17,26 @@ const TAXAS_PARCELA: Record<number, number> = {
 function getTaxa(n: number) { return TAXAS_PARCELA[n] ?? 0; }
 const fmtBRL = (v: number) => `R$ ${Math.ceil(v).toLocaleString("pt-BR", { minimumFractionDigits: 2 })}`;
 
-// Catálogo de produtos com peso pré-cadastrado (kg) — peso com caixa completa
-const PRODUTOS_PESO: { cat: string; nome: string; peso: number }[] = [
-  // MacBooks (caixa completa ~3kg)
+interface ProdutoPeso { cat: string; nome: string; peso: number }
+
+// Fallback caso a API falhe ou o seed ainda nao tenha rodado.
+// Admin edita a lista via aba "Editar produtos" e salva no app_settings
+// (key: calc_importacao_produtos).
+const FALLBACK_PRODUTOS: ProdutoPeso[] = [
   { cat: "MacBook", nome: "MacBook Pro M5 14\"", peso: 3.0 },
   { cat: "MacBook", nome: "MacBook Pro M4 Pro 14\"", peso: 3.0 },
   { cat: "MacBook", nome: "MacBook Air M4 15\"", peso: 3.0 },
   { cat: "MacBook", nome: "MacBook Air M5 13\"", peso: 3.0 },
-  // iPads (caixa completa ~1kg)
   { cat: "iPad", nome: "iPad A16", peso: 1.0 },
   { cat: "iPad", nome: "iPad Air M3 11\"", peso: 1.0 },
   { cat: "iPad", nome: "iPad Air M3 13\"", peso: 1.0 },
   { cat: "iPad", nome: "iPad Pro M5 11\"", peso: 1.0 },
   { cat: "iPad", nome: "iPad Pro M5 13\"", peso: 1.0 },
-  // Mac Mini
   { cat: "Mac", nome: "Mac Mini M4", peso: 1.06 },
   { cat: "Mac", nome: "Mac Mini M4 Pro", peso: 2.0 },
 ];
+
+const SETTINGS_KEY = "calc_importacao_produtos";
 
 interface CalcResult {
   p: number;
@@ -46,7 +49,13 @@ interface CalcResult {
   totalBrl: number;
 }
 
+type Tab = "calcular" | "editar";
+
 export default function CalculadoraImportacao() {
+  const [tab, setTab] = useState<Tab>("calcular");
+  const [produtos, setProdutos] = useState<ProdutoPeso[]>(FALLBACK_PRODUTOS);
+  const [loading, setLoading] = useState(true);
+
   const [preco, setPreco] = useState("");
   const [peso, setPeso] = useState("");
   const [cotacao, setCotacao] = useState("");
@@ -59,6 +68,29 @@ export default function CalculadoraImportacao() {
   const [precoVenda, setPrecoVenda] = useState("");
   const [parcelasSel, setParcelasSel] = useState<number[]>([12, 18, 21]);
   const [copiado, setCopiado] = useState(false);
+
+  // Carrega a lista do app_settings. Usa localStorage.adminPassword pra auth
+  // (mesmo padrao do resto do /admin).
+  const carregarProdutos = useCallback(async () => {
+    setLoading(true);
+    try {
+      const pw = typeof window !== "undefined" ? localStorage.getItem("adminPassword") || "" : "";
+      const res = await fetch(`/api/admin/estoque-settings?key=${SETTINGS_KEY}`, {
+        headers: { "x-admin-password": pw },
+      });
+      if (res.ok) {
+        const json = await res.json();
+        if (Array.isArray(json.value) && json.value.length > 0) {
+          setProdutos(json.value as ProdutoPeso[]);
+        }
+      }
+    } catch { /* usa fallback */ }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    carregarProdutos();
+  }, [carregarProdutos]);
 
   useEffect(() => {
     if (preco && peso && cotacao) {
@@ -82,14 +114,49 @@ export default function CalculadoraImportacao() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
+      {/* Header + abas */}
       <div>
         <h2 className="text-lg font-bold text-[#1D1D1F]">Calculadora de Importação</h2>
         <p className="text-sm text-[#86868B] mt-1">
           Calcule o custo final de importação de produtos Apple dos EUA para o Brasil.
         </p>
+        <div className="mt-4 flex gap-2 border-b border-[#E5E5EA]">
+          <button
+            onClick={() => setTab("calcular")}
+            className={`px-4 py-2 text-sm font-semibold transition-colors border-b-2 ${
+              tab === "calcular"
+                ? "border-[#E8740E] text-[#E8740E]"
+                : "border-transparent text-[#86868B] hover:text-[#1D1D1F]"
+            }`}
+          >
+            Calcular
+          </button>
+          <button
+            onClick={() => setTab("editar")}
+            className={`px-4 py-2 text-sm font-semibold transition-colors border-b-2 ${
+              tab === "editar"
+                ? "border-[#E8740E] text-[#E8740E]"
+                : "border-transparent text-[#86868B] hover:text-[#1D1D1F]"
+            }`}
+          >
+            Editar produtos{loading ? " …" : ` (${produtos.length})`}
+          </button>
+        </div>
       </div>
 
+      {tab === "editar" ? (
+        <EditorProdutos
+          produtos={produtos}
+          onSaved={(novaLista) => {
+            setProdutos(novaLista);
+            // Se o produto selecionado na calculadora foi removido, limpa.
+            if (produtoSelecionado && !novaLista.some(p => p.nome === produtoSelecionado)) {
+              setProdutoSelecionado("");
+            }
+          }}
+        />
+      ) : (
+        <>
       {/* Formula card */}
       <div className="rounded-2xl border border-[#E5E5EA] bg-[#F5F5F7] px-5 py-4">
         <div className="text-[10px] font-semibold text-[#86868B] uppercase tracking-wider mb-2">
@@ -126,10 +193,17 @@ export default function CalculadoraImportacao() {
             </div>
             <div className="overflow-y-auto max-h-[340px]">
               {(() => {
-                const filtrados = PRODUTOS_PESO.filter(p =>
+                const filtrados = produtos.filter(p =>
                   p.nome.toLowerCase().includes(buscaProduto.toLowerCase()) ||
                   p.cat.toLowerCase().includes(buscaProduto.toLowerCase())
                 );
+                if (filtrados.length === 0) {
+                  return (
+                    <div className="px-4 py-6 text-center text-sm text-[#86868B]">
+                      Nenhum produto. Adiciona na aba &quot;Editar produtos&quot;.
+                    </div>
+                  );
+                }
                 let lastCat = "";
                 return filtrados.map((p, i) => {
                   const showCat = p.cat !== lastCat;
@@ -313,6 +387,178 @@ export default function CalculadoraImportacao() {
         </div>
         </>
       )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function EditorProdutos({
+  produtos,
+  onSaved,
+}: {
+  produtos: ProdutoPeso[];
+  onSaved: (novaLista: ProdutoPeso[]) => void;
+}) {
+  const [lista, setLista] = useState<ProdutoPeso[]>(produtos);
+  const [salvando, setSalvando] = useState(false);
+  const [msg, setMsg] = useState("");
+
+  useEffect(() => { setLista(produtos); }, [produtos]);
+
+  const dirty = JSON.stringify(lista) !== JSON.stringify(produtos);
+
+  const atualizar = (i: number, campo: keyof ProdutoPeso, valor: string | number) => {
+    setLista(prev => prev.map((p, idx) => idx === i ? { ...p, [campo]: valor } : p));
+  };
+
+  const adicionar = () => {
+    setLista(prev => [...prev, { cat: "MacBook", nome: "", peso: 1.0 }]);
+  };
+
+  const remover = (i: number) => {
+    if (!confirm(`Remover "${lista[i].nome || "(sem nome)"}"?`)) return;
+    setLista(prev => prev.filter((_, idx) => idx !== i));
+  };
+
+  const salvar = async () => {
+    // Valida: todos precisam de nome, peso > 0
+    const invalidos = lista.filter(p => !p.nome.trim() || !(p.peso > 0));
+    if (invalidos.length > 0) {
+      setMsg(`${invalidos.length} item(ns) com nome vazio ou peso invalido`);
+      setTimeout(() => setMsg(""), 4000);
+      return;
+    }
+    setSalvando(true);
+    try {
+      const pw = typeof window !== "undefined" ? localStorage.getItem("adminPassword") || "" : "";
+      const res = await fetch("/api/admin/estoque-settings", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", "x-admin-password": pw },
+        body: JSON.stringify({ key: SETTINGS_KEY, value: lista }),
+      });
+      if (res.ok) {
+        onSaved(lista);
+        setMsg("Lista salva!");
+      } else {
+        const j = await res.json().catch(() => ({}));
+        setMsg(`Erro ao salvar: ${j.error || res.status}`);
+      }
+    } catch (err) {
+      setMsg(`Erro: ${String(err)}`);
+    }
+    setSalvando(false);
+    setTimeout(() => setMsg(""), 4000);
+  };
+
+  // Categorias sugeridas
+  const cats = [...new Set(lista.map(p => p.cat))].sort();
+  const catsSugeridos = cats.length > 0 ? cats : ["MacBook", "iPad", "Mac", "iPhone", "Apple Watch"];
+
+  return (
+    <div className="rounded-2xl border border-[#E5E5EA] bg-white p-5 space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div>
+          <h3 className="text-sm font-bold text-[#1D1D1F]">Editar lista de produtos</h3>
+          <p className="text-xs text-[#86868B] mt-0.5">
+            Salva no banco (app_settings) — valido pra todos os operadores.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={adicionar}
+            className="px-3 py-2 rounded-lg text-xs font-bold bg-[#F5F5F7] text-[#1D1D1F] hover:bg-[#E8E8ED] transition-colors"
+          >
+            + Adicionar produto
+          </button>
+          <button
+            onClick={salvar}
+            disabled={!dirty || salvando}
+            className={`px-4 py-2 rounded-lg text-xs font-bold transition-colors ${
+              dirty && !salvando
+                ? "bg-[#E8740E] text-white hover:bg-[#D06A0D]"
+                : "bg-[#F5F5F7] text-[#C7C7CC] cursor-not-allowed"
+            }`}
+          >
+            {salvando ? "Salvando..." : dirty ? "Salvar alteracoes" : "Salvo"}
+          </button>
+        </div>
+      </div>
+
+      {msg && (
+        <div className={`px-3 py-2 rounded-lg text-xs ${msg.toLowerCase().includes("erro") || msg.toLowerCase().includes("invalido") ? "bg-red-50 text-red-700" : "bg-green-50 text-green-700"}`}>
+          {msg}
+        </div>
+      )}
+
+      <datalist id="calc-imp-cats">
+        {catsSugeridos.map(c => <option key={c} value={c} />)}
+      </datalist>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-[10px] font-bold text-[#86868B] uppercase tracking-wider border-b border-[#E5E5EA]">
+              <th className="text-left py-2 pr-3">Categoria</th>
+              <th className="text-left py-2 pr-3">Nome</th>
+              <th className="text-left py-2 pr-3 w-24">Peso (kg)</th>
+              <th className="text-right py-2 w-16"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {lista.map((p, i) => (
+              <tr key={i} className="border-b border-[#F5F5F7] last:border-0">
+                <td className="py-2 pr-3">
+                  <input
+                    type="text"
+                    list="calc-imp-cats"
+                    value={p.cat}
+                    onChange={(e) => atualizar(i, "cat", e.target.value)}
+                    placeholder="MacBook"
+                    className="w-full px-2 py-1.5 rounded-lg border border-[#D2D2D7] text-sm outline-none focus:border-[#E8740E]"
+                  />
+                </td>
+                <td className="py-2 pr-3">
+                  <input
+                    type="text"
+                    value={p.nome}
+                    onChange={(e) => atualizar(i, "nome", e.target.value)}
+                    placeholder='MacBook Pro M5 14"'
+                    className="w-full px-2 py-1.5 rounded-lg border border-[#D2D2D7] text-sm outline-none focus:border-[#E8740E]"
+                  />
+                </td>
+                <td className="py-2 pr-3">
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={p.peso}
+                    onChange={(e) => atualizar(i, "peso", parseFloat(e.target.value) || 0)}
+                    placeholder="3.0"
+                    className="w-full px-2 py-1.5 rounded-lg border border-[#D2D2D7] text-sm outline-none focus:border-[#E8740E]"
+                  />
+                </td>
+                <td className="py-2 text-right">
+                  <button
+                    onClick={() => remover(i)}
+                    className="px-2 py-1 rounded text-xs font-semibold text-red-500 hover:text-red-700 hover:bg-red-50 transition-colors"
+                    title="Remover"
+                  >
+                    ✕
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {lista.length === 0 && (
+              <tr>
+                <td colSpan={4} className="py-8 text-center text-sm text-[#86868B]">
+                  Nenhum produto. Clica em <strong>+ Adicionar produto</strong>.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/supabase/migrations/20260419d_seed_calc_importacao_produtos.sql
+++ b/supabase/migrations/20260419d_seed_calc_importacao_produtos.sql
@@ -1,0 +1,23 @@
+-- Seed inicial da lista de produtos da Calculadora de Importacao no
+-- app_settings. Antes os pesos estavam hardcoded no componente React.
+-- Agora admin edita via UI e salva no banco.
+
+INSERT INTO app_settings (key, value, updated_at)
+VALUES (
+  'calc_importacao_produtos',
+  '[
+    { "cat": "MacBook", "nome": "MacBook Pro M5 14\"", "peso": 3.0 },
+    { "cat": "MacBook", "nome": "MacBook Pro M4 Pro 14\"", "peso": 3.0 },
+    { "cat": "MacBook", "nome": "MacBook Air M4 15\"", "peso": 3.0 },
+    { "cat": "MacBook", "nome": "MacBook Air M5 13\"", "peso": 3.0 },
+    { "cat": "iPad", "nome": "iPad A16", "peso": 1.0 },
+    { "cat": "iPad", "nome": "iPad Air M3 11\"", "peso": 1.0 },
+    { "cat": "iPad", "nome": "iPad Air M3 13\"", "peso": 1.0 },
+    { "cat": "iPad", "nome": "iPad Pro M5 11\"", "peso": 1.0 },
+    { "cat": "iPad", "nome": "iPad Pro M5 13\"", "peso": 1.0 },
+    { "cat": "Mac", "nome": "Mac Mini M4", "peso": 1.06 },
+    { "cat": "Mac", "nome": "Mac Mini M4 Pro", "peso": 2.0 }
+  ]'::jsonb,
+  NOW()
+)
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Resumo

Antes a lista de produtos com pesos da Calculadora de Importação era **hardcoded** no componente React (\`CalculadoraImportacao.tsx\`, 11 itens fixos). Qualquer mudança precisava de deploy.

Agora:
- Lista vive em \`app_settings\` (key: \`calc_importacao_produtos\`).
- Componente carrega da API no mount (fallback in-memory se API falhar).
- **Nova aba \"Editar produtos\"** dentro da tela da calculadora com CRUD completo.

## UX

- Aba **Calcular** (default): cálculo igual antes.
- Aba **Editar produtos (N)**: tabela editável com categoria, nome, peso.
  - Categoria tem datalist com valores existentes (autocomplete).
  - Botão \`+ Adicionar produto\` cria linha em branco.
  - \`✕\` remove (com confirmação).
  - Botão \`Salvar alterações\` só habilita se há mudanças pendentes.
  - Validação: nome vazio ou peso ≤ 0 bloqueia salvar.

## Backend

Reaproveita o endpoint genérico \`/api/admin/estoque-settings\` (GET/PUT) que já lê/grava de \`app_settings\`. Não foi preciso criar rota nova.

## Migration

\`20260419d_seed_calc_importacao_produtos.sql\` insere a lista hardcoded atual como seed (\`ON CONFLICT DO NOTHING\` pra não sobrescrever edições futuras).

## Test plan

- [ ] Rodar migration \`20260419d\` em \`/admin/migrations\`
- [ ] Abrir a calculadora → aba Calcular → dropdown \"Selecionar produto\" lista os 11 produtos do seed
- [ ] Ir na aba Editar produtos → ver tabela preenchida
- [ ] Mudar peso de um item → botão Salvar fica laranja
- [ ] Salvar → mensagem \"Lista salva!\" → voltar pra aba Calcular → peso novo reflete no dropdown
- [ ] Adicionar item novo (\"iPhone 17 Pro\", peso 0.5) → salvar → aparece na calculadora
- [ ] Remover item → confirmação → some da lista após salvar
- [ ] Tentar salvar com nome vazio → bloqueia com aviso

🤖 Generated with [Claude Code](https://claude.com/claude-code)