### PR TITLE
fix(compra): Total da msg WhatsApp ignorava produtos extras

### DIFF
--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -425,7 +425,11 @@ function CompraForm() {
 
   // Installment calculations
   const descontoNum = parseFloat(String(descontoParam)) || 0;
-  const valorBase = preco > 0 ? Math.max(preco - descontoNum - trocaNum, 0) : 0;
+  // Soma dos produtos extras (Produto 2+) — inclui no total pra preview do
+  // Total e calculo de parcelas refletir o carrinho completo, nao so o
+  // produto 1.
+  const extrasTotalPreview = produtosExtras.reduce((s, p) => s + (Number(p.preco) || 0), 0);
+  const valorBase = preco > 0 ? Math.max(preco + extrasTotalPreview - descontoNum - trocaNum, 0) : 0;
   const entradaPixNum = parseFloat(entradaPixManual || entradaPixParam) || 0;
   const valorParcelar = entradaPixNum > 0 ? Math.max(valorBase - entradaPixNum, 0) : valorBase;
   const parcOpts = useMemo(() => {
@@ -514,7 +518,11 @@ function CompraForm() {
 
     // Valor base para cálculos (usa precoFinal definido acima)
     const descontoFinal = parseFloat(String(descontoParam)) || 0;
-    const valorBaseFinal = Math.max(precoFinal - descontoFinal - trocaNum, 0);
+    // Soma dos produtos extras (Produto 2+) — nao era somado antes, gerava
+    // Total errado na mensagem de WhatsApp (ex: MacBook 11.694 + iPhone 5.497
+    // - desconto 100 virava Total 11.594 em vez de 17.091).
+    const extrasTotal = produtosExtras.reduce((s, p) => s + (Number(p.preco) || 0), 0);
+    const valorBaseFinal = Math.max(precoFinal + extrasTotal - descontoFinal - trocaNum, 0);
     const entradaFinal = entradaPixNum || parseFloat(entradaPixParam) || 0;
     const valorParcelarFinal = entradaFinal > 0 ? Math.max(valorBaseFinal - entradaFinal, 0) : valorBaseFinal;
 
@@ -763,7 +771,10 @@ function CompraForm() {
     // Calcula valor a cobrar no MP. Se há entrada PIX (pagamento dividido),
     // o MP cobra só o valor parcelar (o PIX fica pendente pra retirada).
     const descontoFinal = parseFloat(String(descontoParam)) || 0;
-    const valorBaseFinal = Math.max(precoFinal - descontoFinal - trocaNum, 0);
+    // Soma dos produtos extras — MP precisa cobrar o valor total incluindo
+    // multi-produto. Sem isso o link pagava so o Produto 1.
+    const extrasTotalMp = produtosExtras.reduce((s, p) => s + (Number(p.preco) || 0), 0);
+    const valorBaseFinal = Math.max(precoFinal + extrasTotalMp - descontoFinal - trocaNum, 0);
     const entradaFinal = entradaPixNum || parseFloat(entradaPixParam) || 0;
     const valorMpCobrado =
       entradaFinal > 0 ? Math.max(valorBaseFinal - entradaFinal, 0) : valorBaseFinal;

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -958,7 +958,7 @@ function CompraForm() {
                       <p className="text-blue-500 font-semibold text-sm">Desconto: - R$ {fmt(descontoParam)}</p>
                     )}
                     {(trocaNum > 0 || descontoParam > 0) && (
-                      <p className="text-green-600 font-semibold text-sm">{trocaNum > 0 ? "Diferenca a pagar" : "Total"}: R$ {fmt(valorBase)}</p>
+                      <p className="text-green-600 font-semibold text-sm">{trocaNum > 0 ? "Diferenca a pagar" : descontoParam > 0 ? "Total com desconto" : "Total"}: R$ {fmt(valorBase)}</p>
                     )}
                   </div>
                 )}
@@ -1022,7 +1022,7 @@ function CompraForm() {
                   <>
                     <p className="text-[#E8740E] font-bold text-xl">R$ {fmt(preco)}</p>
                     {descontoParam > 0 && <p className="text-blue-500 font-semibold text-sm">Desconto: - R$ {fmt(descontoParam)}</p>}
-                    {(trocaNum > 0 || descontoParam > 0) && <p className="text-green-600 font-semibold text-sm">{trocaNum > 0 ? "Diferenca a pagar" : "Total"}: R$ {fmt(valorBase)}</p>}
+                    {(trocaNum > 0 || descontoParam > 0) && <p className="text-green-600 font-semibold text-sm">{trocaNum > 0 ? "Diferenca a pagar" : descontoParam > 0 ? "Total com desconto" : "Total"}: R$ {fmt(valorBase)}</p>}
                   </>
                 ) : (
                   <div>
@@ -1093,7 +1093,7 @@ function CompraForm() {
             </div>
           )}
           {preco > 0 && descontoParam > 0 && <p className="text-blue-500 font-semibold text-sm pt-2 border-t border-green-200">Desconto: - R$ {fmt(descontoParam)}</p>}
-          {preco > 0 && <p className={`text-[#E8740E] font-bold text-lg ${descontoParam > 0 ? "" : "pt-2 border-t border-green-200"}`}>{trocaNum > 0 ? "Diferenca a pagar" : "Total"}: R$ {fmt(valorBase)}</p>}
+          {preco > 0 && <p className={`text-[#E8740E] font-bold text-lg ${descontoParam > 0 ? "" : "pt-2 border-t border-green-200"}`}>{trocaNum > 0 ? "Diferenca a pagar" : descontoParam > 0 ? "Total com desconto" : "Total"}: R$ {fmt(valorBase)}</p>}
         </div>
       )}
 


### PR DESCRIPTION
## Bug

Em compra multi-produto, o \`*Total:*\` da mensagem enviada pelo WhatsApp mostrava apenas \`Produto 1 − desconto − troca\`, **ignorando** o valor dos Produtos 2+.

Exemplo reportado (print do cliente):
\`\`\`
Produto 1: MacBook NEO — R$ 11.694
Produto 2: iPhone 17   — R$ 5.497
Desconto:  - R$ 100
Total: R$ 11.594  ← ERRADO (correto: R$ 17.091)
\`\`\`

## Causa

Em 3 lugares em \`/compra/page.tsx\`, o \`valorBase\` era calculado como:
\`\`\`ts
precoFinal - desconto - troca
\`\`\`
sem somar \`produtosExtras\` (array preenchido via searchParams \`produto2..N\`).

## Fix

Agora soma \`produtosExtras.reduce(...preco)\` antes de descontar em:
- \`valorBase\` (preview do Total na tela de confirmação)
- \`valorBaseFinal\` (mensagem WhatsApp)
- \`valorBaseFinal\` (valor cobrado no link Mercado Pago)

## Impacto

Antes do fix, multi-produto tinha **4 bugs** em cadeia:
1. Total errado na mensagem WhatsApp
2. Preview do Total errado na tela
3. Cálculo de parcelas com valor a menor
4. Link MP cobrava só o Produto 1

Todos corrigidos com essa mudança.

## Test plan

- [ ] Gerar link de compra multi-produto (produto2 preenchido via gerar-link)
- [ ] Abrir o link, verificar preview Total = soma de todos os produtos − desconto − troca
- [ ] Clicar Enviar WhatsApp → mensagem com \`*Total:*\` correto
- [ ] Clicar Pagar via MP → valor cobrado = Total correto
- [ ] Single-produto (sem extras) continua funcionando igual antes

🤖 Generated with [Claude Code](https://claude.com/claude-code)