### PR TITLE
fix(compra): detecta cor no final do nome do produto

### DIFF
--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -274,6 +274,41 @@ function CompraForm() {
     }
   }, [coresDisponiveis, produtoInput, produtoParam]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Fallback: detecta cor PT no final do produtoParam mesmo sem catalogo/estoque.
+  // Fix pro caso do operador incluir a cor no nome do produto via gerar-link
+  // (ex: "iPhone 17 Pro Max 256GB Prata") — antes o /compra ainda pedia pra
+  // escolher a cor de novo porque coresDisponiveis vinha vazio (lookup por
+  // startsWith nao casava com o produto com cor no nome). Roda uma vez no
+  // mount, so se corSel ainda esta vazio.
+  useEffect(() => {
+    if (corSel) return;
+    const prod = produtoParam;
+    if (!prod) return;
+    // Cores PT comuns — ordem importante: multi-palavra ANTES de uma so pra
+    // match correto (ex: "Titanio Preto" antes de "Preto").
+    const CORES_PT = [
+      "Titânio Preto", "Titânio Azul", "Titânio Deserto", "Titânio Natural", "Titânio Branco",
+      "Titanio Preto", "Titanio Azul", "Titanio Deserto", "Titanio Natural", "Titanio Branco",
+      "Space Black", "Space Gray", "Rose Gold", "Midnight Green", "Sky Blue",
+      "Preto", "Branco", "Azul", "Verde", "Prata", "Cinza", "Dourado",
+      "Roxo", "Rosa", "Laranja", "Amarelo", "Vermelho", "Estelar", "Grafite",
+      "Black", "White", "Blue", "Green", "Silver", "Gold", "Purple", "Pink",
+      "Red", "Orange", "Yellow", "Midnight", "Starlight", "Natural", "Graphite",
+    ];
+    const pNorm = prod.toLowerCase();
+    // Ordena por tamanho decrescente e tenta match no sufixo
+    const sorted = [...CORES_PT].sort((a, b) => b.length - a.length);
+    for (const cor of sorted) {
+      if (pNorm.endsWith(" " + cor.toLowerCase())) {
+        setCorSel(cor);
+        // Tira a cor do final do produtoInput pra coresDisponiveis funcionar
+        const semCor = prod.slice(0, prod.length - cor.length - 1).trim();
+        setProdutoInput(semCor);
+        break;
+      }
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
   const preco = precoParam ? parseInt(precoParam) : precoAuto;
 
   // Form state — aceita pre-preenchimento vindo do gerar-link


### PR DESCRIPTION
## Bug

Quando o operador gera link de compra via \`/admin/gerar-link\`, o nome do produto é concatenado com a cor (ex: \`iPhone 17 Pro Max 256GB Prata\`) e enviado no parâmetro \`p\` da URL.

No \`/compra\` o formulário ainda mostrava **\"ESCOLHA A COR * (obrigatório)\"** forçando o cliente a digitar a cor de novo — mesmo já estando no nome do produto.

## Causa

O auto-detect de cor existente (linha 260) dependia de \`coresDisponiveis\` (lookup no catálogo por \`startsWith\`). Como produto + cor no nome nunca casava com itens do catálogo (que não têm cor no nome), a lista vinha vazia e o auto-detect nem rodava.

## Fix

Novo \`useEffect\` que roda no mount e procura cor comum no sufixo do \`produtoParam\`. Se encontra:
- \`setCorSel\` com a cor detectada
- Strip a cor do \`produtoInput\` pra \`coresDisponiveis\` funcionar depois normalmente

Lista de cores suportadas: Preto, Branco, Azul, Verde, Prata, Cinza, Dourado, Roxo, Rosa, Laranja, Amarelo, Vermelho, Estelar, Grafite, Titânio (Preto/Azul/Deserto/Natural/Branco) + variantes EN + multi-palavra (\"Rose Gold\", \"Space Black\", \"Sky Blue\", \"Midnight Green\"). Ordem de match: mais longas primeiro pra evitar casar \"Preto\" quando na verdade é \"Titânio Preto\".

## Test plan

- [ ] Gerar link com cor → \`/compra\` abre com cor já preenchida, sem pedir escolha
- [ ] Gerar link sem cor → comportamento antigo (input vazio pedindo cor)
- [ ] Produto com cor EN (ex: \"MacBook Pro M5 14\\\" 512GB Graphite\") → detecta \"Graphite\"
- [ ] Produto com cor composta (ex: \"iPhone 17 Pro Max 256GB Titânio Natural\") → detecta \"Titânio Natural\" e não \"Natural\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)