### PR TITLE
feat(instagram): tipo Análise Profunda + estilo Emanuel Pessoa + até 14 slides

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -18,10 +18,14 @@ interface Pesquisa {
   fatos_verificados?: string[];
 }
 
+type Tipo = "DICA" | "COMPARATIVO" | "NOTICIA" | "ANALISE_PROFUNDA";
+type Estilo = "PADRAO" | "EMANUEL_PESSOA";
+
 interface Post {
   id: string;
   tema: string;
-  tipo: "DICA" | "COMPARATIVO" | "NOTICIA";
+  tipo: Tipo;
+  estilo: Estilo;
   numero_slides: number;
   status: "RASCUNHO" | "GERANDO" | "GERADO" | "APROVADO" | "AGENDADO" | "POSTADO" | "ERRO";
   slides_json: Slide[] | null;
@@ -48,6 +52,12 @@ const TIPO_LABEL: Record<Post["tipo"], string> = {
   DICA: "💡 Dica",
   COMPARATIVO: "⚖️ Comparativo",
   NOTICIA: "📰 Notícia",
+  ANALISE_PROFUNDA: "🔍 Análise profunda",
+};
+
+const ESTILO_LABEL: Record<Post["estilo"], string> = {
+  PADRAO: "Padrão Tigrão",
+  EMANUEL_PESSOA: "Emanuel Pessoa",
 };
 
 export default function InstagramPostPage() {
@@ -280,6 +290,9 @@ export default function InstagramPostPage() {
           <div className="flex items-center gap-2 flex-wrap mb-2">
             <span className="text-xs px-2 py-1 rounded-lg bg-[#F5F5F7] text-[#6E6E73]">{TIPO_LABEL[post.tipo]}</span>
             <span className="text-xs px-2 py-1 rounded-lg bg-[#F5F5F7] text-[#6E6E73]">{post.numero_slides} slides</span>
+            {post.estilo === "EMANUEL_PESSOA" && (
+              <span className="text-xs px-2 py-1 rounded-lg bg-[#EEF2FF] text-[#4F46E5]">✨ {ESTILO_LABEL[post.estilo]}</span>
+            )}
             <span className="text-xs px-2 py-1 rounded-lg bg-[#FFF5EB] text-[#E8740E]">{STATUS_LABEL[post.status]}</span>
           </div>
           <h1 className="text-2xl font-bold text-[#1D1D1F]">{post.tema}</h1>
@@ -376,6 +389,14 @@ export default function InstagramPostPage() {
                   {ilustrando ? "⏳ Ilustrando..." : "✨ Ilustrar slides"}
                 </button>
               </div>
+            </div>
+          )}
+
+          {/* Dica de markdown pra estilo Emanuel Pessoa */}
+          {post.estilo === "EMANUEL_PESSOA" && podeEditar && (
+            <div className="bg-[#EEF2FF] border border-[#4F46E5]/20 rounded-xl p-3 mb-3 text-xs text-[#4338CA]">
+              <strong>Estilo Emanuel Pessoa:</strong> use <code className="bg-white px-1 rounded">**texto**</code> pra <strong>negrito</strong>.
+              Separe parágrafos com <strong>linha em branco</strong> (dupla quebra de linha). Imagens reais ficam melhor que mockups.
             </div>
           )}
 

--- a/app/admin/instagram/page.tsx
+++ b/app/admin/instagram/page.tsx
@@ -5,10 +5,14 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useAdmin } from "@/components/admin/AdminShell";
 
+type Tipo = "DICA" | "COMPARATIVO" | "NOTICIA" | "ANALISE_PROFUNDA";
+type Estilo = "PADRAO" | "EMANUEL_PESSOA";
+
 interface Post {
   id: string;
   tema: string;
-  tipo: "DICA" | "COMPARATIVO" | "NOTICIA";
+  tipo: Tipo;
+  estilo: Estilo;
   numero_slides: number;
   status: "RASCUNHO" | "GERANDO" | "GERADO" | "APROVADO" | "AGENDADO" | "POSTADO" | "ERRO";
   erro: string | null;
@@ -32,6 +36,12 @@ const TIPO_LABEL: Record<Post["tipo"], string> = {
   DICA: "💡 Dica",
   COMPARATIVO: "⚖️ Comparativo",
   NOTICIA: "📰 Notícia",
+  ANALISE_PROFUNDA: "🔍 Análise profunda",
+};
+
+const ESTILO_LABEL: Record<Post["estilo"], string> = {
+  PADRAO: "Padrão Tigrão",
+  EMANUEL_PESSOA: "Emanuel Pessoa",
 };
 
 export default function InstagramListPage() {
@@ -41,7 +51,7 @@ export default function InstagramListPage() {
   const [loading, setLoading] = useState(true);
   const [filtro, setFiltro] = useState<"TODOS" | Post["status"]>("TODOS");
   const [novoOpen, setNovoOpen] = useState(false);
-  const [form, setForm] = useState({ tema: "", tipo: "DICA" as Post["tipo"], numero_slides: 7 });
+  const [form, setForm] = useState({ tema: "", tipo: "DICA" as Post["tipo"], estilo: "PADRAO" as Post["estilo"], numero_slides: 7 });
   const [saving, setSaving] = useState(false);
   const [refinando, setRefinando] = useState(false);
   const [motivoRefino, setMotivoRefino] = useState("");
@@ -106,7 +116,7 @@ export default function InstagramListPage() {
         setMsg("Erro ao refinar: " + (j.error || "falha"));
         return;
       }
-      setForm({ tema: j.tema, tipo: j.tipo, numero_slides: j.numero_slides });
+      setForm(prev => ({ ...prev, tema: j.tema, tipo: j.tipo, numero_slides: j.numero_slides }));
       setMotivoRefino(j.motivo || "");
     } finally {
       setRefinando(false);
@@ -197,6 +207,8 @@ export default function InstagramListPage() {
                       ? 'ex: "iPhone 17 vs 17 Pro — vale pagar mais pelo Pro?" ou só "comparativo iPad" + Refinar'
                       : form.tipo === "NOTICIA"
                       ? 'ex: "Lançamento do Apple Watch Ultra 3 — o que mudou?" ou só "watch novo" + Refinar'
+                      : form.tipo === "ANALISE_PROFUNDA"
+                      ? 'ex: "Por que o iPhone usado no Brasil virou item de luxo" ou só "análise preço Apple BR" + Refinar'
                       : 'ex: "5 dicas pra economizar bateria no iPhone 15" ou só "dica MacBook" + Refinar'
                   }
                   rows={3}
@@ -210,18 +222,48 @@ export default function InstagramListPage() {
                     Dica: comparativos cobrem câmera + tela + chip + bateria + design + preço + revenda.
                   </p>
                 )}
+                {!motivoRefino && form.tipo === "ANALISE_PROFUNDA" && (
+                  <p className="text-xs text-[#86868B] mt-1">
+                    Dica: análise profunda funciona melhor em 10-14 slides e com estilo &quot;Emanuel Pessoa&quot; (narrativa didática + negrito + foto real).
+                  </p>
+                )}
               </div>
               <div>
                 <label className="text-xs font-medium text-[#6E6E73] mb-1 block">Tipo</label>
                 <select
                   value={form.tipo}
-                  onChange={e => setForm({ ...form, tipo: e.target.value as Post["tipo"] })}
+                  onChange={e => {
+                    const novoTipo = e.target.value as Post["tipo"];
+                    setForm(prev => ({
+                      ...prev,
+                      tipo: novoTipo,
+                      numero_slides: novoTipo === "ANALISE_PROFUNDA" && prev.numero_slides < 10 ? 12 : prev.numero_slides,
+                      estilo: novoTipo === "ANALISE_PROFUNDA" ? "EMANUEL_PESSOA" : prev.estilo,
+                    }));
+                  }}
                   className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
                 >
                   <option value="DICA">💡 Dica prática</option>
                   <option value="COMPARATIVO">⚖️ Comparativo</option>
                   <option value="NOTICIA">📰 Notícia / lançamento</option>
+                  <option value="ANALISE_PROFUNDA">🔍 Análise profunda</option>
                 </select>
+              </div>
+              <div>
+                <label className="text-xs font-medium text-[#6E6E73] mb-1 block">Estilo de escrita + visual</label>
+                <select
+                  value={form.estilo}
+                  onChange={e => setForm({ ...form, estilo: e.target.value as Post["estilo"] })}
+                  className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                >
+                  <option value="PADRAO">Padrão Tigrão (descontraído + técnico, layout capa/meio/CTA)</option>
+                  <option value="EMANUEL_PESSOA">Emanuel Pessoa (narrativa didática, negrito, foto real no rodapé)</option>
+                </select>
+                <p className="text-xs text-[#86868B] mt-1">
+                  {form.estilo === "EMANUEL_PESSOA"
+                    ? "Frases curtas, parágrafos separados, **negrito** em frases-chave, header tipo tweet + imagem real ocupando metade do slide."
+                    : "Estilo original da loja com capa, slides de meio e CTA final."}
+                </p>
               </div>
               <div>
                 <label className="text-xs font-medium text-[#6E6E73] mb-1 block">Nº de slides</label>
@@ -230,9 +272,9 @@ export default function InstagramListPage() {
                   onChange={e => setForm({ ...form, numero_slides: Number(e.target.value) })}
                   className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
                 >
-                  <option value={5}>5 slides</option>
-                  <option value={6}>6 slides</option>
-                  <option value={7}>7 slides</option>
+                  {[5, 6, 7, 8, 9, 10, 11, 12, 13, 14].map(n => (
+                    <option key={n} value={n}>{n} slides</option>
+                  ))}
                 </select>
               </div>
               {msg && <p className="text-sm text-[#E74C3C]">{msg}</p>}
@@ -278,7 +320,12 @@ export default function InstagramListPage() {
             <tbody>
               {filtrados.map(p => (
                 <tr key={p.id} className="border-t border-[#E8E8ED] hover:bg-[#FAFAFA]">
-                  <td className="px-4 py-3 whitespace-nowrap">{TIPO_LABEL[p.tipo]}</td>
+                  <td className="px-4 py-3 whitespace-nowrap">
+                    <div>{TIPO_LABEL[p.tipo]}</div>
+                    {p.estilo === "EMANUEL_PESSOA" && (
+                      <div className="text-[10px] text-[#86868B] mt-0.5">{ESTILO_LABEL[p.estilo]}</div>
+                    )}
+                  </td>
                   <td className="px-4 py-3">
                     <Link href={`/admin/instagram/${p.id}`} className="text-[#E8740E] hover:underline">
                       {p.tema}

--- a/app/api/admin/instagram-posts/route.ts
+++ b/app/api/admin/instagram-posts/route.ts
@@ -36,25 +36,28 @@ export async function POST(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401, headers: noCache });
   const usuario = getUsuario(req);
   const body = await req.json();
-  const { tema, tipo = "DICA", numero_slides = 7 } = body;
+  const { tema, tipo = "DICA", numero_slides = 7, estilo = "PADRAO" } = body;
 
   if (!tema?.trim()) return NextResponse.json({ error: "tema obrigatório" }, { status: 400, headers: noCache });
-  if (!["DICA", "COMPARATIVO", "NOTICIA"].includes(tipo)) {
+  if (!["DICA", "COMPARATIVO", "NOTICIA", "ANALISE_PROFUNDA"].includes(tipo)) {
     return NextResponse.json({ error: "tipo inválido" }, { status: 400, headers: noCache });
   }
+  if (!["PADRAO", "EMANUEL_PESSOA"].includes(estilo)) {
+    return NextResponse.json({ error: "estilo inválido" }, { status: 400, headers: noCache });
+  }
   const n = Number(numero_slides);
-  if (!Number.isInteger(n) || n < 5 || n > 7) {
-    return NextResponse.json({ error: "numero_slides deve estar entre 5 e 7" }, { status: 400, headers: noCache });
+  if (!Number.isInteger(n) || n < 5 || n > 14) {
+    return NextResponse.json({ error: "numero_slides deve estar entre 5 e 14" }, { status: 400, headers: noCache });
   }
 
   const { data, error } = await supabase
     .from("instagram_posts")
-    .insert({ tema: tema.trim(), tipo, numero_slides: n, criado_por: usuario })
+    .insert({ tema: tema.trim(), tipo, numero_slides: n, estilo, criado_por: usuario })
     .select("*")
     .single();
   if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCache });
 
-  await logActivity(usuario, "Post Instagram criado", `${tipo}: ${tema}`, "instagram", data.id);
+  await logActivity(usuario, "Post Instagram criado", `${tipo}/${estilo}: ${tema}`, "instagram", data.id);
   return NextResponse.json({ ok: true, data }, { headers: noCache });
 }
 
@@ -66,7 +69,7 @@ export async function PATCH(req: NextRequest) {
   if (!id) return NextResponse.json({ error: "id obrigatório" }, { status: 400, headers: noCache });
 
   const editaveis = [
-    "tema", "tipo", "numero_slides", "status",
+    "tema", "tipo", "numero_slides", "estilo", "status",
     "pesquisa_json", "slides_json", "legenda", "hashtags",
     "agendado_para", "erro",
   ] as const;

--- a/app/api/instagram/gerar/route.ts
+++ b/app/api/instagram/gerar/route.ts
@@ -50,25 +50,102 @@ Se o tema for estreito (só câmera), ainda distribua slides: 2 ou 3 aprofundand
 
 Não romantize o Pro sem motivo. Se pro base cobre a maioria dos casos, diga.`,
   NOTICIA: "novidade, lançamento ou rumor do ecossistema Apple. Data, fonte e o que muda na prática pro consumidor.",
+  ANALISE_PROFUNDA: `análise profunda estilo carrossel didático longo (10-14 slides). Constrói uma tese destrinchando um fenômeno do mercado Apple/tech que o leitor SENTE mas não entende.
+
+ESTRUTURA NARRATIVA OBRIGATÓRIA (inspirada em carrosséis do @emanuel.pessoa):
+Os slides devem seguir esta arquitetura de construção de argumento:
+
+Slide 1 (HOOK EMOCIONAL): Uma frase curta que captura uma dor/observação que o leitor reconhece. Ex: "O iPhone usado virou item de luxo no Brasil." Termina com reviravolta em negrito: "A culpa não é da Apple."
+Slide 2 (DADO CHOCANTE): Um número concreto + comparativo histórico. Ex: "R$ 6.500 por um iPhone 13 usado. Preço recorde desde que o mercado começou a ser medido."
+Slide 3 (QUEBRA DE PARADIGMA): Descarta os vilões óbvios. "Você culpa a Apple. O dólar. O imposto. Desta vez, todos são coadjuvantes."
+Slide 4 (ESCALA DO PROBLEMA): Mostra o tamanho do fenômeno com números.
+Slide 5 (CAUSA ESTRUTURAL): Explica o "por quê" de fundo.
+Slide 6 (COMPARATIVO): Brasil vs outros mercados.
+Slide 7 (MECANISMO): Como o mecanismo econômico/social funciona na prática.
+Slide 8 (PARADOXO): Algo contra-intuitivo que piora a situação.
+Slide 9 (SÍNTESE): "Três forças. Simultâneas. Não é tendência, é convergência rara."
+Slide 10 (NUANCE EXCLUSIVA): "E aqui tem o detalhe que a maioria não percebe..." — revela dado que aprofunda.
+Slide 11 (PREVISÃO): O que vem depois.
+Slide 12 (HEDGE): Admite os limites da própria tese. "Mas pode não ser tão simples assim."
+Slide 13 (FRASE DE EFEITO): Síntese colável, memorável. Ex: "O iPhone caro é made in shortage."
+Slide 14 (CTA MULTI-CAMADA): Compartilha com família/amigos + Comenta + Salva + Segue + Link na bio.
+
+Adapte o número de slides ao solicitado (se 7, condensa; se 14, expande). SEMPRE termine com CTA multi-camada forte.
+
+TEMAS POSSÍVEIS: preço de iPhone no Brasil, mercado de seminovos, ciclo de obsolescência, valor de revenda, Apple Care, vida útil real de bateria, dólar e Apple Brasil, Zona Franca de Manaus, etc. Conecta economia macro a comportamento de consumo real.`,
 };
 
-function buildSystemPrompt(tipo: string, numeroSlides: number): string {
-  return `Você é o editor de conteúdo do Instagram da @tigraoimports, loja de eletrônicos Apple no Rio de Janeiro. Nicho: iPhone, Mac, Apple Watch, AirPods — novos, seminovos e trade-in.
-
-TAREFA
-Criar um carrossel de ${numeroSlides} slides sobre o tema solicitado. Tipo: ${tipo} — ${TIPO_GUIA[tipo] || ""}.
-
-TOM DE VOZ (misto descontraído + técnico + formal)
+const ESTILO_GUIA: Record<string, string> = {
+  PADRAO: `TOM DE VOZ (misto descontraído + técnico + formal)
 - Descontraído sem ser coloquial demais. Nada de "mano", "brother", "tá ligado". Nada de "ademais", "outrossim", "cumpre ressaltar".
 - Técnico quando ajuda: pode falar "chip A17 Pro", "ProMotion 120Hz", "USB-C 2.0", "câmera de 48MP" sem explicar se for óbvio. Se for detalhe menos conhecido, explica em 1 linha.
 - Formal no sentido de correção gramatical e precisão. Nunca clickbait ("você não vai acreditar", "descubra agora").
 - Português brasileiro. Você pode usar "você" / "seu".
 
+FORMATAÇÃO DO TEXTO
+- Texto corrido normal, sem marcação markdown.
+- Sem **negrito** inline.`,
+
+  EMANUEL_PESSOA: `TOM DE VOZ — ESTILO EMANUEL PESSOA (analítico-didático impactante)
+Inspirado no carrossel investigativo de mercado do @emanuel.pessoa. Linguagem direta, quase telegráfica, como se você estivesse explicando pra um amigo inteligente em uma mesa de bar — mas com dado concreto por trás de cada frase.
+
+REGRAS DE ESCRITA:
+1. Frases CURTAS. Muitas vezes uma única frase por linha. Pontuação marcada (ponto final em frase curta = impacto).
+2. Parágrafos SEPARADOS por linha em branco — muito ar entre ideias. Cada parágrafo respira sozinho.
+3. **Use **negrito** (com asteriscos duplos, estilo markdown) em frases-chave que você quer que grudem na memória do leitor.** Tipicamente 1-3 blocos de negrito por slide. Nunca negrito no slide inteiro — a força está no contraste.
+4. Conversa DIRETA com leitor: "Você culpa a Apple". "De onde você compraria?". Usa "você" / "seu" livremente.
+5. Perguntas RETÓRICAS pra engajar antes de revelar a tese.
+6. Frases de efeito COLÁVEIS: curtas, memoráveis, compartilháveis. Ex: "A culpa é da China." / "O iPhone caro é made in shortage." / "A Apple não invadiu o Brasil. Ela só vendeu iPhone."
+7. Termos técnicos usados com naturalidade (arroba, câmbio, ciclo, obsolescência) sem parecer arrogante. Se for termo menos comum, explica em 1 linha.
+8. Ego-ping positivo ao leitor: "Você acabou de entender o que a maioria vai descobrir meses depois."
+9. NUNCA clickbait tipo "você não vai acreditar". O impacto vem do dado + construção lógica, não da manipulação.
+
+ESTRUTURA DE SLIDE MÉDIO (exemplo):
+---
+O preço do iPhone 13 no mercado brasileiro está em recorde histórico.
+
+**R$ 6.800 num aparelho lançado em 2021.**
+
+Isso não é inflação.
+É escassez programada.
+
+E tem um motivo que quase ninguém te conta.
+---
+
+Note: parágrafos curtos, frase em **negrito** no meio, pergunta/afirmação direta no final que puxa pro próximo slide.
+
+CTA FINAL (último slide) deve ter CAMADAS:
+- "Manda esse carrossel pra [alguém específico]"
+- "Comenta aqui: [pergunta concreta]"
+- "Salva. Quando [evento futuro], você vai querer lembrar."
+- "Me siga pra saber quando [desfecho]."
+- "Link na bio: [oferta concreta]."
+
+FORMATAÇÃO (IMPORTANTE):
+- No campo 'texto' de cada slide, use \\n\\n (dupla quebra de linha) pra separar parágrafos.
+- Use **palavra ou frase** (com asteriscos duplos) pra marcar negrito. O sistema renderiza isso como texto em negrito real.
+- Não use emoji no texto — o visual fica limpo, seco, texto-primeiro.`,
+};
+
+function buildSystemPrompt(tipo: string, numeroSlides: number, estilo: string = "PADRAO"): string {
+  const estiloGuia = ESTILO_GUIA[estilo] || ESTILO_GUIA.PADRAO;
+  const isEmanuel = estilo === "EMANUEL_PESSOA";
+
+  return `Você é o editor de conteúdo do Instagram da @tigraoimports, loja de eletrônicos Apple no Rio de Janeiro. Nicho: iPhone, Mac, Apple Watch, AirPods — novos, seminovos e trade-in.
+
+TAREFA
+Criar um carrossel de ${numeroSlides} slides sobre o tema solicitado. Tipo: ${tipo} — ${TIPO_GUIA[tipo] || ""}.
+
+${estiloGuia}
+
 ESTRUTURA DO CARROSSEL
-- Slide 1 (capa): título curto e impactante (máx 50 caracteres) + uma linha de chamada (máx 80 caracteres). Sem emoji na capa.
+${isEmanuel ? `- Slide 1 (HOOK): frase curta e forte que captura dor do leitor + reviravolta em **negrito** no final. Título máx 50 chars, texto até 280 chars com parágrafos separados por \\n\\n.
+- Slides do meio: 1 ideia central por slide. Pode ter título curto (máx 40 chars) ou só texto corrido. Texto com 2-4 parágrafos curtos, algumas frases em **negrito** pra pontuar, até 400 chars.
+- Último slide (CTA MULTI-CAMADA): manda/comenta/salva/segue/link — como detalhado acima.
+- Campo 'destaque' (opcional): número/dado isolado que merece tipografia gigante.` : `- Slide 1 (capa): título curto e impactante (máx 50 caracteres) + uma linha de chamada (máx 80 caracteres). Sem emoji na capa.
 - Slides do meio: 1 ideia central por slide. Título curto (máx 40 caracteres) + texto corrido (máx 220 caracteres).
 - Último slide: CTA suave. Ex: "Salva pra consultar depois", "Comenta sua dúvida", "Compartilha com quem vai comprar iPhone".
-- Campo 'destaque' (opcional): 1 número/dado que merece virar tipografia grande no slide. Ex: "48MP", "30%", "R$ 6.999". Só usa se for realmente impactante.
+- Campo 'destaque' (opcional): 1 número/dado que merece virar tipografia grande no slide. Ex: "48MP", "30%", "R$ 6.999". Só usa se for realmente impactante.`}
 
 REGRA DE OURO — FACT-CHECK
 1. Use web_search pra pesquisar o tema. Mínimo 2 buscas com ângulos diferentes.
@@ -189,7 +266,7 @@ export async function POST(req: NextRequest) {
 
     await supabase.from("instagram_posts").update({ status: "GERANDO", erro: null, updated_at: new Date().toISOString() }).eq("id", postId);
 
-    const systemPrompt = buildSystemPrompt(post.tipo, post.numero_slides);
+    const systemPrompt = buildSystemPrompt(post.tipo, post.numero_slides, post.estilo || "PADRAO");
     const userPrompt = `Tema do post: "${post.tema}"\n\nPesquise, verifique os fatos e monte o carrossel. Chame salvar_post no final.`;
 
     const messages: Anthropic.MessageParam[] = [{ role: "user", content: userPrompt }];

--- a/app/api/instagram/ilustrar-slides/route.ts
+++ b/app/api/instagram/ilustrar-slides/route.ts
@@ -64,6 +64,17 @@ REGRAS
    - Screenshots de slide/apresentação (meta).
    - Imagem que já apareceu em outro slide (nunca repita).
 
+REGRA ESPECIAL — ESTILO EMANUEL_PESSOA (análise profunda narrativa):
+Quando o post é estilo EMANUEL_PESSOA, as imagens devem ser FOTOS REAIS que conectam emocional/contextualmente com o texto — NÃO apenas fotos de produto limpas.
+Exemplos que funcionam:
+- Slide sobre "preço de iPhone no Brasil" → foto de loja Apple em shopping lotada, filas, ou foto de consumidor segurando caixa de iPhone.
+- Slide sobre "mercado de seminovos" → foto de loja de celulares, balcão com vários aparelhos.
+- Slide sobre "cobrança de imposto" → foto de porto/contêiner, caminhão de importação, alfândega.
+- Slide sobre "Zona Franca de Manaus" → foto real da ZFM, fábricas, operários.
+- Slide com citação/fala de executivo → foto real do executivo (CEO Apple, ministro, analista) em situação pública.
+Busque em: agências de notícia (Reuters, AFP, AP, G1, UOL, Folha), newsroom da Apple com executivos, imagens de redação, Wikipedia commons.
+Evite: ícones vetoriais, mockups de celular em fundo branco pra posts Emanuel Pessoa — ficam sem alma.
+
 5. Formato da URL:
    - Prefira URL DIRETA de imagem (.jpg/.png/.webp).
    - Se só tiver URL de página, passe em \`page_url\` — backend extrai og:image.
@@ -118,6 +129,7 @@ function buildUserMessage(
   slides: SlideData[],
   tema: string,
   tipo: string,
+  estilo: string,
   slideAlvo?: number
 ): string {
   const slidesTxt = slides
@@ -134,7 +146,11 @@ function buildUserMessage(
     ? `Re-ilustre APENAS o slide ${slideAlvo}. Ignore os outros.`
     : `Ilustre todos os ${slides.length} slides. Faça 1-2 web_searches por slide (max_uses=15 total).`;
 
-  return `Tema do post: "${tema}" (tipo: ${tipo})
+  const estiloNota = estilo === "EMANUEL_PESSOA"
+    ? "\n\n⚠️ ESTILO EMANUEL_PESSOA: busque FOTOS REAIS de contexto (pessoas, cenas, situações, executivos, locais) em vez de mockups de produto. Ver regra especial no system prompt."
+    : "";
+
+  return `Tema do post: "${tema}" (tipo: ${tipo}, estilo: ${estilo})${estiloNota}
 
 ${contexto}
 
@@ -283,7 +299,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "slideIndex fora do range" }, { status: 400 });
   }
 
-  const userMsg = buildUserMessage(slides, post.tema, post.tipo, slideIndex);
+  const userMsg = buildUserMessage(slides, post.tema, post.tipo, post.estilo || "PADRAO", slideIndex);
 
   let atribuicoes: AtribuicaoClaude[] = [];
   try {

--- a/app/api/instagram/refinar-tema/route.ts
+++ b/app/api/instagram/refinar-tema/route.ts
@@ -24,14 +24,15 @@ REGRAS
 - Se a ideia é comparativo, escolha 2 modelos ATUAIS confirmados por web_search (ex: iPad Air M-atual vs iPad Pro M-atual). Nunca compare modelo vigente com descontinuado há muito.
 - Se é dica, pegue um cenário de uso real (ex: "5 ajustes pra dar sobrevida de bateria em iPhone 13 que já não segura o dia inteiro").
 - Se é notícia, use web_search pra confirmar se o lançamento é recente mesmo. Foque no fato específico e no que muda pro consumidor.
+- Se é análise profunda, escolha um FENÔMENO (preço de iPhone no Brasil, mercado de seminovos, ciclo de obsolescência, dólar x Apple, Zona Franca, etc) que exija narrativa didática longa (10-14 slides) pra destrinchar.
 - Tom: descontraído mas técnico. Faça perguntas / contraste. Nada de clickbait.
 - Considere o público Rio de Janeiro, Brasil (preço em reais se relevante, sem viés gringo).
 
 SAÍDA
 Depois de confirmar modelos atuais via web_search, chame a ferramenta 'refinar' UMA vez com:
 - tema: o tema expandido (1 frase, <120 caracteres, pronto pra ser título do post).
-- tipo: DICA | COMPARATIVO | NOTICIA (o que melhor encaixa).
-- numero_slides: 5, 6 ou 7 (padrão 7; use menos se tema é simples).
+- tipo: DICA | COMPARATIVO | NOTICIA | ANALISE_PROFUNDA (o que melhor encaixa).
+- numero_slides: entre 5 e 14 (padrão 7 para DICA/COMPARATIVO/NOTICIA; 12 para ANALISE_PROFUNDA).
 - motivo: 1 linha explicando por que escolheu esse ângulo (pode citar o que confirmou via busca).`;
 
 const TOOLS: Anthropic.Tool[] = [
@@ -42,8 +43,8 @@ const TOOLS: Anthropic.Tool[] = [
       type: "object" as const,
       properties: {
         tema: { type: "string", description: "Tema expandido. 1 frase, <120 caracteres, pronto pra usar como título." },
-        tipo: { type: "string", enum: ["DICA", "COMPARATIVO", "NOTICIA"] },
-        numero_slides: { type: "integer", enum: [5, 6, 7] },
+        tipo: { type: "string", enum: ["DICA", "COMPARATIVO", "NOTICIA", "ANALISE_PROFUNDA"] },
+        numero_slides: { type: "integer", minimum: 5, maximum: 14 },
         motivo: { type: "string", description: "Linha curta sobre por que escolheu esse ângulo." },
       },
       required: ["tema", "tipo", "numero_slides", "motivo"],
@@ -81,7 +82,7 @@ export async function POST(req: NextRequest) {
     }
     const input = toolUse.input as {
       tema: string;
-      tipo: "DICA" | "COMPARATIVO" | "NOTICIA";
+      tipo: "DICA" | "COMPARATIVO" | "NOTICIA" | "ANALISE_PROFUNDA";
       numero_slides: number;
       motivo: string;
     };

--- a/app/api/instagram/render-post/route.ts
+++ b/app/api/instagram/render-post/route.ts
@@ -64,6 +64,7 @@ export async function POST(req: NextRequest) {
       index: i,
       total: slides.length,
       tipo: post.tipo,
+      estilo: post.estilo || "PADRAO",
     });
     const img = new ImageResponse(jsx, {
       width: SLIDE_W,

--- a/lib/instagram/slide-layout.tsx
+++ b/lib/instagram/slide-layout.tsx
@@ -2,7 +2,7 @@
 // Mesma funcao e usada pela rota que renderiza via next/og (Satori).
 // Dimensoes: 1080 x 1350 (ratio 4:5).
 
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 export const SLIDE_W = 1080;
 export const SLIDE_H = 1350;
@@ -19,10 +19,13 @@ export interface Config {
   nome_display?: string | null;
 }
 
+export type EstiloLayout = "PADRAO" | "EMANUEL_PESSOA";
+
 export interface LayoutMeta {
   index: number;
   total: number;
-  tipo: "DICA" | "COMPARATIVO" | "NOTICIA";
+  tipo: "DICA" | "COMPARATIVO" | "NOTICIA" | "ANALISE_PROFUNDA";
+  estilo?: EstiloLayout;
 }
 
 const COR = {
@@ -40,7 +43,37 @@ const TIPO_LABEL: Record<LayoutMeta["tipo"], string> = {
   DICA: "DICA",
   COMPARATIVO: "COMPARATIVO",
   NOTICIA: "NOTICIA",
+  ANALISE_PROFUNDA: "ANALISE",
 };
+
+// Parser simples de negrito estilo markdown: **texto** vira <span bold>.
+// Retorna array de nodes pra renderizar dentro de um <div>.
+// Usado principalmente no layout Emanuel Pessoa pra dar enfase em frases-chave.
+function parseBold(texto: string): ReactNode[] {
+  if (!texto) return [];
+  const partes = texto.split(/(\*\*[^*]+\*\*)/g);
+  return partes
+    .filter(p => p.length > 0)
+    .map((p, i) => {
+      if (p.startsWith("**") && p.endsWith("**")) {
+        return (
+          <span key={i} style={{ fontWeight: 700 }}>
+            {p.slice(2, -2)}
+          </span>
+        );
+      }
+      return <span key={i}>{p}</span>;
+    });
+}
+
+// Separa texto em blocos de paragrafo (separados por linha em branco).
+// Emanuel Pessoa usa muito ar entre frases — cada bloco vira 1 div.
+function paragrafos(texto: string): string[] {
+  return texto
+    .split(/\n\s*\n/)
+    .map(s => s.trim())
+    .filter(Boolean);
+}
 
 // Selo azul de perfil verificado (estilo Instagram/Twitter).
 // SVG inline pra o Satori conseguir rasterizar.
@@ -364,7 +397,205 @@ function LayoutCTA({ slide, config, meta }: { slide: SlideData; config: Config; 
   );
 }
 
+// =============================================================
+// LAYOUT EMANUEL PESSOA — estilo X/Twitter-like com imagem grande
+// Inspirado no carrossel de analise didatica do @emanuel.pessoa.
+// Caracteristicas:
+// - Header com avatar, nome bold e @handle cinza (tipo tweet)
+// - Numeracao N/total no canto direito
+// - Texto com paragrafos generosos e **negrito** em frases-chave
+// - Imagem real grande ocupando ~45% do rodape
+// - Watermark circular do autor no canto da imagem
+// =============================================================
+
+function HeaderEmanuel({ config, index, total }: { config: Config; index: number; total: number }) {
+  const handle = config.nome_display || "tigraoimports";
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        justifyContent: "space-between",
+        width: "100%",
+        marginBottom: 30,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center" }}>
+        {config.foto_perfil_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={config.foto_perfil_url}
+            alt=""
+            width={82}
+            height={82}
+            style={{
+              width: 82,
+              height: 82,
+              borderRadius: 41,
+              objectFit: "cover",
+              marginRight: 22,
+            }}
+          />
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 82,
+              height: 82,
+              borderRadius: 41,
+              backgroundColor: "#FFF5EB",
+              marginRight: 22,
+              fontSize: 44,
+            }}
+          >
+            🐯
+          </div>
+        )}
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <div style={{ display: "flex", alignItems: "center" }}>
+            <span style={{ color: COR.titulo, fontSize: 38, fontWeight: 700 }}>
+              Tigrão Imports
+            </span>
+            <SeloVerificado size={28} />
+          </div>
+          <span style={{ color: COR.secundario, fontSize: 26, fontWeight: 400, marginTop: 2 }}>
+            @{handle}
+          </span>
+        </div>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#F0F0F2",
+          color: COR.secundario,
+          fontSize: 22,
+          fontWeight: 600,
+          borderRadius: 20,
+          padding: "8px 16px",
+          marginTop: 8,
+        }}
+      >
+        {index + 1}/{total}
+      </div>
+    </div>
+  );
+}
+
+function WatermarkAutor({ config }: { config: Config }) {
+  if (!config.foto_perfil_url) return null;
+  return (
+    <div
+      style={{
+        display: "flex",
+        position: "absolute",
+        bottom: 16,
+        left: 16,
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={config.foto_perfil_url}
+        alt=""
+        width={68}
+        height={68}
+        style={{
+          width: 68,
+          height: 68,
+          borderRadius: 34,
+          objectFit: "cover",
+          border: "3px solid #FFFFFF",
+          boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+        }}
+      />
+    </div>
+  );
+}
+
+// Bloco de texto estilo Emanuel Pessoa: paragrafos separados com ar generoso,
+// tamanho grande, negrito para frases chave via **markdown**.
+function TextoEmanuel({ texto }: { texto: string }) {
+  const blocos = paragrafos(texto);
+  return (
+    <div style={{ display: "flex", flexDirection: "column", width: "100%" }}>
+      {blocos.map((bloco, i) => (
+        <div
+          key={i}
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            color: COR.corpo,
+            fontSize: 34,
+            fontWeight: 400,
+            lineHeight: 1.3,
+            marginBottom: i < blocos.length - 1 ? 22 : 0,
+          }}
+        >
+          {parseBold(bloco)}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function LayoutEmanuelPessoa({ slide, config, meta }: { slide: SlideData; config: Config; meta: LayoutMeta }) {
+  // Monta texto completo: titulo (geralmente hook curto) + texto (paragrafos).
+  // Se titulo e diferente do comeco do texto, mostra titulo como abertura em bold.
+  const tituloComoAbertura = slide.titulo && !slide.texto.toLowerCase().startsWith(slide.titulo.slice(0, 20).toLowerCase());
+  const textoFinal = tituloComoAbertura && slide.titulo ? `**${slide.titulo}**\n\n${slide.texto}` : slide.texto;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        height: "100%",
+        backgroundColor: COR.fundo,
+        padding: 56,
+      }}
+    >
+      <HeaderEmanuel config={config} index={meta.index} total={meta.total} />
+
+      <div style={{ display: "flex", flexDirection: "column", flex: 1 }}>
+        <TextoEmanuel texto={textoFinal} />
+
+        {slide.imagem_url && (
+          <div
+            style={{
+              display: "flex",
+              position: "relative",
+              width: "100%",
+              height: 560,
+              borderRadius: 18,
+              overflow: "hidden",
+              backgroundColor: "#F5F5F7",
+              marginTop: "auto",
+            }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={slide.imagem_url}
+              alt=""
+              style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            />
+            <WatermarkAutor config={config} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function renderSlideJSX(slide: SlideData, config: Config, meta: LayoutMeta): ReactElement {
+  if (meta.estilo === "EMANUEL_PESSOA") {
+    return <LayoutEmanuelPessoa slide={slide} config={config} meta={meta} />;
+  }
   if (meta.index === 0) return <LayoutCapa slide={slide} config={config} meta={meta} />;
   if (meta.index === meta.total - 1) return <LayoutCTA slide={slide} config={config} meta={meta} />;
   return <LayoutMeio slide={slide} config={config} meta={meta} />;

--- a/supabase/migrations/20260420_instagram_analise_profunda_e_estilo.sql
+++ b/supabase/migrations/20260420_instagram_analise_profunda_e_estilo.sql
@@ -1,0 +1,27 @@
+-- Instagram: adiciona tipo ANALISE_PROFUNDA, expande numero_slides ate 14
+-- e adiciona coluna estilo (PADRAO | EMANUEL_PESSOA) que controla tom de voz,
+-- parser de negrito no texto e layout visual do slide.
+
+-- 1) Expande constraint de tipo: inclui ANALISE_PROFUNDA
+alter table instagram_posts
+  drop constraint if exists instagram_posts_tipo_check;
+alter table instagram_posts
+  add constraint instagram_posts_tipo_check
+  check (tipo in ('DICA', 'COMPARATIVO', 'NOTICIA', 'ANALISE_PROFUNDA'));
+
+-- 2) Expande numero_slides de 3-10 pra 3-14 (suporta carrossel longo tipo Emanuel Pessoa)
+alter table instagram_posts
+  drop constraint if exists instagram_posts_numero_slides_check;
+alter table instagram_posts
+  add constraint instagram_posts_numero_slides_check
+  check (numero_slides between 3 and 14);
+
+-- 3) Coluna estilo: controla linguagem + layout visual
+alter table instagram_posts
+  add column if not exists estilo text not null default 'PADRAO';
+
+alter table instagram_posts
+  drop constraint if exists instagram_posts_estilo_check;
+alter table instagram_posts
+  add constraint instagram_posts_estilo_check
+  check (estilo in ('PADRAO', 'EMANUEL_PESSOA'));


### PR DESCRIPTION
## Summary

- Novo tipo **ANÁLISE PROFUNDA** com estrutura narrativa de 14 slides (hook emocional → dado chocante → quebra de paradigma → mecanismo → paradoxo → síntese → CTA multi-camada) inspirada no carrossel investigativo do @emanuel.pessoa.
- Novo estilo **EMANUEL_PESSOA** com linguagem didática, frases curtas telegráficas, `**negrito**` markdown em frases-chave, e foto real ocupando ~45% do rodapé do slide.
- Número de slides agora configurável de **5 a 14** (antes era só 5, 6 ou 7).
- Layout visual novo: header tipo X/Twitter (avatar + "Tigrão Imports" + @handle + selo verified + numeração N/total) e watermark circular do autor na foto.
- Ilustração de slides agora considera o estilo: quando EMANUEL_PESSOA, Claude busca fotos reais de contexto (pessoas, cenas, executivos, locais) em vez de mockups de produto limpos.

## Arquivos

**Novo:**
- `supabase/migrations/20260420_instagram_analise_profunda_e_estilo.sql`

**Modificados:**
- `lib/instagram/slide-layout.tsx` — parser de `**negrito**`, `LayoutEmanuelPessoa`, renderSlideJSX decide layout por estilo
- `app/api/instagram/gerar/route.ts` — `TIPO_GUIA.ANALISE_PROFUNDA`, `ESTILO_GUIA` (PADRAO + EMANUEL_PESSOA), `buildSystemPrompt` aceita estilo
- `app/api/instagram/refinar-tema/route.ts` — enum inclui ANALISE_PROFUNDA, `numero_slides` aceita 5-14
- `app/api/instagram/ilustrar-slides/route.ts` — regra especial pra busca de imagens reais em estilo EMANUEL_PESSOA
- `app/api/instagram/render-post/route.ts` — passa `estilo` ao renderSlideJSX
- `app/api/admin/instagram-posts/route.ts` — aceita e valida campo `estilo`
- `app/admin/instagram/page.tsx` — select de estilo, opções 5-14, tipo Análise Profunda, dica contextual
- `app/admin/instagram/[id]/page.tsx` — badge de estilo e dica de markdown quando EMANUEL_PESSOA

## Migration

Rodar em `/admin/migrations` após deploy: `20260420_instagram_analise_profunda_e_estilo.sql`

## Test plan

- [ ] Rodar migration em `/admin/migrations`
- [ ] Criar post novo selecionando tipo **Análise profunda** → confirma que auto-seleciona estilo Emanuel Pessoa + sugere 12 slides
- [ ] Gerar conteúdo e validar estrutura narrativa (hook, dado chocante, mecanismo, paradoxo, CTA multi-camada)
- [ ] Verificar que o texto vem com `**negrito**` em frases-chave e parágrafos separados
- [ ] Ilustrar slides e confirmar que busca fotos reais de contexto (não só mockups Apple)
- [ ] Renderizar PNGs e validar o layout novo (header X/Twitter, texto com negrito renderizado, foto grande no rodapé)
- [ ] Testar criar post normal (tipo DICA/COMPARATIVO/NOTICIA) com estilo PADRAO e confirmar que nada quebrou
- [ ] Testar variação de número de slides (ex: 5, 10, 14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)