### PR TITLE
fix(cron): followup-simulacoes não envia sábado tarde nem domingo

### DIFF
--- a/app/api/cron/followup-simulacoes/route.ts
+++ b/app/api/cron/followup-simulacoes/route.ts
@@ -72,11 +72,34 @@ async function enviarWhatsApp(phone: string, message: string): Promise<boolean> 
   }
 }
 
+// Retorna true se o horario atual (America/Sao_Paulo) esta fora da janela
+// comercial pra envio de follow-up de simulacao.
+// Regras (pedido da equipe pra nao incomodar cliente no fim de semana):
+// - Domingo: nao envia o dia todo
+// - Sabado: nao envia a partir do meio-dia (sabado tarde/noite)
+// Segunda a sexta e sabado de manha continuam enviando normal.
+function foraDoHorarioComercial(): { fora: boolean; motivo: string } {
+  const nowSP = new Date(
+    new Date().toLocaleString("en-US", { timeZone: "America/Sao_Paulo" }),
+  );
+  const dow = nowSP.getDay(); // 0=Dom, 6=Sab
+  const hour = nowSP.getHours();
+  if (dow === 0) return { fora: true, motivo: "Domingo — pausado" };
+  if (dow === 6 && hour >= 12) return { fora: true, motivo: "Sabado a tarde — pausado" };
+  return { fora: false, motivo: "" };
+}
+
 // Roda todo dia as 14h — envia WhatsApp automatico pro cliente que simulou e nao fechou
 // Verifica se o cliente ja comprou antes de enviar
 export async function GET(req: NextRequest) {
   if (!authCron(req)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Pausa fim de semana (domingo inteiro + sabado a partir do meio-dia)
+  const janela = foraDoHorarioComercial();
+  if (janela.fora) {
+    return NextResponse.json({ ok: true, skipped: true, motivo: janela.motivo });
   }
 
   try {


### PR DESCRIPTION
## Pedido

Equipe pediu pra não incomodar cliente no fim de semana com follow-up de simulação de troca (\"o robô que usamos para recuperar pedidos\").

## Regra implementada

| Dia | Horário | Envio |
|-----|---------|-------|
| Seg–Sex | qualquer | ✅ envia |
| Sábado | 00h–11h59 | ✅ envia |
| **Sábado** | **12h em diante** | ❌ pausa |
| **Domingo** | **qualquer** | ❌ pausa |

## Implementação

- Novo helper \`foraDoHorarioComercial()\` que checa \`America/Sao_Paulo\`.
- \`GET\` handler verifica antes de processar — se fora da janela, retorna \`{ ok: true, skipped: true, motivo }\` sem chamar Z-API.
- Cron continua rodando no horário programado (14h todo dia), só não dispara mensagem real fora da janela.
- **Não afeta outros crons** (alerta-preço, fiado-alert, etc). Escopo estritamente no follow-up de simulação.

## Nota sobre controle via UI

Se quiser futuramente ajustar os horários sem deploy, dá pra mover pra \`app_settings\` com key \`followup_janela_comercial\`. Por enquanto ta hardcoded conforme o pedido.

## Test plan

- [ ] Rodar manualmente em dia de semana útil → dispara normal
- [ ] Rodar no sábado antes das 12h → dispara normal
- [ ] Rodar no sábado depois das 12h → retorna \`skipped: true, motivo: \"Sabado a tarde — pausado\"\`
- [ ] Rodar no domingo → retorna \`skipped: true, motivo: \"Domingo — pausado\"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)