### PR TITLE
feat(instagram): Refinar com IA respeita o estilo selecionado

### DIFF
--- a/app/admin/instagram/page.tsx
+++ b/app/admin/instagram/page.tsx
@@ -109,7 +109,7 @@ export default function InstagramListPage() {
       const res = await fetch("/api/instagram/refinar-tema", {
         method: "POST",
         headers: apiHeaders({ "Content-Type": "application/json" }),
-        body: JSON.stringify({ ideia: form.tema }),
+        body: JSON.stringify({ ideia: form.tema, estilo: form.estilo }),
       });
       const j = await res.json();
       if (!res.ok || !j.ok) {
@@ -203,7 +203,15 @@ export default function InstagramListPage() {
                   value={form.tema}
                   onChange={e => { setForm({ ...form, tema: e.target.value }); if (motivoRefino) setMotivoRefino(""); }}
                   placeholder={
-                    form.tipo === "COMPARATIVO"
+                    form.estilo === "EMANUEL_PESSOA"
+                      ? form.tipo === "COMPARATIVO"
+                        ? 'ex: "iPhone 17 vs Pro — o Pro não vale pra maioria" ou só "comparativo iPhone" + Refinar'
+                        : form.tipo === "NOTICIA"
+                        ? 'ex: "Apple Watch Ultra 3 chegou — e tem um motivo do alarde ser fraco" ou só "watch novo" + Refinar'
+                        : form.tipo === "ANALISE_PROFUNDA"
+                        ? 'ex: "Por que o iPhone usado no Brasil bate recorde de preço" ou só "preço iPhone BR" + Refinar'
+                        : 'ex: "A bateria do iPhone 13 morre às 18h — tem solução" ou só "bateria iPhone" + Refinar'
+                      : form.tipo === "COMPARATIVO"
                       ? 'ex: "iPhone 17 vs 17 Pro — vale pagar mais pelo Pro?" ou só "comparativo iPad" + Refinar'
                       : form.tipo === "NOTICIA"
                       ? 'ex: "Lançamento do Apple Watch Ultra 3 — o que mudou?" ou só "watch novo" + Refinar'
@@ -217,12 +225,17 @@ export default function InstagramListPage() {
                 {motivoRefino && (
                   <p className="text-xs text-[#2ECC71] mt-1">✨ IA: {motivoRefino}</p>
                 )}
-                {!motivoRefino && form.tipo === "COMPARATIVO" && (
+                {!motivoRefino && form.estilo === "EMANUEL_PESSOA" && (
+                  <p className="text-xs text-[#4F46E5] mt-1">
+                    ✨ Estilo Emanuel Pessoa: Refinar vai sugerir título com gancho narrativo (paradoxo, reviravolta, frase colável).
+                  </p>
+                )}
+                {!motivoRefino && form.estilo !== "EMANUEL_PESSOA" && form.tipo === "COMPARATIVO" && (
                   <p className="text-xs text-[#86868B] mt-1">
                     Dica: comparativos cobrem câmera + tela + chip + bateria + design + preço + revenda.
                   </p>
                 )}
-                {!motivoRefino && form.tipo === "ANALISE_PROFUNDA" && (
+                {!motivoRefino && form.estilo !== "EMANUEL_PESSOA" && form.tipo === "ANALISE_PROFUNDA" && (
                   <p className="text-xs text-[#86868B] mt-1">
                     Dica: análise profunda funciona melhor em 10-14 slides e com estilo &quot;Emanuel Pessoa&quot; (narrativa didática + negrito + foto real).
                   </p>

--- a/app/api/instagram/refinar-tema/route.ts
+++ b/app/api/instagram/refinar-tema/route.ts
@@ -11,10 +11,38 @@ function auth(req: NextRequest) {
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
-const SYSTEM_PROMPT = `Você é o editor de pauta do Instagram da @tigraoimports, loja Apple no Rio de Janeiro. Nicho: iPhone, Mac, Apple Watch, AirPods, iPad — novos, seminovos e trade-in.
+const ESTILO_TITULO_GUIA: Record<string, string> = {
+  PADRAO: `TÍTULO — estilo padrão Tigrão
+Escreva um tema descritivo, claro, direto. Ex: "5 ajustes pra bateria do iPhone 15 durar mais", "iPad Air M4 vs iPad Pro M5: qual comprar em 2026".`,
+
+  EMANUEL_PESSOA: `TÍTULO — estilo Emanuel Pessoa (narrativa impactante)
+Escreva o tema como um HOOK curto e impactante — uma frase que crie tensão ou curiosidade, não um "sobre o que é o post".
+
+Padrões que funcionam:
+- Afirmação direta + reviravolta: "O iPhone 13 usado no Brasil bate recorde de preço. E a culpa não é da Apple."
+- Paradoxo: "O iPhone que menos cai de valor no Brasil é o modelo que a Apple parou de vender."
+- Pergunta provocadora: "Por que o iPad Air M4 sumiu dos estoques do Brasil em março?"
+- Frase colável: "Seu iPhone virou poupança. Em dólar."
+- "Made in algo inesperado": "O preço do MacBook é decidido em Taiwan — não em Cupertino."
+
+Evite: títulos genéricos ("5 dicas..."), "tudo que você precisa saber...", lista seca.
+Prefira: 1 tese afirmativa ou 1 paradoxo, máx 110 caracteres, sem clickbait mas com gancho.
+
+Mesmo para DICA, COMPARATIVO ou NOTICIA em estilo Emanuel Pessoa, o título deve ter essa voz:
+- DICA + Emanuel Pessoa: "A bateria do seu iPhone morre às 18h. Tem solução — e não é carregador novo."
+- COMPARATIVO + Emanuel Pessoa: "iPhone 17 vs 17 Pro: o Pro é superior. Só que não pro que você faz com o celular."
+- NOTICIA + Emanuel Pessoa: "Apple Watch Ultra 3 chegou. E tem um motivo pra Apple não ter feito alarde."`,
+};
+
+function buildSystemPrompt(estilo: string): string {
+  const guiaTitulo = ESTILO_TITULO_GUIA[estilo] || ESTILO_TITULO_GUIA.PADRAO;
+  return `Você é o editor de pauta do Instagram da @tigraoimports, loja Apple no Rio de Janeiro. Nicho: iPhone, Mac, Apple Watch, AirPods, iPad — novos, seminovos e trade-in.
 
 TAREFA
 O admin mandou uma ideia curta ou vaga pra post (ex: "comparativo pra iPad", "dica de bateria", "notícia iPhone novo"). Expanda pra um TEMA específico, acionável, com ângulo claro — o suficiente pra um editor de conteúdo saber o que pesquisar.
+
+ESTILO JÁ ESCOLHIDO PELO ADMIN: ${estilo}
+${guiaTitulo}
 
 IMPORTANTE — MODELOS ATUAIS
 Seu conhecimento interno pode estar desatualizado. ANTES de escolher modelos específicos, faça 1-2 web_search pra confirmar qual é o modelo atual da linha relevante (ex: "iPad Air atual 2026", "iPhone lançamento mais recente", "Apple Watch Ultra versão atual"). Nunca chute o chip/geração — confirme via web_search em apple.com/br, 9to5mac, MacRumors, Tecnoblog.
@@ -25,15 +53,16 @@ REGRAS
 - Se é dica, pegue um cenário de uso real (ex: "5 ajustes pra dar sobrevida de bateria em iPhone 13 que já não segura o dia inteiro").
 - Se é notícia, use web_search pra confirmar se o lançamento é recente mesmo. Foque no fato específico e no que muda pro consumidor.
 - Se é análise profunda, escolha um FENÔMENO (preço de iPhone no Brasil, mercado de seminovos, ciclo de obsolescência, dólar x Apple, Zona Franca, etc) que exija narrativa didática longa (10-14 slides) pra destrinchar.
-- Tom: descontraído mas técnico. Faça perguntas / contraste. Nada de clickbait.
 - Considere o público Rio de Janeiro, Brasil (preço em reais se relevante, sem viés gringo).
+- Nunca use clickbait ("você não vai acreditar", "descubra agora").
 
 SAÍDA
 Depois de confirmar modelos atuais via web_search, chame a ferramenta 'refinar' UMA vez com:
-- tema: o tema expandido (1 frase, <120 caracteres, pronto pra ser título do post).
+- tema: o tema expandido seguindo o GUIA DE TÍTULO acima pro estilo ${estilo}.
 - tipo: DICA | COMPARATIVO | NOTICIA | ANALISE_PROFUNDA (o que melhor encaixa).
 - numero_slides: entre 5 e 14 (padrão 7 para DICA/COMPARATIVO/NOTICIA; 12 para ANALISE_PROFUNDA).
 - motivo: 1 linha explicando por que escolheu esse ângulo (pode citar o que confirmou via busca).`;
+}
 
 const TOOLS: Anthropic.Tool[] = [
   {
@@ -63,16 +92,19 @@ export async function POST(req: NextRequest) {
 
   const body = await req.json().catch(() => ({}));
   const ideia = typeof body?.ideia === "string" ? body.ideia.trim() : "";
+  const estiloRaw = typeof body?.estilo === "string" ? body.estilo : "PADRAO";
+  const estilo = ["PADRAO", "EMANUEL_PESSOA"].includes(estiloRaw) ? estiloRaw : "PADRAO";
   if (!ideia) return NextResponse.json({ error: "ideia obrigatória" }, { status: 400 });
   if (ideia.length > 500) return NextResponse.json({ error: "ideia muito longa (máx 500)" }, { status: 400 });
 
   try {
+    const systemPrompt = buildSystemPrompt(estilo);
     const response = await client.messages.create({
       model: "claude-opus-4-7",
       max_tokens: 4000,
-      system: SYSTEM_PROMPT,
+      system: systemPrompt,
       tools: [WEB_SEARCH_TOOL, ...TOOLS],
-      messages: [{ role: "user", content: `Ideia do admin: "${ideia}"\n\nFaça 1-2 web_searches pra confirmar modelos atuais (estamos em 2026) e depois chame 'refinar' com o tema expandido.` }],
+      messages: [{ role: "user", content: `Ideia do admin: "${ideia}"\nEstilo escolhido: ${estilo}\n\nFaça 1-2 web_searches pra confirmar modelos atuais (estamos em 2026) e depois chame 'refinar' com o tema expandido no estilo ${estilo}.` }],
     });
     const toolUse = response.content.find(
       (b): b is Anthropic.ToolUseBlock => b.type === "tool_use" && b.name === "refinar"


### PR DESCRIPTION
## Summary

- Antes: o botão "✨ Refinar com IA" sempre gerava títulos descritivos secos, independente do estilo.
- Agora: se você escolher estilo **Emanuel Pessoa**, o Refinar sugere títulos com hook narrativo (paradoxo, reviravolta, frase colável) em vez de descritivos.

## Exemplos

**Antes (estilo Emanuel Pessoa + tipo DICA):**
> *"5 ajustes pra economizar bateria no iPhone 15"*

**Agora (mesma ideia, com Refinar respeitando estilo):**
> *"A bateria do seu iPhone morre às 18h. Tem solução — e não é carregador novo."*

---

**Antes (estilo Emanuel Pessoa + tipo COMPARATIVO):**
> *"iPhone 17 vs 17 Pro — vale pagar mais pelo Pro?"*

**Agora:**
> *"iPhone 17 vs 17 Pro: o Pro é superior. Só que não pro que você faz com o celular."*

## Respostas à dúvida do André

- ✅ Estilo **Emanuel Pessoa** funciona com **qualquer tipo** (Dica, Comparativo, Notícia, Análise Profunda) — são dimensões independentes
- ✅ O **Refinar com IA** agora considera o estilo selecionado antes de expandir a ideia

## Test plan

- [ ] Criar post: selecionar estilo **Emanuel Pessoa** + tipo **Dica prática**, escrever "bateria iPhone" + clicar Refinar → confirma que o título vem com gancho narrativo (não descritivo)
- [ ] Repetir pra Comparativo, Notícia e Análise Profunda — todos devem vir com tom Emanuel Pessoa quando esse estilo estiver selecionado
- [ ] Criar post com estilo **Padrão Tigrão** + qualquer tipo → confirma que o Refinar continua gerando títulos descritivos (comportamento anterior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)