### PR TITLE
fix(instagram): imagens pequenas, repetidas e slides em branco

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -140,7 +140,12 @@ export default function InstagramPostPage() {
       }
       if (Array.isArray(j.slides)) setSlidesEdit(j.slides);
       const comImg = (j.slides || []).filter((s: Slide) => s.imagem_url).length;
-      setMsg(`${comImg} de ${(j.slides || []).length} slides receberam imagem. Clique "🔄" em algum slide pra trocar.`);
+      const total = (j.slides || []).length;
+      const duplicadas = j.duplicadas || 0;
+      const dupAviso = duplicadas > 0
+        ? ` ⚠️ ${duplicadas} slide(s) ficaram sem imagem porque o Claude sugeriu URL repetida — clica "🔄 Trocar imagem" nos vazios.`
+        : "";
+      setMsg(`${comImg} de ${total} slides receberam imagem.${dupAviso} Clique "🔄" em algum slide pra trocar.`);
     } finally {
       setIlustrando(false);
     }

--- a/app/api/instagram/ilustrar-slides/route.ts
+++ b/app/api/instagram/ilustrar-slides/route.ts
@@ -39,19 +39,30 @@ interface AtribuicaoClaude {
 const SYSTEM_PROMPT = `Você é editor visual do Instagram da @tigraoimports, loja Apple no Rio de Janeiro.
 
 TAREFA
-Pra cada slide do carrossel (exceto CTA), ache a MELHOR imagem que ilustre o conceito do texto via web_search. Todo slide de conteúdo PRECISA sair com imagem. Depois chame a ferramenta 'definir_imagens' UMA VEZ com as atribuições.
+Pra CADA slide do carrossel (incluindo capa, excluindo apenas o último slide de CTA), ache a MELHOR imagem que ilustre o conceito do texto via web_search. Depois chame a ferramenta 'definir_imagens' UMA VEZ com as atribuições.
 
-REGRAS
+REGRAS CRÍTICAS (⚠️ não quebre)
+⚠️ COBERTURA TOTAL: nenhum slide pode ficar sem imagem, exceto o ÚLTIMO (CTA). Se o conceito é abstrato (ex: "Tela", "Conectividade", "Apple Intelligence"), busque foto CONCRETA que materialize o conceito (ex: close de tela iPad ligada, ícones Wi-Fi/USB-C num iPad, logo "Apple Intelligence" oficial). INSISTA com 2-3 buscas diferentes antes de desistir.
+
+⚠️ NUNCA REPITA URL: a mesma imagem NÃO PODE aparecer em 2 slides. Antes de atribuir, cheque mentalmente a lista de URLs que você já usou nos slides anteriores. O backend vai deduplicar e ZERAR slides com URL repetida — então se você repetir, o operador vai ficar com slide vazio e precisar corrigir manual. Busque uma foto DIFERENTE pra cada slide.
+
+⚠️ COERÊNCIA TEMÁTICA: a imagem DEVE refletir o texto do slide. Se o slide fala de "Veredito honesto", busque foto de balança, iPads enfileirados, ou comparação lado-a-lado — NÃO foto aleatória de revista, meme ou coisa não relacionada.
+
+REGRAS GERAIS
 1. Busca orientada ao CONCEITO do slide, não só ao produto.
    - Slide "Command é o novo Ctrl" → imagem de teclado Mac mostrando tecla ⌘.
    - Slide "Configure Time Machine" → screenshot/foto de Time Machine em Mac.
    - Slide "Câmera iPhone 17 Pro" → foto do módulo de câmera traseira do iPhone 17 Pro.
+   - Slide "Tela OLED ProMotion" → close-up de tela iPad Pro mostrando cor vibrante.
+   - Slide "Conectividade Wi-Fi 7" → iPad com indicador de rede, ou ícone Wi-Fi 7 oficial.
+   - Slide "Tamanhos e peso" → iPads enfileirados por tamanho, ou foto comparativa de 11" vs 13".
 
 2. COMPARATIVO entre 2 ou 3 modelos — use COMPOSIÇÃO:
    Se o texto do slide cita N modelos específicos (ex: "iPad 11, Air M4 ou Pro M5"), em vez de buscar uma imagem com todos juntos (raro ter boa), faça N buscas individuais — UMA foto oficial de cada modelo — e retorne no campo \`composicao: [url1, url2, url3]\`. O backend vai compor as N imagens lado a lado automaticamente.
    - Ideal: fotos de produto em fundo BRANCO (ex: apple.com/br/ipad, product photos).
    - Todas em mesma "perspectiva" se possível (ex: todas frontais, todas com ângulo).
    - Máximo 3 URLs em composição.
+   - Composições são SEMPRE únicas (não contam como repetição), então pode usar em múltiplos slides de comparação.
 
 3. Priorize fontes:
    - apple.com/br, apple.com, newsroom Apple pra produtos específicos.
@@ -59,10 +70,11 @@ REGRAS
    - Wikipedia commons pra imagens com licença aberta.
 
 4. NÃO use:
-   - Ícones pequenos, sprites, logos.
+   - Ícones pequenos, sprites, logos de favicon.
    - Sites de afiliado/cupom.
    - Screenshots de slide/apresentação (meta).
-   - Imagem que já apareceu em outro slide (nunca repita).
+   - Imagens de capa de revista ou trending TikTok (CORECORE, coisas do tipo — sem relação).
+   - Imagem que já apareceu em outro slide (VER REGRA CRÍTICA acima).
 
 REGRA ESPECIAL — ESTILO EMANUEL_PESSOA (análise profunda narrativa):
 Quando o post é estilo EMANUEL_PESSOA, as imagens devem ser FOTOS REAIS que conectam emocional/contextualmente com o texto — NÃO apenas fotos de produto limpas.
@@ -122,7 +134,7 @@ const TOOLS: Anthropic.Tool[] = [
 const WEB_SEARCH_TOOL = {
   type: "web_search_20250305",
   name: "web_search",
-  max_uses: 25,
+  max_uses: 40,
 } as unknown as Anthropic.Tool;
 
 function buildUserMessage(
@@ -143,8 +155,8 @@ function buildUserMessage(
     .join("\n\n");
 
   const contexto = slideAlvo !== undefined
-    ? `Re-ilustre APENAS o slide ${slideAlvo}. Ignore os outros.`
-    : `Ilustre todos os ${slides.length} slides. Faça 1-2 web_searches por slide (max_uses=15 total).`;
+    ? `Re-ilustre APENAS o slide ${slideAlvo}. Ignore os outros. IMPORTANTE: sua imagem não pode ser igual à de nenhum outro slide já existente.`
+    : `Ilustre TODOS os ${slides.length} slides (exceto o último CTA). Faça 2-3 web_searches por slide se necessário (max_uses=40 total). NENHUM slide pode ficar sem imagem. NENHUMA URL pode repetir entre slides.`;
 
   const estiloNota = estilo === "EMANUEL_PESSOA"
     ? "\n\n⚠️ ESTILO EMANUEL_PESSOA: busque FOTOS REAIS de contexto (pessoas, cenas, situações, executivos, locais) em vez de mockups de produto. Ver regra especial no system prompt."
@@ -336,12 +348,48 @@ export async function POST(req: NextRequest) {
         : await resolverImagem(a.image_url, a.page_url);
       return {
         slide_index: a.slide_index,
-        imagem_final,
+        imagem_final: imagem_final as string | null,
         motivo: a.motivo,
         composto: !!(composicaoValida && imagem_final && imagem_final.includes("/composto/")),
+        duplicada: false,
       };
     })
   );
+
+  // Deduplicacao: uma mesma URL nao pode aparecer em 2+ slides.
+  // - Quando ilustrando TODOS: mantem primeira ocorrencia (por slide_index),
+  //   zera as demais. Operador troca manualmente nos vazios via "🔄 Trocar".
+  // - Quando ilustrando UM slide (re-busca): rejeita se URL ja esta em outro.
+  // Composicoes (/composto/) sao sempre unicas (timestamp no path), entao
+  // nao entram no dedup.
+  const urlsJaUsadas = new Set<string>();
+  if (slideIndex !== undefined) {
+    // Re-ilustrando 1 slide — coleta URLs dos OUTROS slides pra nao repetir
+    for (let i = 0; i < slides.length; i++) {
+      if (i === slideIndex) continue;
+      const u = slides[i].imagem_url;
+      if (u && !u.includes("/composto/")) urlsJaUsadas.add(u);
+    }
+    for (const r of resolvidas) {
+      if (r.imagem_final && !r.imagem_final.includes("/composto/") && urlsJaUsadas.has(r.imagem_final)) {
+        r.imagem_final = null;
+        r.duplicada = true;
+      }
+    }
+  } else {
+    // Ilustrando tudo — dedup interno, mantem primeira ocorrencia
+    const porOrdem = [...resolvidas].sort((a, b) => a.slide_index - b.slide_index);
+    for (const r of porOrdem) {
+      if (!r.imagem_final) continue;
+      if (r.imagem_final.includes("/composto/")) continue; // composicoes sao unicas
+      if (urlsJaUsadas.has(r.imagem_final)) {
+        r.imagem_final = null;
+        r.duplicada = true;
+      } else {
+        urlsJaUsadas.add(r.imagem_final);
+      }
+    }
+  }
 
   // Aplica: se slideIndex foi especificado, só mexe naquele slide.
   const slidesNovos = slides.map((s, i) => {
@@ -357,9 +405,11 @@ export async function POST(req: NextRequest) {
     .eq("id", postId);
   if (updErr) return NextResponse.json({ error: updErr.message }, { status: 500 });
 
+  const duplicadas = resolvidas.filter((r) => r.duplicada).length;
   return NextResponse.json({
     ok: true,
     slides: slidesNovos,
     atribuicoes: resolvidas,
+    duplicadas,
   });
 }

--- a/lib/instagram/composicao-layout.tsx
+++ b/lib/instagram/composicao-layout.tsx
@@ -5,15 +5,18 @@
 import type { ReactElement } from "react";
 
 export const COMPOSICAO_W = 1080;
-export const COMPOSICAO_H = 540;
+// Altura maior (antes 540) pra cada imagem individual aparecer maior dentro da
+// composicao — evita o efeito de "miniaturas" quando tem 2-3 produtos lado a lado.
+// Com 720, o ratio fica 3:2, mais proximo do container do slide (~1.85:1).
+export const COMPOSICAO_H = 720;
 
 export function composicaoJSX(imagensDataUrls: string[]): ReactElement {
   const n = imagensDataUrls.length;
-  const paddingLateral = 30;
-  const gap = n === 2 ? 20 : 14;
+  const paddingLateral = 24;
+  const gap = n === 2 ? 24 : 18;
   const disponivel = COMPOSICAO_W - paddingLateral * 2 - gap * (n - 1);
   const larguraCada = Math.floor(disponivel / n);
-  const alturaCada = COMPOSICAO_H - 60;
+  const alturaCada = COMPOSICAO_H - 40;
 
   return (
     <div

--- a/lib/instagram/slide-layout.tsx
+++ b/lib/instagram/slide-layout.tsx
@@ -162,12 +162,18 @@ function Header({ config, index, total }: { config: Config; index: number; total
 }
 
 function Imagem({ url }: { url: string }) {
+  // objectFit: contain — NUNCA corta a imagem. Composicoes (multi-produto
+  // lado a lado) e fotos oficiais Apple com fundo branco ficam centralizadas
+  // preservando toda a informacao visual. Fundo cinza claro ocupa o espaco
+  // residual quando o ratio da imagem e mais largo/estreito que o container.
   return (
     <div
       style={{
         display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
         width: "100%",
-        height: 520,
+        height: 620,
         borderRadius: 24,
         overflow: "hidden",
         backgroundColor: "#F5F5F7",
@@ -177,7 +183,7 @@ function Imagem({ url }: { url: string }) {
       <img
         src={url}
         alt=""
-        style={{ width: "100%", height: "100%", objectFit: "cover" }}
+        style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }}
       />
     </div>
   );
@@ -570,6 +576,8 @@ function LayoutEmanuelPessoa({ slide, config, meta }: { slide: SlideData; config
             style={{
               display: "flex",
               position: "relative",
+              alignItems: "center",
+              justifyContent: "center",
               width: "100%",
               height: 560,
               borderRadius: 18,
@@ -582,7 +590,7 @@ function LayoutEmanuelPessoa({ slide, config, meta }: { slide: SlideData; config
             <img
               src={slide.imagem_url}
               alt=""
-              style={{ width: "100%", height: "100%", objectFit: "cover" }}
+              style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }}
             />
             <WatermarkAutor config={config} />
           </div>


### PR DESCRIPTION
## Problemas observados
Screenshot do render de carrossel comparativo de iPads mostrou:
- Composições multi-produto saíam com imagens **minúsculas** dentro do slide
- Mesma imagem aparecia em **2 slides diferentes** (slide 5 e 9)
- Slides ficavam **em branco** quando o tema era abstrato (Tela, Conectividade, Câmeras)
- Imagem **fora de contexto** ocasional (ex: capa CORECORE num slide de veredito)

## Correções

### 1. Composição maior
[lib/instagram/composicao-layout.tsx](lib/instagram/composicao-layout.tsx)
- Altura: **540 → 720** (ratio 3:2, mais próximo do container do slide)
- Cada imagem individual ganha ~40% mais área visível

### 2. `objectFit: cover` → `contain`
[lib/instagram/slide-layout.tsx](lib/instagram/slide-layout.tsx)
- `<Imagem>` nunca mais corta a imagem. Fundo cinza claro (`#F5F5F7`) faz as vezes de padding visual quando o ratio não bate
- Altura do container: 520 → 620 pra aproveitar melhor o espaço disponível
- Mesma correção aplicada ao layout Emanuel Pessoa

### 3. Deduplicação de URLs no backend
[app/api/instagram/ilustrar-slides/route.ts](app/api/instagram/ilustrar-slides/route.ts)
- Após Claude responder, o backend detecta URLs duplicadas e **mantém a primeira**, zerando as demais
- Operador corrige manualmente via "🔄 Trocar imagem" nos slides zerados
- Composições (`/composto/*`) têm timestamp no path → sempre únicas, não entram no dedup

### 4. Prompt reforçado
Mesma rota. Agora tem 3 **REGRAS CRÍTICAS** em destaque:
1. **Cobertura total** — nenhum slide sem imagem, exceto CTA. Se conceito é abstrato (Tela, Conectividade), busca foto concreta que materialize (close de tela OLED, iPad com Wi-Fi ligado).
2. **Jamais repetir URL** — o backend zera duplicatas, então o operador fica com slide vazio se Claude repetir.
3. **Coerência temática** — imagem DEVE refletir o texto, nunca foto aleatória/trending (CORECORE, memes).

Exemplos de como ilustrar conceitos abstratos foram adicionados.

### 5. Busca aumentada
- `max_uses` do web_search: **25 → 40** pra suportar carrossel de 10+ slides com 2-3 buscas cada

### 6. UI avisa sobre duplicatas
[app/admin/instagram/[id]/page.tsx](app/admin/instagram/[id]/page.tsx)
- Após "Ilustrar slides": *"⚠️ N slides ficaram sem imagem porque Claude sugeriu URL repetida — clica 🔄 Trocar imagem nos vazios."*

## Test plan

- [ ] Re-ilustrar o post comparativo de iPads (ou criar novo) e renderizar PNGs
- [ ] Confirmar que composições multi-produto saem em tamanho maior
- [ ] Confirmar que não há mais imagens repetidas entre slides
- [ ] Se houver duplicata, ver mensagem de aviso e usar "🔄 Trocar imagem" nos vazios
- [ ] Confirmar que slides de temas abstratos (Tela, Conectividade, Apple Intelligence) saem com foto concreta

🤖 Generated with [Claude Code](https://claude.com/claude-code)