### PR TITLE
feat(gastos): campo Descrição (ANC/USB-C) pro AirPods

### DIFF
--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -353,6 +353,7 @@ export default function ProdutoSpecFields({
   const awTamanhoOptions = cfgOr("tamanho_aw", WATCH_TAMANHOS_FULL);
   const awConnOptions = cfgOr("conectividade_aw", ["GPS", "GPS + CEL"]);
   const awBandOptions = cfgOr("pulseiras", WATCH_BAND_MODELS);
+  const airDescricaoOptions = cfgOr("descricao_airpods", ["Com ANC", "Sem ANC", "USB-C"]);
 
   // ── Handlers ──────────────────────────────────────────────────────────────────
 
@@ -954,6 +955,13 @@ export default function ProdutoSpecFields({
               </select>
             </div>
           )}
+          <div>
+            <p className={labelCls}>Descrição</p>
+            <select value={row.spec.air_descricao} onChange={(e) => setSpec("air_descricao", e.target.value)} className={inputCls}>
+              <option value="">— Opcional —</option>
+              {airDescricaoOptions?.map((d) => <option key={d}>{d}</option>)}
+            </select>
+          </div>
         </div>
       )}
 

--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -266,7 +266,7 @@ export interface ProdutoSpec {
   ms_chip: string; ms_nucleos: string; ms_ram: string; ms_storage: string;
   ipad_modelo: string; ipad_chip: string; ipad_tela: string; ipad_storage: string; ipad_conn: string;
   aw_modelo: string; aw_tamanho: string; aw_conn: string; aw_pulseira: string; aw_band: string;
-  air_modelo: string;
+  air_modelo: string; air_descricao: string;
 }
 
 export const DEFAULT_SPEC: ProdutoSpec = {
@@ -276,7 +276,7 @@ export const DEFAULT_SPEC: ProdutoSpec = {
   ms_chip: "M4 MAX", ms_nucleos: "14C CPU/32C GPU", ms_ram: "36GB", ms_storage: "512GB",
   ipad_modelo: "AIR M4", ipad_chip: "", ipad_tela: '11"', ipad_storage: "128GB", ipad_conn: "WIFI",
   aw_modelo: "SERIES 10", aw_tamanho: "42mm", aw_conn: "GPS", aw_pulseira: "", aw_band: "",
-  air_modelo: "AIRPODS 4",
+  air_modelo: "AIRPODS 4", air_descricao: "",
 };
 
 // ── Mapa de cores Português → Inglês (nomes comerciais Apple) ──
@@ -392,8 +392,10 @@ export function buildProdutoName(cat: string, spec: ProdutoSpec, cor?: string): 
       const band = spec.aw_band ? ` ${spec.aw_band}` : "";
       return `APPLE WATCH ${spec.aw_modelo}${tamanho}${conn}${c}${pulseira}${band}`.toUpperCase();
     }
-    case "AIRPODS":
-      return `${spec.air_modelo}${c}`.toUpperCase();
+    case "AIRPODS": {
+      const desc = spec.air_descricao ? ` ${spec.air_descricao}` : "";
+      return `${spec.air_modelo}${desc}${c}`.toUpperCase();
+    }
     default:
       return "";
   }


### PR DESCRIPTION
## Resumo
- Adiciona campo **Descrição** no bloco AirPods do form de "Produtos do Pedido" (Gastos)
- Opções: **Com ANC / Sem ANC / USB-C** — mesmas do catálogo (Configurações > Produtos)
- É opcional (não bloqueia quem não precisar)
- Valor entra no nome final do produto (ex: `AIRPODS 4 COM ANC WHITE`)

## Contexto
A migration `20260401_catalogo.sql` já tinha cadastrado o spec `descricao_airpods` com os valores Com ANC/Sem ANC/USB-C e ligado à categoria AIRPODS, mas o `ProdutoSpecFields.tsx` não renderizava o dropdown quando o catálogo estava carregado — o bloco AirPods ficava vazio. Agora o dropdown aparece sempre que categoria = AIRPODS.

## Test plan
- [ ] Abrir **Admin > Gastos > Compras** e clicar pra registrar nova compra
- [ ] Selecionar categoria **AirPods** → conferir que aparece campo "Descrição"
- [ ] Escolher "Com ANC" → conferir que o **Nome do Produto** vira `AIRPODS 4 COM ANC ...`
- [ ] Deixar em branco → nome não deve ter nada extra (compatível com compras antigas)
- [ ] Registrar gasto e conferir que o produto entra no estoque com o nome certo

🤖 Generated with [Claude Code](https://claude.com/claude-code)