### PR TITLE
fix: bundle 2 — calc-importacao + NF diagnostico + merge cliente robusto

### DIFF
--- a/app/admin/clientes/page.tsx
+++ b/app/admin/clientes/page.tsx
@@ -874,7 +874,13 @@ export default function ClientesPage() {
                     if (!res.ok || !j.ok) {
                       falhas.push(`${antigo}: ${j.error || j.erros?.join(", ") || `HTTP ${res.status}`}`);
                     } else if (j.resultado) {
-                      totalAfetado += Object.values(j.resultado as Record<string, number>).reduce((s, n) => s + Number(n || 0), 0);
+                      const soma = Object.values(j.resultado as Record<string, number>).reduce((s, n) => s + Number(n || 0), 0);
+                      totalAfetado += soma;
+                      // Se API retornou ok=true mas 0 registros afetados, sinaliza — provavel que
+                      // o nome no DB tenha variacao (espaco extra, acento) que o ilike nao casou
+                      if (soma === 0) {
+                        falhas.push(`${antigo}: API retornou OK mas 0 registros foram atualizados. Verifique se o nome bate exatamente (espacos, acentos). Detalhes no console.`);
+                      }
                     }
                   } catch (err) {
                     falhas.push(`${antigo}: ${String(err)}`);

--- a/app/api/admin/merge-cliente/route.ts
+++ b/app/api/admin/merge-cliente/route.ts
@@ -39,18 +39,49 @@ export async function POST(req: NextRequest) {
   const resultado: Record<string, number> = {};
   const erros: string[] = [];
 
-  // Helper: atualiza tabela usando ilike (case-insensitive exact match).
-  // Retorna contagem. Em erro, registra e retorna 0.
+  const antigoNorm = normalizar(antigoRaw);
+
+  // Helper: atualiza tabela via ilike (case-insensitive). Se 0 matches, faz
+  // fallback buscando TODOS os nomes distintos e matching por normalizacao
+  // (sem acentos, espacos colapsados). Protege contra "NEXT PHONE" vs
+  // "NEXT  PHONE" (2 espacos), "NÉXT PHONE", " NEXT PHONE" (padding), etc.
   const updateTabela = async (tabela: string, coluna: string) => {
-    const { data, error } = await supabase.from(tabela)
+    // Primeira tentativa: ilike exato case-insensitive
+    const { data: ilikeData, error: ilikeErr } = await supabase.from(tabela)
       .update({ [coluna]: novo })
       .ilike(coluna, antigoEsc)
       .select("id");
-    if (error) {
-      erros.push(`${tabela}.${coluna}: ${error.message}`);
+    if (ilikeErr) {
+      erros.push(`${tabela}.${coluna} (ilike): ${ilikeErr.message}`);
       return 0;
     }
-    return data?.length || 0;
+    if ((ilikeData?.length || 0) > 0) return ilikeData!.length;
+
+    // Fallback: busca nomes distintos, filtra por match normalizado no JS,
+    // depois atualiza via .in() pra todos os nomes que casarem.
+    const { data: todos, error: selErr } = await supabase.from(tabela)
+      .select(coluna)
+      .not(coluna, "is", null);
+    if (selErr) {
+      erros.push(`${tabela}.${coluna} (select): ${selErr.message}`);
+      return 0;
+    }
+    const nomesMatching = Array.from(new Set(
+      (todos || [])
+        .map(r => (r as unknown as Record<string, unknown>)[coluna] as string)
+        .filter(n => typeof n === "string" && normalizar(n) === antigoNorm && n !== novo),
+    ));
+    if (nomesMatching.length === 0) return 0;
+
+    const { data: updData, error: updErr } = await supabase.from(tabela)
+      .update({ [coluna]: novo })
+      .in(coluna, nomesMatching)
+      .select("id");
+    if (updErr) {
+      erros.push(`${tabela}.${coluna} (update by normalized): ${updErr.message}`);
+      return 0;
+    }
+    return updData?.length || 0;
   };
 
   resultado.vendas = await updateTabela("vendas", "cliente");
@@ -67,7 +98,6 @@ export async function POST(req: NextRequest) {
       .from("lojistas")
       .select("id, nome, saldo_credito");
 
-    const antigoNorm = normalizar(antigoRaw);
     const novoNorm = normalizar(novo);
 
     const lojistasAntigos = (todosLojistas || []).filter(l => normalizar(l.nome || "") === antigoNorm);

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -576,11 +576,29 @@ export async function PATCH(req: NextRequest) {
   if (body.action === "enviar_nf") {
     const { id: vendaId, skipEmail } = body;
     if (!vendaId) return NextResponse.json({ error: "id required" }, { status: 400 });
+    // maybeSingle nao ergue erro se 0 rows — permite diagnostico ao inves de
+    // devolver 404 generico. Se nao encontrar, tenta contar quantas rows
+    // existem com esse id pra sinalizar se e problema de id malformado vs
+    // duplicidade.
     const { data: venda, error: e } = await supabase.from("vendas")
       .select("id, email, cliente, produto, cor, valor_comprovante, preco_vendido, nota_fiscal_url, nota_fiscal_enviada")
       .eq("id", vendaId)
-      .single();
-    if (e || !venda) return NextResponse.json({ error: "venda nao encontrada" }, { status: 404 });
+      .maybeSingle();
+    if (e) {
+      console.error("[Vendas] Erro no SELECT ao enviar NF:", { vendaId, error: e });
+      return NextResponse.json({ error: `Erro ao buscar venda: ${e.message}`, id: vendaId }, { status: 500 });
+    }
+    if (!venda) {
+      // Debug: tenta contar quantas rows existem com id parecido pra ajudar
+      // diagnose (ex: UUID truncado, typo, etc)
+      const { count } = await supabase.from("vendas").select("id", { count: "exact", head: true }).eq("id", vendaId);
+      console.error("[Vendas] Venda nao encontrada:", { vendaId, tipoId: typeof vendaId, count });
+      return NextResponse.json({
+        error: `Venda nao encontrada (id: ${vendaId}). Recarregue a pagina — pode ter sido cancelada ou excluida.`,
+        id: vendaId,
+        tipoId: typeof vendaId,
+      }, { status: 404 });
+    }
     if (!venda.nota_fiscal_url) return NextResponse.json({ error: "venda sem NF anexada" }, { status: 400 });
     if (!skipEmail && !venda.email) return NextResponse.json({ error: "venda sem email do cliente — use skipEmail pra marcar como enviada sem disparar email" }, { status: 400 });
     try {

--- a/components/admin/CalculadoraImportacao.tsx
+++ b/components/admin/CalculadoraImportacao.tsx
@@ -199,42 +199,32 @@ export default function CalculadoraImportacao() {
           <span className="text-[#86868B]">{showProdutos ? "▲" : "▼"}</span>
         </button>
 
-        {produtoBase && (produtoBase.configs?.length || produtoBase.cores?.length) && (
+        {produtoBase && (
           <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {produtoBase.configs && produtoBase.configs.length > 0 && (
-              <div>
-                <label className="block text-xs font-semibold text-[#86868B] mb-1.5 uppercase tracking-wider">
-                  Configuração
-                </label>
-                <select
-                  value={configSelecionada}
-                  onChange={(e) => setConfigSelecionada(e.target.value)}
-                  className="w-full px-3 py-2.5 rounded-xl border border-[#D2D2D7] bg-white text-sm outline-none focus:border-[#E8740E]"
-                >
-                  <option value="">— Selecionar —</option>
-                  {produtoBase.configs.map(c => (
-                    <option key={c} value={c}>{c}</option>
-                  ))}
-                </select>
-              </div>
-            )}
-            {produtoBase.cores && produtoBase.cores.length > 0 && (
-              <div>
-                <label className="block text-xs font-semibold text-[#86868B] mb-1.5 uppercase tracking-wider">
-                  Cor
-                </label>
-                <select
-                  value={corSelecionada}
-                  onChange={(e) => setCorSelecionada(e.target.value)}
-                  className="w-full px-3 py-2.5 rounded-xl border border-[#D2D2D7] bg-white text-sm outline-none focus:border-[#E8740E]"
-                >
-                  <option value="">— Selecionar —</option>
-                  {produtoBase.cores.map(c => (
-                    <option key={c} value={c}>{c}</option>
-                  ))}
-                </select>
-              </div>
-            )}
+            <div>
+              <label className="block text-xs font-semibold text-[#86868B] mb-1.5 uppercase tracking-wider">
+                Configuração (opcional)
+              </label>
+              <input
+                type="text"
+                value={configSelecionada}
+                onChange={(e) => setConfigSelecionada(e.target.value)}
+                placeholder="Ex: 256GB, 512GB, M4 Pro..."
+                className="w-full px-3 py-2.5 rounded-xl border border-[#D2D2D7] bg-white text-sm outline-none focus:border-[#E8740E]"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-semibold text-[#86868B] mb-1.5 uppercase tracking-wider">
+                Cor (opcional)
+              </label>
+              <input
+                type="text"
+                value={corSelecionada}
+                onChange={(e) => setCorSelecionada(e.target.value)}
+                placeholder="Ex: Prata, Grafite, Preto..."
+                className="w-full px-3 py-2.5 rounded-xl border border-[#D2D2D7] bg-white text-sm outline-none focus:border-[#E8740E]"
+              />
+            </div>
           </div>
         )}
 
@@ -278,9 +268,9 @@ export default function CalculadoraImportacao() {
                         onClick={() => {
                           setPeso(String(p.peso));
                           setProdutoBaseNome(p.nome);
-                          // Pre-seleciona primeira config/cor se houver apenas uma
-                          setConfigSelecionada((p.configs && p.configs.length === 1) ? p.configs[0] : "");
-                          setCorSelecionada((p.cores && p.cores.length === 1) ? p.cores[0] : "");
+                          // Config e cor sao digitados livre na tela de Calcular — limpa ao trocar produto
+                          setConfigSelecionada("");
+                          setCorSelecionada("");
                           setShowProdutos(false);
                           setBuscaProduto("");
                         }}
@@ -572,9 +562,7 @@ function EditorProdutos({
 
       <div className="overflow-x-auto">
         <p className="text-[11px] text-[#86868B] mb-2">
-          💡 <strong>Configurações</strong> e <strong>Cores</strong> sao opcionais —
-          separe por virgula (ex: &quot;256GB, 512GB, 1TB&quot; ou &quot;Prata, Grafite&quot;).
-          Se preenchidos, viram seletores na tela de calcular.
+          💡 Configuracao e cor sao digitadas na tela de <strong>Calcular</strong>, produto por produto. Aqui e so lista de modelos com peso.
         </p>
         <table className="w-full text-sm">
           <thead>
@@ -582,8 +570,6 @@ function EditorProdutos({
               <th className="text-left py-2 pr-3 w-28">Categoria</th>
               <th className="text-left py-2 pr-3">Nome</th>
               <th className="text-left py-2 pr-3 w-20">Peso (kg)</th>
-              <th className="text-left py-2 pr-3">Configurações</th>
-              <th className="text-left py-2 pr-3">Cores</th>
               <th className="text-right py-2 w-12"></th>
             </tr>
           </thead>
@@ -617,24 +603,6 @@ function EditorProdutos({
                     value={p.peso}
                     onChange={(e) => atualizar(i, "peso", parseFloat(e.target.value) || 0)}
                     placeholder="3.0"
-                    className="w-full px-2 py-1.5 rounded-lg border border-[#D2D2D7] text-sm outline-none focus:border-[#E8740E]"
-                  />
-                </td>
-                <td className="py-2 pr-3">
-                  <input
-                    type="text"
-                    value={(p.configs || []).join(", ")}
-                    onChange={(e) => atualizarArray(i, "configs", e.target.value)}
-                    placeholder="256GB, 512GB, 1TB"
-                    className="w-full px-2 py-1.5 rounded-lg border border-[#D2D2D7] text-sm outline-none focus:border-[#E8740E]"
-                  />
-                </td>
-                <td className="py-2 pr-3">
-                  <input
-                    type="text"
-                    value={(p.cores || []).join(", ")}
-                    onChange={(e) => atualizarArray(i, "cores", e.target.value)}
-                    placeholder="Prata, Grafite, Preto"
                     className="w-full px-2 py-1.5 rounded-lg border border-[#D2D2D7] text-sm outline-none focus:border-[#E8740E]"
                   />
                 </td>


### PR DESCRIPTION
## Bundle de correcoes apos #585

### 1. Calc importacao — config/cor so no Calcular
No #585 interpretei errado. Usuario queria config/cor no momento do orcamento, nao pre-cadastrar. Agora editor tem so Categoria/Nome/Peso; Calcular mostra 2 inputs livres apos selecionar produto.

### 2. NF pendente — diagnostico do erro 404
Usuario reportou 'HTTP 404: venda nao encontrada' apos tentativa de envio. Mensagem generica nao ajudava. Agora:
- .maybeSingle() em vez de .single() (nao ergue erro em 0 rows)
- Loga no server console {vendaId, tipoId, count}
- Toast mostra o id tentado + sugere recarregar
- Separa erro de SELECT vs row nao encontrada

### 3. Merge cliente/lojista — fallback robusto
Usuario reportou que algumas unificacoes 'nao funcionam por nada'. Hipotese: nome no DB tem variacao sutil (espaco duplo, acentos, padding).

**Server**: Se ilike retorna 0 rows, fallback busca nomes distintos, filtra por normalizacao JS (NFD sem acentos + espacos colapsados + uppercase), atualiza via .in() com os matches.

**Frontend**: Se API retorna ok=true mas 0 registros afetados, flagga como falha no alert (antes passava silencioso).

## Test plan
- [ ] /admin/gerar-link → Calculadora: editor so 3 colunas, Calcular com inputs livres
- [ ] /admin/vendas: "Enviar NF" — se der erro, msg tem id + sugestao
- [ ] /admin/clientes aba Lojistas: selecionar 2 e unificar — merge funciona mesmo com variacoes
- [ ] /admin/clientes: unificar com nome com acento/espaco duplo → fallback normalizado pega

🤖 Generated with [Claude Code](https://claude.com/claude-code)