### PR TITLE
feat(instagram): prioriza 20 sites brasileiros de tech como fonte de imagens

### DIFF
--- a/app/api/instagram/ilustrar-slides/route.ts
+++ b/app/api/instagram/ilustrar-slides/route.ts
@@ -68,10 +68,29 @@ REGRAS GERAIS
    - Máximo 3 URLs em composição.
    - ⚠️ COMPOSIÇÕES TAMBÉM NÃO PODEM REPETIR: se 3 slides falam dos mesmos modelos, NÃO mande a mesma lista de URLs nos 3. Varie — ex: slide A usa foto frontal dos 3, slide B usa foto lateral, slide C usa detalhe de câmera. O backend detecta composições visualmente iguais (mesma lista de URLs ordenada) e ZERA as duplicatas.
 
-3. Priorize fontes:
-   - apple.com/br, apple.com, newsroom Apple pra produtos específicos.
-   - 9to5Mac, MacRumors, The Verge, Tecnoblog, TechTudo pra reviews.
-   - Wikipedia commons pra imagens com licença aberta.
+3. Priorize fontes (⚠️ PREFERENCIA FORTE por sites BRASILEIROS — carrossel em PT-BR, imagens e legendas em PT evitam o problema de overlay em inglês):
+
+   **Oficial Apple:**
+   - apple.com/br, apple.com, newsroom Apple (support.apple.com pra screenshots de tutorial).
+
+   **Sites brasileiros especializados em Apple (TOP):**
+   - macmagazine.com.br — "O melhor pedaço da Maçã", reviews e fotos de alta qualidade.
+   - blogdoiphone.com — referência de iPhone no Brasil desde 2008.
+   - tudocelular.com/apple — portal do mundo Apple do TudoCelular.
+   - blog.iplace.com.br — blog da Apple Premium Reseller, fotos de produto.
+   - iphoneblog.com.br — tutoriais e screenshots iOS em PT.
+
+   **Tech geral brasileiro (cobertura forte Apple):**
+   - tecnoblog.net, canaltech.com.br, olhardigital.com.br, techtudo.com.br (Globo).
+   - gizmodo.uol.com.br, showmetech.com.br, adrenaline.com.br, uol.com.br/tilt.
+   - meiobit.com, manualdousuario.net.
+
+   **Jornalismo BR (tecnologia):**
+   - cnnbrasil.com.br, exame.com, estadao.com.br/link, folha.uol.com.br/tec, mobiletime.com.br.
+
+   **Internacional (só se não achar em BR):**
+   - 9to5Mac, MacRumors, The Verge (tem overlay em inglês — cuidado).
+   - Wikipedia Commons (imagens com licença aberta, fundo limpo).
 
 4. NÃO use:
    - Ícones pequenos, sprites, logos de favicon.


### PR DESCRIPTION
## Contexto
Imagens com overlay em inglês voltavam mesmo com as regras anti-texto — porque Claude buscava muito em sites internacionais onde reviews vêm com títulos sobrepostos.

## Fix
Lista de fontes priorizadas foi expandida pra incluir **20 sites brasileiros** — títulos e overlays vêm em PT, o que naturalmente reduz o problema de texto em inglês.

**Novas categorias no prompt:**

### Especializados em Apple (BR)
- macmagazine.com.br — "O melhor pedaço da Maçã"
- blogdoiphone.com — desde 2008
- tudocelular.com/apple
- blog.iplace.com.br — Apple Premium Reseller
- iphoneblog.com.br — screenshots iOS em PT

### Tech geral (BR)
- tecnoblog.net, canaltech.com.br, olhardigital.com.br, techtudo.com.br
- gizmodo.uol.com.br, showmetech.com.br, adrenaline.com.br, uol.com.br/tilt
- meiobit.com, manualdousuario.net

### Jornalismo BR (tecnologia)
- cnnbrasil.com.br, exame.com, estadao.com.br/link, folha.uol.com.br/tec, mobiletime.com.br

### Internacional (fallback só se não achar em BR)
- 9to5Mac, MacRumors, The Verge (com aviso "tem overlay em inglês")
- Wikipedia Commons

## Test plan
- [ ] Gerar um carrossel após merge
- [ ] Verificar que a maioria das imagens vem de site BR (URLs do tipo macmagazine, tecnoblog, canaltech, etc)
- [ ] Textos nas imagens (quando houver) devem estar em português, não inglês

🤖 Generated with [Claude Code](https://claude.com/claude-code)