### PR TITLE
fix(instagram): slide em branco no render apos upload de imagem

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -209,6 +209,16 @@ export default function InstagramPostPage() {
     setMsg("Imagem atribuída. Lembre de salvar a edição.");
   };
 
+  // Salva direto no banco um array de slides ja atualizado, sem depender do
+  // state do React (evita race entre setSlidesEdit e a proxima acao do user).
+  const persistirSlides = async (novosSlides: Slide[]) => {
+    await fetch("/api/admin/instagram-posts", {
+      method: "PATCH",
+      headers: apiHeaders({ "Content-Type": "application/json" }),
+      body: JSON.stringify({ id, slides_json: novosSlides }),
+    });
+  };
+
   const uploadImagemSlide = async (idx: number, file: File) => {
     setUploadingSlide(idx);
     try {
@@ -238,7 +248,11 @@ export default function InstagramPostPage() {
         setMsg("Erro no upload: " + (uj.error || `HTTP ${up.status}`));
         return;
       }
-      atribuirImagem(idx, uj.url ?? null);
+      const novaUrl = uj.url ?? null;
+      const novosSlides = slidesEdit.map((s, i) => (i === idx ? { ...s, imagem_url: novaUrl } : s));
+      setSlidesEdit(novosSlides);
+      await persistirSlides(novosSlides);
+      setMsg(`Imagem do slide ${idx + 1} salva. Pode re-renderizar.`);
     } catch (err) {
       setMsg("Erro: " + (err instanceof Error ? err.message : String(err)));
     } finally {

--- a/app/api/instagram/render-post/route.ts
+++ b/app/api/instagram/render-post/route.ts
@@ -55,11 +55,34 @@ export async function POST(req: NextRequest) {
 
   const fonts = await loadInterFonts();
 
+  // Pre-fetch imagens dos slides e converte pra data URL. Evita que o Satori
+  // tente fetchar URLs recem-uploaded do Supabase Storage (que as vezes
+  // retornam 404 por propagacao de CDN) e falhe silenciosamente.
+  const slidesComImagens = await Promise.all(
+    slides.map(async (slide, idx) => {
+      if (!slide.imagem_url) return slide;
+      try {
+        const r = await fetch(slide.imagem_url, { cache: "no-store" });
+        if (!r.ok) {
+          console.error(`[render-post] slide ${idx + 1} imagem HTTP ${r.status}: ${slide.imagem_url}`);
+          return slide;
+        }
+        const buf = await r.arrayBuffer();
+        const mime = r.headers.get("content-type") || "image/jpeg";
+        const b64 = Buffer.from(buf).toString("base64");
+        return { ...slide, imagem_url: `data:${mime};base64,${b64}` };
+      } catch (err) {
+        console.error(`[render-post] slide ${idx + 1} imagem erro:`, err);
+        return slide;
+      }
+    })
+  );
+
   const urls: string[] = [];
   const ts = Date.now();
 
-  for (let i = 0; i < slides.length; i++) {
-    const slide = slides[i];
+  for (let i = 0; i < slidesComImagens.length; i++) {
+    const slide = slidesComImagens[i];
     const jsx = renderSlideJSX(slide, cfg, {
       index: i,
       total: slides.length,


### PR DESCRIPTION
## Summary
- Após upload de imagem num slide, o PNG final do render ficava em branco (sem a imagem).
- **Causa 1:** upload só atualizava state local. Se o user clicasse "Re-renderizar" rápido, o banco ainda não tinha a URL (race com setState).
- **Causa 2:** Satori/next-og às vezes falha silenciosamente ao fetchar URL do Supabase Storage recém-criada (propagação de CDN).

## Fix
- Upload agora persiste `slides_json` direto no banco (PATCH imediato) — elimina a race.
- `render-post` pre-fetcha cada imagem e converte pra data URL antes de passar pro Satori — Satori não precisa mais fetchar por HTTP. Log de erro server-side se fetch falhar.

## Test plan
- [ ] Merge + deploy
- [ ] Abrir post que tinha slide em branco
- [ ] Upload imagem no slide 8
- [ ] Clicar "Re-renderizar"
- [ ] Conferir que o PNG do slide 8 agora tem a imagem

🤖 Generated with [Claude Code](https://claude.com/claude-code)