### PR TITLE
fix(vendas): corrige 3º item venda Paulo Vidal 23/03 (trade-in Tamara)

### DIFF
--- a/supabase/migrations/20260420_corrige_venda_paulo_vidal_23mar_tamara.sql
+++ b/supabase/migrations/20260420_corrige_venda_paulo_vidal_23mar_tamara.sql
@@ -1,0 +1,42 @@
+-- Corrige venda pra PAULO VIDAL de 23/03 — 3º item estava com serial/imei/produto
+-- errados, duplicando os dados do 1º item (J5W293YN92 / IPHONE 13 PRETO).
+--
+-- O item fisico REAL do 3º registro eh o iPhone 13 128GB BRANCO que veio do
+-- trade-in da Tamara Romano Bezerra (venda de 20/03, upgrade pro iPhone 17):
+--   - Serial: PTPH95XXQH
+--   - IMEI:   352364225571656
+--   - Bateria: 79%
+--   - Custo: R$ 1.300 (valor avaliado do trade-in)
+--
+-- Tambem completa o backfill da troca na venda da Tamara (preenche troca_*
+-- se ainda estiver NULL — idempotente via COALESCE).
+
+------------------------------------------------------------
+-- 1. Corrige o 3º item da venda do PAULO VIDAL (23/03)
+-- Identificacao: mesmo cliente/data + serial duplicado J5W293YN92 + custo 1300
+-- (o item legitimo com esse serial tem custo 1200 — guard contra reexecucao).
+------------------------------------------------------------
+UPDATE vendas
+SET
+  produto    = 'IPHONE 13 128GB BRANCO SEMINOVO',
+  serial_no  = 'PTPH95XXQH',
+  imei       = '352364225571656',
+  fornecedor = 'UPGRADE'
+WHERE UPPER(cliente) = 'PAULO VIDAL'
+  AND data = '2026-03-23'
+  AND serial_no = 'J5W293YN92'
+  AND custo = 1300;
+
+------------------------------------------------------------
+-- 2. Backfill do trade-in na venda da TAMARA ROMANO BEZERRA (20/03)
+-- Tamara deu o iPhone 13 Branco (PTPH95XXQH) no upgrade pro iPhone 17.
+-- COALESCE garante que so preenche campos ainda NULL.
+------------------------------------------------------------
+UPDATE vendas
+SET
+  troca_produto   = COALESCE(troca_produto,   'IPHONE 13 128GB BRANCO SEMINOVO'),
+  troca_serial    = COALESCE(troca_serial,    'PTPH95XXQH'),
+  troca_imei      = COALESCE(troca_imei,      '352364225571656'),
+  troca_categoria = COALESCE(troca_categoria, 'IPHONES')
+WHERE UPPER(cliente) = 'TAMARA ROMANO BEZERRA'
+  AND data = '2026-03-20';


### PR DESCRIPTION
## Summary
- 3º item da venda pra Paulo Vidal em 23/03 estava com serial/imei/produto errados, duplicando os dados do 1º item (J5W293YN92).
- O aparelho fisico real era o iPhone 13 128GB BRANCO (SN PTPH95XXQH, IMEI 352364225571656) que veio do trade-in da Tamara Romano Bezerra.
- Migration tambem backfilla os campos troca_* na venda da Tamara de 20/03 (idempotente via COALESCE).

## Identificacao (guard idempotente)
- Item errado: `cliente = 'PAULO VIDAL' AND data = '2026-03-23' AND serial_no = 'J5W293YN92' AND custo = 1300` (o legitimo tem custo 1200).

## Test plan
- [ ] Testar no preview do Vercel
- [ ] `/admin/migrations` → achar `20260420_corrige_venda_paulo_vidal_23mar_tamara` → ▶ Rodar
- [ ] Conferir operacao do Paulo Vidal 23/03 — 3º item agora mostra IPHONE 13 BRANCO com SN PTPH95XXQH
- [ ] Conferir venda da Tamara 20/03 — troca_* preenchidos

🤖 Generated with [Claude Code](https://claude.com/claude-code)