### PR TITLE
feat(instagram): permitir editar imagem/texto apos aprovar

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -413,7 +413,7 @@ export default function InstagramPostPage() {
   if (!post) return <div className="max-w-5xl mx-auto p-6 text-[#E74C3C]">Post não encontrado.</div>;
 
   const jaTemConteudo = post.status !== "RASCUNHO" && post.status !== "GERANDO" && slidesEdit.length > 0;
-  const podeEditar = ["GERADO", "ERRO"].includes(post.status);
+  const podeEditar = !["RASCUNHO", "GERANDO", "POSTADO"].includes(post.status);
   const temImagensRenderizadas = Array.isArray(post.imagens_urls) && post.imagens_urls.length > 0;
 
   return (


### PR DESCRIPTION
## Summary
- Relaxa regra de `podeEditar`: antes só era true em `GERADO`/`ERRO`, agora vale em qualquer status exceto `RASCUNHO`/`GERANDO`/`POSTADO`
- Permite trocar imagem, fazer upload e editar texto/legenda até o momento de publicar
- Fixa bug onde depois de aprovar o post os botões "🔄 Trocar imagem" e "📤 Upload" sumiam dos slides

## Test plan
- [ ] Abrir um post com status APROVADO ou AGENDADO
- [ ] Confirmar que botões "🔄 Trocar imagem" e "📤 Upload" aparecem em cada slide
- [ ] Trocar imagem de um slide, re-renderizar, verificar que ficou correto

🤖 Generated with [Claude Code](https://claude.com/claude-code)