### PR TITLE
fix: bugs troca/venda/estoque + seminovos WhatsApp + encomendas auth

### DIFF
--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -19,6 +19,19 @@ import { INSTALLMENT_RATES } from "@/lib/calculations";
 import type { UsedDeviceValue } from "@/lib/types";
 import { buildWaFollowUpUrl } from "@/lib/whatsappFollowUp";
 import FlexiblePaymentSimulator from "@/components/FlexiblePaymentSimulator";
+import { WHATSAPP_NUMBERS } from "@/lib/whatsapp-config";
+
+/** Traduz um numero de WhatsApp (E.164 sem +) para o nome do destinatario.
+ *  Usado para mostrar "Nicolas"/"Bianca" em vez do numero bruto. */
+function nomeWhatsappDestino(numero: string | null | undefined): string | null {
+  if (!numero) return null;
+  const clean = String(numero).replace(/\D/g, "");
+  for (const [nome, num] of Object.entries(WHATSAPP_NUMBERS)) {
+    if (num === clean) return nome.charAt(0).toUpperCase() + nome.slice(1);
+  }
+  // Numero desconhecido (fallback): mostra os 4 ultimos digitos
+  return clean ? `(...${clean.slice(-4)})` : null;
+}
 
 const FunnelPanel = dynamic(() => import("@/app/admin/analytics/page"), { ssr: false });
 
@@ -53,6 +66,7 @@ interface SimulacaoRow {
   contatado: boolean | null;
   vendedor: string | null;
   follow_up_enviado: boolean | null;
+  whatsapp_destino?: string | null;
 }
 
 const fmt = (v: number) =>
@@ -1623,11 +1637,21 @@ export default function AdminPage() {
                         )}
                       </td>
                       <td className="px-4 py-3 whitespace-nowrap">
-                        {row.vendedor ? (
-                          <span className="px-2 py-1 rounded-lg text-xs font-semibold bg-purple-100 text-purple-700">{row.vendedor}</span>
-                        ) : (
-                          <span className="text-[#86868B] text-xs">—</span>
-                        )}
+                        <div className="flex flex-col gap-1">
+                          {row.vendedor ? (
+                            <span className="px-2 py-1 rounded-lg text-xs font-semibold bg-purple-100 text-purple-700">{row.vendedor}</span>
+                          ) : (
+                            <span className="text-[#86868B] text-xs">—</span>
+                          )}
+                          {nomeWhatsappDestino(row.whatsapp_destino) && (
+                            <span
+                              className="px-2 py-0.5 rounded-lg text-[10px] font-semibold bg-blue-100 text-blue-700"
+                              title={`Formulario enviado para ${row.whatsapp_destino}`}
+                            >
+                              → {nomeWhatsappDestino(row.whatsapp_destino)}
+                            </span>
+                          )}
+                        </div>
                       </td>
                       <td className="px-4 py-3 text-[#1D1D1F] whitespace-nowrap">
                         {row.modelo_novo} {row.storage_novo}
@@ -1842,6 +1866,14 @@ export default function AdminPage() {
                 </span>
                 {modalRow.vendedor && (
                   <span className="ml-2 px-2 py-1 rounded-lg text-xs font-semibold bg-purple-100 text-purple-700">{modalRow.vendedor}</span>
+                )}
+                {nomeWhatsappDestino(modalRow.whatsapp_destino) && (
+                  <span
+                    className="ml-2 px-2 py-1 rounded-lg text-xs font-semibold bg-blue-100 text-blue-700"
+                    title={`Formulario enviado para ${modalRow.whatsapp_destino}`}
+                  >
+                    → {nomeWhatsappDestino(modalRow.whatsapp_destino)}
+                  </span>
                 )}
               </div>
 

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -41,6 +41,8 @@ export async function POST(req: NextRequest) {
     if (body.corUsado2 != null) row.cor_usado2 = body.corUsado2 || null;
     if (body.avaliacaoUsado2) row.avaliacao_usado2 = body.avaliacaoUsado2;
     if (body.condicaoLinhas2) row.condicao_linhas2 = body.condicaoLinhas2;
+    // Numero de WhatsApp destino: rastreio de para quem foi o formulario
+    if (body.whatsappDestino) row.whatsapp_destino = String(body.whatsappDestino).replace(/\D/g, "") || null;
 
     // Checagem de duplicidade real: mesmo whatsapp + produto novo + produto usado nos últimos 2 minutos
     const twoMinAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
@@ -67,6 +69,12 @@ export async function POST(req: NextRequest) {
       console.warn("[leads] coluna cor_usado ausente, retry sem cor");
       delete row.cor_usado;
       delete row.cor_usado2;
+      ({ error } = await supabase.from("simulacoes").insert([row]));
+    }
+    // Fallback: se whatsapp_destino ainda nao existe no banco (migration nao rodou), tenta sem ela
+    if (error && /column\s+["']?whatsapp_destino/i.test(error.message || "")) {
+      console.warn("[leads] coluna whatsapp_destino ausente, retry sem campo (rodar migration 20260421)");
+      delete row.whatsapp_destino;
       ({ error } = await supabase.from("simulacoes").insert([row]));
     }
 

--- a/components/StepNewDevice.tsx
+++ b/components/StepNewDevice.tsx
@@ -391,6 +391,12 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
                   // Salvar simulação seminovo no banco de dados (com dados completos de condição)
                   const condLines = condition && deviceType ? getAnyConditionLines(deviceType, condition) : [];
                   const condLines2 = condition2 && deviceType2 ? getAnyConditionLines(deviceType2, condition2) : [];
+                  // whatsappNumber eh passado pelo TradeInCalculator ja com a
+                  // logica correta pra seminovos (prefere vendedor selecionado;
+                  // senao tradeinConfig.whatsapp_formularios_seminovos; senao
+                  // principal). O fallback WHATSAPP_SEMINOVO so entra se o prop
+                  // nao foi passado (componente usado standalone).
+                  const waNum = whatsappNumber || WHATSAPP_SEMINOVO;
                   fetch("/api/leads", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
@@ -409,6 +415,7 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
                       status: "GOSTEI",
                       formaPagamento: "WhatsApp Seminovo",
                       condicaoLinhas: condLines,
+                      whatsappDestino: waNum,
                       ...(usedModel2 ? {
                         modeloUsado2: usedModel2,
                         storageUsado2: usedStorage2,
@@ -419,12 +426,6 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
                       website: getHoneypotValue(),
                     }),
                   }).catch(() => {});
-                  // whatsappNumber eh passado pelo TradeInCalculator ja com a
-                  // logica correta pra seminovos (prefere vendedor selecionado;
-                  // senao tradeinConfig.whatsapp_formularios_seminovos; senao
-                  // principal). O fallback WHATSAPP_SEMINOVO so entra se o prop
-                  // nao foi passado (componente usado standalone).
-                  const waNum = whatsappNumber || WHATSAPP_SEMINOVO;
                   const msg = encodeURIComponent(buildWhatsAppMsg());
                   window.location.href = `https://wa.me/${waNum}?text=${msg}`;
                 }}

--- a/components/StepQuote.tsx
+++ b/components/StepQuote.tsx
@@ -122,6 +122,7 @@ export default function StepQuote(p: StepQuoteProps) {
     modeloNovo: newModel, storageNovo: newStorage, precoNovo: newPrice, modeloUsado: usedModel,
     storageUsado: usedStorage, corUsado: usedColor || "", avaliacaoUsado: hasSecond ? (tradeInValue1 ?? tradeInValue) : tradeInValue, diferenca: dif, condicaoLinhas: condLines,
     vendedor: vendedor || undefined, origem: clienteOrigem || undefined,
+    whatsappDestino: whatsappNumero,
     ...(hasSecond ? { modeloUsado2: usedModel2, storageUsado2: usedStorage2, corUsado2: usedColor2 || "", avaliacaoUsado2: tradeInValue2 ?? 0, condicaoLinhas2: condition2 ? getAnyConditionLines(deviceType2 ?? "iphone", condition2) : [] } : {}) };
 
   const cardStyle: React.CSSProperties = { backgroundColor: "var(--ti-card-bg)", border: "1px solid var(--ti-card-border)" };

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -103,7 +103,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
   const [questionsConfig, setQuestionsConfig] = useState<TradeInQuestion[] | null>(null);
   const [catConfigs, setCatConfigs] = useState<{ categoria: string; modo: string; ativo: boolean }[]>([]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
+  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios_seminovos?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
   // Mapa dinamico de WhatsApp por vendedor — usa DB se disponivel
   const VENDEDOR_WHATSAPP = useMemo(() => {
     const dbMap = tradeinConfig?.whatsapp_vendedores;
@@ -111,6 +111,9 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
   }, [tradeinConfig]);
   // WhatsApp principal — usa DB se disponivel
   const whatsappPrincipal: string = tradeinConfig?.whatsapp_principal || config.whatsappNumero;
+  // WhatsApp destino dos formularios de seminovo — Nicolas por padrao,
+  // configurado em /admin/configuracoes. Fallback pro principal.
+  const whatsappFormulariosSeminovos: string = tradeinConfig?.whatsapp_formularios_seminovos || whatsappPrincipal;
   const [deviceType, setDeviceType] = useState<DeviceType>("iphone");
   const [usedModel, setUsedModel] = useState("");
   const [usedStorage, setUsedStorage] = useState("");
@@ -500,7 +503,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
           )}
 
           {step === 2 && (
-            <StepNewDevice products={products} tradeInValue={totalTradeInValue} onNext={handleStep2Complete} onBack={() => setStep(hasSecondDevice ? 1.7 : 1)} usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappPrincipal} condition={condition} deviceType={deviceType} tradeinConfig={tradeinConfig} usedModel2={hasSecondDevice ? usedModel2 : undefined} usedStorage2={hasSecondDevice ? usedStorage2 : undefined} usedColor2={hasSecondDevice ? usedColor2 : undefined} condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined} tradeInValue1={hasSecondDevice ? tradeInValue : undefined} tradeInValue2={hasSecondDevice ? tradeInValue2 : undefined} />
+            <StepNewDevice products={products} tradeInValue={totalTradeInValue} onNext={handleStep2Complete} onBack={() => setStep(hasSecondDevice ? 1.7 : 1)} usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormulariosSeminovos} condition={condition} deviceType={deviceType} tradeinConfig={tradeinConfig} usedModel2={hasSecondDevice ? usedModel2 : undefined} usedStorage2={hasSecondDevice ? usedStorage2 : undefined} usedColor2={hasSecondDevice ? usedColor2 : undefined} condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined} tradeInValue1={hasSecondDevice ? tradeInValue : undefined} tradeInValue2={hasSecondDevice ? tradeInValue2 : undefined} />
           )}
 
           {step === 3 && (

--- a/supabase/migrations/20260421_add_whatsapp_destino_simulacoes.sql
+++ b/supabase/migrations/20260421_add_whatsapp_destino_simulacoes.sql
@@ -1,0 +1,13 @@
+-- Adiciona coluna whatsapp_destino em simulacoes para rastrear para qual
+-- numero de WhatsApp o formulario foi enviado. Serve de auditoria: permite
+-- ao admin ver em /admin/simulacoes se o lead foi pro Nicolas, Bianca,
+-- Andre ou vendedor especifico.
+--
+-- Preenchido pelo POST /api/leads com o numero que o cliente clicou.
+-- NULL em linhas antigas (anteriores a esta migration).
+
+ALTER TABLE simulacoes
+  ADD COLUMN IF NOT EXISTS whatsapp_destino TEXT;
+
+COMMENT ON COLUMN simulacoes.whatsapp_destino IS
+  'Numero de WhatsApp (E.164 sem +) para onde o formulario foi enviado. Ex: 5521995618747 (Nicolas).';


### PR DESCRIPTION
## Summary

Quatro fixes distintos descobertos na mesma sessão:

### 1. Seminovos indo pra Bianca em vez do Nicolas
[TradeInCalculatorMulti.tsx:503](components/TradeInCalculatorMulti.tsx) ignorava a config `whatsapp_formularios_seminovos`. Agora usa o mesmo fallback do `TradeInCalculator` não-multi.

### 2. Rastreio — pra onde cada formulário foi
Migration `20260421` adiciona coluna `simulacoes.whatsapp_destino`. POSTs `/api/leads` enviam `whatsappDestino` (seminovo + lacrado). Badge azul `→ Nicolas` na lista e modal de `/admin/simulacoes`.

### 3. Encomendas → "Editar produtos" → Unauthorized
[CalculadoraImportacao.tsx](components/admin/CalculadoraImportacao.tsx) lia `localStorage.adminPassword`, mas a chave correta é `admin_pw`.

### 4. Produto da troca não podia ser marcado como Lacrado
Form de gerar venda só permitia seminovo. Toggle **🟡 Seminovo / 🔵 Lacrado** adicionado no bloco "Produto na troca" (1º e 2º). Lacrado esconde campos específicos de seminovo (bateria, grade, caixa/cabo/fonte/pulseira/ciclos). API grava tag `[LACRADO]` e na hora de receber, a pendência vira `NOVO` em vez de `SEMINOVO`.

### 5. Pendência saía direto pra Estoque ao trocar "Condição"
Select "Condição" no detalhe de produto em PENDÊNCIA trocava `tipo` sem mexer no `status`. O produto sumia de Pendências (filtro é por tipo) e aparecia em Estoque com `status=PENDENTE`. Agora, quando `tipo=PENDENCIA`, o select é substituído por badge `🟠 Pendência (defina condição ao receber)`. Forçando uso do botão "Receber" que faz o fluxo completo.

## ⚠️ Pós-deploy

1. Rodar migration `20260421_add_whatsapp_destino_simulacoes.sql` em `/admin/migrations` ▶
2. Em `/admin/configuracoes` → "📱 WhatsApp Troca — Seminovos" com `5521995618747` (Nicolas).

## Test plan

- [ ] Migration `20260421` rodou
- [ ] Formulário seminovo → WhatsApp do Nicolas + badge azul em `/admin/simulacoes`
- [ ] Encomendas → Editar produtos → Salvar sem 401
- [ ] Gerar venda com troca: alternar Lacrado/Seminovo funciona; Lacrado esconde bateria/grade/caixa
- [ ] Pendência com [LACRADO]: ao clicar Receber, vai como NOVO (Lacrado), não Seminovo
- [ ] Detalhe de pendência: select Condição substituído por badge laranja

🤖 Generated with [Claude Code](https://claude.com/claude-code)