### PR TITLE
fix: 5 bugs (historico, valor entrega, cor truncada, refresh estoque, URL vercel)

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -2965,7 +2965,9 @@ export default function EntregasPage() {
                         const tipoLabel = isUpgrade ? "UPGRADE (Troca)" : "Compra";
                         const trocaTexto = e.detalhes_upgrade
                           ? e.detalhes_upgrade.split("\n").filter(l => !l.startsWith("Avaliação:"))
-                              .map(l => l.replace(/\s*—\s*R\$\s*[\d.,]+/g, "")) // Remove valor avaliado (motoboy não vê)
+                              // Remove valor avaliado (motoboy nao ve). Cobre os
+                              // separadores em uso: em-dash (—), bullet (•) e hifen (-).
+                              .map(l => l.replace(/\s*[—•\-]\s*R\$\s*[\d.,]+/g, ""))
                               .join(" / ")
                           : "";
                         const obsLimpa = (e.observacao || "").split(" | ").filter(p => !p.startsWith("Endereço cadastro:")).join(" | ").trim();

--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -1862,9 +1862,11 @@ export default function EstoquePage() {
     } catch { /* ignore */ }
   }, [password]);
 
-  // Fetch inicial + refetch ao voltar de aba oculta (sem polling constante)
+  // Fetch inicial + refetch ao voltar de aba oculta (sem polling constante).
+  // useAutoRefetch ja faz o fetch inicial no mount e registra o listener de
+  // visibilitychange — nao ter um useEffect separado aqui evita fetch duplo
+  // toda vez que refetchAll muda de referencia.
   const refetchAll = useCallback(() => { fetchEstoque(); fetchFornecedores(); }, [fetchEstoque, fetchFornecedores]);
-  useEffect(() => { refetchAll(); }, [refetchAll]);
   useAutoRefetch(refetchAll, !!password);
 
   // Carregar ordem customizada das seções do estoque

--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -273,17 +273,16 @@ export default function AdminPage() {
       let items: HistoricoItem[] = [];
       if (res.ok) {
         const json = await res.json();
-        // Aqui mostramos APENAS clientes que vieram pelo Simulador de trade-in publico
-        // (formulario de troca no site) e seguiram ate o link de compra.
-        // Links criados manualmente no /admin/gerar-link aparecem so naquela tela,
-        // nao aqui (eles nao vieram pelo funil de trade-in).
-        // Criterio: operador === "Simulador" OU simulacao_id preenchido.
+        // Mostra todo cliente que preencheu o formulario de compra — tanto
+        // via Simulador de trade-in quanto via link manual do /gerar-link. O
+        // filtro anterior exigia operador === "Simulador" OU simulacao_id,
+        // excluindo clientes reais que o vendedor atendeu diretamente pelo
+        // link manual (ex: MARCELLA 21/04).
         const valido = (r: HistoricoItem) =>
           (!!r.cliente_preencheu_em || !!r.entrega_id || !!r.pagamento_pago) &&
           r.status !== "GOSTEI" &&
           r.status !== "SAIR" &&
-          r.status !== "AGUARDANDO_MP" &&
-          (r.operador === "Simulador" || !!r.simulacao_id);
+          r.status !== "AGUARDANDO_MP";
         items = (json.data || []).filter(valido);
       }
       setHistorico(items);

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -491,8 +491,11 @@ function CompraForm() {
 
     // Cor sempre obrigatoria — se tem cores no estoque, cliente escolhe chip;
     // senao, digita manualmente no input. Evita mensagens chegando sem cor.
-    if (!corSel || !corSel.trim()) {
-      alert("Escolha a cor do produto antes de enviar.");
+    // Minimo 3 chars evita caso de cliente enviar so "P" quando ia digitar
+    // "Prata" (mensagem chegava pra vendedora com "— P —").
+    const corTrim = (corSel || "").trim();
+    if (corTrim.length < 3) {
+      alert("Informe a cor do produto completa (ex: Prata, Azul, Preto).");
       document.getElementById("escolha-cor")?.scrollIntoView({ behavior: "smooth", block: "center" });
       return;
     }

--- a/components/StepQuote.tsx
+++ b/components/StepQuote.tsx
@@ -6,6 +6,7 @@ import type { LeadSaiu } from "@/lib/supabase";
 import type { NewProduct } from "@/lib/types";
 import { calculateQuote, getWhatsAppUrl, getAnyConditionLines, formatBRL } from "@/lib/calculations";
 import { getHoneypotValue } from "@/lib/honeypot-client";
+import { getPublicBaseUrl } from "@/lib/public-url";
 import FlexiblePaymentSimulator, { type PaymentBlock, type PaymentSummary, calculatePaymentSummary } from "./FlexiblePaymentSimulator";
 
 const PARCELAS_OPCOES = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21];
@@ -328,7 +329,12 @@ export default function StepQuote(p: StepQuoteProps) {
           ...(parc && parc !== "pix" ? { parcelas: parc } : {}),
           ...(entNum > 0 ? { entrada_pix: String(Math.round(entNum)) } : {}),
         });
-        const baseOrigin = typeof window !== "undefined" ? window.location.origin : "";
+        // Usa getPublicBaseUrl() em vez de window.location.origin pra garantir
+        // que o link gerado sempre aponta pro dominio de producao, mesmo se o
+        // cliente acessou o simulador via preview do Vercel (tigrao-tradein.
+        // vercel.app). Evita links com url_curta apontando pra preview, que
+        // depois confundiam o admin no Historico de Formularios.
+        const baseOrigin = getPublicBaseUrl();
         const compraUrl = `${baseOrigin}/compra?${params.toString()}`;
         return (
           <button disabled={fechando} onClick={async () => {

--- a/lib/useAutoRefetch.ts
+++ b/lib/useAutoRefetch.ts
@@ -10,7 +10,13 @@ import { useEffect, useRef } from "react";
  * setInterval / listener a cada render. Antes, passar uma função
  * inline causava clear+reset do timer constantemente (travando
  * polling e gerando lag percebido).
+ *
+ * Visibility threshold: só refetch quando a aba ficou oculta por >30s.
+ * Alt-tab rápido não dispara fetch (evita ver a página "piscando" toda
+ * vez que o usuário troca de janela brevemente).
  */
+const VISIBILITY_REFETCH_THRESHOLD_MS = 30_000;
+
 export function useAutoRefetch(refetch: () => void, enabled: boolean = true, intervalMs: number = 0) {
   const refetchRef = useRef(refetch);
   useEffect(() => { refetchRef.current = refetch; }, [refetch]);
@@ -21,11 +27,15 @@ export function useAutoRefetch(refetch: () => void, enabled: boolean = true, int
     // Fetch inicial imediato na montagem
     call();
     const interval = intervalMs > 0 ? setInterval(call, intervalMs) : null;
-    // Refetch ao focar apenas se a aba esteve oculta (evita re-fetch em toda troca de foco de janela)
-    let wasHidden = false;
+    // Refetch ao voltar o foco só quando a aba ficou oculta por tempo
+    // suficiente pra valer a pena — alt-tab curto não dispara.
+    let hiddenAt: number | null = null;
     const onVisibility = () => {
-      if (document.hidden) { wasHidden = true; return; }
-      if (wasHidden) { wasHidden = false; call(); }
+      if (document.hidden) { hiddenAt = Date.now(); return; }
+      if (hiddenAt !== null && Date.now() - hiddenAt >= VISIBILITY_REFETCH_THRESHOLD_MS) {
+        call();
+      }
+      hiddenAt = null;
     };
     document.addEventListener("visibilitychange", onVisibility);
     return () => {


### PR DESCRIPTION
## Summary

Cinco fixes independentes. Cada um é um commit separado — se squash mergear, vão todos juntos.

### 1. MARCELLA não aparecia no Histórico de Formulários
[`simulacoes/page.tsx:281`](app/admin/simulacoes/page.tsx) exigia `operador=Simulador OR simulacao_id`. Links que chegaram via preview `.vercel.app` (ou criados manualmente) ficavam invisíveis mesmo com `cliente_preencheu_em` preenchido. Filtro relaxado: basta ter `cliente_preencheu_em` OR `entrega_id` OR `pagamento_pago`.

### 2. Valor avaliado vazando na mensagem pro motoboy
Regex em [`entregas/page.tsx:2968`](app/admin/entregas/page.tsx) só removia `— R\$` (em-dash), mas `detalhes_upgrade` usa `• R\$` (bullet). Regex agora cobre `—`, `•` e `-`.

### 3. Mensagem pra vendedora chegando com "— P —" no lugar da cor
Cliente Monike digitou só "P" no campo livre de cor e mandou. Validação em [`/compra`](app/compra/page.tsx) agora exige `trim.length >= 3`.

### 4. Estoque dando refresh toda hora no alt-tab
- [`estoque/page.tsx:1867`](app/admin/estoque/page.tsx) tinha `useEffect(() => refetchAll(), [refetchAll])` em cima do fetch que `useAutoRefetch` já faz no mount → dobrava requests.
- [`useAutoRefetch`](lib/useAutoRefetch.ts) refazia fetch em qualquer visibilitychange hidden→visible. Agora só dispara se a aba ficou oculta por ≥30s.

### 5. Links do simulador gerados com domínio da preview (raiz do bug #1)
[`StepQuote.tsx:331`](components/StepQuote.tsx) usava `window.location.origin` direto — quando cliente entra no simulador via `tigrao-tradein.vercel.app` (preview), o `url_curta` e o redirect iam pra preview também. Agora usa `getPublicBaseUrl()` (mesmo helper que `/admin/gerar-link` já usa), forçando sempre `www.tigraoimports.com`. Cliente em produção: zero diferença. Cliente em preview: agora redireciona pra produção.

## Test plan

- [ ] MARCELLA aparece no Histórico de Formulários depois do merge
- [ ] Mensagem de entrega com troca não mostra `R\$ X` no produto da troca
- [ ] Digitar "P" e enviar em `/compra` mostra alerta pra digitar cor completa
- [ ] Alt-tab pro navegador e voltar em <30s não dispara refresh na página de estoque
- [ ] Clicar "DESEJO FECHAR MEU PEDIDO" do simulador em produção continua redirecionando pra `/compra` normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)