### PR TITLE
fix(simulacoes): historico mostra so funis com troca de aparelho

### DIFF
--- a/app/admin/simulacoes/page.tsx
+++ b/app/admin/simulacoes/page.tsx
@@ -273,16 +273,16 @@ export default function AdminPage() {
       let items: HistoricoItem[] = [];
       if (res.ok) {
         const json = await res.json();
-        // Mostra todo cliente que preencheu o formulario de compra — tanto
-        // via Simulador de trade-in quanto via link manual do /gerar-link. O
-        // filtro anterior exigia operador === "Simulador" OU simulacao_id,
-        // excluindo clientes reais que o vendedor atendeu diretamente pelo
-        // link manual (ex: MARCELLA 21/04).
+        // Mostra so clientes que completaram o funil COM troca de aparelho.
+        // Qualquer origem (Simulador, link manual, via preview, etc) entra
+        // desde que tenha troca_produto preenchido — compras simples sem
+        // upgrade ficam so na aba Simulacoes/Gerar Link.
         const valido = (r: HistoricoItem) =>
           (!!r.cliente_preencheu_em || !!r.entrega_id || !!r.pagamento_pago) &&
           r.status !== "GOSTEI" &&
           r.status !== "SAIR" &&
-          r.status !== "AGUARDANDO_MP";
+          r.status !== "AGUARDANDO_MP" &&
+          !!(r.troca_produto || r.troca_produto2);
         items = (json.data || []).filter(valido);
       }
       setHistorico(items);


### PR DESCRIPTION
## Summary

Clientes que compraram sem upgrade (compra direta de aparelho lacrado, ex: JOANA DARC com iPhone 17 Pro Max) estavam aparecendo na aba **Histórico de Formulários**. O propósito dessa aba é rastrear quem fez o funil de **trade-in** (troca) completo.

## Fix

[`simulacoes/page.tsx:valido`](app/admin/simulacoes/page.tsx) agora exige `troca_produto` OU `troca_produto2` preenchido além do resto.

## Test plan

- [ ] Clientes com troca (PEDRO, MARCELLA, MONIKE etc) continuam aparecendo
- [ ] Clientes sem troca (JOANA DARC) somem daqui e ficam só em Gerar Link > Histórico

🤖 Generated with [Claude Code](https://claude.com/claude-code)