### PR TITLE
feat(instagram): adicionar detalhes extras ao re-gerar texto

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -89,6 +89,10 @@ export default function InstagramPostPage() {
   const [agendando, setAgendando] = useState(false);
   const [agendadoInput, setAgendadoInput] = useState("");
 
+  // Adicionar detalhes e re-gerar
+  const [mostrandoDetalhes, setMostrandoDetalhes] = useState(false);
+  const [detalhesExtras, setDetalhesExtras] = useState("");
+
   const fetchPost = useCallback(async () => {
     if (!password || !id) return;
     try {
@@ -107,14 +111,19 @@ export default function InstagramPostPage() {
 
   useEffect(() => { fetchPost(); }, [fetchPost]);
 
-  const gerar = async () => {
+  const gerar = async (detalhes?: string) => {
+    const temDetalhes = !!detalhes && detalhes.trim().length > 0;
     setGerando(true);
-    setMsg("Gerando... isso pode levar até 2 minutos (pesquisa + fact-check).");
+    setMsg(
+      temDetalhes
+        ? "Re-gerando com suas informações adicionais... (~2 min)"
+        : "Gerando... isso pode levar até 2 minutos (pesquisa + fact-check)."
+    );
     try {
       const res = await fetch("/api/instagram/gerar", {
         method: "POST",
         headers: apiHeaders({ "Content-Type": "application/json" }),
-        body: JSON.stringify({ postId: id }),
+        body: JSON.stringify({ postId: id, detalhesExtras: temDetalhes ? detalhes : undefined }),
       });
       const j = await res.json();
       if (!res.ok || !j.ok) {
@@ -126,7 +135,11 @@ export default function InstagramPostPage() {
       if (j.data.slides_json) setSlidesEdit(j.data.slides_json);
       if (j.data.legenda) setLegendaEdit(j.data.legenda);
       if (j.data.hashtags) setHashtagsEdit(j.data.hashtags.join(" "));
-      setMsg("Gerado com sucesso.");
+      setMsg(temDetalhes ? "Re-gerado com seus detalhes incorporados." : "Gerado com sucesso.");
+      if (temDetalhes) {
+        setDetalhesExtras("");
+        setMostrandoDetalhes(false);
+      }
     } catch (e) {
       setMsg("Erro de rede: " + (e instanceof Error ? e.message : String(e)));
     } finally {
@@ -462,7 +475,7 @@ export default function InstagramPostPage() {
             Clique pra a IA pesquisar o tema, verificar os fatos em múltiplas fontes e montar os {post.numero_slides} slides do carrossel.
           </p>
           <button
-            onClick={gerar}
+            onClick={() => gerar()}
             disabled={gerando}
             className="px-5 py-2.5 rounded-xl bg-[#E8740E] text-white font-semibold hover:bg-[#F5A623] transition-colors disabled:opacity-50"
           >
@@ -485,11 +498,18 @@ export default function InstagramPostPage() {
             {podeEditar && (
               <div className="flex gap-2 flex-wrap">
                 <button
-                  onClick={gerar}
+                  onClick={() => gerar()}
                   disabled={gerando}
                   className="px-3 py-1.5 rounded-xl border border-[#D2D2D7] text-xs text-[#6E6E73] hover:bg-[#F5F5F7] disabled:opacity-50"
                 >
                   {gerando ? "Gerando..." : "🔄 Re-gerar texto"}
+                </button>
+                <button
+                  onClick={() => setMostrandoDetalhes(v => !v)}
+                  disabled={gerando}
+                  className="px-3 py-1.5 rounded-xl border border-[#4F46E5] text-xs text-[#4338CA] hover:bg-[#EEF2FF] disabled:opacity-50"
+                >
+                  {mostrandoDetalhes ? "✖ Fechar detalhes" : "✍️ Adicionar detalhes"}
                 </button>
                 <button
                   onClick={() => salvarEdicao()}
@@ -508,6 +528,40 @@ export default function InstagramPostPage() {
               </div>
             )}
           </div>
+
+          {/* Adicionar detalhes e re-gerar */}
+          {podeEditar && mostrandoDetalhes && (
+            <div className="bg-[#EEF2FF] border border-[#4F46E5]/30 rounded-2xl p-4 mb-4">
+              <h3 className="text-sm font-semibold text-[#1D1D1F] mb-1">✍️ Adicionar mais detalhes</h3>
+              <p className="text-xs text-[#6E6E73] mb-3">
+                Escreva o que você quer que seja incluído/ajustado no carrossel. A IA vai pegar o texto atual + o que você escrever aqui e refazer os slides incorporando seus pontos.
+              </p>
+              <textarea
+                value={detalhesExtras}
+                onChange={e => setDetalhesExtras(e.target.value)}
+                placeholder="Ex: menciona também que temos em estoque no RJ para retirada imediata; destaca que aceitamos trade-in; o modelo Ultra tem botão Action dedicado..."
+                rows={5}
+                className="w-full px-3 py-2 rounded-xl border border-[#D2D2D7] text-sm text-[#1D1D1F] bg-white focus:outline-none focus:border-[#4F46E5]"
+                disabled={gerando}
+              />
+              <div className="flex gap-2 mt-3 justify-end">
+                <button
+                  onClick={() => { setDetalhesExtras(""); setMostrandoDetalhes(false); }}
+                  disabled={gerando}
+                  className="px-3 py-1.5 rounded-xl border border-[#D2D2D7] text-xs text-[#6E6E73] hover:bg-[#F5F5F7] disabled:opacity-50"
+                >
+                  Cancelar
+                </button>
+                <button
+                  onClick={() => gerar(detalhesExtras)}
+                  disabled={gerando || !detalhesExtras.trim()}
+                  className="px-4 py-1.5 rounded-xl bg-[#4F46E5] text-white text-xs font-semibold hover:bg-[#4338CA] disabled:opacity-50"
+                >
+                  {gerando ? "Re-gerando..." : "🔄 Re-gerar com detalhes"}
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Ilustrar slides */}
           {podeEditar && (

--- a/app/api/instagram/gerar/route.ts
+++ b/app/api/instagram/gerar/route.ts
@@ -252,7 +252,7 @@ export async function POST(req: NextRequest) {
   const supabase = getSupabase();
   try {
     const body = await req.json();
-    const { postId } = body;
+    const { postId, detalhesExtras } = body as { postId?: string; detalhesExtras?: string };
     if (!postId) return NextResponse.json({ error: "postId obrigatório" }, { status: 400 });
 
     const { data: post, error: fetchErr } = await supabase
@@ -267,7 +267,23 @@ export async function POST(req: NextRequest) {
     await supabase.from("instagram_posts").update({ status: "GERANDO", erro: null, updated_at: new Date().toISOString() }).eq("id", postId);
 
     const systemPrompt = buildSystemPrompt(post.tipo, post.numero_slides, post.estilo || "PADRAO");
-    const userPrompt = `Tema do post: "${post.tema}"\n\nPesquise, verifique os fatos e monte o carrossel. Chame salvar_post no final.`;
+
+    const detalhesTrim = (detalhesExtras || "").trim();
+    const temDetalhes = detalhesTrim.length > 0 && !!post.slides_json && Array.isArray(post.slides_json) && post.slides_json.length > 0;
+
+    const userPrompt = temDetalhes
+      ? `Tema do post: "${post.tema}"
+
+CARROSSEL ATUAL (já gerado anteriormente — use como base, mantenha o que está bom):
+${JSON.stringify({ slides: post.slides_json, legenda: post.legenda, hashtags: post.hashtags }, null, 2)}
+
+INFORMAÇÕES ADICIONAIS QUE O USUÁRIO QUER INCLUIR (OBRIGATÓRIO incorporar no carrossel refeito — não omita):
+"""
+${detalhesTrim}
+"""
+
+Refaça o carrossel incorporando as informações adicionais acima. Mantenha a estrutura, tom e fatos já verificados, mas ajuste/expanda o conteúdo para incluir os pontos trazidos pelo usuário. Pode reorganizar slides se fizer sentido. Continue seguindo as regras de fact-check (web_search se precisar validar algum fato novo trazido pelo usuário). Chame salvar_post no final.`
+      : `Tema do post: "${post.tema}"\n\nPesquise, verifique os fatos e monte o carrossel. Chame salvar_post no final.`;
 
     const messages: Anthropic.MessageParam[] = [{ role: "user", content: userPrompt }];
 


### PR DESCRIPTION
## Summary

- Adiciona botão **✍️ Adicionar detalhes** ao lado do "Re-gerar texto" na página de edição de post do Instagram
- Quando o André/Nicolas clica, abre um card com textarea pra escrever informações adicionais que ele quer incluir
- A IA refaz o carrossel pegando o texto atual **+** os novos detalhes como contexto obrigatório

## Motivação

Hoje só dava pra "Re-gerar texto" do zero — perdendo o que já estava bom. Agora é possível adicionar informações da cabeça sem perder o trabalho da primeira geração.

## Mudanças

**Backend** (`app/api/instagram/gerar/route.ts`):
- Aceita campo opcional `detalhesExtras: string` no body
- Quando vem com slides já gerados, monta um prompt que mostra o carrossel atual como base e marca os detalhes do usuário como OBRIGATÓRIO incorporar

**Frontend** (`app/admin/instagram/[id]/page.tsx`):
- Novo botão "✍️ Adicionar detalhes" ao lado de "Re-gerar texto"
- Card expansível com textarea (5 linhas) + botões Cancelar / 🔄 Re-gerar com detalhes
- Mensagem de status ajustada pra indicar que está re-gerando com detalhes

## Test plan

- [ ] Abrir um post já gerado em `/admin/instagram/[id]`
- [ ] Clicar "✍️ Adicionar detalhes" → card deve aparecer com textarea
- [ ] Escrever algo como "mencionar que temos estoque pra retirada no RJ"
- [ ] Clicar "🔄 Re-gerar com detalhes" → aguardar ~2min → slides devem vir refeitos incluindo o ponto
- [ ] Confirmar que "Re-gerar texto" sem detalhes continua funcionando como antes (do zero)
- [ ] Botão "Cancelar" fecha o card e limpa o textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)