### PR TITLE
feat(compra): IMEI/Serial digitaveis + prints obrigatorios no formulario de troca

### DIFF
--- a/app/api/create-mp-from-form/route.ts
+++ b/app/api/create-mp-from-form/route.ts
@@ -62,6 +62,8 @@ interface CreateMpFromFormBody {
       valor?: number;
       condicao?: string;
       caixa?: boolean;
+      serial?: string;
+      imei?: string;
     }>;
     descricaoLivre?: string;
   };
@@ -202,6 +204,11 @@ export async function POST(req: NextRequest) {
     troca_valor: Number(body.troca?.aparelhos?.[0]?.valor) || 0,
     troca_produto2: body.troca?.aparelhos?.[1]?.modelo || null,
     troca_valor2: Number(body.troca?.aparelhos?.[1]?.valor) || 0,
+    // IMEI/Serial digitados pelo cliente (prints anexados ficam em troca_print_*_url)
+    troca_serial: body.troca?.aparelhos?.[0]?.serial || null,
+    troca_imei: body.troca?.aparelhos?.[0]?.imei || null,
+    troca_serial2: body.troca?.aparelhos?.[1]?.serial || null,
+    troca_imei2: body.troca?.aparelhos?.[1]?.imei || null,
     // Snapshot completo
     cliente_dados_preenchidos: snapshot,
     // IMPORTANTE: NÃO setamos cliente_preencheu_em aqui. Esse timestamp só

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -389,6 +389,14 @@ function CompraForm() {
   const [printsErro, setPrintsErro] = useState<Record<string, string>>({});
   const temSegundoAparelho = !!trocaProduto2Param;
 
+  // Cliente digita o IMEI e Nº de Série dos aparelhos na troca (campo texto
+  // ao lado do print — o print serve como comprovação visual, o texto fica
+  // disponível pronto pro contrato/venda e aparece no WhatsApp do pedido).
+  const [trocaSerial1, setTrocaSerial1] = useState("");
+  const [trocaImei1, setTrocaImei1] = useState("");
+  const [trocaSerial2, setTrocaSerial2] = useState("");
+  const [trocaImei2, setTrocaImei2] = useState("");
+
   async function uploadPrint(slot: PrintSlot, file: File) {
     if (!shortCode) {
       setPrintsErro((p) => ({ ...p, [`${slot.tipo}${slot.aparelho}`]: "Link de compra inválido" }));
@@ -544,6 +552,25 @@ function CompraForm() {
         }
         return;
       }
+
+      // Valida IMEI/Serial digitados (mínimo 6 chars, sem espaços/traços contados).
+      // IMEI tem 15 dígitos, Serial varia (iPhone antigo: 11-12 chars; novo: até 12).
+      // Usamos 6 como limite seguro contra preenchimento preguiçoso ("123").
+      const soDigitos = (s: string) => s.replace(/\D/g, "");
+      const serial1Ok = trocaSerial1.trim().length >= 6;
+      const imei1Ok = soDigitos(trocaImei1).length >= 14;
+      const serial2Ok = !temSegundoAparelho || trocaSerial2.trim().length >= 6;
+      const imei2Ok = !temSegundoAparelho || soDigitos(trocaImei2).length >= 14;
+      if (!serial1Ok || !imei1Ok || !serial2Ok || !imei2Ok) {
+        const el = document.getElementById("prints-troca");
+        if (el) {
+          el.scrollIntoView({ behavior: "smooth", block: "center" });
+          el.classList.add("ring-4", "ring-red-500", "animate-pulse");
+          setTimeout(() => el.classList.remove("ring-4", "ring-red-500", "animate-pulse"), 3000);
+        }
+        alert("Digite o Nº de Série e o IMEI de cada aparelho na troca. O IMEI tem 15 dígitos — você encontra nos prints que enviou.");
+        return;
+      }
     }
 
     // Janela de agendamento: rejeita datas fora de [min, max] e domingos.
@@ -695,6 +722,8 @@ function CompraForm() {
         if (trocaNum1 > 0) lines.push(`*Valor avaliado:* R$ ${fmt(trocaNum1)}`);
         if (trocaCond) lines.push(`*Condição:* ${trocaCond}`);
         if (trocaCaixaParam) lines.push(`*Caixa original:* ${trocaCaixaParam === "1" ? "Sim" : "Não"}`);
+        if (trocaSerial1.trim()) lines.push(`*Nº de Série:* ${trocaSerial1.trim()}`);
+        if (trocaImei1.trim()) lines.push(`*IMEI:* ${trocaImei1.trim()}`);
       } else if (descTroca) {
         lines.push(`*Modelo:* ${descTroca}`);
       }
@@ -706,6 +735,8 @@ function CompraForm() {
         if (trocaNum2 > 0) lines.push(`*Valor avaliado:* R$ ${fmt(trocaNum2)}`);
         if (trocaCond2Param) lines.push(`*Condição:* ${trocaCond2Param}`);
         if (trocaCaixa2Param) lines.push(`*Caixa original:* ${trocaCaixa2Param === "1" ? "Sim" : "Não"}`);
+        if (trocaSerial2.trim()) lines.push(`*Nº de Série:* ${trocaSerial2.trim()}`);
+        if (trocaImei2.trim()) lines.push(`*IMEI:* ${trocaImei2.trim()}`);
       }
       if (valorBase > 0) { lines.push(""); lines.push(`*Diferença a pagar:* R$ ${fmt(valorBase)}`); }
     }
@@ -751,6 +782,10 @@ function CompraForm() {
           forma_pagamento: pagLines.join(" | "),
           local: localStr, horario, data_entrega: dataEntrega,
           vendedor, origem,
+          troca_serial: temTroca ? trocaSerial1.trim() : "",
+          troca_imei: temTroca ? trocaImei1.trim() : "",
+          troca_serial2: temTroca && temSegundoAparelho ? trocaSerial2.trim() : "",
+          troca_imei2: temTroca && temSegundoAparelho ? trocaImei2.trim() : "",
           website: honeypot,
         },
       });
@@ -886,6 +921,8 @@ function CompraForm() {
                         valor: trocaNum1,
                         condicao: trocaCondParam,
                         caixa: trocaCaixaParam === "1",
+                        serial: trocaSerial1.trim() || undefined,
+                        imei: trocaImei1.trim() || undefined,
                       }]
                     : []),
                   ...(trocaProduto2Param
@@ -895,6 +932,8 @@ function CompraForm() {
                         valor: trocaNum2,
                         condicao: trocaCond2Param,
                         caixa: trocaCaixa2Param === "1",
+                        serial: trocaSerial2.trim() || undefined,
+                        imei: trocaImei2.trim() || undefined,
                       }]
                     : []),
                 ],
@@ -1576,11 +1615,12 @@ function CompraForm() {
             quanto quando o cliente marca troca manualmente */}
         {temTroca && shortCode && (
           <div className={cardCls}>
-            <p className={sectionTitle}>📸 Prints do seu aparelho (obrigatório)</p>
+            <p className={sectionTitle}>📸 Nº de Série e IMEI do seu aparelho (obrigatório)</p>
             <div id="prints-troca" className="p-4 rounded-xl bg-amber-50 border-2 border-amber-300 transition-all">
               <p className="text-xs text-[#6E6E73] mb-3">
-                No seu iPhone, vá em <strong>Ajustes → Geral → Sobre</strong> e tire 2 prints:
-                um mostrando o <strong>Nº de Série</strong> e outro mostrando o <strong>IMEI</strong>.
+                No seu iPhone, vá em <strong>Ajustes → Geral → Sobre</strong>. Para cada aparelho da troca,
+                <strong> digite</strong> os números do <strong>Nº de Série</strong> e <strong>IMEI</strong>,
+                e <strong>anexe 2 prints</strong> da tela (um mostrando o Nº de Série e outro o IMEI) como prova.
               </p>
 
               {/* Explicação do POR QUE pedimos essa info — passa segurança ao cliente */}
@@ -1606,13 +1646,37 @@ function CompraForm() {
                 const url = printsUrls[key];
                 const uploading = printsUploading[key];
                 const erro = printsErro[key];
+                // Valor digitado + setter do input de texto do mesmo slot
+                const textValue =
+                  slot.aparelho === 1
+                    ? (slot.tipo === "serial" ? trocaSerial1 : trocaImei1)
+                    : (slot.tipo === "serial" ? trocaSerial2 : trocaImei2);
+                const setTextValue = (v: string) => {
+                  if (slot.aparelho === 1) {
+                    if (slot.tipo === "serial") setTrocaSerial1(v); else setTrocaImei1(v);
+                  } else {
+                    if (slot.tipo === "serial") setTrocaSerial2(v); else setTrocaImei2(v);
+                  }
+                };
+                const isImei = slot.tipo === "imei";
+                const placeholder = isImei ? "Digite os 15 dígitos do IMEI" : "Digite o Nº de Série";
                 return (
                   <div key={key} className="mb-3 last:mb-0">
                     <label className="block text-xs font-medium text-[#1D1D1F] mb-1.5">{slot.label} *</label>
+                    <input
+                      type="text"
+                      inputMode={isImei ? "numeric" : "text"}
+                      autoComplete="off"
+                      value={textValue}
+                      onChange={(e) => setTextValue(e.target.value)}
+                      placeholder={placeholder}
+                      maxLength={isImei ? 20 : 30}
+                      className="w-full px-3 py-2 mb-2 rounded-lg border border-[#D2D2D7] text-sm text-[#1D1D1F] bg-white focus:outline-none focus:border-[#E8740E]"
+                    />
                     {url ? (
                       <div className="flex items-center gap-2">
                         <img src={url} alt={slot.label} className="w-14 h-14 rounded-lg object-cover border border-[#D2D2D7]" />
-                        <span className="text-xs text-green-600 font-semibold">✓ Enviado</span>
+                        <span className="text-xs text-green-600 font-semibold">✓ Print enviado</span>
                         <button
                           type="button"
                           onClick={() => setPrintsUrls((p) => { const n = { ...p }; delete n[key]; return n; })}
@@ -1635,7 +1699,7 @@ function CompraForm() {
                           }}
                         />
                         <span className="text-sm text-[#E8740E] font-semibold">
-                          {uploading ? "⏳ Enviando..." : "📤 Toque aqui pra escolher o print"}
+                          {uploading ? "⏳ Enviando..." : "📤 Anexar print como prova"}
                         </span>
                       </label>
                     )}
@@ -1644,11 +1708,14 @@ function CompraForm() {
                 );
               })}
 
-              {/* Aviso sobre o Termo de Procedência (aparece quando todos os prints foram enviados) */}
+              {/* Aviso sobre o Termo de Procedência (aparece quando todos os prints + textos foram preenchidos) */}
               {(() => {
-                const todosEnviados = temSegundoAparelho
+                const textosOk1 = trocaSerial1.trim().length >= 6 && trocaImei1.replace(/\D/g, "").length >= 14;
+                const textosOk2 = !temSegundoAparelho || (trocaSerial2.trim().length >= 6 && trocaImei2.replace(/\D/g, "").length >= 14);
+                const printsOk = temSegundoAparelho
                   ? !!(printsUrls.serial1 && printsUrls.imei1 && printsUrls.serial2 && printsUrls.imei2)
                   : !!(printsUrls.serial1 && printsUrls.imei1);
+                const todosEnviados = printsOk && textosOk1 && textosOk2;
                 if (!todosEnviados) return null;
                 return (
                   <div className="mt-4 p-3 rounded-lg bg-green-50 border-2 border-green-300">

--- a/app/pagamento-confirmado/page.tsx
+++ b/app/pagamento-confirmado/page.tsx
@@ -183,6 +183,8 @@ function buildPedidoData(
       valor?: number;
       condicao?: string;
       caixa?: boolean;
+      serial?: string;
+      imei?: string;
     }>;
     descricaoLivre?: string;
   } | null;

--- a/lib/formatPedido.ts
+++ b/lib/formatPedido.ts
@@ -61,6 +61,8 @@ export interface PedidoTrocaItem {
   valor?: number;
   condicao?: string;
   caixa?: boolean;
+  serial?: string;
+  imei?: string;
 }
 
 export interface PedidoTroca {
@@ -266,6 +268,8 @@ export function formatPedidoMessage(
         if (ap.valor && ap.valor > 0) lines.push(`*Valor avaliado:* R$ ${fmt(ap.valor)}`);
         if (ap.condicao) lines.push(`*Condição:* ${ap.condicao}`);
         if (ap.caixa !== undefined) lines.push(`*Caixa original:* ${ap.caixa ? "Sim" : "Não"}`);
+        if (ap.serial && ap.serial.trim()) lines.push(`*Nº de Série:* ${ap.serial.trim()}`);
+        if (ap.imei && ap.imei.trim()) lines.push(`*IMEI:* ${ap.imei.trim()}`);
       });
     } else if (troca?.descricaoLivre) {
       lines.push(`*Modelo:* ${troca.descricaoLivre}`);

--- a/supabase/migrations/20260422_add_troca_imei_serial_link_compras.sql
+++ b/supabase/migrations/20260422_add_troca_imei_serial_link_compras.sql
@@ -1,0 +1,22 @@
+-- Adiciona campos digitáveis de IMEI e Nº de Série na tabela link_compras
+--
+-- Motivo: hoje o cliente anexa 2 prints (serial + IMEI) da tela Ajustes > Sobre,
+-- mas o número em si não fica digitado em lugar nenhum — a equipe tem que olhar
+-- a imagem e transcrever manualmente pro contrato/venda. Passamos a pedir o
+-- cliente digitar os números E anexar o print (o print vira comprovação visual).
+--
+-- Esses campos vão aparecer na mensagem de WhatsApp do formulário, abaixo da
+-- seção "APARELHO NA TROCA", pra facilitar a conferência pelo atendente.
+--
+-- Aparelho 2 existe quando o cliente troca 2 produtos (trocaProduto2Param).
+
+ALTER TABLE link_compras
+  ADD COLUMN IF NOT EXISTS troca_imei    TEXT,
+  ADD COLUMN IF NOT EXISTS troca_serial  TEXT,
+  ADD COLUMN IF NOT EXISTS troca_imei2   TEXT,
+  ADD COLUMN IF NOT EXISTS troca_serial2 TEXT;
+
+COMMENT ON COLUMN link_compras.troca_imei IS 'IMEI digitado pelo cliente (aparelho 1 da troca). Print em troca_print_imei_url serve como prova visual.';
+COMMENT ON COLUMN link_compras.troca_serial IS 'Nº de Série digitado pelo cliente (aparelho 1 da troca).';
+COMMENT ON COLUMN link_compras.troca_imei2 IS 'IMEI digitado pelo cliente (aparelho 2, quando há 2 produtos na troca).';
+COMMENT ON COLUMN link_compras.troca_serial2 IS 'Nº de Série digitado pelo cliente (aparelho 2).';


### PR DESCRIPTION
## Summary

- Cliente agora **digita** IMEI e Nº de Série dos aparelhos na troca (campos de texto novos no formulário)
- Continua **obrigatório anexar os 2 prints** como prova visual (serial + IMEI de Ajustes > Sobre)
- A mensagem de WhatsApp que chega pra equipe mostra IMEI/Serial logo abaixo de *APARELHO NA TROCA* — prontos pra copiar direto pro contrato/venda, sem transcrever do print

## Motivação (do André)

> Quando cliente for preencher o formulário de compra, que tem um produto usado na troca, é obrigatório ele anexar 2 prints da tela mostrando Número de série e IMEI. Gostaria que quando o formulário do cliente chegar no nosso WhatsApp ter essas duas informações inclusas no formulário, logo abaixo de *PRODUTO NA TROCA* aí vem as informações do produto incluindo número de série e IMEI.

Nesta primeira versão **sem OCR** — o cliente digita manualmente os números E anexa o print. Mais seguro e grátis. OCR automático pode vir numa fase 2 se a taxa de erro manual for alta.

## Mudanças

### Migration
[supabase/migrations/20260422_add_troca_imei_serial_link_compras.sql](https://github.com/tigraoimports-a11y/tigrao-tradein/blob/claude/prints-imei-whatsapp/supabase/migrations/20260422_add_troca_imei_serial_link_compras.sql) — adiciona colunas \`troca_imei\`, \`troca_serial\`, \`troca_imei2\`, \`troca_serial2\` em \`link_compras\`. Tabela \`vendas\` já tinha essas colunas.

⚠️ **Rodar em [/admin/migrations](https://tigrao-tradein.vercel.app/admin/migrations)** após merge.

### Frontend — [/compra](app/compra/page.tsx)
- 4 novos states (\`trocaSerial1/2\`, \`trocaImei1/2\`)
- Novos inputs dentro do card "📸 Nº de Série e IMEI do seu aparelho"
- Validação no submit: Serial >= 6 chars, IMEI >= 14 dígitos
- IMEI/Serial entram na mensagem WhatsApp abaixo de \`*APARELHO NA TROCA*\`
- Mesmas infos no payload beacon (\`cliente_dados_preenchidos\`) e no body do \`/api/create-mp-from-form\`

### Template WhatsApp — [lib/formatPedido.ts](lib/formatPedido.ts)
\`PedidoTrocaItem\` ganha campos opcionais \`serial\` e \`imei\`, que aparecem no final de cada aparelho com \`*Nº de Série:*\` e \`*IMEI:*\`.

### API MP — [app/api/create-mp-from-form/route.ts](app/api/create-mp-from-form/route.ts)
Interface atualizada e \`UPDATE link_compras\` persiste nas colunas dedicadas. \`/pagamento-confirmado\` também atualizado pra propagar no snapshot.

## Test plan

- [ ] Rodar migration em /admin/migrations
- [ ] Abrir formulário de compra com troca (ex: \`/compra?troca_produto=iPhone+13\&short=XXX\`)
- [ ] Scrollar até "📸 Nº de Série e IMEI" — confirmar que aparecem 2 inputs de texto + 2 uploads
- [ ] Tentar submeter sem digitar IMEI/Serial → alerta aparece
- [ ] Preencher tudo + submit → mensagem WhatsApp mostra \`*Nº de Série:* XXX\` e \`*IMEI:* YYY\` abaixo do aparelho
- [ ] Fluxo MP: preencher → "Pagar MP" → verificar que link_compras.troca_imei foi salvo no banco
- [ ] Quando cliente volta em /pagamento-confirmado, a mensagem também mostra IMEI/Serial

🤖 Generated with [Claude Code](https://claude.com/claude-code)