### PR TITLE
feat(compra): OCR automatico dos prints — Claude Vision le IMEI e Serial

### DIFF
--- a/app/api/link-compras/upload-print/route.ts
+++ b/app/api/link-compras/upload-print/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
 import { getSupabase } from "@/lib/supabase";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
 
 /**
  * Upload do print do iPhone (N° de Série ou IMEI) pra link_compras.
@@ -10,6 +14,11 @@ import { getSupabase } from "@/lib/supabase";
  *   short_code: código curto do link de compra
  *   tipo: "serial" | "imei"
  *   aparelho: "1" | "2" (qual aparelho da troca)
+ *
+ * Além de salvar o print, roda OCR com Claude Haiku Vision pra extrair
+ * o número digitado na tela "Ajustes > Geral > Sobre" e grava na coluna
+ * de texto correspondente (troca_serial, troca_imei, troca_serial2,
+ * troca_imei2). Retorna o valor extraído pro frontend exibir imediatamente.
  */
 export async function POST(req: NextRequest) {
   const supabase = getSupabase();
@@ -119,24 +128,142 @@ export async function POST(req: NextRequest) {
       .getPublicUrl(uploadData?.path || filename);
     const publicUrl = urlData?.publicUrl || "";
 
-    // Mapeia qual coluna atualizar
-    const col =
+    // OCR com Claude Haiku Vision: extrai o número digitado no print.
+    // Roda em paralelo com a gravação da URL no banco.
+    const extracted = await extractNumberFromPrint(buffer, file.type, tipo);
+
+    // Mapeia qual coluna da URL do print atualizar
+    const urlCol =
       tipo === "serial" && aparelhoNum === 1 ? "troca_print_serial_url" :
       tipo === "imei" && aparelhoNum === 1 ? "troca_print_imei_url" :
       tipo === "serial" && aparelhoNum === 2 ? "troca_print_serial2_url" :
       "troca_print_imei2_url";
 
+    // Mapeia qual coluna de texto (IMEI/Serial digitado) atualizar
+    const textCol =
+      tipo === "serial" && aparelhoNum === 1 ? "troca_serial" :
+      tipo === "imei" && aparelhoNum === 1 ? "troca_imei" :
+      tipo === "serial" && aparelhoNum === 2 ? "troca_serial2" :
+      "troca_imei2";
+
+    const updatePayload: Record<string, string> = { [urlCol]: publicUrl };
+    if (extracted.ok && extracted.value) {
+      updatePayload[textCol] = extracted.value;
+    }
+
     const { error: updateError } = await supabase
       .from("link_compras")
-      .update({ [col]: publicUrl })
+      .update(updatePayload)
       .eq("id", link.id);
 
     if (updateError) {
       return NextResponse.json({ error: updateError.message }, { status: 500 });
     }
 
-    return NextResponse.json({ url: publicUrl, field: col, ok: true });
+    return NextResponse.json({
+      ok: true,
+      url: publicUrl,
+      field: urlCol,
+      extracted: extracted.value || null,
+      extractedOk: extracted.ok,
+      extractedError: extracted.ok ? null : extracted.error,
+    });
   } catch (e) {
     return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}
+
+// ============================================================
+// OCR via Claude Haiku Vision
+// ============================================================
+// Recebe o buffer da imagem + tipo (serial|imei) e retorna o número
+// extraído da tela "Ajustes > Geral > Sobre" do iPhone.
+//
+// Modelo: claude-haiku-4-5 (rápido, barato ~$0.01/imagem, suficiente
+// pra leitura de números de tela Apple com alta legibilidade).
+//
+// Fallback: se falhar (API fora, imagem ilegível, timeout), retorna
+// { ok: false } e o frontend permite o cliente digitar manualmente.
+// ============================================================
+interface ExtractResult {
+  ok: boolean;
+  value?: string;
+  error?: string;
+}
+
+async function extractNumberFromPrint(
+  buffer: Buffer,
+  mediaType: string,
+  tipo: "serial" | "imei"
+): Promise<ExtractResult> {
+  try {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      return { ok: false, error: "ANTHROPIC_API_KEY não configurado" };
+    }
+
+    // Claude aceita apenas image/jpeg, image/png, image/gif, image/webp
+    const supportedTypes: Record<string, "image/jpeg" | "image/png" | "image/gif" | "image/webp"> = {
+      "image/jpeg": "image/jpeg",
+      "image/jpg": "image/jpeg",
+      "image/png": "image/png",
+      "image/gif": "image/gif",
+      "image/webp": "image/webp",
+    };
+    const mt = supportedTypes[mediaType.toLowerCase()] || "image/png";
+
+    const base64 = buffer.toString("base64");
+    const client = new Anthropic({ apiKey });
+
+    const prompt = tipo === "imei"
+      ? `Esta é uma captura de tela do iPhone na tela "Ajustes > Geral > Sobre". Extraia APENAS o IMEI (15 dígitos, geralmente aparece como "IMEI" ou "IMEI 1"). Retorne SOMENTE os 15 dígitos sem espaços, traços, pontos ou qualquer outro caractere. Se houver múltiplos IMEIs, retorne o primeiro. Se não conseguir identificar o IMEI com certeza, retorne exatamente "NAO_ENCONTRADO".`
+      : `Esta é uma captura de tela do iPhone na tela "Ajustes > Geral > Sobre". Extraia APENAS o Número de Série (aparece como "Número de Série" ou "Serial Number"). Retorne SOMENTE o código alfanumérico (letras e números, sem espaços ou traços). Se não conseguir identificar o Número de Série com certeza, retorne exatamente "NAO_ENCONTRADO".`;
+
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: 100,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: { type: "base64", media_type: mt, data: base64 },
+            },
+            { type: "text", text: prompt },
+          ],
+        },
+      ],
+    });
+
+    const text = response.content
+      .filter((b): b is Anthropic.TextBlock => b.type === "text")
+      .map((b) => b.text)
+      .join("")
+      .trim();
+
+    if (!text || text === "NAO_ENCONTRADO") {
+      return { ok: false, error: "Não foi possível ler o número do print" };
+    }
+
+    // Sanitiza: remove espaços, traços, pontos
+    const cleaned = text.replace(/[\s\-.]/g, "");
+
+    // Validação mínima por tipo
+    if (tipo === "imei") {
+      const digits = cleaned.replace(/\D/g, "");
+      if (digits.length < 14 || digits.length > 17) {
+        return { ok: false, error: `IMEI com ${digits.length} dígitos (esperado 15)` };
+      }
+      return { ok: true, value: digits };
+    }
+    // serial: alfanumérico, tipicamente 10-12 chars
+    if (cleaned.length < 6 || cleaned.length > 20) {
+      return { ok: false, error: `Serial com ${cleaned.length} chars (fora do esperado)` };
+    }
+    return { ok: true, value: cleaned };
+  } catch (err) {
+    console.error("[upload-print:ocr]", err);
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
 }

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -389,13 +389,31 @@ function CompraForm() {
   const [printsErro, setPrintsErro] = useState<Record<string, string>>({});
   const temSegundoAparelho = !!trocaProduto2Param;
 
-  // Cliente digita o IMEI e Nº de Série dos aparelhos na troca (campo texto
-  // ao lado do print — o print serve como comprovação visual, o texto fica
-  // disponível pronto pro contrato/venda e aparece no WhatsApp do pedido).
+  // IMEI e Nº de Série dos aparelhos na troca.
+  // Fluxo: cliente anexa o print → backend usa Claude Vision pra ler o
+  // número automaticamente → valor aparece preenchido aqui (read-only por
+  // default, com botão "Corrigir" como fallback se o OCR errar).
   const [trocaSerial1, setTrocaSerial1] = useState("");
   const [trocaImei1, setTrocaImei1] = useState("");
   const [trocaSerial2, setTrocaSerial2] = useState("");
   const [trocaImei2, setTrocaImei2] = useState("");
+
+  // Resultado do OCR por slot (serial1/imei1/serial2/imei2).
+  // "ok" = OCR conseguiu ler; "fail" = OCR falhou (cliente digita manual).
+  type OcrStatus = { state: "idle" | "reading" | "ok" | "fail"; error?: string };
+  const [ocrStatus, setOcrStatus] = useState<Record<string, OcrStatus>>({});
+  // Controla se o cliente abriu o input manual via "Corrigir" (mesmo quando OCR deu certo).
+  const [manualMode, setManualMode] = useState<Record<string, boolean>>({});
+
+  function setTextBySlot(slot: PrintSlot, value: string) {
+    if (slot.aparelho === 1) {
+      if (slot.tipo === "serial") setTrocaSerial1(value);
+      else setTrocaImei1(value);
+    } else {
+      if (slot.tipo === "serial") setTrocaSerial2(value);
+      else setTrocaImei2(value);
+    }
+  }
 
   async function uploadPrint(slot: PrintSlot, file: File) {
     if (!shortCode) {
@@ -405,6 +423,7 @@ function CompraForm() {
     const key = `${slot.tipo}${slot.aparelho}`;
     setPrintsUploading((p) => ({ ...p, [key]: true }));
     setPrintsErro((p) => ({ ...p, [key]: "" }));
+    setOcrStatus((p) => ({ ...p, [key]: { state: "reading" } }));
     try {
       const fd = new FormData();
       fd.append("file", file);
@@ -422,11 +441,20 @@ function CompraForm() {
       const json = await res.json();
       if (json.ok) {
         setPrintsUrls((p) => ({ ...p, [key]: json.url }));
+        if (json.extractedOk && json.extracted) {
+          setTextBySlot(slot, json.extracted);
+          setOcrStatus((p) => ({ ...p, [key]: { state: "ok" } }));
+        } else {
+          setOcrStatus((p) => ({ ...p, [key]: { state: "fail", error: json.extractedError || "Não consegui ler o print" } }));
+          setManualMode((p) => ({ ...p, [key]: true }));
+        }
       } else {
         setPrintsErro((p) => ({ ...p, [key]: json.error || "Falha no upload" }));
+        setOcrStatus((p) => ({ ...p, [key]: { state: "idle" } }));
       }
     } catch {
       setPrintsErro((p) => ({ ...p, [key]: "Erro ao enviar" }));
+      setOcrStatus((p) => ({ ...p, [key]: { state: "idle" } }));
     } finally {
       setPrintsUploading((p) => ({ ...p, [key]: false }));
     }
@@ -553,9 +581,9 @@ function CompraForm() {
         return;
       }
 
-      // Valida IMEI/Serial digitados (mínimo 6 chars, sem espaços/traços contados).
-      // IMEI tem 15 dígitos, Serial varia (iPhone antigo: 11-12 chars; novo: até 12).
-      // Usamos 6 como limite seguro contra preenchimento preguiçoso ("123").
+      // Valida que o IMEI e Nº de Série foram extraídos com sucesso (via OCR
+      // ou preenchidos manualmente quando OCR falha). Serial mínimo 6 chars,
+      // IMEI mínimo 14 dígitos (IMEI tem 15, aceita 14+ pra tolerar 1 falha do OCR).
       const soDigitos = (s: string) => s.replace(/\D/g, "");
       const serial1Ok = trocaSerial1.trim().length >= 6;
       const imei1Ok = soDigitos(trocaImei1).length >= 14;
@@ -568,7 +596,7 @@ function CompraForm() {
           el.classList.add("ring-4", "ring-red-500", "animate-pulse");
           setTimeout(() => el.classList.remove("ring-4", "ring-red-500", "animate-pulse"), 3000);
         }
-        alert("Digite o Nº de Série e o IMEI de cada aparelho na troca. O IMEI tem 15 dígitos — você encontra nos prints que enviou.");
+        alert("Não conseguimos ler o Nº de Série ou o IMEI em algum dos prints. Tire novos prints mais nítidos (tela do iPhone em Ajustes > Geral > Sobre) ou use o botão 'Corrigir' pra digitar manualmente.");
         return;
       }
     }
@@ -1642,9 +1670,9 @@ function CompraForm() {
             <p className={sectionTitle}>📸 Nº de Série e IMEI do seu aparelho (obrigatório)</p>
             <div id="prints-troca" className="p-4 rounded-xl bg-amber-50 border-2 border-amber-300 transition-all">
               <p className="text-xs text-[#6E6E73] mb-3">
-                No seu iPhone, vá em <strong>Ajustes → Geral → Sobre</strong>. Para cada aparelho da troca,
-                <strong> digite</strong> os números do <strong>Nº de Série</strong> e <strong>IMEI</strong>,
-                e <strong>anexe 2 prints</strong> da tela (um mostrando o Nº de Série e outro o IMEI) como prova.
+                No seu iPhone, vá em <strong>Ajustes → Geral → Sobre</strong> e tire <strong>2 prints</strong>:
+                um mostrando o <strong>Nº de Série</strong> e outro o <strong>IMEI</strong>. Nosso sistema lê
+                os números automaticamente — você só precisa anexar os prints.
               </p>
 
               {/* Explicação do POR QUE pedimos essa info — passa segurança ao cliente */}
@@ -1670,40 +1698,30 @@ function CompraForm() {
                 const url = printsUrls[key];
                 const uploading = printsUploading[key];
                 const erro = printsErro[key];
-                // Valor digitado + setter do input de texto do mesmo slot
+                const ocr = ocrStatus[key] || { state: "idle" };
+                const isManual = manualMode[key] === true;
                 const textValue =
                   slot.aparelho === 1
                     ? (slot.tipo === "serial" ? trocaSerial1 : trocaImei1)
                     : (slot.tipo === "serial" ? trocaSerial2 : trocaImei2);
-                const setTextValue = (v: string) => {
-                  if (slot.aparelho === 1) {
-                    if (slot.tipo === "serial") setTrocaSerial1(v); else setTrocaImei1(v);
-                  } else {
-                    if (slot.tipo === "serial") setTrocaSerial2(v); else setTrocaImei2(v);
-                  }
-                };
                 const isImei = slot.tipo === "imei";
                 const placeholder = isImei ? "Digite os 15 dígitos do IMEI" : "Digite o Nº de Série";
+                const tipoLabel = isImei ? "IMEI" : "Nº de Série";
                 return (
                   <div key={key} className="mb-3 last:mb-0">
                     <label className="block text-xs font-medium text-[#1D1D1F] mb-1.5">{slot.label} *</label>
-                    <input
-                      type="text"
-                      inputMode={isImei ? "numeric" : "text"}
-                      autoComplete="off"
-                      value={textValue}
-                      onChange={(e) => setTextValue(e.target.value)}
-                      placeholder={placeholder}
-                      maxLength={isImei ? 20 : 30}
-                      className="w-full px-3 py-2 mb-2 rounded-lg border border-[#D2D2D7] text-sm text-[#1D1D1F] bg-white focus:outline-none focus:border-[#E8740E]"
-                    />
                     {url ? (
-                      <div className="flex items-center gap-2">
+                      <div className="flex items-center gap-2 mb-2">
                         <img src={url} alt={slot.label} className="w-14 h-14 rounded-lg object-cover border border-[#D2D2D7]" />
                         <span className="text-xs text-green-600 font-semibold">✓ Print enviado</span>
                         <button
                           type="button"
-                          onClick={() => setPrintsUrls((p) => { const n = { ...p }; delete n[key]; return n; })}
+                          onClick={() => {
+                            setPrintsUrls((p) => { const n = { ...p }; delete n[key]; return n; });
+                            setOcrStatus((p) => ({ ...p, [key]: { state: "idle" } }));
+                            setManualMode((p) => ({ ...p, [key]: false }));
+                            setTextBySlot(slot, "");
+                          }}
                           className="text-xs text-red-600 hover:underline ml-auto"
                         >
                           Trocar
@@ -1723,10 +1741,46 @@ function CompraForm() {
                           }}
                         />
                         <span className="text-sm text-[#E8740E] font-semibold">
-                          {uploading ? "⏳ Enviando..." : "📤 Anexar print como prova"}
+                          {uploading
+                            ? (ocr.state === "reading" ? "⏳ Lendo número..." : "⏳ Enviando...")
+                            : "📤 Anexar print"}
                         </span>
                       </label>
                     )}
+
+                    {/* Resultado do OCR (após upload) */}
+                    {url && ocr.state === "ok" && !isManual && (
+                      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-green-50 border border-green-300">
+                        <span className="text-xs text-green-800">
+                          ✓ <strong>{tipoLabel} detectado:</strong> <span className="font-mono">{textValue}</span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => setManualMode((p) => ({ ...p, [key]: true }))}
+                          className="text-[11px] text-[#6E6E73] hover:text-[#E8740E] hover:underline ml-auto"
+                        >
+                          Corrigir
+                        </button>
+                      </div>
+                    )}
+                    {url && ocr.state === "fail" && (
+                      <p className="text-xs text-amber-700 mb-1.5">
+                        ⚠️ Não consegui ler o {tipoLabel} do print. Digite manualmente abaixo.
+                      </p>
+                    )}
+                    {url && isManual && (
+                      <input
+                        type="text"
+                        inputMode={isImei ? "numeric" : "text"}
+                        autoComplete="off"
+                        value={textValue}
+                        onChange={(e) => setTextBySlot(slot, e.target.value)}
+                        placeholder={placeholder}
+                        maxLength={isImei ? 20 : 30}
+                        className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm text-[#1D1D1F] bg-white focus:outline-none focus:border-[#E8740E]"
+                      />
+                    )}
+
                     {erro && <p className="text-xs text-red-600 mt-1">{erro}</p>}
                   </div>
                 );


### PR DESCRIPTION
## Summary

Cliente **não precisa mais digitar** IMEI e Nº de Série. O sistema lê automaticamente do print usando **Claude Haiku Vision**:

1. Cliente anexa print do Nº de Série → backend envia a imagem pro Claude Haiku → UI mostra `✓ Nº de Série detectado: C39ABC123XY`
2. Mesmo com IMEI
3. Botão **Corrigir** discreto (pequeno, cinza) — só entra em cena se o OCR errar (print muito escuro, cortado etc)

## Por que dessa forma

Seu pedido direto: \"cliente só coloca o print, sistema capta e preenche\". Essa é exatamente a entrega.

**Salvaguarda:** se o OCR falhar (imagem ruim, número cortado, baixa luz), o campo de texto manual aparece automaticamente com aviso laranja \"⚠️ Não consegui ler. Digite manualmente\". Sem isso, número errado chega no WhatsApp sem o cliente poder consertar.

## Custo

**~R\$ 0,06 por formulário com troca** (2 prints × ~R\$ 0,03/imagem via Claude Haiku 4.5). Praticamente de graça.

## Mudanças

### Backend — [app/api/link-compras/upload-print/route.ts](app/api/link-compras/upload-print/route.ts)
- Após upload bem-sucedido, chama \`extractNumberFromPrint()\` com o buffer da imagem em memória (sem round-trip extra)
- Modelo: \`claude-haiku-4-5\` com prompt específico pra IMEI (15 dígitos) ou Serial (alfanumérico)
- Sanitização: remove espaços/traços/pontos; valida comprimento esperado
- Persiste direto em \`link_compras.troca_imei\` / \`troca_serial\` (colunas já existentes do PR #622)
- Retorno estendido: \`{ url, extracted, extractedOk, extractedError }\`

### Frontend — [app/compra/page.tsx](app/compra/page.tsx)
- Sem inputs de texto visíveis por default
- Novo estado \`ocrStatus\` por slot: \`idle / reading / ok / fail\`
- Durante upload: \"⏳ Lendo número...\"
- Sucesso: card verde com \`✓ [tipo] detectado: [valor]\` + botão \"Corrigir\" pequeno
- Falha: aviso âmbar \"⚠️ Não consegui ler — digite manualmente\" + input aparece
- Cliente pode clicar \"Corrigir\" pra trocar do OCR pro manual
- Botão \"Trocar\" print limpa OCR + texto + manual mode

### Texto instrucional atualizado
> \"Nosso sistema lê os números automaticamente — você só precisa anexar os prints.\"

## Test plan

- [ ] Abrir formulário de compra com troca (ex: \`/compra?troca_produto=iPhone+13\&short=XXX\`)
- [ ] Anexar print bom do Nº de Série → ver \"⏳ Lendo número...\" → \"✓ Nº de Série detectado: XXXX\"
- [ ] Anexar print do IMEI → mesmo fluxo com 15 dígitos
- [ ] Clicar \"Corrigir\" → input aparece com o valor pré-preenchido, editável
- [ ] Clicar \"Trocar\" → remove o print, limpa tudo
- [ ] Anexar imagem aleatória (não é tela Ajustes > Sobre) → OCR deve retornar \"fail\" e mostrar input manual
- [ ] Submeter → mensagem WhatsApp mostra IMEI/Serial corretos

🤖 Generated with [Claude Code](https://claude.com/claude-code)