### PR TITLE
feat(vendas): criar venda em andamento automatica ao preencher /compra

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -26,8 +26,8 @@ export default function VendasPage() {
   const [vendas, setVendas] = useState<Venda[]>([]);
   const [termosPorVenda, setTermosPorVenda] = useState<Record<string, { id: string; status: string; zapsign_sign_url?: string | null; signed_pdf_url?: string | null }>>({});
   const [loading, setLoading] = useState(true);
-  const VENDAS_TABS = ["nova", "andamento", "programadas", "hoje", "finalizadas", "correios"] as const;
-  const [tab, setTab] = useTabParam<"nova" | "andamento" | "programadas" | "hoje" | "finalizadas" | "correios">("nova", VENDAS_TABS);
+  const VENDAS_TABS = ["nova", "formularios", "andamento", "programadas", "hoje", "finalizadas", "correios"] as const;
+  const [tab, setTab] = useTabParam<"nova" | "formularios" | "andamento" | "programadas" | "hoje" | "finalizadas" | "correios">("nova", VENDAS_TABS);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [uploadingId, setUploadingId] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -2118,6 +2118,7 @@ export default function VendasPage() {
         <div className="flex gap-2">
           {([
             { key: "nova", label: "Nova Venda", count: 0, color: "bg-[#E8740E]", visible: podeVerHistorico || !!(user?.permissoes?.includes("vendas_registrar")) },
+            { key: "formularios", label: "📝 Formulários Preenchidos", count: vendas.filter(v => v.status_pagamento === "FORMULARIO_PREENCHIDO").length, color: "bg-indigo-500", visible: podeVerAndamento },
             { key: "andamento", label: "Em Andamento", count: vendas.filter(v => v.status_pagamento === "AGUARDANDO").length, color: "bg-yellow-500", visible: podeVerAndamento },
             { key: "hoje", label: "Finalizadas Hoje", count: vendas.filter(v => (v.status_pagamento === "FINALIZADO" || !v.status_pagamento) && (v.data_programada || v.data) === hojeStr).length, color: "bg-blue-500", visible: podeVerAndamento },
             { key: "finalizadas", label: "Histórico", count: vendas.filter(v => v.status_pagamento === "FINALIZADO" || !v.status_pagamento).length, color: "bg-green-600", visible: podeVerHistorico },
@@ -4534,6 +4535,8 @@ export default function VendasPage() {
           const hoje = hojeStr;
           const filteredRaw = (tab === "andamento"
             ? vendas.filter(v => v.status_pagamento === "AGUARDANDO")
+            : tab === "formularios"
+            ? vendas.filter(v => v.status_pagamento === "FORMULARIO_PREENCHIDO")
             : tab === "programadas"
             ? vendas.filter(v => v.status_pagamento === "PROGRAMADA")
             : tab === "hoje"
@@ -4579,7 +4582,7 @@ export default function VendasPage() {
           }
           const datasOrdenadas = [...vendasPorData.keys()].sort((a, b) => b.localeCompare(a));
 
-          const titulo = tab === "andamento" ? "Vendas em Andamento" : tab === "hoje" ? "Finalizadas Hoje" : tab === "correios" ? "📦 Envios pelos Correios" : tab === "programadas" ? "Vendas Programadas" : "Histórico de Vendas";
+          const titulo = tab === "andamento" ? "Vendas em Andamento" : tab === "formularios" ? "📝 Formulários Preenchidos pelo Cliente" : tab === "hoje" ? "Finalizadas Hoje" : tab === "correios" ? "📦 Envios pelos Correios" : tab === "programadas" ? "Vendas Programadas" : "Histórico de Vendas";
           const filteredFinanceiro = filtered.filter(v => v.status_pagamento !== "PROGRAMADA");
           const totalVendido = filteredFinanceiro.reduce((s, v) => s + (v.preco_vendido || 0), 0);
           const totalLucro = filteredFinanceiro.reduce((s, v) => s + (v.lucro || 0), 0);
@@ -4655,6 +4658,36 @@ export default function VendasPage() {
                   })()}
                   {selecionadas.size > 0 && (
                     <div className="flex gap-2">
+                      {tab === "formularios" && (
+                        <button
+                          disabled={finalizandoLote}
+                          onClick={async (e) => {
+                            e.stopPropagation();
+                            const ids = Array.from(selecionadas);
+                            if (ids.length === 0) return;
+                            if (!confirm(`Enviar ${ids.length} venda(s) para "Vendas Pendentes"?\n\nDepois disso cada venda vai aparecer na aba "Em Andamento" para finalização.`)) return;
+                            setFinalizandoLote(true);
+                            let ok = 0, fail = 0;
+                            for (const id of ids) {
+                              try {
+                                const res = await fetch("/api/vendas", {
+                                  method: "PATCH",
+                                  headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
+                                  body: JSON.stringify({ id, status_pagamento: "AGUARDANDO" }),
+                                });
+                                if (res.ok) ok++; else fail++;
+                              } catch { fail++; }
+                            }
+                            setVendas(prev => prev.map(v => ids.includes(v.id) ? { ...v, status_pagamento: "AGUARDANDO" } : v));
+                            setSelecionadas(new Set());
+                            setFinalizandoLote(false);
+                            setMsg(fail > 0 ? `${ok} enviada(s), ${fail} falha(s)` : `${ok} venda(s) enviada(s) para Pendentes!`);
+                          }}
+                          className="px-4 py-1.5 rounded-lg bg-yellow-500 text-white font-semibold hover:bg-yellow-600 transition-colors"
+                        >
+                          {finalizandoLote ? "Enviando..." : `➡️ Enviar ${selecionadas.size} para Pendentes`}
+                        </button>
+                      )}
                       {tab === "andamento" && (
                         <button
                           disabled={finalizandoLote}
@@ -4777,7 +4810,7 @@ export default function VendasPage() {
               ) : (
                 <div>
                   {filtered.length === 0 ? (
-                    <div className="px-4 py-8 text-center text-[#86868B]">Nenhuma venda {tab === "andamento" ? "em andamento" : tab === "hoje" ? "finalizada hoje" : tab === "correios" ? "com rastreio dos Correios" : "finalizada"}</div>
+                    <div className="px-4 py-8 text-center text-[#86868B]">Nenhuma venda {tab === "andamento" ? "em andamento" : tab === "formularios" ? "com formulário preenchido aguardando conferência" : tab === "hoje" ? "finalizada hoje" : tab === "correios" ? "com rastreio dos Correios" : "finalizada"}</div>
                   ) : datasOrdenadas.map((dataKey) => {
                     const vendasDoDia = vendasPorData.get(dataKey) || [];
                     const vendasDoDiaFinanceiro = vendasDoDia.filter(v => v.status_pagamento !== "PROGRAMADA");

--- a/app/api/vendas/from-formulario/route.ts
+++ b/app/api/vendas/from-formulario/route.ts
@@ -1,0 +1,233 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { rateLimitSubmission, checkHoneypot } from "@/lib/rate-limit";
+
+// ============================================================
+// POST /api/vendas/from-formulario
+// ============================================================
+// Endpoint PÚBLICO chamado pelo /compra no momento do submit (tanto
+// "Enviar no WhatsApp" quanto "Pagar com Mercado Pago").
+//
+// Cria uma venda rascunho em `vendas` com status_pagamento = FORMULARIO_PREENCHIDO
+// contendo TODOS os dados do formulário: cliente, produto, cor, troca (incluindo
+// IMEI/serial extraídos via OCR), forma de pagamento, etc. estoque_id fica NULL
+// até a equipe vincular o aparelho físico na aba "Formulários Preenchidos".
+//
+// Deduplicação: se já existe uma venda com esse short_code, ATUALIZA em vez de
+// criar duplicada (cliente pode submeter o formulário mais de uma vez, ex: corrige
+// endereço e reenvia).
+// ============================================================
+
+export const runtime = "nodejs";
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || "";
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+interface BodyIn {
+  shortCode: string;
+  // Cliente
+  nome?: string;
+  pessoa?: "PF" | "PJ";
+  cpf?: string;
+  cnpj?: string;
+  email?: string;
+  telefone?: string;
+  instagram?: string;
+  cep?: string;
+  endereco?: string;
+  numero?: string;
+  complemento?: string;
+  bairro?: string;
+  // Produto
+  produto: string;
+  cor?: string;
+  preco: number;
+  desconto?: number;
+  // Pagamento
+  formaPagamento?: string;
+  parcelas?: string | number;
+  entradaPix?: number;
+  // Troca
+  trocaProduto?: string;
+  trocaCor?: string;
+  trocaValor?: number;
+  trocaCondicao?: string;
+  trocaCaixa?: boolean;
+  trocaSerial?: string;
+  trocaImei?: string;
+  trocaProduto2?: string;
+  trocaCor2?: string;
+  trocaValor2?: number;
+  trocaCondicao2?: string;
+  trocaCaixa2?: boolean;
+  trocaSerial2?: string;
+  trocaImei2?: string;
+  // Entrega
+  localEntrega?: string;
+  dataEntrega?: string;
+  horarioEntrega?: string;
+  vendedor?: string;
+  origem?: string;
+  // Honeypot
+  website?: string;
+}
+
+// Forma de pagamento do formulário → campos canônicos de vendas
+function mapForma(formaPagamento?: string): { forma: string; banco: string; recebimento: string } {
+  const f = (formaPagamento || "").toUpperCase();
+  if (f.includes("PIX") && f.includes("CART")) return { forma: "PIX", banco: "ITAU", recebimento: "D+1" };
+  if (f.includes("PIX")) return { forma: "PIX", banco: "ITAU", recebimento: "D+0" };
+  if (f.includes("DEBITO") || f.includes("DÉBITO")) return { forma: "CARTAO", banco: "INFINITE", recebimento: "D+1" };
+  if (f.includes("CART")) return { forma: "CARTAO", banco: "INFINITE", recebimento: "PARCELADO" };
+  if (f.includes("DINHEIRO") || f.includes("ESPECIE")) return { forma: "DINHEIRO", banco: "ESPECIE", recebimento: "D+0" };
+  if (f.includes("MERCADO") || f.includes("MP") || f.includes("LINK")) return { forma: "PIX", banco: "MERCADO_PAGO", recebimento: "D+1" };
+  return { forma: "PIX", banco: "ITAU", recebimento: "D+0" };
+}
+
+export async function POST(req: NextRequest) {
+  const limited = rateLimitSubmission(req, "venda-formulario");
+  if (limited) return limited;
+
+  let body: BodyIn;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+  }
+
+  const honeypot = checkHoneypot(body as unknown as Record<string, unknown>);
+  if (honeypot) return honeypot;
+
+  if (!body.shortCode) {
+    return NextResponse.json({ error: "shortCode obrigatório" }, { status: 400 });
+  }
+  if (!body.produto) {
+    return NextResponse.json({ error: "produto obrigatório" }, { status: 400 });
+  }
+  if (!body.nome) {
+    return NextResponse.json({ error: "nome obrigatório" }, { status: 400 });
+  }
+
+  const supabase = getSupabase();
+
+  // Hoje local no fuso de SP (padrão do resto do sistema)
+  const hojeStr = new Date().toLocaleDateString("en-CA", { timeZone: "America/Sao_Paulo" });
+
+  const precoNum = Number(body.preco) || 0;
+  const trocaValorNum = Number(body.trocaValor) || 0;
+  const trocaValor2Num = Number(body.trocaValor2) || 0;
+  const descontoNum = Number(body.desconto) || 0;
+  const entradaPixNum = Number(body.entradaPix) || 0;
+  const valorLiquido = Math.max(precoNum - trocaValorNum - trocaValor2Num - descontoNum, 0);
+
+  const parcelasNum = body.parcelas ? Number(body.parcelas) || 1 : 1;
+  const { forma, banco, recebimento } = mapForma(body.formaPagamento);
+
+  // Telefone normalizado
+  const telefoneDigits = (body.telefone || "").replace(/\D/g, "");
+
+  // CPF/CNPJ — usa o que vier
+  const cpfDigits = (body.cpf || "").replace(/\D/g, "");
+  const cnpjDigits = (body.cnpj || "").replace(/\D/g, "");
+
+  // Endereço completo pra coluna de display
+  const enderecoFull = [body.endereco, body.numero, body.complemento, body.bairro]
+    .filter(Boolean).join(", ");
+
+  // Se tem troca → tipo UPGRADE; senão → VENDA
+  const tipo = body.trocaProduto ? "UPGRADE" : "VENDA";
+
+  // Payload canônico pra inserir/atualizar em vendas
+  const payload: Record<string, unknown> = {
+    short_code: body.shortCode,
+    status_pagamento: "FORMULARIO_PREENCHIDO",
+    tipo,
+    data: hojeStr,
+    // Cliente
+    cliente: body.nome,
+    cpf: body.pessoa === "PJ" ? null : (cpfDigits || null),
+    cnpj: body.pessoa === "PJ" ? (cnpjDigits || null) : null,
+    telefone: telefoneDigits || null,
+    email: body.email || null,
+    endereco: enderecoFull || null,
+    cep: body.cep || null,
+    // Produto
+    produto: body.produto,
+    cor: body.cor || null,
+    preco_vendido: valorLiquido,
+    // Pagamento
+    forma,
+    banco,
+    recebimento,
+    qnt_parcelas: forma === "CARTAO" ? parcelasNum : 1,
+    sinal_antecipado: entradaPixNum > 0 ? entradaPixNum : null,
+    // Troca (aparelho 1)
+    produto_na_troca: body.trocaProduto ? "SIM" : "NAO",
+    troca_produto: body.trocaProduto || null,
+    troca_cor: body.trocaCor || null,
+    troca_valor: trocaValorNum || null,
+    troca_caixa: body.trocaCaixa === true ? "SIM" : (body.trocaCaixa === false ? "NAO" : null),
+    troca_serial: body.trocaSerial || null,
+    troca_imei: body.trocaImei || null,
+    // Troca (aparelho 2)
+    troca_produto2: body.trocaProduto2 || null,
+    troca_cor2: body.trocaCor2 || null,
+    troca_valor2: trocaValor2Num || null,
+    troca_caixa2: body.trocaCaixa2 === true ? "SIM" : (body.trocaCaixa2 === false ? "NAO" : null),
+    troca_serial2: body.trocaSerial2 || null,
+    troca_imei2: body.trocaImei2 || null,
+    // Origem canônica: "FORMULARIO" (constraint da tabela vendas).
+    // O origem bruto que o cliente respondeu (Anúncio/Story/Indicação/etc) fica
+    // guardado em `origem_detalhe` pro admin ver na aba Formulários Preenchidos.
+    origem: "FORMULARIO",
+    origem_detalhe: body.origem || null,
+    vendedor: body.vendedor || null,
+    // estoque_id: NULL por design — equipe vincula depois na aba Formulários Preenchidos
+    estoque_id: null,
+  };
+
+  // Deduplicação: já existe venda com esse short_code?
+  const { data: existente } = await supabase
+    .from("vendas")
+    .select("id, status_pagamento")
+    .eq("short_code", body.shortCode)
+    .maybeSingle();
+
+  if (existente) {
+    // Só atualiza se ainda está em rascunho. Se equipe já moveu pra
+    // AGUARDANDO/FINALIZADO, não sobrescreve o trabalho deles.
+    if (existente.status_pagamento !== "FORMULARIO_PREENCHIDO") {
+      return NextResponse.json({
+        ok: true,
+        vendaId: existente.id,
+        skipped: true,
+        reason: `Venda já está em status ${existente.status_pagamento} — não atualizado.`,
+      });
+    }
+    const { error: updErr } = await supabase
+      .from("vendas")
+      .update(payload)
+      .eq("id", existente.id);
+    if (updErr) {
+      console.error("[vendas/from-formulario] update err:", updErr);
+      return NextResponse.json({ error: updErr.message }, { status: 500 });
+    }
+    return NextResponse.json({ ok: true, vendaId: existente.id, action: "updated" });
+  }
+
+  const { data: nova, error: insErr } = await supabase
+    .from("vendas")
+    .insert(payload)
+    .select("id")
+    .single();
+
+  if (insErr || !nova) {
+    console.error("[vendas/from-formulario] insert err:", insErr);
+    return NextResponse.json({ error: insErr?.message || "Erro ao criar venda" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, vendaId: nova.id, action: "created" });
+}

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -866,6 +866,50 @@ function CompraForm() {
           body: payload,
         }).catch(() => {});
       }
+
+      // Cria/atualiza venda em status FORMULARIO_PREENCHIDO — equipe vê na aba
+      // "📝 Formulários Preenchidos" de /admin/vendas, confere e envia pra
+      // "Vendas Pendentes" manualmente. Fire-and-forget via sendBeacon/keepalive.
+      const vendaPayload = JSON.stringify({
+        shortCode,
+        nome, pessoa, cpf, cnpj, email, telefone, instagram,
+        cep, endereco, numero, complemento, bairro,
+        produto: produtoFinal, cor: corSel, preco: precoFinal, desconto: descontoNum,
+        formaPagamento, parcelas, entradaPix: entradaPixNum,
+        trocaProduto: temTroca ? trocaProduto : undefined,
+        trocaCor: temTroca ? trocaCorParam : undefined,
+        trocaValor: temTroca ? trocaNum1 : undefined,
+        trocaCondicao: temTroca ? trocaCond : undefined,
+        trocaCaixa: temTroca ? trocaCaixaParam === "1" : undefined,
+        trocaSerial: temTroca ? trocaSerial1.trim() : undefined,
+        trocaImei: temTroca ? trocaImei1.trim() : undefined,
+        trocaProduto2: temTroca && temSegundoAparelho ? trocaProduto2Param : undefined,
+        trocaCor2: temTroca && temSegundoAparelho ? trocaCor2Param : undefined,
+        trocaValor2: temTroca && temSegundoAparelho ? trocaNum2 : undefined,
+        trocaCondicao2: temTroca && temSegundoAparelho ? trocaCond2Param : undefined,
+        trocaCaixa2: temTroca && temSegundoAparelho ? trocaCaixa2Param === "1" : undefined,
+        trocaSerial2: temTroca && temSegundoAparelho ? trocaSerial2.trim() : undefined,
+        trocaImei2: temTroca && temSegundoAparelho ? trocaImei2.trim() : undefined,
+        localEntrega: localStr, dataEntrega, horarioEntrega: horario,
+        vendedor, origem,
+        website: honeypot,
+      });
+      const vendaUrl = "/api/vendas/from-formulario";
+      let vendaBeaconOk = false;
+      if (typeof navigator !== "undefined" && "sendBeacon" in navigator) {
+        try {
+          const blob = new Blob([vendaPayload], { type: "application/json" });
+          vendaBeaconOk = navigator.sendBeacon(vendaUrl, blob);
+        } catch { /* fallback */ }
+      }
+      if (!vendaBeaconOk) {
+        fetch(vendaUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          keepalive: true,
+          body: vendaPayload,
+        }).catch(() => {});
+      }
     }
 
     const url = `https://wa.me/${whatsappFinal}?text=${encodeURIComponent(lines.join("\n"))}`;
@@ -1029,6 +1073,40 @@ function CompraForm() {
       if (!res.ok || !json.init_point) {
         throw new Error(json.error || "Não foi possível gerar o link de pagamento");
       }
+
+      // Cria venda em FORMULARIO_PREENCHIDO antes de redirecionar pro MP.
+      // Fire-and-forget — se falhar por qq motivo, não bloqueia o cliente.
+      try {
+        await fetch("/api/vendas/from-formulario", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          keepalive: true,
+          body: JSON.stringify({
+            shortCode,
+            nome, pessoa, cpf, cnpj, email, telefone, instagram,
+            cep, endereco, numero, complemento, bairro,
+            produto: produtoFinal, cor: corSel, preco: precoFinal, desconto: descontoFinal,
+            formaPagamento: formaPagamento || "Link de Pagamento",
+            parcelas, entradaPix: entradaFinal,
+            trocaProduto: trocaProdutoParam || undefined,
+            trocaCor: trocaCorParam || undefined,
+            trocaValor: trocaNum1 || undefined,
+            trocaCondicao: trocaCondParam || undefined,
+            trocaCaixa: trocaCaixaParam === "1",
+            trocaSerial: trocaSerial1.trim() || undefined,
+            trocaImei: trocaImei1.trim() || undefined,
+            trocaProduto2: trocaProduto2Param || undefined,
+            trocaCor2: trocaCor2Param || undefined,
+            trocaValor2: trocaNum2 || undefined,
+            trocaCondicao2: trocaCond2Param || undefined,
+            trocaCaixa2: trocaCaixa2Param === "1",
+            trocaSerial2: trocaSerial2.trim() || undefined,
+            trocaImei2: trocaImei2.trim() || undefined,
+            vendedor, origem,
+            website: honeypot,
+          }),
+        });
+      } catch { /* não bloqueia redirect */ }
 
       // Redireciona pro Mercado Pago (troca a URL, não abre nova aba — assim
       // o cliente não perde o contexto do pedido).

--- a/supabase/migrations/20260422b_vendas_formulario_preenchido.sql
+++ b/supabase/migrations/20260422b_vendas_formulario_preenchido.sql
@@ -1,0 +1,46 @@
+-- Adiciona novo status 'FORMULARIO_PREENCHIDO' em vendas + coluna short_code
+--
+-- Motivo: cliente agora preenche o formulário público /compra e isso cria
+-- automaticamente uma venda rascunho em vendas com status FORMULARIO_PREENCHIDO.
+-- A equipe vê essas vendas na aba "📝 Formulários Preenchidos" de /admin/vendas,
+-- confere os dados, completa o que faltar (estoque_id, etc) e clica
+-- "Enviar para Vendas Pendentes" — aí o status muda para AGUARDANDO.
+--
+-- short_code permite deduplicar: se cliente submete de novo o mesmo formulário,
+-- atualiza a venda existente em vez de criar duplicada. Também serve de ponte
+-- entre vendas e link_compras (que já tem short_code como chave pública).
+
+-- Novo status no enum
+ALTER TABLE vendas DROP CONSTRAINT IF EXISTS vendas_status_pagamento_check;
+
+ALTER TABLE vendas ADD CONSTRAINT vendas_status_pagamento_check
+  CHECK (status_pagamento IN (
+    'FINALIZADO',
+    'AGUARDANDO',
+    'CANCELADO',
+    'PROGRAMADA',
+    'FORMULARIO_PREENCHIDO'
+  ));
+
+-- Linka com link_compras (mesma chave pública)
+ALTER TABLE vendas
+  ADD COLUMN IF NOT EXISTS short_code TEXT;
+
+-- Index pra buscar venda pelo short_code no webhook MP e nos updates
+CREATE INDEX IF NOT EXISTS idx_vendas_short_code ON vendas(short_code);
+
+COMMENT ON COLUMN vendas.short_code IS 'short_code do link_compras que originou essa venda. NULL pra vendas criadas manualmente pelo admin.';
+
+-- Novo valor "FORMULARIO" no enum de origem (ANUNCIO/RECOMPRA/INDICACAO/ATACADO)
+-- Marca vendas criadas automaticamente quando cliente preenche /compra.
+ALTER TABLE vendas DROP CONSTRAINT IF EXISTS vendas_origem_check;
+ALTER TABLE vendas ADD CONSTRAINT vendas_origem_check
+  CHECK (origem IN ('ANUNCIO','RECOMPRA','INDICACAO','ATACADO','FORMULARIO'));
+
+-- Detalhe de origem que o cliente respondeu no formulário
+-- (Anúncio / Story / Direct / Indicação / etc) — info qualitativa pra entender
+-- de onde vêm os clientes. origem fica fixo em FORMULARIO, origem_detalhe varia.
+ALTER TABLE vendas
+  ADD COLUMN IF NOT EXISTS origem_detalhe TEXT;
+
+COMMENT ON COLUMN vendas.origem_detalhe IS 'Texto livre de como o cliente conheceu a loja (Anúncio, Story, Direct, Indicação, etc). Só preenchido em vendas vindas do formulário /compra.';


### PR DESCRIPTION
## Summary

Cliente preenche o formulário \`/compra\` (tanto \"Enviar WhatsApp\" quanto \"Pagar MP\") e o sistema **cria automaticamente uma venda rascunho** em \`vendas\` com TODOS os dados: cliente, endereço, produto, cor, troca (com IMEI/Serial extraídos pelo OCR), forma de pagamento, etc.

Equipe vê na nova aba **📝 Formulários Preenchidos** em \`/admin/vendas\`, confere os dados, completa o que falta (ex: vincula o aparelho do estoque) e clica **➡️ Enviar para Pendentes** — aí a venda muda pra \`AGUARDANDO\` e cai na aba \"Em Andamento\" como qualquer outra venda manual.

## Decisões (validadas com o André)

- **Nunca finaliza automaticamente** — mesmo quando cliente paga MP, a venda continua em \`FORMULARIO_PREENCHIDO\` ou \`AGUARDANDO\`. Finalização é sempre manual (precisa anexar NF e conferir)
- **\`estoque_id\` fica NULL** quando o cliente preenche — equipe vincula depois na entrega
- **Deduplicação via \`short_code\`**: se cliente submeter o mesmo formulário 2x (ex: corrigir endereço), atualiza em vez de criar duplicada
- **Proteção**: se equipe já moveu pra AGUARDANDO/FINALIZADO, submissões posteriores NÃO sobrescrevem o trabalho

## Migration

⚠️ **Rodar em [/admin/migrations](https://tigrao-tradein.vercel.app/admin/migrations) após merge.**

[supabase/migrations/20260422b_vendas_formulario_preenchido.sql](supabase/migrations/20260422b_vendas_formulario_preenchido.sql):
- Novo status \`FORMULARIO_PREENCHIDO\` no enum \`status_pagamento\`
- Novo valor \`FORMULARIO\` no enum \`origem\`
- Nova coluna \`short_code\` (linka com \`link_compras\`)
- Nova coluna \`origem_detalhe\` (guarda \"Anúncio/Story/Direct/Indicação\" do formulário)

## Mudanças

### Endpoint novo — [app/api/vendas/from-formulario/route.ts](app/api/vendas/from-formulario/route.ts)
- Recebe payload do \`/compra\` com todos os campos
- Mapeia forma de pagamento (PIX/CARTAO/DEBITO/PIX+Cartao/MP) → colunas canônicas \`forma/banco/recebimento\`
- \`tipo = UPGRADE\` se tem troca, senão \`VENDA\`
- Deduplicação + proteção de status já movido

### Frontend — [app/compra/page.tsx](app/compra/page.tsx)
- **handleSubmit** (WhatsApp direto): chama endpoint via \`sendBeacon\` (fire-and-forget, sobrevive ao wa.me abrir)
- **handlePagarMp**: chama via \`fetch keepalive\` antes de redirecionar pro MP

### Admin — [app/admin/vendas/page.tsx](app/admin/vendas/page.tsx)
- Nova aba \"📝 Formulários Preenchidos\" (cor indigo) entre \"Nova Venda\" e \"Em Andamento\"
- Filtro: \`status_pagamento = FORMULARIO_PREENCHIDO\`
- Bulk action: \"➡️ Enviar X para Pendentes\" → muda pra \`AGUARDANDO\`
- Título e empty state adaptados

## Test plan

- [ ] Rodar migration em /admin/migrations
- [ ] Abrir formulário de compra (ex: \`/compra?troca_produto=iPhone+13\&short=XXX\`)
- [ ] Preencher tudo, anexar prints (OCR popular IMEI/Serial), clicar \"Enviar WhatsApp\"
- [ ] Ir em \`/admin/vendas\` → aba \"📝 Formulários Preenchidos\" → ver a venda
- [ ] Confirmar que cliente, produto, cor, troca (IMEI/Serial) estão preenchidos
- [ ] Selecionar e clicar \"➡️ Enviar para Pendentes\" → venda some daqui e aparece em \"Em Andamento\"
- [ ] Submeter o mesmo formulário de novo (short_code igual) → NÃO cria duplicada
- [ ] Mover uma venda pra \"Em Andamento\", depois cliente reenviar formulário → NÃO deve sobrescrever
- [ ] Testar fluxo MP: preencher → \"Pagar MP\" → venda aparece em \"Formulários Preenchidos\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)