### PR TITLE
debug(ocr): mostra erro na UI + valida MIME antes de chamar Claude

### DIFF
--- a/app/api/link-compras/upload-print/route.ts
+++ b/app/api/link-compras/upload-print/route.ts
@@ -295,8 +295,18 @@ async function extractNumberFromPrint(
     "image/gif": "image/gif",
     "image/webp": "image/webp",
   };
-  const mt = supportedTypes[mediaType.toLowerCase()] || "image/png";
+  const originalMime = mediaType.toLowerCase();
+  const mt = supportedTypes[originalMime] || "image/png";
+  const mimeMismatch = !supportedTypes[originalMime];
   const base64 = buffer.toString("base64");
+  console.log(`[upload-print:ocr] image ${tipo}: mime=${originalMime} → ${mt}${mimeMismatch ? " (FALLBACK - Claude pode rejeitar)" : ""}, size=${buffer.length} bytes, base64=${base64.length} chars`);
+  if (mimeMismatch) {
+    console.warn(`[upload-print:ocr] MIME type não suportado pelo Claude Vision: ${originalMime}. HEIC/HEIF precisa ser convertido antes do upload.`);
+    return {
+      ok: false,
+      error: `Formato "${originalMime}" não suportado. Use JPG ou PNG (tire o print de novo com Botão Direito + Botão Volume).`,
+    };
+  }
   const client = new Anthropic({ apiKey });
   const prompt = buildPrompt(tipo);
 

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -1843,9 +1843,14 @@ function CompraForm() {
                       </div>
                     )}
                     {url && ocr.state === "fail" && (
-                      <p className="text-xs text-amber-700 mb-1.5">
-                        ⚠️ Não consegui ler o {tipoLabel} do print. Digite manualmente abaixo.
-                      </p>
+                      <div className="text-xs text-amber-700 mb-1.5">
+                        <p>⚠️ Não consegui ler o {tipoLabel} do print. Digite manualmente abaixo.</p>
+                        {ocr.error && (
+                          <p className="text-[10px] text-amber-600 mt-0.5 opacity-80 font-mono break-all">
+                            (debug: {ocr.error})
+                          </p>
+                        )}
+                      </div>
                     )}
                     {url && isManual && (
                       <input


### PR DESCRIPTION
## Contexto

PR #629 (\`temperature: 0\`) tornou o OCR determinístico, mas agora Haiku e Sonnet respondem NAO_ENCONTRADO consistentemente no print do André.

Preciso entender **o que está no print** que o Claude não consegue ler. Duas hipóteses:

1. **MIME type errado** — iPhone salva fotos em HEIC por default. Se o cliente tirar foto da tela (em vez de screenshot), vira \`image/heic\` e o Claude rejeita silenciosamente.
2. **Imagem genuinamente ilegível** — resolução baixa, print cortado, ou iOS 26.3.1 tem layout que confunde o modelo.

## Mudanças

**Frontend (\`/compra\`):** UI mostra a mensagem de erro completa abaixo do \"⚠️ Não consegui ler\" (ex: \`debug: Haiku: \"NAO_ENCONTRADO\" | Sonnet: \"NAO_ENCONTRADO\"\`). André vê direto na tela o que o Claude respondeu, sem abrir Vercel logs.

**Backend:** Log com MIME original, tamanho do buffer e do base64. Se MIME não for suportado (HEIC/HEIF), falha cedo com mensagem \"Formato X não suportado\" em vez de enviar bytes corrompidos pro Claude.

## Test plan

- [ ] Merge + deploy
- [ ] Testar mesmo print que falhou → UI agora mostra texto debug completo
- [ ] Se for HEIC: mensagem \"Formato image/heic não suportado\" aparece
- [ ] Se for PNG/JPEG: texto debug mostra exatamente o que Claude disse
- [ ] Copiar o debug text e mandar no chat pra decidir próximo passo (melhorar prompt, preprocessar imagem, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)