### PR TITLE
fix(from-formulario): bug que impedia venda de ser criada (coluna 'cor' não existe em vendas)

### DIFF
--- a/app/api/vendas/from-formulario/route.ts
+++ b/app/api/vendas/from-formulario/route.ts
@@ -155,9 +155,9 @@ export async function POST(req: NextRequest) {
     email: body.email || null,
     endereco: enderecoFull || null,
     cep: body.cep || null,
-    // Produto
-    produto: body.produto,
-    cor: body.cor || null,
+    // Produto — cor vai concatenada no nome (ex: "iPhone 17 Pro Max 1TB ROSA"),
+    // tabela vendas não tem coluna `cor` separada (ao contrário de link_compras).
+    produto: body.cor ? `${body.produto} ${String(body.cor).toUpperCase()}`.trim() : body.produto,
     preco_vendido: valorLiquido,
     // Pagamento
     forma,


### PR DESCRIPTION
## Problema

Logs do Vercel mostraram 3 erros 500 consecutivos no \`from-formulario\` hoje (12:08, 12:26, 12:29):

\`\`\`
[vendas/from-formulario] insert err: {
  code: 'PGRST204',
  message: \"Could not find the 'cor' column of 'vendas' in the schema cache\"
}
\`\`\`

Consequência: **nenhuma venda submetida via /compra apareceu em \"Formulários Preenchidos\"** e **nenhum contrato automático foi disparado** (depende da venda existir).

## Causa raiz

Tabela \`vendas\` não tem coluna \`cor\` separada — a cor sempre foi concatenada no nome do produto (ex: \`\"iPhone 17 Pro Max 1TB ROSA\"\`). Só \`link_compras\`, \`estoque\` e \`encomendas\` têm \`cor\` como coluna.

Introduzi esse payload com \`cor\` no PR #627 (criação de vendas FORMULARIO_PREENCHIDO via formulário) — não validei contra o schema real. Passou na PR porque o TypeScript não tipa o schema Supabase em runtime.

## Fix

Concatena \`body.cor\` no nome do produto antes do insert — consistente com vendas antigas:

\`\`\`typescript
// Antes
produto: body.produto,
cor: body.cor || null,

// Depois
produto: body.cor ? \`\${body.produto} \${String(body.cor).toUpperCase()}\`.trim() : body.produto,
\`\`\`

## Test plan

- [ ] Merge + deploy
- [ ] Refazer fluxo /troca → /compra → WhatsApp
- [ ] Confirmar que venda aparece em \`/admin/vendas → 📝 Formulários Preenchidos\`
- [ ] Confirmar que cliente recebe link ZapSign no WhatsApp em ~30s
- [ ] Se algum dos dois falhar, ver Vercel logs filtrando por \`from-formulario\` ou \`contrato-auto\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)