### PR TITLE
fix(migration): recupera 20260422b que falhou em produção (origem enum)

### DIFF
--- a/supabase/migrations/20260422d_fix_vendas_origem_detalhe.sql
+++ b/supabase/migrations/20260422d_fix_vendas_origem_detalhe.sql
@@ -1,0 +1,54 @@
+-- Recupera as alterações da migration 20260422b que falharam em produção.
+--
+-- A 20260422b abortou em
+--   "check constraint vendas_origem_check of relation vendas is violated by some row"
+-- porque a tabela tinha vendas com origem fora do novo enum
+-- (ANUNCIO/RECOMPRA/INDICACAO/ATACADO/FORMULARIO). Provavelmente
+-- NAO_INFORMARAM vindo de imports de CSV antigos.
+--
+-- Como ALTER TABLE ADD CONSTRAINT faz rollback da transação inteira quando
+-- falha, NADA da 20260422b foi aplicado: nem short_code, nem origem_detalhe,
+-- nem o status FORMULARIO_PREENCHIDO. Por isso o /compra → from-formulario
+-- estava quebrado em produção (erros PGRST204 "coluna cor/origem_detalhe não
+-- existe").
+--
+-- Essa migration:
+--   1. Normaliza origens inválidas pra NAO_INFORMARAM (preserva histórico)
+--   2. Aplica a nova constraint INCLUINDO NAO_INFORMARAM (não quebra vendas antigas)
+--   3. Reaplica todas as outras mudanças da 20260422b (IF NOT EXISTS é safe)
+
+-- 1. Backfill: qualquer origem fora da lista vai pra NAO_INFORMARAM
+UPDATE vendas SET origem = 'NAO_INFORMARAM'
+WHERE origem IS NULL
+   OR origem NOT IN ('ANUNCIO','RECOMPRA','INDICACAO','ATACADO','FORMULARIO','NAO_INFORMARAM');
+
+-- 2. Status FORMULARIO_PREENCHIDO (igual 20260422b)
+ALTER TABLE vendas DROP CONSTRAINT IF EXISTS vendas_status_pagamento_check;
+
+ALTER TABLE vendas ADD CONSTRAINT vendas_status_pagamento_check
+  CHECK (status_pagamento IN (
+    'FINALIZADO',
+    'AGUARDANDO',
+    'CANCELADO',
+    'PROGRAMADA',
+    'FORMULARIO_PREENCHIDO'
+  ));
+
+-- 3. short_code + índice (igual 20260422b)
+ALTER TABLE vendas
+  ADD COLUMN IF NOT EXISTS short_code TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_vendas_short_code ON vendas(short_code);
+
+COMMENT ON COLUMN vendas.short_code IS 'short_code do link_compras que originou essa venda. NULL pra vendas criadas manualmente pelo admin.';
+
+-- 4. Origem FORMULARIO + NAO_INFORMARAM preservado
+ALTER TABLE vendas DROP CONSTRAINT IF EXISTS vendas_origem_check;
+ALTER TABLE vendas ADD CONSTRAINT vendas_origem_check
+  CHECK (origem IN ('ANUNCIO','RECOMPRA','INDICACAO','ATACADO','FORMULARIO','NAO_INFORMARAM'));
+
+-- 5. origem_detalhe (igual 20260422b)
+ALTER TABLE vendas
+  ADD COLUMN IF NOT EXISTS origem_detalhe TEXT;
+
+COMMENT ON COLUMN vendas.origem_detalhe IS 'Texto livre de como o cliente conheceu a loja (Anúncio, Story, Direct, Indicação, etc). Só preenchido em vendas vindas do formulário /compra.';


### PR DESCRIPTION
## Descoberta

Vendo o /admin/migrations, a migration \`20260422b_vendas_formulario_preenchido\` está com ❌ vermelho:

> Erro: check constraint \"vendas_origem_check\" of relation \"vendas\" is violated by some row

Alguma venda antiga (provavelmente importada via \`scripts/import-csv.ts\` que usa \`NAO_INFORMARAM\`) tinha \`origem\` fora do novo enum \`(ANUNCIO/RECOMPRA/INDICACAO/ATACADO/FORMULARIO)\`.

## Consequência

O \`ADD CONSTRAINT\` abortou e o PostgreSQL **rolled-back a transação inteira** — NADA da migration foi aplicado:

- ❌ status \`FORMULARIO_PREENCHIDO\` no enum
- ❌ coluna \`short_code\` em vendas  
- ❌ coluna \`origem_detalhe\` em vendas

**Por isso** o fluxo /compra → from-formulario → contrato automático tava falhando com erros PGRST204 (\"column 'cor'\", \"column 'origem_detalhe'\"). Nenhuma venda de formulário foi criada hoje, nenhum contrato disparado.

## Fix

Nova migration \`20260422d\`:

1. **Backfill**: \`UPDATE\` em qualquer origem fora do enum → \`NAO_INFORMARAM\` (preserva histórico das vendas importadas)
2. **Nova constraint** inclui \`NAO_INFORMARAM\` (enum cresce de 5 pra 6 valores)
3. **Reaplica** short_code, origem_detalhe, status FORMULARIO_PREENCHIDO (\`IF NOT EXISTS\` é idempotente)

## Test plan

- [ ] Merge + deploy
- [ ] Rodar migration \`20260422d_fix_vendas_origem_detalhe\` em /admin/migrations
- [ ] Confirmar que aparece ✅ verde
- [ ] Refazer fluxo /troca → /compra → WhatsApp
- [ ] Venda agora deve aparecer em /admin/vendas → Formulários Preenchidos
- [ ] Cliente recebe link ZapSign em ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)