### PR TITLE
feat(vendas): botao Mover para Andamento em Formularios Preenchidos

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -5997,7 +5997,7 @@ export default function VendasPage() {
                                         >
                                           💲 Reajuste
                                         </button>}
-                                        {podeVerHistorico && v.status_pagamento === "FINALIZADO" && (
+                                        {podeVerHistorico && (v.status_pagamento === "FINALIZADO" || v.status_pagamento === "FORMULARIO_PREENCHIDO") && (
                                           <button
                                             onClick={async (e) => {
                                               e.stopPropagation();


### PR DESCRIPTION
## Summary
- Adiciona o status `FORMULARIO_PREENCHIDO` na condição do botão "⏳ Mover para Andamento" que antes só aparecia para `FINALIZADO`.
- Agora admin consegue promover com 1 clique a venda rascunho criada pelo `/compra` pra fila "Em Andamento".

## Test plan
- [ ] Abrir `/admin/vendas` → aba `📝 Formulários Preenchidos`
- [ ] Expandir a venda
- [ ] Confirmar que aparece botão amarelo `⏳ Mover para Andamento`
- [ ] Clicar → venda some dessa aba e aparece em `Em Andamento`

🤖 Generated with [Claude Code](https://claude.com/claude-code)