### PR TITLE
fix(from-formulario): valor da troca e bateria preenchem no Editar

### DIFF
--- a/app/api/vendas/from-formulario/route.ts
+++ b/app/api/vendas/from-formulario/route.ts
@@ -141,6 +141,18 @@ export async function POST(req: NextRequest) {
   // Se tem troca → tipo UPGRADE; senão → VENDA
   const tipo = body.trocaProduto ? "UPGRADE" : "VENDA";
 
+  // A condição do trade-in vem como texto livre (ex: "Bateria 90% | Com caixa
+  // original | Sem marcas de uso"). O admin usa coluna `troca_bateria` separada
+  // pra exibir no form Editar, então extraímos o número daqui. Resto do texto
+  // vai pra `troca_obs` pro admin ver.
+  const extrairBateria = (cond?: string): string | null => {
+    if (!cond) return null;
+    const m = cond.match(/bateria\s+(\d+)\s*%/i);
+    return m ? m[1] : null;
+  };
+  const trocaBateria = extrairBateria(body.trocaCondicao);
+  const trocaBateria2 = extrairBateria(body.trocaCondicao2);
+
   // Payload canônico pra inserir/atualizar em vendas
   const payload: Record<string, unknown> = {
     short_code: body.shortCode,
@@ -165,18 +177,24 @@ export async function POST(req: NextRequest) {
     recebimento,
     qnt_parcelas: forma === "CARTAO" ? parcelasNum : 1,
     sinal_antecipado: entradaPixNum > 0 ? entradaPixNum : null,
-    // Troca (aparelho 1)
-    produto_na_troca: body.trocaProduto ? "SIM" : "NAO",
+    // Troca (aparelho 1) — admin lê produto_na_troca como VALOR MONETÁRIO em
+    // string (não "SIM"/"NAO"). Mantemos troca_valor também pra contratos/reports.
+    produto_na_troca: body.trocaProduto ? String(trocaValorNum || 0) : null,
     troca_produto: body.trocaProduto || null,
     troca_cor: body.trocaCor || null,
     troca_valor: trocaValorNum || null,
+    troca_bateria: trocaBateria,
+    troca_obs: body.trocaCondicao || null,
     troca_caixa: body.trocaCaixa === true ? "SIM" : (body.trocaCaixa === false ? "NAO" : null),
     troca_serial: body.trocaSerial || null,
     troca_imei: body.trocaImei || null,
     // Troca (aparelho 2)
+    produto_na_troca2: body.trocaProduto2 ? String(trocaValor2Num || 0) : null,
     troca_produto2: body.trocaProduto2 || null,
     troca_cor2: body.trocaCor2 || null,
     troca_valor2: trocaValor2Num || null,
+    troca_bateria2: trocaBateria2,
+    troca_obs2: body.trocaCondicao2 || null,
     troca_caixa2: body.trocaCaixa2 === true ? "SIM" : (body.trocaCaixa2 === false ? "NAO" : null),
     troca_serial2: body.trocaSerial2 || null,
     troca_imei2: body.trocaImei2 || null,


### PR DESCRIPTION
## Problema

Ao clicar ✏️ Editar numa venda vinda do /compra (aba Formulários Preenchidos):
- Campo **VALOR DA TROCA** aparece zerado
- Campo **BATERIA (%)** aparece vazio

## Causa raiz

1. **Valor da troca**: admin usa `produto_na_troca` como VALOR MONETÁRIO em string (ex: `"3000"`), mas o from-formulario salvava `"SIM"`/`"NAO"`. O `parseFloat("SIM")` no form = NaN = 0.
2. **Bateria**: a condição vem como texto livre (ex: `"Bateria 90% | Com caixa"`) mas o from-formulario não extraía nem salvava em `troca_bateria`/`troca_obs`.

## Fix

- `produto_na_troca` / `produto_na_troca2` agora salvam o valor monetário em string (mantém `troca_valor`/`troca_valor2` também pra contratos/reports).
- Regex simples extrai bateria de `trocaCondicao` (`/bateria\s+(\d+)\s*%/i`) e salva em `troca_bateria` / `troca_bateria2`.
- Texto completo da condição vai pra `troca_obs` / `troca_obs2`.

## Test plan
- [ ] Cliente faz simulação em /troca (aparelho com bateria, ex: 90%)
- [ ] Clica fechar → preenche /compra → submit
- [ ] Admin abre a venda em `/admin/vendas → 📝 Formulários Preenchidos → ✏️ Editar`
- [ ] Confirmar: **VALOR DA TROCA** = valor da avaliação
- [ ] Confirmar: **BATERIA (%)** = 90
- [ ] Confirmar: **OBS DO SEMINOVO** traz texto da condição

## Obs
Não corrige retroativamente a venda de teste que já está no banco — só afeta vendas criadas daqui em diante. Se quiser corrigir a existente, basta clicar Editar + preencher manual + Salvar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)