### PR TITLE
feat(gastos): campo Tela em acessorios usando config do modelo

### DIFF
--- a/app/admin/gastos/page.tsx
+++ b/app/admin/gastos/page.tsx
@@ -867,13 +867,14 @@ export default function GastosPage() {
         // Para categorias estruturadas, SEMPRE usar buildProdutoName (ignora nome livre)
         const isStructured = STRUCTURED_CATS.includes(p.categoria);
         const nome = isStructured ? buildProdutoName(p.categoria, p.spec, p.cor) : (p.produto || "");
-        // Condição + caixa + grade → prefixo no observacao
+        // Condição + caixa + grade + tela acessório → prefixo no observacao
         const _cond = p.condicao || "NOVO";
         const _prefix = _cond !== "NOVO" ? `[${_cond}]` : "";
         const _caixaTag = p.caixa ? "[COM_CAIXA]" : "";
         const _gradeKey = p.grade ? (p.grade) : "";
         const _gradeTag = _gradeKey ? `[GRADE_${_gradeKey}]` : "";
-        const _tags = `${_prefix}${_caixaTag}${_gradeTag}`;
+        const _telaTag = p.categoria === "ACESSORIOS" && p.spec.ac_tela ? `[TELA:${p.spec.ac_tela}]` : "";
+        const _tags = `${_prefix}${_caixaTag}${_gradeTag}${_telaTag}`;
         const obsCondicao = _tags || null;
         // Cliente registrado sobrescreve fornecedor
         const fornecedorFinal = p.cliente?.trim() || p.fornecedor || null;

--- a/components/admin/ProdutoSpecFields.tsx
+++ b/components/admin/ProdutoSpecFields.tsx
@@ -965,6 +965,19 @@ export default function ProdutoSpecFields({
         </div>
       )}
 
+      {/* Acessórios: campo Tela se o modelo tem telas configuradas em /admin/catalogo */}
+      {row.categoria === "ACESSORIOS" && hasCatalogModel && (modeloConfigs.telas?.length || 0) > 0 && (
+        <div className={`grid grid-cols-2 gap-3 p-3 ${bgSection} rounded-lg`}>
+          <div>
+            <p className={labelCls}>Tela</p>
+            <select value={row.spec.ac_tela} onChange={(e) => setSpec("ac_tela", e.target.value)} className={inputCls}>
+              <option value="">— Selecionar —</option>
+              {modeloConfigs.telas?.map((t) => <option key={t} value={t}>{t}</option>)}
+            </select>
+          </div>
+        </div>
+      )}
+
       {/* Cor — após specs específicos da categoria */}
       {(hasCatalogModel || !categoryModelos.length) && (
         <div className={`grid gap-3 ${compactMode ? "grid-cols-1" : "grid-cols-2 md:grid-cols-3"}`}>

--- a/lib/produto-display.ts
+++ b/lib/produto-display.ts
@@ -166,8 +166,9 @@ export function formatProdutoDisplay(p: {
     else if (hasGps) parts.push("GPS");
     if (cor) parts.push(cor);
   } else {
-    // ACESSORIOS e outras categorias não estruturadas: nome limpo + cor em PT
+    // ACESSORIOS e outras categorias não estruturadas: nome limpo + tela (se houver) + cor em PT
     parts.push(cleanProdutoDisplay(nomeRaw));
+    if (tela) parts.push(tela);
     if (cor) parts.push(cor);
   }
 

--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -267,6 +267,7 @@ export interface ProdutoSpec {
   ipad_modelo: string; ipad_chip: string; ipad_tela: string; ipad_storage: string; ipad_conn: string;
   aw_modelo: string; aw_tamanho: string; aw_conn: string; aw_pulseira: string; aw_band: string;
   air_modelo: string; air_descricao: string;
+  ac_tela: string;
 }
 
 export const DEFAULT_SPEC: ProdutoSpec = {
@@ -277,6 +278,7 @@ export const DEFAULT_SPEC: ProdutoSpec = {
   ipad_modelo: "AIR M4", ipad_chip: "", ipad_tela: '11"', ipad_storage: "128GB", ipad_conn: "WIFI",
   aw_modelo: "SERIES 10", aw_tamanho: "42mm", aw_conn: "GPS", aw_pulseira: "", aw_band: "",
   air_modelo: "AIRPODS 4", air_descricao: "",
+  ac_tela: "",
 };
 
 // ── Mapa de cores Português → Inglês (nomes comerciais Apple) ──


### PR DESCRIPTION
## Problema

Ao registrar compra de fornecedor (/admin/gastos), produtos da categoria **Acessorios** (como Magic Keyboard, Trackpad) não mostravam o campo **Tela** — mesmo tendo \"Telas Disponiveis\" (11\", 13\", 16\") marcadas na configuracao do produto em /admin/catalogo.

Outros campos (Cor) ja filtram pela config do modelo. Tela estava so em iPad/MacBook.

## Fix

Adicionar bloco render para categoria ACESSORIOS no componente compartilhado `ProdutoSpecFields` — dropdown Tela que aparece so quando:
- Modelo tem `catalogo_modelo_id` vinculado
- A config `telas` tem valores

A selecao e salva na observacao como `[TELA:X\"]` (mesmo padrao de `[RAM:]`, `[SSD:]`, `[GRADE:]`). O `formatProdutoDisplay` para categorias nao estruturadas agora inclui a tela no nome exibido.

## Mudancas

| Arquivo | Mudanca |
|---------|---------|
| [lib/produto-specs.ts](../blob/claude/feat-tela-acessorios/lib/produto-specs.ts) | novo campo `ac_tela` em `ProdutoSpec` |
| [components/admin/ProdutoSpecFields.tsx](../blob/claude/feat-tela-acessorios/components/admin/ProdutoSpecFields.tsx) | bloco render condicional ACESSORIOS |
| [app/admin/gastos/page.tsx](../blob/claude/feat-tela-acessorios/app/admin/gastos/page.tsx) | handleSubmit inclui `[TELA:X\"]` na obs |
| [lib/produto-display.ts](../blob/claude/feat-tela-acessorios/lib/produto-display.ts) | ACESSORIOS mostra tela no nome |

## Resultado esperado

Na listagem A CAMINHO ou detalhe do gasto:
- \"Magic Keyboard iPad Pro M4 13\\\" Preto\" (antes: apenas \"MAGIC KEYBOARD IPAD PRO M4\")

## Test plan
- [ ] Configurar um Magic Keyboard em /admin/catalogo com apenas 2 telas (11\", 13\") selecionadas
- [ ] Criar gasto FORNECEDOR com Magic Keyboard — dropdown Tela aparece com apenas 11\" e 13\"
- [ ] Selecionar uma tela e salvar — observacao gravada com \`[TELA:13\"]\`
- [ ] Listagem A CAMINHO exibe \"Magic Keyboard iPad Pro M4 13\\\" Preto\"
- [ ] Regressao iPads/MacBooks: campo Tela existente continua funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)