### PR TITLE
fix(instagram): fundo branco nas imagens dos slides (sem bordas cinza)

### DIFF
--- a/lib/instagram/slide-layout.tsx
+++ b/lib/instagram/slide-layout.tsx
@@ -164,8 +164,9 @@ function Header({ config, index, total }: { config: Config; index: number; total
 function Imagem({ url }: { url: string }) {
   // objectFit: contain — NUNCA corta a imagem. Composicoes (multi-produto
   // lado a lado) e fotos oficiais Apple com fundo branco ficam centralizadas
-  // preservando toda a informacao visual. Fundo cinza claro ocupa o espaco
-  // residual quando o ratio da imagem e mais largo/estreito que o container.
+  // preservando toda a informacao visual. Fundo BRANCO se funde com fotos
+  // Apple oficiais (que vem com fundo branco), criando visual "sem moldura"
+  // consistente entre todos os slides.
   return (
     <div
       style={{
@@ -176,7 +177,7 @@ function Imagem({ url }: { url: string }) {
         height: 620,
         borderRadius: 24,
         overflow: "hidden",
-        backgroundColor: "#F5F5F7",
+        backgroundColor: "#FFFFFF",
       }}
     >
       {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -582,7 +583,7 @@ function LayoutEmanuelPessoa({ slide, config, meta }: { slide: SlideData; config
               height: 560,
               borderRadius: 18,
               overflow: "hidden",
-              backgroundColor: "#F5F5F7",
+              backgroundColor: "#FFFFFF",
               marginTop: "auto",
             }}
           >


### PR DESCRIPTION
## Problema
André apontou nos slides renderizados: quando a imagem do slide tem proporção diferente do container (ex: produto centralizado, composição horizontal de múltiplos produtos), sobrava **espaço cinza (#F5F5F7) nas bordas** que parecia moldura indesejada. Também fazia os slides parecerem de **tamanhos diferentes** visualmente, mesmo todos sendo 1080×1350.

## Fix
Trocado o \`backgroundColor\` do container de imagem de \`#F5F5F7\` pra \`#FFFFFF\` nos 2 lugares:

- \`Imagem\` (componente usado pelos layouts PADRAO e variantes)
- Container inline do \`LayoutEmanuelPessoa\` (estilo Emanuel Pessoa com imagem no rodapé)

Como as fotos oficiais Apple já vêm com fundo branco, o container agora **se funde com a imagem** — a "moldura" some visualmente e todos os slides ficam com aparência consistente mesmo com imagens de proporções diferentes.

## Test plan
- [ ] Após merge, abrir o post existente e clicar **🔄 Re-renderizar**
- [ ] Confirmar que o cinza em volta das imagens some (agora tudo branco)
- [ ] Confirmar que slides com 1 imagem (tipo o Apple Watch SE 3) e slides com múltiplas imagens (tipo o Series 11 com 4 cores) ficam visualmente alinhados/consistentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)