### PR TITLE
fix(vendas): aplicar taxa do cartao em pagamento multi-data (Datas diferentes)

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -787,7 +787,8 @@ export default function VendasPage() {
 
   // Recalcular preco_vendido automaticamente no modo "Datas diferentes".
   // Sem isso, preco_vendido fica 0 e a venda grava com lucro negativo (custo - 0).
-  // Soma valor liquido de cada pagEntry respeitando a forma (taxa de cartao/link/debito).
+  // Soma valor LIQUIDO de cada pagEntry respeitando a forma (taxa de cartao/link/debito).
+  // Se for PIX/ESPECIE/FIADO: liquido = bruto (sem taxa).
   useEffect(() => {
     if (!multiDatePagamento) return;
     const pTroca1 = parseFloat(form.produto_na_troca) || 0;
@@ -796,7 +797,16 @@ export default function VendasPage() {
     const totalPagEntries = pagEntries.reduce((sum, e) => {
       const bruto = parseFloat(String(e.valor).replace(/\./g, "").replace(",", ".")) || 0;
       if (bruto <= 0) return sum;
-      // preco_vendido = valor BRUTO (o que o cliente pagou) — sem descontar taxa
+      const forma = e.forma || "";
+      if (forma === "CARTAO" || forma === "LINK" || forma === "DEBITO") {
+        const banco = forma === "LINK" ? "MERCADO_PAGO" : (e.banco || "ITAU");
+        const parcelas = parseInt(e.parcelas) || 0;
+        const bandeira = e.bandeira || null;
+        const formaTaxa = (forma === "LINK" ? "CARTAO" : forma) as "CARTAO" | "DEBITO";
+        const taxa = getTaxa(banco, bandeira, parcelas, formaTaxa);
+        return sum + (taxa > 0 ? calcularLiquido(bruto, taxa) : bruto);
+      }
+      // PIX, ESPECIE, DINHEIRO, FIADO: sem taxa
       return sum + bruto;
     }, 0);
     const newVendido = String(Math.round(totalPagEntries + totalTroca));


### PR DESCRIPTION
## Problema reportado

No modo **\"Datas diferentes\"** (multi-data pagamento) em /admin/vendas, quando o cliente paga parte em cartão, o sistema trata o valor BRUTO do cartão como se fosse líquido. Resultado: preço de venda inflado, Recebimento/Taxa não calculados.

**Exemplo:**
- PIX R$ 4.000 (21/04) + Cartão 8x Mastercard R$ 5.233 (22/04)
- Bruto cartão: 5.233, taxa ~7% → líquido real: **4.867,71**
- Preco_vendido esperado: 4.000 + 4.867,71 = **8.867,71**
- Preco_vendido exibido (errado): 4.000 + 5.233 = **9.233**

## Causa

[app/admin/vendas/page.tsx:796-801](../blob/claude/fix-datas-diferentes-taxa/app/admin/vendas/page.tsx#L796) — o useEffect que recalcula preco_vendido no modo multi-data somava apenas valores BRUTOS, com comentário explicito \"sem descontar taxa\":

```ts
const totalPagEntries = pagEntries.reduce((sum, e) => {
  const bruto = parseFloat(...) || 0;
  return sum + bruto;  // ❌ sem taxa
}, 0);
```

Mas no fluxo de pagamento normal (não multi-data) e no save do grupo, preco_vendido é calculado como LÍQUIDO (após taxa). Inconsistência causava lucro falso.

## Fix

Aplicar `calcularLiquido(bruto, taxa)` quando forma for CARTAO/LINK/DEBITO, usando `getTaxa(banco, bandeira, parcelas, forma)`. PIX/ESPECIE/FIADO continuam sem taxa.

```ts
if (forma === \"CARTAO\" || forma === \"LINK\" || forma === \"DEBITO\") {
  const taxa = getTaxa(banco, bandeira, parcelas, formaTaxa);
  return sum + (taxa > 0 ? calcularLiquido(bruto, taxa) : bruto);
}
return sum + bruto;
```

## Test plan
- [ ] Modo \"Datas diferentes\" com PIX + Cartão: preco_vendido = PIX bruto + cartão líquido
- [ ] Modo \"Datas diferentes\" com só PIX: preco_vendido = soma bruta
- [ ] Modo \"Datas diferentes\" com Link MP: taxa específica do MP aplicada
- [ ] Regressão modo normal (sem \"Datas diferentes\"): funciona igual

🤖 Generated with [Claude Code](https://claude.com/claude-code)