### PR TITLE
fix(instagram): validacao aceita os 5 estilos novos

### DIFF
--- a/app/api/admin/instagram-posts/route.ts
+++ b/app/api/admin/instagram-posts/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: NextRequest) {
   if (!["DICA", "COMPARATIVO", "NOTICIA", "ANALISE_PROFUNDA"].includes(tipo)) {
     return NextResponse.json({ error: "tipo inválido" }, { status: 400, headers: noCache });
   }
-  if (!["PADRAO", "EMANUEL_PESSOA"].includes(estilo)) {
+  if (!["PADRAO", "EMANUEL_PESSOA", "CARIOCA_DESCONTRAIDO", "STORYTELLING_PREMIUM", "COMPARATIVO_TECNICO", "VIRAL_POLEMICO", "EDUCATIVO_DIDATICO"].includes(estilo)) {
     return NextResponse.json({ error: "estilo inválido" }, { status: 400, headers: noCache });
   }
   const n = Number(numero_slides);

--- a/app/api/instagram/refinar-tema/route.ts
+++ b/app/api/instagram/refinar-tema/route.ts
@@ -93,7 +93,7 @@ export async function POST(req: NextRequest) {
   const body = await req.json().catch(() => ({}));
   const ideia = typeof body?.ideia === "string" ? body.ideia.trim() : "";
   const estiloRaw = typeof body?.estilo === "string" ? body.estilo : "PADRAO";
-  const estilo = ["PADRAO", "EMANUEL_PESSOA"].includes(estiloRaw) ? estiloRaw : "PADRAO";
+  const estilo = ["PADRAO", "EMANUEL_PESSOA", "CARIOCA_DESCONTRAIDO", "STORYTELLING_PREMIUM", "COMPARATIVO_TECNICO", "VIRAL_POLEMICO", "EDUCATIVO_DIDATICO"].includes(estiloRaw) ? estiloRaw : "PADRAO";
   if (!ideia) return NextResponse.json({ error: "ideia obrigatória" }, { status: 400 });
   if (ideia.length > 500) return NextResponse.json({ error: "ideia muito longa (máx 500)" }, { status: 400 });
 


### PR DESCRIPTION
## Problema
André tentou criar post com o estilo novo **Educativo didático** — erro: **\"estilo inválido\"**.

## Causa
PR [#651](https://github.com/tigraoimports-a11y/tigrao-tradein/pull/651) adicionou os 5 estilos novos em:
- Dropdown do frontend
- Constants de prompt (\`ESTILO_GUIA\`)
- Constraint SQL

Mas esqueci de 2 arrays hardcoded que validam o estilo:

1. [app/api/admin/instagram-posts/route.ts:45](app/api/admin/instagram-posts/route.ts#L45) — **bloqueava criação** com 400 \"estilo inválido\"
2. [app/api/instagram/refinar-tema/route.ts:96](app/api/instagram/refinar-tema/route.ts#L96) — silent fallback pra \`PADRAO\` quando admin clicava Refinar com estilo novo

## Fix
Adicionado os 5 estilos novos nos 2 arrays. Agora os 7 estilos funcionam end-to-end.

## Test plan
- [ ] Criar post novo com estilo **Educativo didático** → criar sem erro
- [ ] Criar post com estilo **Carioca descontraído** → criar sem erro
- [ ] Clicar **✨ Refinar com IA** com estilo novo → tema refinado sai no tom correto (não cai pro PADRAO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)