### PR TITLE
fix(instagram): imagem ocupa espaco residual do slide (sem sobrar branco)

### DIFF
--- a/lib/instagram/slide-layout.tsx
+++ b/lib/instagram/slide-layout.tsx
@@ -580,11 +580,16 @@ function LayoutEmanuelPessoa({ slide, config, meta }: { slide: SlideData; config
               alignItems: "center",
               justifyContent: "center",
               width: "100%",
-              height: 560,
+              // flex: 1 deixa a imagem ocupar TODO o espaco restante depois
+              // do texto (em vez de height fixo 560 que sobrava branco em
+              // slides com texto curto). minHeight evita que a imagem vire
+              // tirinha quando o texto for muito longo.
+              flex: 1,
+              minHeight: 360,
               borderRadius: 18,
               overflow: "hidden",
               backgroundColor: "#FFFFFF",
-              marginTop: "auto",
+              marginTop: 24,
             }}
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}


### PR DESCRIPTION
## Problema
André apontou nos slides do post de Apple Watch: alguns têm muito espaço em branco entre o texto e a imagem. Acontece quando o texto é curto — a imagem fica pequena no rodapé com bastante área em branco entre eles.

## Causa
\`LayoutEmanuelPessoa\` tinha:
- \`height: 560\` fixo no container da imagem
- \`marginTop: \"auto\"\` empurrando a imagem pro rodapé

Resultado: texto curto → muito espaço em branco entre header/texto e imagem.

## Fix
Trocado \`height: 560\` + \`marginTop: auto\` por:
- \`flex: 1\` — ocupa todo o espaço restante depois do texto
- \`minHeight: 360\` — garante que mesmo com texto MUITO longo a imagem não vira tirinha
- \`marginTop: 24\` — só espacinho de respiro entre texto e imagem

\`objectFit: contain\` continua preservando aspect ratio da imagem original — ela cresce até o limite do container sem distorcer.

## Test plan
- [ ] Após merge, abrir o post de Apple Watch e clicar **🔄 Re-renderizar**
- [ ] Slide 1 (\"Não entendo nada de Apple Watch\") — imagem dos 3 watches deve ficar maior, ocupando toda a área embaixo do texto
- [ ] Slide 4 (\"Series 11 — o completo\") — imagem dos 4 watches também deve ocupar mais espaço
- [ ] Comparar com versão antiga: agora deve ter pouco/nenhum espaço em branco "morto"

🤖 Generated with [Claude Code](https://claude.com/claude-code)