### PR TITLE
fix(estoque): esconder tags [TELA:] e [NUCLEOS:] da observacao exibida

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -2440,6 +2440,8 @@ export default function EstoquePage() {
       .replace(/\[BAND:[^\]]+\]/g, "")
       .replace(/\[RESP:[^\]]+\]/g, "")
       .replace(/\[COM_QUEM:[^\]]+\]/g, "")
+      .replace(/\[TELA:[^\]]+\]/g, "")
+      .replace(/\[NUCLEOS:[^\]]+\]/g, "")
       .replace(/\s+/g, " ")
       .trim() || null;
   };


### PR DESCRIPTION
## Problema

Apos PRs #646 e #650 (feature Tela em acessorios), a tag `[TELA:X\"]` salva na observacao aparecia literal na listagem ao lado do nome:

**\"MAGIC KEYBOARD IPAD PRO M4 13\\\" Preto · [TELA:13\"]\"**

A tela ja aparece no nome via formatProdutoDisplay e getModeloBase, entao a tag na observacao ficava redundante.

## Fix

Adicionar `\\[TELA:...\\]` e `\\[NUCLEOS:...\\]` ao regex do helper `cleanObs` em [app/admin/estoque/page.tsx:2433](../blob/claude/fix-esconder-tela-nucleos-obs/app/admin/estoque/page.tsx#L2433). Agora a observacao exibida fica limpa.

## Test plan
- [ ] Magic Keyboard com tela: exibe \"MAGIC KEYBOARD IPAD PRO M4 13\\\" Preto\" sem `[TELA:13\"]`
- [ ] MacBook com nucleos: exibe sem `[NUCLEOS:...]`
- [ ] Observacao com outras tags continua sem literais (grade, caixa, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)