### PR TITLE
feat(instagram): campo destaque editavel no editor de slides

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -675,7 +675,15 @@ export default function InstagramPostPage() {
                   disabled={!podeEditar}
                   placeholder="Texto"
                   rows={3}
+                  className="w-full mb-2 px-3 py-2 rounded-lg border border-[#E8E8ED] text-sm focus:outline-none focus:border-[#E8740E]"
+                />
+                <input
+                  value={slide.destaque || ""}
+                  onChange={e => atualizarSlide(idx, "destaque", e.target.value)}
+                  disabled={!podeEditar}
+                  placeholder="💥 Destaque (texto GIGANTE em laranja — deixa vazio pra não aparecer)"
                   className="w-full px-3 py-2 rounded-lg border border-[#E8E8ED] text-sm focus:outline-none focus:border-[#E8740E]"
+                  maxLength={10}
                 />
                 <div className="text-xs text-[#86868B] mt-1 flex gap-4 flex-wrap">
                   <span>Título: {slide.titulo.length} chars</span>


### PR DESCRIPTION
## Problema
André não conseguia corrigir/apagar o texto **\"Air M3\"** que aparecia em laranja gigante num slide. No editor só mostrava como badge visual não-editável.

\"Air M3\" é o campo \`destaque\` do slide (renderizado com \`fontSize: 160\` em laranja pelo layout). O LLM gerou com texto errado (não existe Air M3, é Air M4) mas não tinha como corrigir pela UI.

## Fix
Adicionado um \`<input>\` pro campo \`destaque\` em cada card de slide, abaixo do texto:

\`\`\`
💥 Destaque (texto GIGANTE em laranja — deixa vazio pra não aparecer)
\`\`\`

- \`maxLength: 10\` (mesmo limite do layout — acima de 10 chars não renderiza)
- Vazio → não aparece no PNG
- Edita → re-renderiza com o texto novo

## Test plan
- [ ] Abre o post do iPad
- [ ] No slide \"Perfil 2 — Estudante\": apagar o destaque \"Air M3\" (ou trocar por \"Air M4\")
- [ ] Salvar + Re-renderizar
- [ ] PNG atualizado sem o texto errado

## Sobre a qualidade das letras
André também mencionou queda de qualidade das letras. Isso provavelmente é só a miniatura do grid (resolução reduzida). Pra verificar: clicar num slide abre o PNG full-res (1080×1350) — a qualidade deve tá normal. Se não tiver, investigo separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)