### PR TITLE
feat(instagram): botao Trocar linguagem preservando imagens

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -93,6 +93,10 @@ export default function InstagramPostPage() {
   const [mostrandoDetalhes, setMostrandoDetalhes] = useState(false);
   const [detalhesExtras, setDetalhesExtras] = useState("");
 
+  // Trocar linguagem (re-gerar texto em outro estilo, preservando imagens)
+  const [mostrandoTrocarLing, setMostrandoTrocarLing] = useState(false);
+  const [novoEstilo, setNovoEstilo] = useState("");
+
   const fetchPost = useCallback(async () => {
     if (!password || !id) return;
     try {
@@ -111,11 +115,14 @@ export default function InstagramPostPage() {
 
   useEffect(() => { fetchPost(); }, [fetchPost]);
 
-  const gerar = async (detalhes?: string) => {
+  const gerar = async (detalhes?: string, opts?: { estilo?: string; preservarImagens?: boolean }) => {
     const temDetalhes = !!detalhes && detalhes.trim().length > 0;
+    const trocouLinguagem = !!opts?.estilo;
     setGerando(true);
     setMsg(
-      temDetalhes
+      trocouLinguagem
+        ? `Re-gerando texto em outra linguagem (imagens preservadas)... (~2 min)`
+        : temDetalhes
         ? "Re-gerando com suas informações adicionais... (~2 min)"
         : "Gerando... isso pode levar até 2 minutos (pesquisa + fact-check)."
     );
@@ -123,7 +130,12 @@ export default function InstagramPostPage() {
       const res = await fetch("/api/instagram/gerar", {
         method: "POST",
         headers: apiHeaders({ "Content-Type": "application/json" }),
-        body: JSON.stringify({ postId: id, detalhesExtras: temDetalhes ? detalhes : undefined }),
+        body: JSON.stringify({
+          postId: id,
+          detalhesExtras: temDetalhes ? detalhes : undefined,
+          estilo: opts?.estilo,
+          preservarImagens: opts?.preservarImagens,
+        }),
       });
       const j = await res.json();
       if (!res.ok || !j.ok) {
@@ -135,10 +147,20 @@ export default function InstagramPostPage() {
       if (j.data.slides_json) setSlidesEdit(j.data.slides_json);
       if (j.data.legenda) setLegendaEdit(j.data.legenda);
       if (j.data.hashtags) setHashtagsEdit(j.data.hashtags.join(" "));
-      setMsg(temDetalhes ? "Re-gerado com seus detalhes incorporados." : "Gerado com sucesso.");
+      setMsg(
+        trocouLinguagem
+          ? "Texto re-gerado na nova linguagem. Imagens mantidas. Lembra de clicar Re-renderizar."
+          : temDetalhes
+          ? "Re-gerado com seus detalhes incorporados."
+          : "Gerado com sucesso."
+      );
       if (temDetalhes) {
         setDetalhesExtras("");
         setMostrandoDetalhes(false);
+      }
+      if (trocouLinguagem) {
+        setNovoEstilo("");
+        setMostrandoTrocarLing(false);
       }
     } catch (e) {
       setMsg("Erro de rede: " + (e instanceof Error ? e.message : String(e)));
@@ -512,6 +534,14 @@ export default function InstagramPostPage() {
                   {mostrandoDetalhes ? "✖ Fechar detalhes" : "✍️ Adicionar detalhes"}
                 </button>
                 <button
+                  onClick={() => setMostrandoTrocarLing(v => !v)}
+                  disabled={gerando}
+                  className="px-3 py-1.5 rounded-xl border border-[#E8740E] text-xs text-[#E8740E] hover:bg-[#FFF5EB] disabled:opacity-50"
+                  title="Re-gera o texto em outra linguagem. Imagens dos slides são preservadas."
+                >
+                  {mostrandoTrocarLing ? "✖ Fechar linguagem" : "🎨 Trocar linguagem"}
+                </button>
+                <button
                   onClick={() => salvarEdicao()}
                   disabled={salvando}
                   className="px-3 py-1.5 rounded-xl border border-[#D2D2D7] text-xs text-[#6E6E73] hover:bg-[#F5F5F7] disabled:opacity-50"
@@ -528,6 +558,48 @@ export default function InstagramPostPage() {
               </div>
             )}
           </div>
+
+          {/* Trocar linguagem (preserva imagens) */}
+          {podeEditar && mostrandoTrocarLing && (
+            <div className="bg-[#FFF5EB] border border-[#E8740E]/30 rounded-2xl p-4 mb-4">
+              <h3 className="text-sm font-semibold text-[#1D1D1F] mb-1">🎨 Trocar linguagem do texto</h3>
+              <p className="text-xs text-[#6E6E73] mb-3">
+                Re-gera o texto dos slides em outro estilo de escrita. <strong>As imagens já atribuídas a cada slide ficam preservadas</strong>. Depois clica em Re-renderizar pra atualizar os PNGs.
+              </p>
+              <label className="text-xs font-medium text-[#6E6E73] mb-1 block">Novo estilo</label>
+              <select
+                value={novoEstilo}
+                onChange={e => setNovoEstilo(e.target.value)}
+                disabled={gerando}
+                className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm bg-white focus:outline-none focus:border-[#E8740E] mb-2"
+              >
+                <option value="">-- Escolher --</option>
+                <option value="PADRAO" disabled={post?.estilo === "PADRAO"}>Padrão Tigrão (descontraído + técnico){post?.estilo === "PADRAO" ? " — atual" : ""}</option>
+                <option value="EMANUEL_PESSOA" disabled={post?.estilo === "EMANUEL_PESSOA"}>Emanuel Pessoa (narrativa didática){post?.estilo === "EMANUEL_PESSOA" ? " — atual" : ""}</option>
+                <option value="CARIOCA_DESCONTRAIDO" disabled={post?.estilo === "CARIOCA_DESCONTRAIDO"}>Carioca descontraído (papo de balcão){post?.estilo === "CARIOCA_DESCONTRAIDO" ? " — atual" : ""}</option>
+                <option value="STORYTELLING_PREMIUM" disabled={post?.estilo === "STORYTELLING_PREMIUM"}>Storytelling premium (narrativa Apple Keynote){post?.estilo === "STORYTELLING_PREMIUM" ? " — atual" : ""}</option>
+                <option value="COMPARATIVO_TECNICO" disabled={post?.estilo === "COMPARATIVO_TECNICO"}>Comparativo técnico (dados + veredicto){post?.estilo === "COMPARATIVO_TECNICO" ? " — atual" : ""}</option>
+                <option value="VIRAL_POLEMICO" disabled={post?.estilo === "VIRAL_POLEMICO"}>Viral polêmico (hot-take){post?.estilo === "VIRAL_POLEMICO" ? " — atual" : ""}</option>
+                <option value="EDUCATIVO_DIDATICO" disabled={post?.estilo === "EDUCATIVO_DIDATICO"}>Educativo didático (passo-a-passo){post?.estilo === "EDUCATIVO_DIDATICO" ? " — atual" : ""}</option>
+              </select>
+              <div className="flex gap-2 mt-3 justify-end">
+                <button
+                  onClick={() => { setNovoEstilo(""); setMostrandoTrocarLing(false); }}
+                  disabled={gerando}
+                  className="px-3 py-1.5 rounded-xl border border-[#D2D2D7] text-xs text-[#6E6E73] hover:bg-[#F5F5F7] disabled:opacity-50"
+                >
+                  Cancelar
+                </button>
+                <button
+                  onClick={() => gerar(undefined, { estilo: novoEstilo, preservarImagens: true })}
+                  disabled={gerando || !novoEstilo}
+                  className="px-4 py-1.5 rounded-xl bg-[#E8740E] text-white text-xs font-semibold hover:bg-[#F5A623] disabled:opacity-50"
+                >
+                  {gerando ? "Re-gerando..." : "🎨 Re-gerar texto na nova linguagem"}
+                </button>
+              </div>
+            </div>
+          )}
 
           {/* Adicionar detalhes e re-gerar */}
           {podeEditar && mostrandoDetalhes && (

--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -19,7 +19,7 @@ interface Pesquisa {
 }
 
 type Tipo = "DICA" | "COMPARATIVO" | "NOTICIA" | "ANALISE_PROFUNDA";
-type Estilo = "PADRAO" | "EMANUEL_PESSOA";
+type Estilo = "PADRAO" | "EMANUEL_PESSOA" | "CARIOCA_DESCONTRAIDO" | "STORYTELLING_PREMIUM" | "COMPARATIVO_TECNICO" | "VIRAL_POLEMICO" | "EDUCATIVO_DIDATICO";
 
 interface Post {
   id: string;
@@ -62,6 +62,11 @@ const TIPO_LABEL: Record<Post["tipo"], string> = {
 const ESTILO_LABEL: Record<Post["estilo"], string> = {
   PADRAO: "Padrão Tigrão",
   EMANUEL_PESSOA: "Emanuel Pessoa",
+  CARIOCA_DESCONTRAIDO: "Carioca descontraído",
+  STORYTELLING_PREMIUM: "Storytelling premium",
+  COMPARATIVO_TECNICO: "Comparativo técnico",
+  VIRAL_POLEMICO: "Viral polêmico",
+  EDUCATIVO_DIDATICO: "Educativo didático",
 };
 
 export default function InstagramPostPage() {

--- a/app/api/instagram/gerar/route.ts
+++ b/app/api/instagram/gerar/route.ts
@@ -344,7 +344,12 @@ export async function POST(req: NextRequest) {
   const supabase = getSupabase();
   try {
     const body = await req.json();
-    const { postId, detalhesExtras } = body as { postId?: string; detalhesExtras?: string };
+    const { postId, detalhesExtras, estilo: estiloOverride, preservarImagens } = body as {
+      postId?: string;
+      detalhesExtras?: string;
+      estilo?: string;
+      preservarImagens?: boolean;
+    };
     if (!postId) return NextResponse.json({ error: "postId obrigatório" }, { status: 400 });
 
     const { data: post, error: fetchErr } = await supabase
@@ -356,9 +361,13 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: fetchErr?.message || "post não encontrado" }, { status: 404 });
     }
 
+    // Se admin pediu outro estilo, valida e usa ele; senao mantem o do post.
+    const estilosValidos = ["PADRAO", "EMANUEL_PESSOA", "CARIOCA_DESCONTRAIDO", "STORYTELLING_PREMIUM", "COMPARATIVO_TECNICO", "VIRAL_POLEMICO", "EDUCATIVO_DIDATICO"];
+    const estiloAtivo = estiloOverride && estilosValidos.includes(estiloOverride) ? estiloOverride : (post.estilo || "PADRAO");
+
     await supabase.from("instagram_posts").update({ status: "GERANDO", erro: null, updated_at: new Date().toISOString() }).eq("id", postId);
 
-    const systemPrompt = buildSystemPrompt(post.tipo, post.numero_slides, post.estilo || "PADRAO");
+    const systemPrompt = buildSystemPrompt(post.tipo, post.numero_slides, estiloAtivo);
 
     const detalhesTrim = (detalhesExtras || "").trim();
     const temDetalhes = detalhesTrim.length > 0 && !!post.slides_json && Array.isArray(post.slides_json) && post.slides_json.length > 0;
@@ -432,9 +441,17 @@ Refaça o carrossel incorporando as informações adicionais acima. Mantenha a e
       return NextResponse.json({ error: msg }, { status: 500 });
     }
 
-    const { error: updErr } = await supabase.from("instagram_posts").update({
+    // Merge: preserva imagem_url por POSICAO quando admin trocou de linguagem.
+    // Slide N novo herda imagem do slide N antigo — permite re-escrever texto
+    // sem perder as imagens que admin ja refinou/trocou/fez upload.
+    const slidesAntigos = Array.isArray(post.slides_json) ? (post.slides_json as Array<{ imagem_url?: string | null }>) : [];
+    const slidesFinais = preservarImagens
+      ? resultado.slides.map((s, i) => ({ ...s, imagem_url: slidesAntigos[i]?.imagem_url ?? null }))
+      : resultado.slides;
+
+    const atualizacoes: Record<string, unknown> = {
       status: "GERADO",
-      slides_json: resultado.slides,
+      slides_json: slidesFinais,
       legenda: resultado.legenda,
       hashtags: resultado.hashtags,
       pesquisa_json: {
@@ -443,7 +460,12 @@ Refaça o carrossel incorporando as informações adicionais acima. Mantenha a e
       },
       erro: null,
       updated_at: new Date().toISOString(),
-    }).eq("id", postId);
+    };
+    // Se admin trocou de linguagem, persiste no post pra render usar o novo estilo.
+    if (estiloOverride && estilosValidos.includes(estiloOverride) && estiloOverride !== post.estilo) {
+      atualizacoes.estilo = estiloOverride;
+    }
+    const { error: updErr } = await supabase.from("instagram_posts").update(atualizacoes).eq("id", postId);
 
     if (updErr) {
       return NextResponse.json({ error: updErr.message }, { status: 500 });


### PR DESCRIPTION
## O que faz
Admin pode **re-gerar o texto dos slides em outra linguagem** sem perder as imagens já atribuídas.

Fluxo:
1. Post já gerado com imagens em cada slide (via Buscar na web / Gemini / Upload)
2. Admin não gostou do tom do texto
3. Clica **🎨 Trocar linguagem** → escolhe outro estilo → Re-gerar
4. Texto muda; **imagens dos slides ficam intactas**
5. Clicar **🔄 Re-renderizar** pra regerar os PNGs com o novo texto + imagens antigas

## Backend
[api/instagram/gerar/route.ts](app/api/instagram/gerar/route.ts) aceita no body:
- \`estilo\` (opcional) — 1 dos 7 válidos. Se vier, sobrescreve o estilo do post
- \`preservarImagens\` (opcional) — quando \`true\`, faz merge position-based: slide N novo herda \`imagem_url\` do slide N antigo
- Se \`estilo\` != atual, **persiste no DB** — renderização usa novo layout (ex: Emanuel Pessoa tem visual específico com header tipo tweet)

## Frontend
[admin/instagram/[id]/page.tsx](app/admin/instagram/[id]/page.tsx):
- Botão laranja **🎨 Trocar linguagem** ao lado de "Adicionar detalhes"
- Abre painel com dropdown dos 7 estilos; o atual aparece marcado \"— atual\" e disabled
- Botão **🎨 Re-gerar texto na nova linguagem** chama endpoint com \`{ estilo, preservarImagens: true }\`
- Msg pós-sucesso lembra admin de clicar **Re-renderizar**

## Test plan
- [ ] Post do iPad tá em **Educativo didático** com imagens em cada slide
- [ ] Clicar **🎨 Trocar linguagem** → escolher **Viral polêmico** → Re-gerar
- [ ] Texto dos slides sai com tom de hot-take
- [ ] Imagens dos slides continuam as mesmas (iPad, chip, cena de FaceTime, etc.)
- [ ] Clicar **🔄 Re-renderizar** → PNGs atualizados com texto novo + imagens antigas

## Custo
Cada uso chama Claude Opus 4.7 + até 5 web searches → ~\$0.50 (R\$ 2,50) por troca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)