### PR TITLE
fix(estoque): dropdown Tela em 'Vincular ao catalogo' para acessorios

### DIFF
--- a/app/admin/estoque/page.tsx
+++ b/app/admin/estoque/page.tsx
@@ -5593,7 +5593,9 @@ export default function EstoquePage() {
                             const telaObsMatch = (p.observacao || "").match(/\[TELA:([^\]]+)\]/);
                             if (telaObsMatch) spec.ac_tela = telaObsMatch[1].trim();
                           }
-                          setRecatRow({ ...base, categoria: baseCat || p.categoria || "IPHONES", spec, cor: p.cor || "" });
+                          // Passar produto pro auto-match identificar o catalogo_modelo_id,
+                          // senao o dropdown Tela (e outros specs do catalogo) nao aparece
+                          setRecatRow({ ...base, categoria: baseCat || p.categoria || "IPHONES", spec, cor: p.cor || "", produto: p.produto || "" });
                           setRecatMode(true);
                         } else {
                           setRecatMode(false);


### PR DESCRIPTION
## Problema reportado

User: \"produtos a caminho continua igual para os modelos requisitados e gastos tambem\" — sobre a feature Tela em acessorios.

## Causa

Em /admin/estoque aba **A CAMINHO**, ao clicar **\"Vincular ao catalogo\"** num Magic Keyboard (ou outro acessorio), o dropdown **Tela** nao aparecia. Motivo:

[app/admin/estoque/page.tsx:5596](../blob/claude/fix-tela-dropdown-estoque-recatmode/app/admin/estoque/page.tsx#L5596) inicializava `recatRow` com `produto: \"\"` (de `createEmptyProdutoRow`). O auto-match em `ProdutoSpecFields` (linha 268) sai imediatamente se `row.produto` vazio:

```ts
if (!allModelos.length || row.catalogo_modelo_id || !row.produto) return;
```

Sem catalogo_modelo_id, `modeloConfigs.telas` fica vazio → dropdown Tela nunca renderiza (bloco ACESSORIOS exige `modeloConfigs.telas?.length > 0`).

## Fix

Passar `p.produto` ao `setRecatRow` pra o auto-match funcionar:

```ts
setRecatRow({ ...base, categoria, spec, cor, produto: p.produto || \"\" });
```

O /admin/gastos ja faz isso corretamente via `produtoToRowState` que inclui `produto: p.produto || \"\"`.

## Test plan
- [ ] /admin/estoque aba A CAMINHO > produto Magic Keyboard > Vincular ao catalogo > dropdown Tela aparece com 11\"/13\"/etc
- [ ] Selecionar tela, Aplicar — obs do produto fica com `[TELA:13\"]`
- [ ] Regressao iPhone/MacBook: auto-match continua funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)