### PR TITLE
feat(seminovos): variantes com preco individual

### DIFF
--- a/components/StepNewDevice.tsx
+++ b/components/StepNewDevice.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import type { NewProduct, TradeInConfig, SeminovoCategoria } from "@/lib/types";
-import { SEMINOVO_CATEGORIAS, SEMINOVO_CAT_LABELS } from "@/lib/types";
+import type { NewProduct, TradeInConfig, SeminovoCategoria, SeminovoVariante } from "@/lib/types";
+import { SEMINOVO_CATEGORIAS, SEMINOVO_CAT_LABELS, getSeminovoVariantes } from "@/lib/types";
 import { getUniqueModels, getStoragesForModel, getProductPrice } from "@/lib/sheets";
 import { formatBRL, calculateQuote, getAnyConditionLines, type AnyConditionData, type DeviceType } from "@/lib/calculations";
 import { WHATSAPP_SEMINOVO } from "@/lib/whatsapp-config";
@@ -53,12 +53,13 @@ function getCategory(modelo: string): ProductCategory {
   return "iPhone";
 }
 
-// Defaults usados apenas quando o banco não respondeu ainda
-const SEMINOVOS_DEFAULT: { modelo: string; storages: string[]; ativo: boolean; categoria: SeminovoCategoria }[] = [
-  { modelo: "iPhone 15 Pro", storages: ["128GB", "256GB"], ativo: true, categoria: "iphone" },
-  { modelo: "iPhone 15 Pro Max", storages: ["256GB", "512GB"], ativo: true, categoria: "iphone" },
-  { modelo: "iPhone 16 Pro", storages: ["128GB", "256GB"], ativo: true, categoria: "iphone" },
-  { modelo: "iPhone 16 Pro Max", storages: ["256GB"], ativo: true, categoria: "iphone" },
+// Defaults usados apenas quando o banco não respondeu ainda (todas sem preço
+// → fallback para WhatsApp manual, mesmo comportamento pré-refactor).
+const SEMINOVOS_DEFAULT: { modelo: string; variantes: SeminovoVariante[]; ativo: boolean; categoria: SeminovoCategoria }[] = [
+  { modelo: "iPhone 15 Pro", variantes: [{ storage: "128GB", ativo: true }, { storage: "256GB", ativo: true }], ativo: true, categoria: "iphone" },
+  { modelo: "iPhone 15 Pro Max", variantes: [{ storage: "256GB", ativo: true }, { storage: "512GB", ativo: true }], ativo: true, categoria: "iphone" },
+  { modelo: "iPhone 16 Pro", variantes: [{ storage: "128GB", ativo: true }, { storage: "256GB", ativo: true }], ativo: true, categoria: "iphone" },
+  { modelo: "iPhone 16 Pro Max", variantes: [{ storage: "256GB", ativo: true }], ativo: true, categoria: "iphone" },
 ];
 
 export default function StepNewDevice({ products, tradeInValue, onNext, onBack, usedModel, usedStorage, usedColor, whatsappNumber, condition, deviceType, tradeinConfig, usedModel2, usedStorage2, usedColor2, condition2, deviceType2, tradeInValue1, tradeInValue2 }: StepNewDeviceProps) {
@@ -75,16 +76,24 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
   // porque os dois universos são independentes (mesma divisão do admin).
   const [semiCat, setSemiCat] = useState<SeminovoCategoria | "">("");
 
-  // Normaliza a lista vinda do DB com categoria (backfill: item sem categoria → iphone).
-  // Inclui apenas ativos, já prontos pra uso.
+  // Normaliza a lista vinda do DB (backfill: categoria ausente → iphone) e já
+  // converte legado `storages[]` em `variantes[]` via helper. Filtra:
+  //  • Modelo inativo → oculto
+  //  • Variante inativa → removida
+  //  • Modelo sem variante ativa → oculto (sem storage pra escolher)
   const seminovosAll = useMemo(() => {
     const raw = tradeinConfig?.seminovos?.filter((s) => s.ativo);
     const src = raw && raw.length > 0 ? raw : SEMINOVOS_DEFAULT;
-    return src.map((s) => ({
-      modelo: s.modelo,
-      storages: s.storages,
-      categoria: ((s as { categoria?: string }).categoria as SeminovoCategoria) || "iphone",
-    }));
+    return src
+      .map((s) => {
+        const variantes = getSeminovoVariantes(s).filter((v) => v.ativo !== false && v.storage.trim());
+        return {
+          modelo: s.modelo,
+          variantes,
+          categoria: ((s as { categoria?: string }).categoria as SeminovoCategoria) || "iphone",
+        };
+      })
+      .filter((s) => s.variantes.length > 0);
   }, [tradeinConfig]);
 
   // Categorias com ao menos 1 seminovo ativo (as únicas abas clicáveis).
@@ -355,23 +364,58 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
             </Sec>
           )}
 
-          {semiModel && (
-            <Sec title="Armazenamento">
-              <div className="flex gap-2 flex-wrap">
-                {seminovos.find(s => s.modelo === semiModel)?.storages.map((st) => (
-                  <button key={st} onClick={() => setSemiStorage(st)}
-                    className="flex-1 min-w-[80px] px-4 py-3.5 rounded-2xl text-[14px] font-medium transition-all duration-200"
-                    style={semiStorage === st
-                      ? { backgroundColor: "var(--ti-accent-light)", color: "var(--ti-accent-text)", border: "1px solid var(--ti-accent)" }
-                      : { backgroundColor: "var(--ti-btn-bg)", color: "var(--ti-btn-text)", border: "1px solid var(--ti-btn-border)" }}>
-                    {st}
-                  </button>
-                ))}
-              </div>
-            </Sec>
-          )}
+          {semiModel && (() => {
+            const variantes = seminovos.find(s => s.modelo === semiModel)?.variantes || [];
+            return (
+              <Sec title="Armazenamento">
+                <div className="flex gap-2 flex-wrap">
+                  {variantes.map((v) => (
+                    <button key={v.storage} onClick={() => setSemiStorage(v.storage)}
+                      className="flex-1 min-w-[80px] px-4 py-3.5 rounded-2xl text-[14px] font-medium transition-all duration-200 flex flex-col items-center gap-1"
+                      style={semiStorage === v.storage
+                        ? { backgroundColor: "var(--ti-accent-light)", color: "var(--ti-accent-text)", border: "1px solid var(--ti-accent)" }
+                        : { backgroundColor: "var(--ti-btn-bg)", color: "var(--ti-btn-text)", border: "1px solid var(--ti-btn-border)" }}>
+                      <span className="font-semibold">{v.storage}</span>
+                      {typeof v.preco === "number" && (
+                        <span className="text-[12px] font-normal" style={{ opacity: 0.7 }}>{formatBRL(v.preco)}</span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </Sec>
+            );
+          })()}
 
-          {semiModel && semiStorage && (
+          {semiModel && semiStorage && (() => {
+            // Busca a variante selecionada pra decidir o fluxo: preço definido
+            // → orçamento automático (onNext → StepQuote); senão → WhatsApp.
+            const selectedVariante = seminovos
+              .find((s) => s.modelo === semiModel)?.variantes
+              .find((v) => v.storage === semiStorage);
+            const precoAuto = typeof selectedVariante?.preco === "number" ? selectedVariante.preco : null;
+            if (precoAuto !== null) {
+              // Orçamento automático — envia pro StepQuote com preço conhecido.
+              // O marker "SEMINOVO" no modelo permite ao StepQuote ajustar a
+              // mensagem (garantia 3 meses, sem "lacrado na caixa").
+              return (
+                <div className="space-y-3 animate-fadeIn">
+                  <div className="rounded-2xl p-4 text-center" style={{ backgroundColor: "var(--ti-card-bg)", border: "1px solid var(--ti-card-border)" }}>
+                    <p className="text-[13px] mb-2" style={{ color: "var(--ti-muted)" }}>Voce selecionou:</p>
+                    <p className="text-[18px] font-bold" style={{ color: "var(--ti-text)" }}>{semiModel} {semiStorage}</p>
+                    <p className="text-[12px] mt-1" style={{ color: "var(--ti-accent)" }}>SEMINOVO</p>
+                    <p className="text-[16px] font-bold mt-2" style={{ color: "var(--ti-text)" }}>{formatBRL(precoAuto)}</p>
+                  </div>
+                  <button
+                    onClick={() => onNext({ newModel: `${semiModel} SEMINOVO`, newStorage: semiStorage, newPrice: precoAuto })}
+                    className="w-full py-4 rounded-2xl text-[15px] font-semibold text-white transition-all duration-200 active:scale-[0.98]"
+                    style={{ backgroundColor: "var(--ti-accent)" }}>
+                    Ver cotação
+                  </button>
+                </div>
+              );
+            }
+            // Fluxo WhatsApp manual — variante sem preço cadastrado.
+            return (
             <div className="space-y-3 animate-fadeIn">
               <div className="rounded-2xl p-4 text-center" style={{ backgroundColor: "var(--ti-card-bg)", border: "1px solid var(--ti-card-border)" }}>
                 <p className="text-[13px] mb-2" style={{ color: "var(--ti-muted)" }}>Voce selecionou:</p>
@@ -435,7 +479,8 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
                 Consultar no WhatsApp
               </button>
             </div>
-          )}
+            );
+          })()}
         </div>
       )}
 

--- a/components/StepQuote.tsx
+++ b/components/StepQuote.tsx
@@ -115,7 +115,11 @@ export default function StepQuote(p: StepQuoteProps) {
   const origemTexto = clienteOrigem ? (origemMap[origemKey] || origemMap[clienteOrigem?.toLowerCase().normalize("NFC") || ""] || `Vim por ${clienteOrigem}`) : "";
   const origemLine = origemTexto ? `\n${origemTexto} e desejo fechar meu pedido!\n` : "";
 
-  const waMsg = `Olá, me chamo ${clienteNome}. ${origemTexto || "Vi meu orçamento no site"} e desejo fechar meu pedido!\n\n*WhatsApp:* ${clienteWhatsApp}\n${igLine}\n*ORÇAMENTO DE TROCA -- TigraoImports*\n---\n\n*Produto novo:*\n${newModel} ${newStorage} -- ${f2(newPrice)}\nLacrado | 1 ano de garantia | Nota Fiscal\n\n${usadoSec}\n\n---\n*Diferença no PIX: ${f2(dif)}*\n\n*Forma de pagamento escolhida:*\n${formaPag}\n\n_Validade deste orçamento: ${validadeHoras} horas_`;
+  // StepNewDevice marca seminovos embutindo " SEMINOVO" no newModel — a
+  // mensagem do WhatsApp troca garantia/descrição sem precisar de prop extra.
+  const isSeminovo = / SEMINOVO$/i.test(newModel);
+  const produtoDesc = isSeminovo ? "Seminovo | garantia 3 meses | Nota Fiscal" : "Lacrado | 1 ano de garantia | Nota Fiscal";
+  const waMsg = `Olá, me chamo ${clienteNome}. ${origemTexto || "Vi meu orçamento no site"} e desejo fechar meu pedido!\n\n*WhatsApp:* ${clienteWhatsApp}\n${igLine}\n*ORÇAMENTO DE TROCA -- TigraoImports*\n---\n\n*Produto novo:*\n${newModel} ${newStorage} -- ${f2(newPrice)}\n${produtoDesc}\n\n${usadoSec}\n\n---\n*Diferença no PIX: ${f2(dif)}*\n\n*Forma de pagamento escolhida:*\n${formaPag}\n\n_Validade deste orçamento: ${validadeHoras} horas_`;
   const waUrl = getWhatsAppUrl(whatsappNumero, waMsg);
   const condLines = getAnyConditionLines(deviceType, condition);
 

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import { TradeInQuestion, TradeInQuestionOption, SeminovoOption, SeminovoCategoria, SEMINOVO_CAT_LABELS } from "@/lib/types";
+import { TradeInQuestion, TradeInQuestionOption, SeminovoOption, SeminovoVariante, SeminovoCategoria, SEMINOVO_CAT_LABELS, getSeminovoVariantes, consolidateSeminovos } from "@/lib/types";
 
 interface Props {
   password: string;
@@ -485,10 +485,10 @@ const DEFAULT_LABELS: Record<string, string> = {
 };
 
 const DEFAULT_SEMINOVOS: SeminovoOption[] = [
-  { modelo: "iPhone 15 Pro", storages: ["128GB", "256GB"], ativo: true, categoria: "iphone" },
-  { modelo: "iPhone 15 Pro Max", storages: ["256GB", "512GB"], ativo: true, categoria: "iphone" },
-  { modelo: "iPhone 16 Pro", storages: ["128GB", "256GB"], ativo: true, categoria: "iphone" },
-  { modelo: "iPhone 16 Pro Max", storages: ["256GB"], ativo: true, categoria: "iphone" },
+  { modelo: "iPhone 15 Pro", ativo: true, categoria: "iphone", variantes: [{ storage: "128GB", ativo: true }, { storage: "256GB", ativo: true }] },
+  { modelo: "iPhone 15 Pro Max", ativo: true, categoria: "iphone", variantes: [{ storage: "256GB", ativo: true }, { storage: "512GB", ativo: true }] },
+  { modelo: "iPhone 16 Pro", ativo: true, categoria: "iphone", variantes: [{ storage: "128GB", ativo: true }, { storage: "256GB", ativo: true }] },
+  { modelo: "iPhone 16 Pro Max", ativo: true, categoria: "iphone", variantes: [{ storage: "256GB", ativo: true }] },
 ];
 
 const DEFAULT_ORIGENS = ["Anúncio", "Story", "Direct", "WhatsApp", "Indicação", "Já sou cliente"];
@@ -535,7 +535,6 @@ function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceT
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
   const [newOrigem, setNewOrigem] = useState("");
   const [newSemiModelo, setNewSemiModelo] = useState("");
-  const [newSemiStorage, setNewSemiStorage] = useState("");
 
   // Itens sem categoria (pré-migration) caem em "iphone" para compatibilidade.
   const categoriaAtiva: SeminovoCategoria = (deviceTab as SeminovoCategoria) in SEMINOVO_CAT_LABELS ? (deviceTab as SeminovoCategoria) : "iphone";
@@ -566,10 +565,14 @@ function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceT
         const d = json.data;
         if (d) {
           if (Array.isArray(d.seminovos) && d.seminovos.length > 0) {
-            // Backfill: itens antigos sem categoria caem em "iphone"
+            // Backfill: itens antigos sem categoria caem em "iphone"; legado
+            // sem `variantes` é convertido via helper. Não mexemos no banco —
+            // só no estado local; a forma canônica será escrita no próximo save.
             const normalized: SeminovoOption[] = d.seminovos.map((s: SeminovoOption) => ({
-              ...s,
+              modelo: s.modelo,
+              ativo: s.ativo !== false,
               categoria: (s.categoria as SeminovoCategoria) || "iphone",
+              variantes: getSeminovoVariantes(s),
             }));
             setSeminovos(normalized);
           }
@@ -584,10 +587,16 @@ function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceT
   async function handleSave() {
     setSaving(true);
     try {
+      // Consolida duplicatas antes de persistir. Operador pode ter criado
+      // "iPhone 15 Pro" duas vezes editando categorias diferentes — aqui colapsa
+      // em uma única entrada com todas variantes.
+      const consolidated = consolidateSeminovos(seminovos);
+      // Reflete a consolidação no state pra UI já mostrar o resultado final.
+      if (consolidated.length !== seminovos.length) setSeminovos(consolidated);
       const res = await fetch("/api/admin/tradein-config", {
         method: "PUT",
         headers: getHeaders(),
-        body: JSON.stringify({ seminovos, labels, origens }),
+        body: JSON.stringify({ seminovos: consolidated, labels, origens }),
       });
       const json = await res.json();
       if (json.ok) {
@@ -660,8 +669,26 @@ function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceT
           )}
           {visibleIndices.map((si) => {
             const s = seminovos[si];
+            const variantes = s.variantes || [];
+            const updateVariante = (vi: number, patch: Partial<SeminovoVariante>) => {
+              const arr = [...seminovos];
+              const v = [...(arr[si].variantes || [])];
+              v[vi] = { ...v[vi], ...patch };
+              arr[si] = { ...arr[si], variantes: v };
+              setSeminovos(arr);
+            };
+            const removeVariante = (vi: number) => {
+              const arr = [...seminovos];
+              arr[si] = { ...arr[si], variantes: (arr[si].variantes || []).filter((_, i) => i !== vi) };
+              setSeminovos(arr);
+            };
+            const addVariante = () => {
+              const arr = [...seminovos];
+              arr[si] = { ...arr[si], variantes: [...(arr[si].variantes || []), { storage: "", ativo: true }] };
+              setSeminovos(arr);
+            };
             return (
-            <div key={si} className={`rounded-lg border border-[#E5E5EA] p-3 space-y-2 ${!s.ativo ? "opacity-50" : ""}`}>
+            <div key={si} className={`rounded-lg border border-[#E5E5EA] p-3 space-y-3 ${!s.ativo ? "opacity-50" : ""}`}>
               <div className="flex items-center gap-2">
                 <input
                   value={s.modelo}
@@ -679,6 +706,7 @@ function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceT
                     arr[si] = { ...arr[si], ativo: !arr[si].ativo };
                     setSeminovos(arr);
                   }}
+                  title={s.ativo ? "Modelo visível ao cliente" : "Modelo oculto"}
                   className={`w-10 h-5 rounded-full transition-colors relative ${s.ativo ? "bg-[#E8740E]" : "bg-[#D2D2D7]"}`}
                 >
                   <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform shadow-sm ${s.ativo ? "left-5" : "left-0.5"}`} />
@@ -686,71 +714,72 @@ function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceT
                 <button
                   onClick={() => setSeminovos(seminovos.filter((_, i) => i !== si))}
                   className="text-red-400 hover:text-red-600 text-sm px-1"
+                  title="Remover modelo"
                 >
                   ✕
                 </button>
               </div>
-              <div className="flex flex-wrap gap-1.5">
-                {s.storages.map((st, sti) => (
-                  <span key={sti} className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-[#F5F5F7] text-xs text-[#1D1D1F]">
-                    {st}
-                    <button
-                      onClick={() => {
-                        const arr = [...seminovos];
-                        arr[si] = { ...arr[si], storages: arr[si].storages.filter((_, i) => i !== sti) };
-                        setSeminovos(arr);
+
+              {/* Variantes: uma linha por storage. Preço definido → orçamento
+                  automático no cliente; sem preço → fallback WhatsApp manual. */}
+              <div className="space-y-1.5">
+                <div className="grid grid-cols-[1fr_auto_auto_auto] gap-2 items-center px-1 text-[10px] font-semibold uppercase tracking-wider text-[#86868B]">
+                  <span>Storage</span>
+                  <span className="text-right pr-1">Preço (R$)</span>
+                  <span className="text-center w-10">Ativo</span>
+                  <span className="w-4" />
+                </div>
+                {variantes.length === 0 && (
+                  <div className="text-[11px] italic text-[#86868B] px-1 py-1">
+                    Sem variantes. Adicione ao menos uma abaixo.
+                  </div>
+                )}
+                {variantes.map((v, vi) => (
+                  <div key={vi} className={`grid grid-cols-[1fr_auto_auto_auto] gap-2 items-center ${v.ativo === false ? "opacity-50" : ""}`}>
+                    <input
+                      value={v.storage}
+                      onChange={(e) => updateVariante(vi, { storage: e.target.value })}
+                      placeholder="Ex: 256GB"
+                      className="px-2 py-1 rounded border border-[#D2D2D7] text-xs focus:outline-none focus:border-[#E8740E]"
+                    />
+                    <input
+                      type="number"
+                      inputMode="numeric"
+                      value={typeof v.preco === "number" ? String(v.preco) : ""}
+                      onChange={(e) => {
+                        const raw = e.target.value.trim();
+                        const num = raw === "" ? undefined : Number(raw);
+                        updateVariante(vi, { preco: Number.isFinite(num as number) ? (num as number) : undefined });
                       }}
-                      className="text-[#86868B] hover:text-red-500 text-[10px]"
+                      placeholder="—"
+                      className="w-24 px-2 py-1 rounded border border-[#D2D2D7] text-xs text-right focus:outline-none focus:border-[#E8740E]"
+                    />
+                    <button
+                      onClick={() => updateVariante(vi, { ativo: v.ativo === false })}
+                      title={v.ativo !== false ? "Variante visível" : "Variante oculta"}
+                      className={`w-10 h-5 rounded-full transition-colors relative ${v.ativo !== false ? "bg-[#E8740E]" : "bg-[#D2D2D7]"}`}
+                    >
+                      <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform shadow-sm ${v.ativo !== false ? "left-5" : "left-0.5"}`} />
+                    </button>
+                    <button
+                      onClick={() => removeVariante(vi)}
+                      className="text-[#86868B] hover:text-red-500 text-xs w-4"
+                      title="Remover variante"
                     >
                       ✕
                     </button>
-                  </span>
+                  </div>
                 ))}
-                <div className="inline-flex items-center gap-1">
-                  <input
-                    value={si === visibleIndices[visibleIndices.length - 1] ? newSemiStorage : ""}
-                    onChange={(e) => setNewSemiStorage(e.target.value)}
-                    onFocus={() => setNewSemiStorage("")}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" && newSemiStorage.trim()) {
-                        const arr = [...seminovos];
-                        arr[si] = { ...arr[si], storages: [...arr[si].storages, newSemiStorage.trim()] };
-                        setSeminovos(arr);
-                        setNewSemiStorage("");
-                      }
-                    }}
-                    placeholder="+ storage"
-                    className="w-20 px-2 py-0.5 rounded border border-dashed border-[#D2D2D7] text-xs focus:outline-none focus:border-[#E8740E]"
-                  />
-                </div>
+                <button
+                  onClick={addVariante}
+                  className="text-[11px] font-semibold text-[#E8740E] hover:underline mt-1"
+                >
+                  + Adicionar variante
+                </button>
+                <p className="text-[10px] text-[#86868B] leading-relaxed pt-1">
+                  Com preço → orçamento automático. Sem preço → cliente é levado ao WhatsApp pra cotação manual.
+                </p>
               </div>
-              {/* Campo de preço — reservado pra futuro. Hoje opcional e escondido
-                  atrás de um detalhamento pra não poluir a UI. O valor já é
-                  persistido no banco (preco?: number), então quando ativarmos
-                  a precificação automática nada precisa ser migrado. */}
-              <details className="text-[11px] text-[#86868B]">
-                <summary className="cursor-pointer select-none hover:text-[#1D1D1F]">
-                  Preço (opcional — uso futuro){typeof s.preco === "number" ? ` · R$ ${s.preco.toLocaleString("pt-BR")}` : ""}
-                </summary>
-                <div className="mt-2 flex items-center gap-2">
-                  <span>R$</span>
-                  <input
-                    type="number"
-                    inputMode="numeric"
-                    value={typeof s.preco === "number" ? String(s.preco) : ""}
-                    onChange={(e) => {
-                      const arr = [...seminovos];
-                      const raw = e.target.value.trim();
-                      const num = raw === "" ? undefined : Number(raw);
-                      arr[si] = { ...arr[si], preco: Number.isFinite(num as number) ? (num as number) : undefined };
-                      setSeminovos(arr);
-                    }}
-                    placeholder="Ex: 5500"
-                    className="w-32 px-2 py-1 rounded border border-[#D2D2D7] text-xs focus:outline-none focus:border-[#E8740E]"
-                  />
-                  <span className="text-[10px] italic">Ainda não exibido ao cliente.</span>
-                </div>
-              </details>
             </div>
             );
           })}
@@ -764,12 +793,16 @@ function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceT
             <button
               onClick={() => {
                 if (newSemiModelo.trim()) {
-                  // Novo item herda a categoria da aba aberta.
+                  // Novo item herda a categoria da aba aberta e vem com duas
+                  // variantes vazias — operador preenche storage/preço inline.
                   setSeminovos([...seminovos, {
                     modelo: newSemiModelo.trim(),
-                    storages: ["128GB", "256GB"],
                     ativo: true,
                     categoria: categoriaAtiva,
+                    variantes: [
+                      { storage: "128GB", ativo: true },
+                      { storage: "256GB", ativo: true },
+                    ],
                   }]);
                   setNewSemiModelo("");
                 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -72,15 +72,81 @@ export const SEMINOVO_CAT_LABELS: Record<SeminovoCategoria, { label: string; ico
   watch: { label: "Apple Watch", icon: "⌚" },
 };
 
+/** Uma variação de armazenamento de um seminovo.
+ *  `preco` definido → orçamento automático (como lacrado).
+ *  `preco` ausente → flow WhatsApp manual (cotação sob medida).
+ *  `ativo === false` esconde esta variante sem apagar (útil quando só um
+ *  storage está temporariamente esgotado). Por padrão variantes são ativas. */
+export interface SeminovoVariante {
+  storage: string;
+  preco?: number;
+  ativo?: boolean;
+}
+
 /** Configuração do formulário trade-in (Supabase tradein_config).
- *  `preco` é opcional e reservado para futura precificação direta —
- *  ainda não aparece no formulário do cliente. */
+ *  `variantes` é o formato canônico. `storages` + `preco` (legado, pré-refactor
+ *  das variantes) continuam aceitos na leitura via `getSeminovoVariantes`
+ *  — nenhuma migration é necessária porque o campo `seminovos` é JSONB livre. */
 export interface SeminovoOption {
   modelo: string;
-  storages: string[];
   ativo: boolean;
   categoria: SeminovoCategoria;
+  variantes?: SeminovoVariante[];
+  /** @deprecated use `variantes` */
+  storages?: string[];
+  /** @deprecated preço por modelo — agora vive em cada variante */
   preco?: number;
+}
+
+/** Retorna a lista normalizada de variantes, convertendo o formato legado
+ *  (`storages` + `preco` por modelo) quando `variantes` não está presente. */
+export function getSeminovoVariantes(s: SeminovoOption): SeminovoVariante[] {
+  if (Array.isArray(s.variantes) && s.variantes.length > 0) return s.variantes;
+  const storages = Array.isArray(s.storages) ? s.storages : [];
+  return storages.map((storage) => ({
+    storage,
+    preco: typeof s.preco === "number" ? s.preco : undefined,
+    ativo: true,
+  }));
+}
+
+/** Mescla duplicatas de modelo (case-insensitive, dentro da mesma categoria).
+ *  Ao salvar o admin, evita que duas entradas de "iPhone 15 Pro" sobrevivam.
+ *  Variantes são deduplicadas por `storage` — a primeira entrada com preço
+ *  definido vence se houver conflito. */
+export function consolidateSeminovos(list: SeminovoOption[]): SeminovoOption[] {
+  const byKey = new Map<string, SeminovoOption>();
+  for (const raw of list) {
+    const modelo = (raw.modelo || "").trim();
+    if (!modelo) continue;
+    const categoria = raw.categoria || "iphone";
+    const key = `${categoria}::${modelo.toLowerCase()}`;
+    const variantes = getSeminovoVariantes(raw);
+    const prev = byKey.get(key);
+    if (!prev) {
+      byKey.set(key, { modelo, categoria, ativo: raw.ativo !== false, variantes });
+      continue;
+    }
+    // Mescla: ativo OR, variantes deduplicadas por storage
+    const byStorage = new Map<string, SeminovoVariante>();
+    for (const v of [...(prev.variantes || []), ...variantes]) {
+      const storage = v.storage.trim();
+      if (!storage) continue;
+      const existing = byStorage.get(storage);
+      if (!existing) { byStorage.set(storage, v); continue; }
+      // Mantém a primeira, mas se ela não tem preço e a nova tem, promove
+      if (typeof existing.preco !== "number" && typeof v.preco === "number") {
+        byStorage.set(storage, { ...existing, preco: v.preco });
+      }
+    }
+    byKey.set(key, {
+      modelo: prev.modelo,
+      categoria,
+      ativo: prev.ativo || raw.ativo !== false,
+      variantes: [...byStorage.values()],
+    });
+  }
+  return [...byKey.values()];
 }
 
 export interface TradeInConfig {


### PR DESCRIPTION
## Summary
- Cada modelo seminovo passa a ter uma lista de **variantes** (`storage` + `preco` opcional + `ativo`), em vez de `storages[]` soltos sem preço por variação
- No admin, card reescrito com linha por storage (toggle + preço + ✕); salvar consolida duplicatas via `consolidateSeminovos()`
- No cliente, `StepNewDevice` mostra preço no botão do storage; variante com preço → orçamento automático (StepQuote); sem preço → fluxo WhatsApp manual (comportamento atual)
- StepQuote detecta sufixo `SEMINOVO` para trocar "Lacrado | 1 ano de garantia" por "Seminovo | garantia 3 meses" na mensagem do WhatsApp
- Schema `seminovos` é JSONB livre: formato legado (`storages[]` + `preco` por modelo) continua sendo lido via `getSeminovoVariantes`, sem migration necessária

## Test plan
- [ ] Abrir `/admin/simulacoes` → Perguntas Trade-In → **Modelos Seminovo** na aba iPhone
- [ ] Confirmar que modelos legados (iPhone 15 Pro 128GB/256GB) aparecem como duas linhas de variante no mesmo card, em vez de dois cards separados
- [ ] Cadastrar preço em uma variante, ex: "iPhone 15 Pro 256GB" = R$ 4.197
- [ ] Salvar e recarregar — variante deve persistir com o preço
- [ ] Criar duplicata de modelo no mesmo card (ex: dois "iPhone 15 Pro") e salvar — confirmar que colapsou em uma entrada só
- [ ] No cliente (simulador trade-in), selecionar seminovo iPhone 15 Pro 256GB → deve ir direto pro `StepQuote` com o preço cadastrado
- [ ] Selecionar storage sem preço (ex: 128GB) → deve cair no fluxo WhatsApp manual (comportamento atual)
- [ ] Verificar mensagem do WhatsApp do StepQuote para seminovo: deve dizer "Seminovo | garantia 3 meses | Nota Fiscal"

🤖 Generated with [Claude Code](https://claude.com/claude-code)