### PR TITLE
feat(vendas): segundo PIX opcional (dividir recebimento entre 2 bancos)

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -145,7 +145,7 @@ export default function VendasPage() {
     cliente: "", cpf: "", cnpj: "", email: "", telefone: "", endereco: "", pessoa: "PF" as "PF" | "PJ", origem: "", tipo: "", produto: "", fornecedor: "",
     custo: "", preco_vendido: "", valor_comprovante_input: "", banco: "ITAU", forma: "",
     qnt_parcelas: "", bandeira: "", local: "", produto_na_troca: "",
-    entrada_pix: "", banco_pix: "ITAU", entrada_especie: "", banco_2nd: "", banco_alt: "",
+    entrada_pix: "", banco_pix: "ITAU", entrada_pix_2: "", banco_pix_2: "INFINITE", entrada_especie: "", banco_2nd: "", banco_alt: "",
     forma_alt: "", parc_alt: "", band_alt: "", comp_alt: "", sinal_antecipado: "", banco_sinal: "", forma_sinal: "PIX",
     entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
     valor_total_venda: "",
@@ -1098,6 +1098,8 @@ export default function VendasPage() {
       produto_na_troca: pValorTroca1 > 0 ? String(pValorTroca1) : (prodFields.troca_produto ? "0" : null),
       entrada_pix: gEntradaPix,
       banco_pix: gTemEntradaPix ? (gBancoPix || "ITAU") : null,
+      entrada_pix_2: parseFloat(form.entrada_pix_2) || 0,
+      banco_pix_2: (parseFloat(form.entrada_pix_2) || 0) > 0 ? (form.banco_pix_2 || "INFINITE") : null,
       entrada_especie: gEntradaEspecie,
       entrada_fiado: gForma === "FIADO" ? (gValorComprovanteInput || pCusto) : (parseFloat(form.entrada_fiado) || 0),
       fiado_parcelas: (() => {
@@ -1438,6 +1440,13 @@ export default function VendasPage() {
     for (const prod of allProducts) {
       payloads.push(buildPayload(prod));
     }
+    // Multi-produto: entrada_pix_2 fica inteira no primeiro payload (nao
+    // distribuimos proporcional como entrada_pix — mantem a logica simples e
+    // os saldos continuam somando ao total correto porque leitura e por row).
+    for (let i = 1; i < payloads.length; i++) {
+      payloads[i].entrada_pix_2 = 0;
+      payloads[i].banco_pix_2 = null;
+    }
     // Single-product: se tem segundo cartão, SEMPRE recalcular preco_vendido como
     // líquido(cartão principal) + líquido(2o cartão) + pix + espécie + troca
     if (payloads.length === 1) {
@@ -1708,7 +1717,7 @@ export default function VendasPage() {
               cliente: "", cpf: "", cnpj: "", email: "", telefone: "", endereco: "", pessoa: "PF" as "PF" | "PJ", origem: "", tipo: "", produto: "", fornecedor: "",
               custo: "", preco_vendido: "", valor_comprovante_input: "", banco: "ITAU", forma: "",
               qnt_parcelas: "", bandeira: "", local: "", produto_na_troca: "",
-              entrada_pix: "", banco_pix: "ITAU", entrada_especie: "", banco_2nd: "", banco_alt: "",
+              entrada_pix: "", banco_pix: "ITAU", entrada_pix_2: "", banco_pix_2: "INFINITE", entrada_especie: "", banco_2nd: "", banco_alt: "",
               forma_alt: "", parc_alt: "", band_alt: "", comp_alt: "", sinal_antecipado: "", banco_sinal: "", forma_sinal: "PIX",
               entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
               valor_total_venda: "",
@@ -1750,7 +1759,7 @@ export default function VendasPage() {
               cliente: "", cpf: "", cnpj: "", email: "", telefone: "", endereco: "", pessoa: "PF" as "PF" | "PJ", origem: "", tipo: "", produto: "", fornecedor: "",
               custo: "", preco_vendido: "", valor_comprovante_input: "", banco: "ITAU", forma: "",
               qnt_parcelas: "", bandeira: "", local: "", produto_na_troca: "",
-              entrada_pix: "", banco_pix: "ITAU", entrada_especie: "", banco_2nd: "", banco_alt: "",
+              entrada_pix: "", banco_pix: "ITAU", entrada_pix_2: "", banco_pix_2: "INFINITE", entrada_especie: "", banco_2nd: "", banco_alt: "",
               forma_alt: "", parc_alt: "", band_alt: "", comp_alt: "", sinal_antecipado: "", banco_sinal: "", forma_sinal: "PIX",
               entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
               valor_total_venda: "",
@@ -1828,7 +1837,7 @@ export default function VendasPage() {
         cliente: "", cpf: "", cnpj: "", email: "", telefone: "", endereco: "", pessoa: "PF" as "PF" | "PJ", origem: "", tipo: "", produto: "", fornecedor: "",
         custo: "", preco_vendido: "", valor_comprovante_input: "", banco: "ITAU", forma: "",
         qnt_parcelas: "", bandeira: "", local: "", produto_na_troca: "",
-        entrada_pix: "", banco_pix: "ITAU", entrada_especie: "", banco_2nd: "", banco_alt: "",
+        entrada_pix: "", banco_pix: "ITAU", entrada_pix_2: "", banco_pix_2: "INFINITE", entrada_especie: "", banco_2nd: "", banco_alt: "",
         forma_alt: "", parc_alt: "", band_alt: "", comp_alt: "", sinal_antecipado: "", banco_sinal: "", forma_sinal: "PIX",
         entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
         valor_total_venda: "",
@@ -2080,6 +2089,8 @@ export default function VendasPage() {
       produto_na_troca: "",
       entrada_pix: "",
       banco_pix: v.banco_pix || "ITAU",
+      entrada_pix_2: "",
+      banco_pix_2: v.banco_pix_2 || "INFINITE",
       entrada_especie: "",
       entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
       valor_total_venda: "",
@@ -2330,7 +2341,7 @@ export default function VendasPage() {
                     data: hojeBR(), cliente: "", cpf: "", cnpj: "", email: "", telefone: "", endereco: "", pessoa: "PF" as "PF" | "PJ", origem: "", tipo: "", produto: "", fornecedor: "",
                     custo: "", preco_vendido: "", valor_comprovante_input: "", banco: "ITAU", forma: "",
                     qnt_parcelas: "", bandeira: "", local: "", produto_na_troca: "",
-                    entrada_pix: "", banco_pix: "ITAU", entrada_especie: "", banco_2nd: "", banco_alt: "",
+                    entrada_pix: "", banco_pix: "ITAU", entrada_pix_2: "", banco_pix_2: "INFINITE", entrada_especie: "", banco_2nd: "", banco_alt: "",
                     forma_alt: "", parc_alt: "", band_alt: "", comp_alt: "", sinal_antecipado: "", banco_sinal: "", forma_sinal: "PIX",
                     entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
                     valor_total_venda: "",
@@ -3196,7 +3207,7 @@ export default function VendasPage() {
                     cliente: "", cpf: "", cnpj: "", email: "", telefone: "", endereco: "", pessoa: "PF", origem: "", tipo: "", produto: "", fornecedor: "",
                     custo: "", preco_vendido: "", valor_comprovante_input: "", banco: "ITAU", forma: "",
                     qnt_parcelas: "", bandeira: "", local: "", produto_na_troca: "",
-                    entrada_pix: "", banco_pix: "ITAU", entrada_especie: "", banco_2nd: "", banco_alt: "",
+                    entrada_pix: "", banco_pix: "ITAU", entrada_pix_2: "", banco_pix_2: "INFINITE", entrada_especie: "", banco_2nd: "", banco_alt: "",
                     forma_alt: "", parc_alt: "", band_alt: "", comp_alt: "", sinal_antecipado: "", banco_sinal: "", forma_sinal: "PIX",
                     entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
                     valor_total_venda: "",
@@ -3652,6 +3663,22 @@ export default function VendasPage() {
                 )}
               </div>
               )}
+
+              {/* 2o PIX opcional — usa-se quando o cliente divide o pagamento
+                  entre dois bancos. Valor sai do banco principal e entra no
+                  banco_pix_2. Sempre visível pra que o operador lembre que
+                  pode dividir; fica inerte se deixado zerado. */}
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                <div><p className={labelCls}>2º PIX (R$) — opcional</p><input type="text" inputMode="numeric" value={fmtMil(form.entrada_pix_2)} onChange={(e) => {
+                  const clean = e.target.value.replace(/\./g, "").replace(/\D/g, "");
+                  setForm(f => ({ ...f, entrada_pix_2: clean, ...(parseFloat(clean) > 0 && !f.banco_pix_2 ? { banco_pix_2: "INFINITE" } : {}) }));
+                }} placeholder="0" className={inputCls} /></div>
+                {parseFloat(form.entrada_pix_2) > 0 && (
+                  <div><p className={labelCls}>Banco do 2º PIX</p><select value={form.banco_pix_2} onChange={(e) => set("banco_pix_2", e.target.value)} className={selectCls}>
+                    <option>ITAU</option><option>INFINITE</option><option>MERCADO_PAGO</option>
+                  </select></div>
+                )}
+              </div>
 
               {/* Entrada Especie */}
               {form.forma !== "ESPECIE" && (
@@ -5552,6 +5579,8 @@ export default function VendasPage() {
                                               produto_na_troca: grupoVendas.length > 1 ? "" : String(primaryVenda.produto_na_troca || trocaValorPend || ""),
                                               entrada_pix: String(grupoVendas.reduce((s, gv) => s + (gv.entrada_pix || 0), 0) || ""),
                                               banco_pix: primaryVenda.banco_pix || "ITAU",
+                                              entrada_pix_2: String(grupoVendas.reduce((s, gv) => s + (gv.entrada_pix_2 || 0), 0) || ""),
+                                              banco_pix_2: primaryVenda.banco_pix_2 || "INFINITE",
                                               entrada_especie: String(grupoVendas.reduce((s, gv) => s + (gv.entrada_especie || 0), 0) || ""),
                                               entrada_fiado: String(primaryVenda.entrada_fiado || ""),
                                               fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
@@ -6738,7 +6767,7 @@ export default function VendasPage() {
                     cliente: "", cpf: "", cnpj: "", email: "", telefone: "", endereco: "", pessoa: "PF", origem: "", tipo: "", produto: "", fornecedor: "",
                     custo: "", preco_vendido: "", valor_comprovante_input: "", banco: "ITAU", forma: "",
                     qnt_parcelas: "", bandeira: "", local: "", produto_na_troca: "",
-                    entrada_pix: "", banco_pix: "ITAU", entrada_especie: "", banco_2nd: "", banco_alt: "",
+                    entrada_pix: "", banco_pix: "ITAU", entrada_pix_2: "", banco_pix_2: "INFINITE", entrada_especie: "", banco_2nd: "", banco_alt: "",
                     forma_alt: "", parc_alt: "", band_alt: "", comp_alt: "", sinal_antecipado: "", banco_sinal: "", forma_sinal: "PIX",
                     entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
                     valor_total_venda: "",
@@ -6774,7 +6803,7 @@ export default function VendasPage() {
                     cliente: "", cpf: "", cnpj: "", email: "", telefone: "", endereco: "", pessoa: "PF", origem: "", tipo: "", produto: "", fornecedor: "",
                     custo: "", preco_vendido: "", valor_comprovante_input: "", banco: "ITAU", forma: "",
                     qnt_parcelas: "", bandeira: "", local: "", produto_na_troca: "",
-                    entrada_pix: "", banco_pix: "ITAU", entrada_especie: "", banco_2nd: "", banco_alt: "",
+                    entrada_pix: "", banco_pix: "ITAU", entrada_pix_2: "", banco_pix_2: "INFINITE", entrada_especie: "", banco_2nd: "", banco_alt: "",
                     forma_alt: "", parc_alt: "", band_alt: "", comp_alt: "", sinal_antecipado: "", banco_sinal: "", forma_sinal: "PIX",
                     entrada_fiado: "", fiado_qnt_parcelas: "1", fiado_data_inicio: "", fiado_intervalo: "7",
                     valor_total_venda: "",

--- a/lib/admin-types.ts
+++ b/lib/admin-types.ts
@@ -36,6 +36,10 @@ export interface Venda {
   fiado_parcelas: { valor: number; data: string; recebido: boolean }[];
   fiado_recebido?: boolean;
   banco_pix: string | null;
+  // Segundo PIX opcional: permite dividir o recebimento entre dois bancos.
+  // O valor sai do banco principal e entra no banco_pix_2.
+  entrada_pix_2: number;
+  banco_pix_2: string | null;
   banco_2nd: string | null;
   qnt_parcelas: number | null;
   bandeira: Bandeira | null;

--- a/lib/reports.ts
+++ b/lib/reports.ts
@@ -9,9 +9,18 @@ import { getTaxa, calcularLiquido } from "./taxas";
 import { recalcularSaldoDia } from "./saldos";
 
 function sumByBanco(vendas: Venda[], banco: string): number {
+  // Banco principal recebe preco_vendido - entrada_pix_2; o 2o PIX vai pro
+  // banco_pix_2 via addSegundoPix.
   return vendas
     .filter((v) => v.banco === banco)
-    .reduce((s, v) => s + Number(v.preco_vendido), 0);
+    .reduce((s, v) => s + Number(v.preco_vendido) - Number(v.entrada_pix_2 || 0), 0);
+}
+
+/** Soma entrada_pix_2 nas vendas cujo banco_pix_2 === banco. */
+function sumSegundoPix(vendas: Venda[], banco: string): number {
+  return vendas
+    .filter((v) => v.banco_pix_2 === banco && Number(v.entrada_pix_2 || 0) > 0)
+    .reduce((s, v) => s + Number(v.entrada_pix_2), 0);
 }
 
 function sumByBancoField(rows: { valor: number; banco: string | null }[], banco: string): number {
@@ -120,9 +129,9 @@ export async function gerarNoite(
     .neq("status_pagamento", "PROGRAMADA");
 
   const d0 = (vendasHoje ?? []) as Venda[];
-  let pix_itau = sumByBanco(d0, "ITAU");
-  let pix_inf = sumByBanco(d0, "INFINITE");
-  let pix_mp = sumByBanco(d0, "MERCADO_PAGO");
+  let pix_itau = sumByBanco(d0, "ITAU") + sumSegundoPix(d0, "ITAU");
+  let pix_inf = sumByBanco(d0, "INFINITE") + sumSegundoPix(d0, "INFINITE");
+  let pix_mp = sumByBanco(d0, "MERCADO_PAGO") + sumSegundoPix(d0, "MERCADO_PAGO");
   let pix_esp = sumByBanco(d0, "ESPECIE");
 
   // 2b. Entradas PIX/espécie de vendas D+1 de hoje (PIX entra no D+0, cartão no D+1)
@@ -136,12 +145,18 @@ export async function gerarNoite(
 
   for (const v of (vendasD1Hoje ?? []) as Venda[]) {
     const pixVal = Number(v.entrada_pix || 0);
+    const pix2Val = Number(v.entrada_pix_2 || 0);
     const espVal = Number(v.entrada_especie || 0);
     const bancoPix = v.banco_pix || v.banco || "";
     if (pixVal > 0) {
       if (bancoPix === "ITAU") pix_itau += pixVal;
       else if (bancoPix === "INFINITE") pix_inf += pixVal;
       else if (bancoPix === "MERCADO_PAGO") pix_mp += pixVal;
+    }
+    if (pix2Val > 0 && v.banco_pix_2) {
+      if (v.banco_pix_2 === "ITAU") pix_itau += pix2Val;
+      else if (v.banco_pix_2 === "INFINITE") pix_inf += pix2Val;
+      else if (v.banco_pix_2 === "MERCADO_PAGO") pix_mp += pix2Val;
     }
     if (espVal > 0) pix_esp += espVal;
   }
@@ -185,7 +200,7 @@ export async function gerarNoite(
         else if (v.banco === "MERCADO_PAGO") d1_mp += val;
       } else {
         // Fallback: preco_vendido - partes que já entraram no D+0
-        const val = Number(v.preco_vendido) - Number(v.entrada_pix || 0) - Number(v.entrada_especie || 0) - Number(v.produto_na_troca || 0);
+        const val = Number(v.preco_vendido) - Number(v.entrada_pix || 0) - Number(v.entrada_pix_2 || 0) - Number(v.entrada_especie || 0) - Number(v.produto_na_troca || 0);
         if (val > 0) {
           if (v.banco === "ITAU") d1_itau += val;
           else if (v.banco === "INFINITE") d1_inf += val;
@@ -383,7 +398,7 @@ export async function gerarManha(
         else if (v.banco === "MERCADO_PAGO") creditos_mp += val;
       } else {
         // Fallback: preco_vendido - partes que já entraram no D+0 (PIX, espécie, troca)
-        const val = Number(v.preco_vendido) - Number(v.entrada_pix || 0) - Number(v.entrada_especie || 0) - Number(v.produto_na_troca || 0);
+        const val = Number(v.preco_vendido) - Number(v.entrada_pix || 0) - Number(v.entrada_pix_2 || 0) - Number(v.entrada_especie || 0) - Number(v.produto_na_troca || 0);
         if (val > 0) {
           if (v.banco === "ITAU") creditos_itau += val;
           else if (v.banco === "INFINITE") creditos_inf += val;

--- a/lib/saldos.ts
+++ b/lib/saldos.ts
@@ -62,10 +62,22 @@ export async function recalcularSaldoDia(
     .eq("recebimento", "D+0");
 
   const d0 = (vendasD0 ?? []) as Venda[];
-  let pix_itau = d0.filter((v) => v.banco === "ITAU").reduce((s, v) => s + Number(v.preco_vendido), 0);
-  let pix_inf = d0.filter((v) => v.banco === "INFINITE").reduce((s, v) => s + Number(v.preco_vendido), 0);
-  let pix_mp = d0.filter((v) => v.banco === "MERCADO_PAGO").reduce((s, v) => s + Number(v.preco_vendido), 0);
-  let pix_esp = d0.filter((v) => v.banco === "ESPECIE").reduce((s, v) => s + Number(v.preco_vendido), 0);
+  // Banco principal recebe preco_vendido menos o que foi direcionado pro 2o PIX.
+  // (entrada_pix_2 é subtraída aqui e somada no loop abaixo, de modo que o total
+  // entre os dois bancos bate com preco_vendido.)
+  const d0MainVal = (v: Venda) => Number(v.preco_vendido) - Number(v.entrada_pix_2 || 0);
+  let pix_itau = d0.filter((v) => v.banco === "ITAU").reduce((s, v) => s + d0MainVal(v), 0);
+  let pix_inf = d0.filter((v) => v.banco === "INFINITE").reduce((s, v) => s + d0MainVal(v), 0);
+  let pix_mp = d0.filter((v) => v.banco === "MERCADO_PAGO").reduce((s, v) => s + d0MainVal(v), 0);
+  let pix_esp = d0.filter((v) => v.banco === "ESPECIE").reduce((s, v) => s + d0MainVal(v), 0);
+  // 2o PIX (D+0): adiciona no banco_pix_2 correspondente
+  for (const v of d0) {
+    const pix2 = Number(v.entrada_pix_2 || 0);
+    if (pix2 <= 0) continue;
+    if (v.banco_pix_2 === "ITAU") pix_itau += pix2;
+    else if (v.banco_pix_2 === "INFINITE") pix_inf += pix2;
+    else if (v.banco_pix_2 === "MERCADO_PAGO") pix_mp += pix2;
+  }
 
   // 2b. Entradas PIX/espécie de vendas D+1 de hoje (PIX entra D+0, cartão D+1)
   const { data: vendasD1Hoje } = await supabase
@@ -76,12 +88,18 @@ export async function recalcularSaldoDia(
 
   for (const v of (vendasD1Hoje ?? []) as Venda[]) {
     const pixVal = Number(v.entrada_pix || 0);
+    const pix2Val = Number(v.entrada_pix_2 || 0);
     const espVal = Number(v.entrada_especie || 0);
     const bancoPix = v.banco_pix || v.banco || "";
     if (pixVal > 0) {
       if (bancoPix === "ITAU") pix_itau += pixVal;
       else if (bancoPix === "INFINITE") pix_inf += pixVal;
       else if (bancoPix === "MERCADO_PAGO") pix_mp += pixVal;
+    }
+    if (pix2Val > 0 && v.banco_pix_2) {
+      if (v.banco_pix_2 === "ITAU") pix_itau += pix2Val;
+      else if (v.banco_pix_2 === "INFINITE") pix_inf += pix2Val;
+      else if (v.banco_pix_2 === "MERCADO_PAGO") pix_mp += pix2Val;
     }
     if (espVal > 0) pix_esp += espVal;
   }
@@ -118,7 +136,7 @@ export async function recalcularSaldoDia(
         else if (v.banco === "INFINITE") d1_inf += val;
         else if (v.banco === "MERCADO_PAGO") d1_mp += val;
       } else {
-        const val = Number(v.preco_vendido) - Number(v.entrada_pix || 0) - Number(v.entrada_especie || 0) - Number(v.produto_na_troca || 0);
+        const val = Number(v.preco_vendido) - Number(v.entrada_pix || 0) - Number(v.entrada_pix_2 || 0) - Number(v.entrada_especie || 0) - Number(v.produto_na_troca || 0);
         if (val > 0) {
           if (v.banco === "ITAU") d1_itau += val;
           else if (v.banco === "INFINITE") d1_inf += val;

--- a/supabase/migrations/20260422_vendas_entrada_pix_2.sql
+++ b/supabase/migrations/20260422_vendas_entrada_pix_2.sql
@@ -1,0 +1,9 @@
+-- Adiciona segundo PIX opcional nas vendas: permite dividir o valor recebido
+-- entre dois bancos. Semantica:
+--   entrada_pix_2 : valor do segundo PIX (sempre opcional). Subtrai do valor
+--     que iria pro banco principal e adiciona no banco_pix_2.
+--   banco_pix_2   : banco de destino desse segundo PIX (ITAU/INFINITE/MP).
+-- Exemplo: venda PIX de R$ 2000 com entrada_pix_2=500 e banco_pix_2=INFINITE
+--   → banco principal recebe 1500, INFINITE recebe 500.
+ALTER TABLE vendas ADD COLUMN IF NOT EXISTS entrada_pix_2 NUMERIC DEFAULT 0;
+ALTER TABLE vendas ADD COLUMN IF NOT EXISTS banco_pix_2 TEXT;


### PR DESCRIPTION
## Summary
- Nova venda pode receber PIX dividido em dois bancos (ex: ITAU + INFINITE)
- Campos novos: \`entrada_pix_2\` + \`banco_pix_2\` na tabela \`vendas\`
- Semântica: o valor do 2º PIX **sai do banco principal** e entra no \`banco_pix_2\`. Total entre os dois bancos bate com \`preco_vendido\`. Funciona tanto pra venda 100% PIX (dividir) quanto pra pagamento misto (duas entradas PIX distintas além do cartão)
- Saldos (\`lib/saldos.ts\`) e relatórios (\`lib/reports.ts\`) contabilizam D+0 (banco principal subtrai pix2, banco_pix_2 recebe pix2) e D+1 (soma pix2 no banco correspondente)
- UI: form de Nova Venda ganha campo "2º PIX (R$)" e seletor de banco logo abaixo da Entrada PIX existente
- Edição de venda já restaura o segundo PIX

## ⚠️ Migration obrigatória antes de usar
Após o deploy do preview do Vercel:
1. Abrir \`/admin/migrations\`
2. Achar \`20260422_vendas_entrada_pix_2\` como **Pendente**
3. Clicar **▶ Rodar**

A migration só adiciona duas colunas (\`entrada_pix_2 NUMERIC DEFAULT 0\`, \`banco_pix_2 TEXT\`) — sem impacto em dados existentes.

## Test plan
- [ ] Rodar a migration
- [ ] Criar venda PIX de R\$ 2000, deixar \`entrada_pix_2\` zerado → Banco principal recebe 2000 (comportamento atual preservado)
- [ ] Criar venda PIX de R\$ 2000 com \`entrada_pix_2 = 500\` e \`banco_pix_2 = INFINITE\` → Banco principal recebe 1500, INFINITE recebe 500
- [ ] Conferir em \`/admin/saldos\` que os dois bancos receberam os valores corretos
- [ ] Criar venda CARTÃO com entrada PIX de R\$ 500 (ITAU) + 2º PIX de R\$ 300 (INFINITE) → ITAU +500, INFINITE +300
- [ ] Editar venda com 2º PIX e conferir que os valores voltam preenchidos
- [ ] Teste multi-produto: venda de 2 produtos com 2º PIX → conferir que só a primeira row carrega o \`entrada_pix_2\` (evita double-count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)