### PR TITLE
feat(precos): aba Valores Seminovos no Painel de Precos

### DIFF
--- a/app/admin/precos/page.tsx
+++ b/app/admin/precos/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef, lazy, Suspense } from "react";
+import { useEffect, useState, useCallback, useRef, useMemo, lazy, Suspense } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
 import { useTabParam } from "@/lib/useTabParam";
-import { getCategoriasPrecos, addCategoriaPrecos, removeCategoriaPrecos, EMOJI_OPTIONS } from "@/lib/categorias";
+import { getCategoriasPrecos, addCategoriaPrecos, removeCategoriaPrecos, EMOJI_OPTIONS, DEFAULT_CATEGORIAS_SEMINOVOS } from "@/lib/categorias";
 import type { Categoria } from "@/lib/categorias";
 import { corParaPT } from "@/lib/cor-pt";
 
@@ -66,13 +66,34 @@ function PrecosContent() {
   // Headers editáveis (renomear colunas)
   const [editingHeader, setEditingHeader] = useState<{ catKey: string; colIdx: number } | null>(null);
 
-  // Categorias dinâmicas
+  // Categorias dinâmicas (somente para lacrados — seminovos tem lista fixa)
   const [categorias, setCategorias] = useState<Categoria[]>(() => getCategoriasPrecos());
   const [showNewCat, setShowNewCat] = useState(false);
   const [newCat, setNewCat] = useState({ label: "", emoji: "\u{1F4E6}" });
 
-  const tabKeys = categorias.map((c) => c.key);
-  const [tab, setTab] = useTabParam<string>("IPHONE", tabKeys);
+  // Top-level tab: Lacrados (Trade-In) vs Seminovos. Seminovos tem categorias
+  // fixas (IPHONE_SEMINOVO/IPAD_SEMINOVO/MACBOOK_SEMINOVO/APPLE_WATCH_SEMINOVO)
+  // e rows da tabela `precos` sao distinguidas pelo campo `tipo = "SEMINOVO"`.
+  const [viewTipo, setViewTipo] = useState<"LACRADO" | "SEMINOVO">("LACRADO");
+
+  // Categorias mostradas na aba ativa — muda conforme o top-level tab.
+  const activeCategorias = useMemo<Categoria[]>(
+    () => (viewTipo === "SEMINOVO" ? DEFAULT_CATEGORIAS_SEMINOVOS : categorias),
+    [viewTipo, categorias]
+  );
+
+  const tabKeys = activeCategorias.map((c) => c.key);
+  const [tab, setTab] = useTabParam<string>(
+    viewTipo === "SEMINOVO" ? "IPHONE_SEMINOVO" : "IPHONE",
+    tabKeys
+  );
+
+  // Quando troca Lacrados<->Seminovos, reseta a aba de categoria pra 1a
+  // disponivel no novo view (as keys sao disjuntas: IPHONE vs IPHONE_SEMINOVO).
+  useEffect(() => {
+    if (!tabKeys.includes(tab) && tabKeys.length > 0) setTab(tabKeys[0]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewTipo]);
   const [showAdd, setShowAdd] = useState(false);
   const [newProd, setNewProd] = useState({ modelo: "", preco_pix: "", tipo: "TRADEIN" });
   // Campos de especificação dinâmicos (label + valor) — combinados com " | " no armazenamento
@@ -171,7 +192,10 @@ function PrecosContent() {
   async function handleSave(row: PrecoProduto) {
     const key = `${row.modelo}|${row.armazenamento}`;
     const newPrice = parseFloat((editing[key] ?? String(row.preco_pix)).replace(",", "."));
-    if (isNaN(newPrice) || newPrice <= 0) return;
+    if (isNaN(newPrice) || newPrice < 0) return;
+    // Lacrado precisa ter preco > 0; seminovo aceita 0 como "sem orcamento
+    // automatico — cliente vai pro WhatsApp".
+    if (row.tipo !== "SEMINOVO" && newPrice <= 0) return;
 
     setSaving(key);
     await fetch("/api/admin/precos", {
@@ -252,11 +276,16 @@ function PrecosContent() {
     // Combinar campos de spec com " | "
     const filledSpecs = specFields.filter((s) => s.value.trim());
     const armazenamentoFinal = filledSpecs.map((s) => s.value.trim()).join(" | ");
-    if (!newProd.modelo || !armazenamentoFinal || isNaN(preco) || preco <= 0) return;
+    if (!newProd.modelo || !armazenamentoFinal || isNaN(preco) || preco < 0) return;
+    // Seminovos aceitam preco 0 (cliente vai pro WhatsApp); lacrados exigem > 0.
+    if (viewTipo !== "SEMINOVO" && preco <= 0) return;
     // Salvar labels dos campos para essa categoria (pra tabela mostrar nomes corretos)
     const currentLabels = specFields.map((s) => s.label || `Spec ${specFields.indexOf(s) + 1}`);
     saveLabels(tab, currentLabels);
     setSaving("new");
+    // Tipo: em Seminovos (view=SEMINOVO) sempre "SEMINOVO"; em Lacrados,
+    // respeita o select do form (default TRADEIN).
+    const tipoFinal = viewTipo === "SEMINOVO" ? "SEMINOVO" : (newProd.tipo || "TRADEIN");
     await fetch("/api/admin/precos", {
       method: "POST",
       headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
@@ -266,7 +295,7 @@ function PrecosContent() {
         preco_pix: preco,
         status: "ativo",
         categoria: tab,
-        tipo: newProd.tipo || "TRADEIN",
+        tipo: tipoFinal,
       }),
     });
     await fetchData(password);
@@ -282,7 +311,9 @@ function PrecosContent() {
     const preco = parseFloat(editingFull.preco_pix.replace(",", "."));
     const filledSpecs = editingFull.specs.filter((s) => s.value.trim());
     const newArm = filledSpecs.map((s) => s.value.trim()).join(" | ");
-    if (!editingFull.modelo.trim() || !newArm || isNaN(preco) || preco <= 0) return;
+    if (!editingFull.modelo.trim() || !newArm || isNaN(preco) || preco < 0) return;
+    // Lacrado precisa > 0; seminovo aceita 0 (WhatsApp manual).
+    if (editingFull.tipo !== "SEMINOVO" && preco <= 0) return;
 
     setSaving("full");
     const headers = { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") };
@@ -323,8 +354,14 @@ function PrecosContent() {
 
   if (!data) return null;
 
-  // Filtrar por categoria da tab e aplicar ordem salva
+  // Match de tipo por view: SEMINOVO so mostra rows com tipo=SEMINOVO; LACRADO
+  // mostra o resto (TRADEIN/CATALOGO/AMBOS/null — compatibilidade com rows antigas).
+  const matchesView = (r: PrecoProduto) =>
+    viewTipo === "SEMINOVO" ? r.tipo === "SEMINOVO" : r.tipo !== "SEMINOVO";
+
+  // Filtrar por categoria da tab + view ativo, depois aplicar ordem salva
   const filteredRaw = data.filter((r) => {
+    if (!matchesView(r)) return false;
     const cat = r.categoria || inferCategoria(r.modelo);
     return cat === tab;
   });
@@ -395,7 +432,7 @@ function PrecosContent() {
     return a.localeCompare(b);
   });
 
-  const catInfo = categorias.find((c) => c.key === tab) || { key: tab, label: tab, emoji: "\u{1F4E6}" };
+  const catInfo = activeCategorias.find((c) => c.key === tab) || { key: tab, label: tab, emoji: "\u{1F4E6}" };
 
   return (
     <div className="max-w-4xl mx-auto space-y-4">
@@ -405,7 +442,7 @@ function PrecosContent() {
           <p className="text-[#86868B] text-xs">Edite os precos diretamente aqui. Alteracoes notificam via Telegram.</p>
         </div>
         <div className="flex gap-2">
-          {tab === "IPHONE" && (
+          {tab === "IPHONE" && viewTipo === "LACRADO" && (
             <button
               onClick={handleImport}
               disabled={importing}
@@ -423,10 +460,38 @@ function PrecosContent() {
         </div>
       </div>
 
+      {/* Top-level tabs: Lacrados vs Seminovos */}
+      <div className="flex gap-2 flex-wrap items-center border-b border-[#E5E5EA] pb-2">
+        {[
+          { key: "LACRADO" as const, label: "Valores Lacrados" },
+          { key: "SEMINOVO" as const, label: "Valores Seminovos" },
+        ].map((t) => (
+          <button
+            key={t.key}
+            onClick={() => { setViewTipo(t.key); setShowAdd(false); setShowNewCat(false); }}
+            className={`px-4 py-2 rounded-xl text-sm font-semibold transition-colors ${
+              viewTipo === t.key
+                ? "bg-[#E8740E] text-white"
+                : "bg-white border border-[#D2D2D7] text-[#1D1D1F] hover:border-[#E8740E]"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      {viewTipo === "SEMINOVO" && (
+        <div className="rounded-xl bg-[#FFF7ED] border border-[#E8740E]/30 px-4 py-2.5 text-xs text-[#86868B] leading-relaxed">
+          <strong className="text-[#1D1D1F]">Seminovos:</strong> preço {'>'} 0 → orçamento automático no cliente.
+          Preço em branco (0) → cliente é direcionado ao WhatsApp pra cotação manual.
+          Status <em>esgotado</em> → variante não aparece.
+        </div>
+      )}
+
       {/* Tabs por categoria */}
       <div className="flex gap-2 flex-wrap items-center">
-        {categorias.map((c) => {
-          const count = data.filter((r) => (r.categoria || inferCategoria(r.modelo)) === c.key).length;
+        {activeCategorias.map((c) => {
+          const count = data.filter((r) => matchesView(r) && (r.categoria || inferCategoria(r.modelo)) === c.key).length;
           return (
             <div key={c.key} className="relative group">
               <button
@@ -439,7 +504,7 @@ function PrecosContent() {
               >
                 {c.emoji} {c.label} {count > 0 ? `(${count})` : ""}
               </button>
-              {c.custom && (
+              {c.custom && viewTipo === "LACRADO" && (
                 <button
                   onClick={(e) => { e.stopPropagation(); handleRemoveCategoria(c.key); }}
                   className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-red-500 text-white text-[9px] leading-none flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
@@ -451,13 +516,15 @@ function PrecosContent() {
             </div>
           );
         })}
-        <button
-          onClick={() => setShowNewCat(!showNewCat)}
-          className="px-3 py-2 rounded-xl text-xs font-semibold border border-dashed border-[#D2D2D7] text-[#86868B] hover:border-[#E8740E] hover:text-[#E8740E] transition-colors"
-          title="Criar nova categoria"
-        >
-          + Categoria
-        </button>
+        {viewTipo === "LACRADO" && (
+          <button
+            onClick={() => setShowNewCat(!showNewCat)}
+            className="px-3 py-2 rounded-xl text-xs font-semibold border border-dashed border-[#D2D2D7] text-[#86868B] hover:border-[#E8740E] hover:text-[#E8740E] transition-colors"
+            title="Criar nova categoria"
+          >
+            + Categoria
+          </button>
+        )}
       </div>
 
       {/* Modal criar categoria */}
@@ -575,19 +642,21 @@ function PrecosContent() {
                 className="w-full px-3 py-2 border border-[#D2D2D7] rounded-lg text-sm"
               />
             </div>
-            {/* Tipo */}
-            <div className="min-w-[120px]">
-              <p className="text-[10px] font-bold text-[#86868B] uppercase mb-1">Tipo</p>
-              <select
-                value={newProd.tipo}
-                onChange={(e) => setNewProd({ ...newProd, tipo: e.target.value })}
-                className="w-full px-3 py-2 border border-[#D2D2D7] rounded-lg text-sm"
-              >
-                <option value="TRADEIN">Trade-In</option>
-                <option value="CATALOGO">Catálogo</option>
-                <option value="AMBOS">Ambos</option>
-              </select>
-            </div>
+            {/* Tipo — escondido em Seminovos (fixo como SEMINOVO) */}
+            {viewTipo === "LACRADO" && (
+              <div className="min-w-[120px]">
+                <p className="text-[10px] font-bold text-[#86868B] uppercase mb-1">Tipo</p>
+                <select
+                  value={newProd.tipo}
+                  onChange={(e) => setNewProd({ ...newProd, tipo: e.target.value })}
+                  className="w-full px-3 py-2 border border-[#D2D2D7] rounded-lg text-sm"
+                >
+                  <option value="TRADEIN">Trade-In</option>
+                  <option value="CATALOGO">Catálogo</option>
+                  <option value="AMBOS">Ambos</option>
+                </select>
+              </div>
+            )}
           </div>
           <div className="flex gap-2">
             <button
@@ -679,18 +748,27 @@ function PrecosContent() {
                   className="w-full px-3 py-2 border border-[#D2D2D7] rounded-lg text-sm focus:border-[#E8740E] outline-none"
                 />
               </div>
-              <div className="w-36">
-                <p className="text-[10px] font-bold text-[#86868B] uppercase mb-1">Tipo</p>
-                <select
-                  value={editingFull.tipo}
-                  onChange={(e) => setEditingFull({ ...editingFull, tipo: e.target.value })}
-                  className="w-full px-3 py-2 border border-[#D2D2D7] rounded-lg text-sm"
-                >
-                  <option value="TRADEIN">Trade-In</option>
-                  <option value="CATALOGO">Catálogo</option>
-                  <option value="AMBOS">Ambos</option>
-                </select>
-              </div>
+              {editingFull.tipo === "SEMINOVO" ? (
+                <div className="w-36">
+                  <p className="text-[10px] font-bold text-[#86868B] uppercase mb-1">Tipo</p>
+                  <div className="w-full px-3 py-2 rounded-lg text-sm bg-[#FFF7ED] text-[#E8740E] border border-[#E8740E]/30 font-semibold">
+                    Seminovo
+                  </div>
+                </div>
+              ) : (
+                <div className="w-36">
+                  <p className="text-[10px] font-bold text-[#86868B] uppercase mb-1">Tipo</p>
+                  <select
+                    value={editingFull.tipo}
+                    onChange={(e) => setEditingFull({ ...editingFull, tipo: e.target.value })}
+                    className="w-full px-3 py-2 border border-[#D2D2D7] rounded-lg text-sm"
+                  >
+                    <option value="TRADEIN">Trade-In</option>
+                    <option value="CATALOGO">Catálogo</option>
+                    <option value="AMBOS">Ambos</option>
+                  </select>
+                </div>
+              )}
             </div>
 
             <div className="flex gap-2 pt-2">
@@ -860,34 +938,40 @@ function PrecosContent() {
                         </button>
                       </td>
                       <td className="px-5 py-3">
-                        <select
-                          value={row.tipo ?? "TRADEIN"}
-                          onChange={async (e) => {
-                            const newTipo = e.target.value;
-                            setData((prev) => prev?.map((r) =>
-                              r.modelo === row.modelo && r.armazenamento === row.armazenamento
-                                ? { ...r, tipo: newTipo }
-                                : r
-                            ) ?? null);
-                            await fetch("/api/admin/precos", {
-                              method: "POST",
-                              headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
-                              body: JSON.stringify({
-                                modelo: row.modelo,
-                                armazenamento: row.armazenamento,
-                                preco_pix: row.preco_pix,
-                                status: row.status,
-                                categoria: row.categoria || inferCategoria(row.modelo),
-                                tipo: newTipo,
-                              }),
-                            });
-                          }}
-                          className="px-2 py-1 rounded-lg text-xs border border-[#D2D2D7] bg-white text-[#1D1D1F]"
-                        >
-                          <option value="TRADEIN">Trade-In</option>
-                          <option value="CATALOGO">Catálogo</option>
-                          <option value="AMBOS">Ambos</option>
-                        </select>
+                        {row.tipo === "SEMINOVO" ? (
+                          <span className="px-2 py-1 rounded-lg text-xs font-semibold bg-[#FFF7ED] text-[#E8740E] border border-[#E8740E]/30">
+                            Seminovo
+                          </span>
+                        ) : (
+                          <select
+                            value={row.tipo ?? "TRADEIN"}
+                            onChange={async (e) => {
+                              const newTipo = e.target.value;
+                              setData((prev) => prev?.map((r) =>
+                                r.modelo === row.modelo && r.armazenamento === row.armazenamento
+                                  ? { ...r, tipo: newTipo }
+                                  : r
+                              ) ?? null);
+                              await fetch("/api/admin/precos", {
+                                method: "POST",
+                                headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
+                                body: JSON.stringify({
+                                  modelo: row.modelo,
+                                  armazenamento: row.armazenamento,
+                                  preco_pix: row.preco_pix,
+                                  status: row.status,
+                                  categoria: row.categoria || inferCategoria(row.modelo),
+                                  tipo: newTipo,
+                                }),
+                              });
+                            }}
+                            className="px-2 py-1 rounded-lg text-xs border border-[#D2D2D7] bg-white text-[#1D1D1F]"
+                          >
+                            <option value="TRADEIN">Trade-In</option>
+                            <option value="CATALOGO">Catálogo</option>
+                            <option value="AMBOS">Ambos</option>
+                          </select>
+                        )}
                       </td>
                       <td className="px-5 py-3 text-right">
                         {isEditing ? (

--- a/app/api/admin/precos/route.ts
+++ b/app/api/admin/precos/route.ts
@@ -19,17 +19,31 @@ function getPermissoes(req: NextRequest): string[] {
   try { return JSON.parse(req.headers.get("x-admin-permissoes") || "[]"); } catch { return []; }
 }
 
-// GET — lista todos os preços
+// GET — lista preços. Filtros opcionais:
+//   ?tipo=SEMINOVO   → só seminovos
+//   ?tipo=LACRADO    → só lacrados (TRADEIN/CATALOGO/AMBOS/null)
+//   (sem tipo)       → tudo (backwards-compat)
 export async function GET(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const { supabase } = await import("@/lib/supabase");
 
-  const { data, error } = await supabase
+  const tipoFilter = req.nextUrl.searchParams.get("tipo");
+  let q = supabase
     .from("precos")
     .select("*")
     .order("modelo")
     .order("armazenamento");
+
+  if (tipoFilter === "SEMINOVO") {
+    q = q.eq("tipo", "SEMINOVO");
+  } else if (tipoFilter === "LACRADO") {
+    // Qualquer coisa que não seja SEMINOVO conta como lacrado (inclui rows
+    // antigas com tipo null/undefined).
+    q = q.or("tipo.neq.SEMINOVO,tipo.is.null");
+  }
+
+  const { data, error } = await q;
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 

--- a/app/api/produtos/route.ts
+++ b/app/api/produtos/route.ts
@@ -14,6 +14,12 @@ const FALLBACK_PRODUCTS: NewProduct[] = [
 export async function GET(req: NextRequest) {
   const limited = rateLimitPublic(req);
   if (limited) return limited;
+
+  // ?tipo=SEMINOVO retorna apenas seminovos (nova aba do Painel de Preços).
+  // Sem ?tipo ou tipo=LACRADO mantém comportamento antigo (TRADEIN/CATALOGO/AMBOS/null).
+  const tipoFilter = req.nextUrl.searchParams.get("tipo");
+  const wantSeminovos = tipoFilter === "SEMINOVO";
+
   // Tenta Supabase primeiro (painel de preços)
   try {
     if (process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY) {
@@ -26,7 +32,13 @@ export async function GET(req: NextRequest) {
 
       if (data && data.length > 0) {
         const products: NewProduct[] = data
-          .filter((r) => r.status !== "esgotado" && (r.tipo === "TRADEIN" || r.tipo === "AMBOS" || r.tipo == null))
+          .filter((r) => {
+            if (r.status === "esgotado") return false;
+            if (wantSeminovos) return r.tipo === "SEMINOVO";
+            // Lacrados: tudo que não for seminovo (inclui null/undefined pra
+            // compatibilidade com rows antigas pré-refactor).
+            return r.tipo === "TRADEIN" || r.tipo === "AMBOS" || r.tipo == null;
+          })
           .map((r) => ({
             modelo: r.modelo,
             armazenamento: r.armazenamento,
@@ -40,7 +52,10 @@ export async function GET(req: NextRequest) {
     // fallthrough para Sheets
   }
 
-  // Fallback: Google Sheets
+  // Seminovos não têm fallback no Sheets — retorna vazio se não achou no DB.
+  if (wantSeminovos) return NextResponse.json([]);
+
+  // Fallback: Google Sheets (só pra lacrados)
   try {
     const products = await fetchNewProducts();
     return NextResponse.json(products);

--- a/components/StepNewDevice.tsx
+++ b/components/StepNewDevice.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import type { NewProduct, TradeInConfig, SeminovoCategoria, SeminovoVariante } from "@/lib/types";
 import { SEMINOVO_CATEGORIAS, SEMINOVO_CAT_LABELS, getSeminovoVariantes } from "@/lib/types";
 import { getUniqueModels, getStoragesForModel, getProductPrice } from "@/lib/sheets";
@@ -76,12 +76,61 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
   // porque os dois universos são independentes (mesma divisão do admin).
   const [semiCat, setSemiCat] = useState<SeminovoCategoria | "">("");
 
+  // Seminovos cadastrados em /admin/precos (fonte nova — Painel de Precos).
+  // Se retornar vazio, cai no fallback do tradein_config.seminovos (legado).
+  type SemiRow = { modelo: string; armazenamento: string; precoPix: number; categoria?: string | null };
+  const [seminovosDb, setSeminovosDb] = useState<SemiRow[] | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/produtos?tipo=SEMINOVO");
+        if (!res.ok) return;
+        const json = (await res.json()) as SemiRow[];
+        if (!cancelled) setSeminovosDb(Array.isArray(json) ? json : []);
+      } catch {
+        if (!cancelled) setSeminovosDb([]);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  // Mapeia categoria do Painel de Precos ("IPHONE_SEMINOVO"/...) para a chave
+  // do SeminovoCategoria usado aqui ("iphone"/"ipad"/"macbook"/"watch").
+  function categoriaPrecosToSemi(cat: string | null | undefined): SeminovoCategoria {
+    const c = (cat || "").toUpperCase();
+    if (c.startsWith("IPAD")) return "ipad";
+    if (c.startsWith("MACBOOK")) return "macbook";
+    if (c.startsWith("APPLE_WATCH")) return "watch";
+    return "iphone";
+  }
+
   // Normaliza a lista vinda do DB (backfill: categoria ausente → iphone) e já
   // converte legado `storages[]` em `variantes[]` via helper. Filtra:
   //  • Modelo inativo → oculto
   //  • Variante inativa → removida
   //  • Modelo sem variante ativa → oculto (sem storage pra escolher)
+  //
+  // Prioridade: 1) /api/produtos?tipo=SEMINOVO (fonte nova), 2) tradein_config.seminovos
+  // (fallback durante transicao), 3) hardcoded default (banco nao respondeu).
   const seminovosAll = useMemo(() => {
+    // Fonte 1: Painel de Precos — agrupa rows por modelo.
+    if (seminovosDb && seminovosDb.length > 0) {
+      const byModel = new Map<string, { modelo: string; variantes: SeminovoVariante[]; categoria: SeminovoCategoria }>();
+      for (const row of seminovosDb) {
+        const cat = categoriaPrecosToSemi(row.categoria);
+        const entry = byModel.get(row.modelo) || { modelo: row.modelo, variantes: [], categoria: cat };
+        // preco 0 (sentinela) → variante sem preco → fluxo WhatsApp manual.
+        entry.variantes.push({
+          storage: row.armazenamento,
+          preco: row.precoPix > 0 ? row.precoPix : undefined,
+          ativo: true,
+        });
+        byModel.set(row.modelo, entry);
+      }
+      return [...byModel.values()].filter((s) => s.variantes.length > 0);
+    }
+    // Fonte 2: tradein_config.seminovos (legado, sera removido apos migracao completa).
     const raw = tradeinConfig?.seminovos?.filter((s) => s.ativo);
     const src = raw && raw.length > 0 ? raw : SEMINOVOS_DEFAULT;
     return src
@@ -94,7 +143,7 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
         };
       })
       .filter((s) => s.variantes.length > 0);
-  }, [tradeinConfig]);
+  }, [seminovosDb, tradeinConfig]);
 
   // Categorias com ao menos 1 seminovo ativo (as únicas abas clicáveis).
   const semiCats = useMemo(() => {

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -1,6 +1,6 @@
 "use client";
-import React, { useEffect, useMemo, useState } from "react";
-import { TradeInQuestion, TradeInQuestionOption, SeminovoOption, SeminovoVariante, SeminovoCategoria, SEMINOVO_CAT_LABELS, getSeminovoVariantes, consolidateSeminovos } from "@/lib/types";
+import React, { useEffect, useState } from "react";
+import { TradeInQuestion, TradeInQuestionOption, SeminovoOption, SeminovoCategoria, getSeminovoVariantes, consolidateSeminovos } from "@/lib/types";
 
 interface Props {
   password: string;
@@ -523,7 +523,7 @@ const LABEL_GROUPS: { title: string; keys: { key: string; label: string }[] }[] 
   },
 ];
 
-function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceTab: string }) {
+function TradeInConfigAdmin({ password, deviceTab: _deviceTab }: { password: string; deviceTab: string }) {
   // Mantemos a lista inteira em memória — o banco persiste tudo num único
   // JSONB, então precisa voltar completa no PUT. A filtragem é por render.
   const [seminovos, setSeminovos] = useState<SeminovoOption[]>(DEFAULT_SEMINOVOS);
@@ -534,25 +534,11 @@ function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceT
   const [msg, setMsg] = useState("");
   const [expandedSection, setExpandedSection] = useState<string | null>(null);
   const [newOrigem, setNewOrigem] = useState("");
-  const [newSemiModelo, setNewSemiModelo] = useState("");
-
-  // Itens sem categoria (pré-migration) caem em "iphone" para compatibilidade.
-  const categoriaAtiva: SeminovoCategoria = (deviceTab as SeminovoCategoria) in SEMINOVO_CAT_LABELS ? (deviceTab as SeminovoCategoria) : "iphone";
-
-  // Índices reais na lista completa — toggles/edições precisam do índice certo
-  // mesmo com a UI filtrada.
-  const visibleIndices = useMemo(
-    () => seminovos.reduce<number[]>((acc, s, i) => {
-      if ((s.categoria || "iphone") === categoriaAtiva) acc.push(i);
-      return acc;
-    }, []),
-    [seminovos, categoriaAtiva]
-  );
-
-  const countCategoriaAtiva = useMemo(
-    () => seminovos.filter((s) => (s.categoria || "iphone") === categoriaAtiva && s.ativo).length,
-    [seminovos, categoriaAtiva]
-  );
+  // Seminovos continuam vivos em `seminovos`/`setSeminovos` pra manter compat
+  // com o PUT de config (que persiste o array inteiro). Mas a UI foi movida
+  // pro /admin/precos (aba "Valores Seminovos") — aqui so carrega e devolve
+  // sem alteracao. O deviceTab (iphone/ipad/macbook/watch) ainda e usado
+  // pelas perguntas do simulador de troca.
 
   function getHeaders() {
     return { "x-admin-password": password, "Content-Type": "application/json" };
@@ -652,168 +638,21 @@ function TradeInConfigAdmin({ password, deviceTab }: { password: string; deviceT
 
       {showMsg()}
 
-      {/* === SEMINOVOS ===
-          O botão mostra "(n)" = nº de modelos ativos NA CATEGORIA da aba atual
-          (antes mostrava o total geral, o que causava confusão). */}
-      {sectionBtn("seminovos", `Modelos Seminovo — ${SEMINOVO_CAT_LABELS[categoriaAtiva].label}`, countCategoriaAtiva)}
-      {expandedSection === "seminovos" && (
-        <div className="border border-[#D2D2D7] rounded-xl bg-white p-4 space-y-3">
-          <div className="text-[11px] text-[#86868B] bg-[#F5F5F7] rounded-lg px-3 py-2 leading-relaxed">
-            <strong>{SEMINOVO_CAT_LABELS[categoriaAtiva].label}:</strong> apenas os modelos seminovos desta categoria aparecem aqui.
-            Troque a aba acima para ver/editar outras categorias.
-          </div>
-          {visibleIndices.length === 0 && (
-            <div className="text-center text-sm text-[#86868B] py-4 italic">
-              Nenhum modelo seminovo cadastrado para {SEMINOVO_CAT_LABELS[categoriaAtiva].label}.
-            </div>
-          )}
-          {visibleIndices.map((si) => {
-            const s = seminovos[si];
-            const variantes = s.variantes || [];
-            const updateVariante = (vi: number, patch: Partial<SeminovoVariante>) => {
-              const arr = [...seminovos];
-              const v = [...(arr[si].variantes || [])];
-              v[vi] = { ...v[vi], ...patch };
-              arr[si] = { ...arr[si], variantes: v };
-              setSeminovos(arr);
-            };
-            const removeVariante = (vi: number) => {
-              const arr = [...seminovos];
-              arr[si] = { ...arr[si], variantes: (arr[si].variantes || []).filter((_, i) => i !== vi) };
-              setSeminovos(arr);
-            };
-            const addVariante = () => {
-              const arr = [...seminovos];
-              arr[si] = { ...arr[si], variantes: [...(arr[si].variantes || []), { storage: "", ativo: true }] };
-              setSeminovos(arr);
-            };
-            return (
-            <div key={si} className={`rounded-lg border border-[#E5E5EA] p-3 space-y-3 ${!s.ativo ? "opacity-50" : ""}`}>
-              <div className="flex items-center gap-2">
-                <input
-                  value={s.modelo}
-                  onChange={(e) => {
-                    const arr = [...seminovos];
-                    arr[si] = { ...arr[si], modelo: e.target.value };
-                    setSeminovos(arr);
-                  }}
-                  className="flex-1 px-2 py-1.5 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
-                  placeholder="Nome do modelo"
-                />
-                <button
-                  onClick={() => {
-                    const arr = [...seminovos];
-                    arr[si] = { ...arr[si], ativo: !arr[si].ativo };
-                    setSeminovos(arr);
-                  }}
-                  title={s.ativo ? "Modelo visível ao cliente" : "Modelo oculto"}
-                  className={`w-10 h-5 rounded-full transition-colors relative ${s.ativo ? "bg-[#E8740E]" : "bg-[#D2D2D7]"}`}
-                >
-                  <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform shadow-sm ${s.ativo ? "left-5" : "left-0.5"}`} />
-                </button>
-                <button
-                  onClick={() => setSeminovos(seminovos.filter((_, i) => i !== si))}
-                  className="text-red-400 hover:text-red-600 text-sm px-1"
-                  title="Remover modelo"
-                >
-                  ✕
-                </button>
-              </div>
-
-              {/* Variantes: uma linha por storage. Preço definido → orçamento
-                  automático no cliente; sem preço → fallback WhatsApp manual. */}
-              <div className="space-y-1.5">
-                <div className="grid grid-cols-[1fr_auto_auto_auto] gap-2 items-center px-1 text-[10px] font-semibold uppercase tracking-wider text-[#86868B]">
-                  <span>Storage</span>
-                  <span className="text-right pr-1">Preço (R$)</span>
-                  <span className="text-center w-10">Ativo</span>
-                  <span className="w-4" />
-                </div>
-                {variantes.length === 0 && (
-                  <div className="text-[11px] italic text-[#86868B] px-1 py-1">
-                    Sem variantes. Adicione ao menos uma abaixo.
-                  </div>
-                )}
-                {variantes.map((v, vi) => (
-                  <div key={vi} className={`grid grid-cols-[1fr_auto_auto_auto] gap-2 items-center ${v.ativo === false ? "opacity-50" : ""}`}>
-                    <input
-                      value={v.storage}
-                      onChange={(e) => updateVariante(vi, { storage: e.target.value })}
-                      placeholder="Ex: 256GB"
-                      className="px-2 py-1 rounded border border-[#D2D2D7] text-xs focus:outline-none focus:border-[#E8740E]"
-                    />
-                    <input
-                      type="number"
-                      inputMode="numeric"
-                      value={typeof v.preco === "number" ? String(v.preco) : ""}
-                      onChange={(e) => {
-                        const raw = e.target.value.trim();
-                        const num = raw === "" ? undefined : Number(raw);
-                        updateVariante(vi, { preco: Number.isFinite(num as number) ? (num as number) : undefined });
-                      }}
-                      placeholder="—"
-                      className="w-24 px-2 py-1 rounded border border-[#D2D2D7] text-xs text-right focus:outline-none focus:border-[#E8740E]"
-                    />
-                    <button
-                      onClick={() => updateVariante(vi, { ativo: v.ativo === false })}
-                      title={v.ativo !== false ? "Variante visível" : "Variante oculta"}
-                      className={`w-10 h-5 rounded-full transition-colors relative ${v.ativo !== false ? "bg-[#E8740E]" : "bg-[#D2D2D7]"}`}
-                    >
-                      <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform shadow-sm ${v.ativo !== false ? "left-5" : "left-0.5"}`} />
-                    </button>
-                    <button
-                      onClick={() => removeVariante(vi)}
-                      className="text-[#86868B] hover:text-red-500 text-xs w-4"
-                      title="Remover variante"
-                    >
-                      ✕
-                    </button>
-                  </div>
-                ))}
-                <button
-                  onClick={addVariante}
-                  className="text-[11px] font-semibold text-[#E8740E] hover:underline mt-1"
-                >
-                  + Adicionar variante
-                </button>
-                <p className="text-[10px] text-[#86868B] leading-relaxed pt-1">
-                  Com preço → orçamento automático. Sem preço → cliente é levado ao WhatsApp pra cotação manual.
-                </p>
-              </div>
-            </div>
-            );
-          })}
-          <div className="flex gap-2">
-            <input
-              value={newSemiModelo}
-              onChange={(e) => setNewSemiModelo(e.target.value)}
-              placeholder={`Ex: ${categoriaAtiva === "iphone" ? "iPhone 17 Pro" : categoriaAtiva === "ipad" ? "iPad Pro M4" : categoriaAtiva === "macbook" ? "MacBook Air M3" : "Apple Watch Series 10"}`}
-              className="flex-1 px-3 py-2 rounded-lg border border-dashed border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
-            />
-            <button
-              onClick={() => {
-                if (newSemiModelo.trim()) {
-                  // Novo item herda a categoria da aba aberta e vem com duas
-                  // variantes vazias — operador preenche storage/preço inline.
-                  setSeminovos([...seminovos, {
-                    modelo: newSemiModelo.trim(),
-                    ativo: true,
-                    categoria: categoriaAtiva,
-                    variantes: [
-                      { storage: "128GB", ativo: true },
-                      { storage: "256GB", ativo: true },
-                    ],
-                  }]);
-                  setNewSemiModelo("");
-                }
-              }}
-              className="px-4 py-2 rounded-lg text-sm font-semibold text-[#E8740E] border border-[#E8740E] hover:bg-[#FFF5EB] transition-colors"
-            >
-              + Adicionar
-            </button>
-          </div>
+      {/* === SEMINOVOS (migrado) ===
+          A gestão de modelos/preço/status de seminovos foi movida para o
+          Painel de Preços (aba "Valores Seminovos"). Aqui fica só um aviso
+          pra operador saber pra onde ir. */}
+      <a
+        href="/admin/precos?tab=IPHONE_SEMINOVO"
+        className="block rounded-xl border border-[#E8740E]/30 bg-[#FFF7ED] px-4 py-3 text-xs text-[#1D1D1F] leading-relaxed hover:bg-[#FFEFE0] transition-colors"
+      >
+        <div className="font-semibold mb-1">📱 Modelos Seminovo → movido</div>
+        <div className="text-[#86868B]">
+          Cadastro e preços agora ficam em <strong className="text-[#E8740E]">Alteração de Preços → Valores Seminovos</strong>.
+          Clique aqui pra abrir.
         </div>
-      )}
+      </a>
+
 
       {/* === ORIGENS === */}
       {sectionBtn("origens", "Origens de Contato", origens.length)}

--- a/lib/categorias.ts
+++ b/lib/categorias.ts
@@ -22,6 +22,17 @@ export const DEFAULT_CATEGORIAS_PRECOS: Categoria[] = [
   { key: "ACESSORIOS", label: "Acess\u00F3rios", emoji: "\u{1F50C}" },
 ];
 
+/** Categorias fixas da aba "Alteração Valores Seminovos" em /admin/precos.
+ *  Deliberadamente mais enxuta que as de lacrados — só os 4 tipos que a loja
+ *  oferece como seminovo hoje. Não expõe botão de "+ Categoria" pra evitar
+ *  cadastros soltos que ninguém usa. */
+export const DEFAULT_CATEGORIAS_SEMINOVOS: Categoria[] = [
+  { key: "IPHONE_SEMINOVO", label: "iPhones", emoji: "\u{1F4F1}" },
+  { key: "IPAD_SEMINOVO", label: "iPads", emoji: "\u{1F4DF}" },
+  { key: "MACBOOK_SEMINOVO", label: "MacBooks", emoji: "\u{1F4BB}" },
+  { key: "APPLE_WATCH_SEMINOVO", label: "Apple Watch", emoji: "\u231A" },
+];
+
 export const DEFAULT_CATEGORIAS_ESTOQUE: Categoria[] = [
   { key: "IPHONES", label: "iPhones", emoji: "\u{1F4F1}" },
   { key: "IPADS", label: "iPads", emoji: "\u{1F4DF}" },

--- a/supabase/migrations/20260423_precos_seed_seminovos.sql
+++ b/supabase/migrations/20260423_precos_seed_seminovos.sql
@@ -1,0 +1,52 @@
+-- Migra os seminovos do JSONB `tradein_config.seminovos` pra rows da tabela
+-- `precos` com tipo = 'SEMINOVO'. Depois dessa migration a aba "Valores
+-- Seminovos" em /admin/precos passa a listar esses modelos, e o
+-- /admin/simulacoes deixa de ser a fonte de verdade.
+--
+-- Safe pra rodar multiplas vezes: ON CONFLICT DO NOTHING evita duplicar
+-- rows (a chave e modelo+armazenamento). Nao mexe no tradein_config antigo
+-- — ele continua servindo de fallback no cliente ate o proximo PR de cleanup.
+--
+-- Mapeamento de categoria do JSONB -> categoria na tabela precos:
+--   iphone  -> IPHONE_SEMINOVO
+--   ipad    -> IPAD_SEMINOVO
+--   macbook -> MACBOOK_SEMINOVO
+--   watch   -> APPLE_WATCH_SEMINOVO
+
+INSERT INTO precos (modelo, armazenamento, preco_pix, status, categoria, tipo, updated_at)
+SELECT
+  s.modelo::text                           AS modelo,
+  v.storage::text                          AS armazenamento,
+  COALESCE((v.preco)::numeric, 0)          AS preco_pix,
+  CASE WHEN COALESCE(v.ativo, true) THEN 'ativo' ELSE 'esgotado' END AS status,
+  CASE s.categoria
+    WHEN 'iphone'  THEN 'IPHONE_SEMINOVO'
+    WHEN 'ipad'    THEN 'IPAD_SEMINOVO'
+    WHEN 'macbook' THEN 'MACBOOK_SEMINOVO'
+    WHEN 'watch'   THEN 'APPLE_WATCH_SEMINOVO'
+    ELSE 'IPHONE_SEMINOVO'
+  END                                      AS categoria,
+  'SEMINOVO'                               AS tipo,
+  NOW()                                    AS updated_at
+FROM tradein_config tc,
+     jsonb_to_recordset(tc.seminovos) AS s(modelo text, ativo boolean, categoria text, variantes jsonb, storages jsonb, preco numeric),
+     LATERAL (
+       -- Normaliza pra variantes: se ja tem `variantes`, usa; senao converte
+       -- o legado `storages[]` + `preco` (por modelo) em variantes ativas.
+       SELECT x.storage, x.preco, x.ativo FROM jsonb_to_recordset(
+         COALESCE(
+           s.variantes,
+           (
+             SELECT COALESCE(jsonb_agg(jsonb_build_object(
+               'storage', st,
+               'preco', s.preco,
+               'ativo', true
+             )), '[]'::jsonb)
+             FROM jsonb_array_elements_text(COALESCE(s.storages, '[]'::jsonb)) AS st
+           )
+         )
+       ) AS x(storage text, preco numeric, ativo boolean)
+     ) AS v
+WHERE COALESCE(s.ativo, true) = true
+  AND v.storage IS NOT NULL AND length(trim(v.storage)) > 0
+ON CONFLICT (modelo, armazenamento) DO NOTHING;


### PR DESCRIPTION
## Summary
- Move gestão de seminovos de \`/admin/simulacoes\` pro \`/admin/precos\`
- Nova top-level tab **Valores Seminovos** ao lado da atual **Valores Lacrados**
- Seminovos têm 4 categorias fixas (iPhones, iPads, MacBooks, Apple Watch)
- Rows são distinguidas no DB via \`tipo = "SEMINOVO"\` (campo já existente, só passa a aceitar esse valor)
- Preço \`0\` em seminovo = sem orçamento auto → cliente vai pro WhatsApp manual
- Preço \`> 0\` em seminovo = orçamento automático (mesma UX do lacrado)
- Status \`esgotado\` esconde variante do cliente

## Arquivos mexidos
- [lib/categorias.ts](lib/categorias.ts) — \`DEFAULT_CATEGORIAS_SEMINOVOS\` (4 fixas)
- [app/api/admin/precos/route.ts](app/api/admin/precos/route.ts) — GET aceita \`?tipo=SEMINOVO|LACRADO\`
- [app/api/produtos/route.ts](app/api/produtos/route.ts) — GET aceita \`?tipo=SEMINOVO\` (filtra rows)
- [app/admin/precos/page.tsx](app/admin/precos/page.tsx) — top-level tabs, filtro de view, form adaptado (\`tipo\` fixo na aba nova, sem "+ Categoria", sem "Importar Sheets", select tipo escondido, preço 0 permitido)
- [components/StepNewDevice.tsx](components/StepNewDevice.tsx) — lê \`/api/produtos?tipo=SEMINOVO\` com fallback pro \`tradein_config.seminovos\` durante a transição
- [components/admin/TradeInQuestionsAdmin.tsx](components/admin/TradeInQuestionsAdmin.tsx) — card antigo removido, deixa aviso clicável apontando pra nova aba
- [supabase/migrations/20260423_precos_seed_seminovos.sql](supabase/migrations/20260423_precos_seed_seminovos.sql) — migra seminovos atuais do JSONB pra tabela \`precos\`

## Transição segura (sem janela de quebra)
A migration é **aditiva** — insere os seminovos atuais em \`precos\` com \`tipo=SEMINOVO\` sem mexer no \`tradein_config.seminovos\`. O cliente (\`StepNewDevice\`) prioriza a fonte nova mas cai no fallback do \`tradein_config\` se a nova vier vazia. Nada quebra se a migration ainda não rodou.

Depois que confirmar que tá tudo batendo, abro um PR menor que remove o \`tradein_config.seminovos\` e o fallback.

## ⚠️ Passos pós-merge
1. Deploy do Vercel passa
2. \`/admin/migrations\` → achar \`20260423_precos_seed_seminovos\` Pendente → ▶ Rodar
3. Abrir \`/admin/precos\` → clicar **Valores Seminovos** → conferir que as 4 abas apareceram e que modelos atuais estão lá
4. Testar no simulador de troca (\`/\` → Simular Troca → escolher seminovo) que os preços aparecem e orçamento automático funciona pra quem tiver preço cadastrado

## Test plan
- [ ] Rodar migration
- [ ] Abrir \`/admin/precos\` → aba **Valores Seminovos** aparece
- [ ] Clicar em \`iPhones\` (aba de categoria dentro de Seminovos) → ver modelos migrados
- [ ] Editar um modelo, trocar preço, salvar → persiste
- [ ] Marcar um modelo como "esgotado" → no cliente desaparece
- [ ] Adicionar novo modelo com preço 0 → no cliente aparece sem preço e cai no WhatsApp
- [ ] Adicionar novo modelo com preço > 0 → no cliente aparece com preço e vai pro orçamento automático
- [ ] Abrir \`/admin/simulacoes\` → card antigo deu lugar ao aviso clicável
- [ ] Clicar no aviso → abre \`/admin/precos\` na aba certa

🤖 Generated with [Claude Code](https://claude.com/claude-code)