### PR TITLE
feat(config): WhatsApp de seminovos por categoria (iPhone/iPad/MacBook/Watch)

### DIFF
--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -18,7 +18,14 @@ export default function ConfiguracoesPage() {
   // Contato do formulário de troca
   const [principal, setPrincipal] = useState("5521972461357"); // Bianca default
   const [formLacrados, setFormLacrados] = useState(""); // WhatsApp formulários lacrados
-  const [formSeminovos, setFormSeminovos] = useState(""); // WhatsApp formulários seminovos
+  const [formSeminovos, setFormSeminovos] = useState(""); // WhatsApp formulários seminovos (fallback geral)
+  // Override por categoria de seminovo — se setado, sobrepoe o formSeminovos
+  // pra aquela categoria. Ex: iPhone Seminovo pro Nicolas, iPad Seminovo pro
+  // Rodrigo. Vazio = usa o fallback geral.
+  const [formSemiIphone, setFormSemiIphone] = useState("");
+  const [formSemiIpad, setFormSemiIpad] = useState("");
+  const [formSemiMacbook, setFormSemiMacbook] = useState("");
+  const [formSemiWatch, setFormSemiWatch] = useState("");
   const [vendedores, setVendedores] = useState(VENDEDORES_BASE.map(v => ({ ...v })));
 
   const [loading, setLoading] = useState(true);
@@ -38,6 +45,10 @@ export default function ConfiguracoesPage() {
         if (data.whatsapp_principal) setPrincipal(String(data.whatsapp_principal));
         if (data.whatsapp_formularios) setFormLacrados(String(data.whatsapp_formularios));
         if (data.whatsapp_formularios_seminovos) setFormSeminovos(String(data.whatsapp_formularios_seminovos));
+        if (data.whatsapp_seminovo_iphone) setFormSemiIphone(String(data.whatsapp_seminovo_iphone));
+        if (data.whatsapp_seminovo_ipad) setFormSemiIpad(String(data.whatsapp_seminovo_ipad));
+        if (data.whatsapp_seminovo_macbook) setFormSemiMacbook(String(data.whatsapp_seminovo_macbook));
+        if (data.whatsapp_seminovo_watch) setFormSemiWatch(String(data.whatsapp_seminovo_watch));
         // Merge padrão + banco em lib/vendedores.ts (fonte única).
         setVendedores(mergeVendedores(
           data.whatsapp_vendedores as Record<string, string> | null,
@@ -120,6 +131,11 @@ export default function ConfiguracoesPage() {
           whatsapp_principal: principal,
           whatsapp_formularios: formLacrados || principal,
           whatsapp_formularios_seminovos: formSeminovos || principal,
+          // Overrides por categoria: vazio = usa fallback (formSeminovos).
+          whatsapp_seminovo_iphone: formSemiIphone || "",
+          whatsapp_seminovo_ipad: formSemiIpad || "",
+          whatsapp_seminovo_macbook: formSemiMacbook || "",
+          whatsapp_seminovo_watch: formSemiWatch || "",
           whatsapp_vendedores: waMap,
           whatsapp_vendedores_nomes: waNomes,
           whatsapp_vendedores_recebe_links: waRecebe,
@@ -294,6 +310,75 @@ export default function ConfiguracoesPage() {
               🔗 Testar: wa.me/{formSeminovos}
             </a>
           )}
+        </div>
+
+        {/* WhatsApp Seminovos — por categoria (override do geral acima) */}
+        <div className="bg-white rounded-xl p-5 shadow-sm border border-[#E8E8ED] space-y-4">
+          <div>
+            <p className="font-bold text-[#1D1D1F]">🎯 WhatsApp Seminovos por Categoria</p>
+            <p className="text-xs text-[#86868B] mt-1">
+              Sobrepõe o número acima quando a avaliação for de um seminovo dessa categoria específica.
+              Deixe <b>vazio</b> pra usar o padrão (WhatsApp Troca — Seminovos).
+            </p>
+          </div>
+
+          {([
+            { key: "iphone", label: "iPhone Seminovo", icon: "📱", value: formSemiIphone, set: setFormSemiIphone },
+            { key: "ipad", label: "iPad Seminovo", icon: "📱", value: formSemiIpad, set: setFormSemiIpad },
+            { key: "macbook", label: "MacBook Seminovo", icon: "💻", value: formSemiMacbook, set: setFormSemiMacbook },
+            { key: "watch", label: "Apple Watch Seminovo", icon: "⌚", value: formSemiWatch, set: setFormSemiWatch },
+          ] as const).map((cat) => (
+            <div key={cat.key} className="border-t border-[#F5F5F7] pt-3 first:border-t-0 first:pt-0 space-y-2">
+              <div className="flex items-center justify-between">
+                <p className="font-semibold text-sm text-[#1D1D1F]">{cat.icon} {cat.label}</p>
+                {cat.value && (
+                  <a
+                    href={`https://wa.me/${cat.value}`}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs text-[#E8740E] hover:underline"
+                  >
+                    🔗 wa.me/{cat.value}
+                  </a>
+                )}
+              </div>
+              <div className="flex gap-2 flex-wrap">
+                <button
+                  type="button"
+                  onClick={() => cat.set("")}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-all ${
+                    cat.value === ""
+                      ? "bg-[#E8740E] text-white shadow-sm"
+                      : "bg-[#F5F5F7] border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E]"
+                  }`}
+                  title="Usa o WhatsApp Troca — Seminovos (fallback)"
+                >
+                  Usar padrão {cat.value === "" && "✓"}
+                </button>
+                {vendedores.filter(v => v.numero && v.ativo !== false).map(v => (
+                  <button
+                    key={v.nome}
+                    type="button"
+                    onClick={() => cat.set(v.numero)}
+                    className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-all ${
+                      cat.value === v.numero
+                        ? "bg-[#E8740E] text-white shadow-sm"
+                        : "bg-[#F5F5F7] border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E]"
+                    }`}
+                  >
+                    {v.nome} {cat.value === v.numero && "✓"}
+                  </button>
+                ))}
+              </div>
+              <input
+                value={cat.value}
+                onChange={e => cat.set(e.target.value.replace(/\D/g, ""))}
+                placeholder="5521... (opcional — vazio = usa padrão)"
+                className={inputCls}
+                inputMode="numeric"
+              />
+            </div>
+          ))}
         </div>
 
         {/* Números dos vendedores */}

--- a/app/api/admin/tradein-config/route.ts
+++ b/app/api/admin/tradein-config/route.ts
@@ -22,6 +22,13 @@ export async function GET(req: NextRequest) {
   if (labels._whatsapp_principal) result.whatsapp_principal = labels._whatsapp_principal;
   if (labels._whatsapp_formularios) result.whatsapp_formularios = labels._whatsapp_formularios;
   if (labels._whatsapp_formularios_seminovos) result.whatsapp_formularios_seminovos = labels._whatsapp_formularios_seminovos;
+  // WhatsApp por categoria de seminovo — permite roteamento granular (iPhone
+  // vai pra X, iPad/MacBook/Watch pra Y, etc). Fallback no cliente cai em
+  // whatsapp_formularios_seminovos se a categoria nao tiver numero especifico.
+  if (labels._whatsapp_seminovo_iphone) result.whatsapp_seminovo_iphone = labels._whatsapp_seminovo_iphone;
+  if (labels._whatsapp_seminovo_ipad) result.whatsapp_seminovo_ipad = labels._whatsapp_seminovo_ipad;
+  if (labels._whatsapp_seminovo_macbook) result.whatsapp_seminovo_macbook = labels._whatsapp_seminovo_macbook;
+  if (labels._whatsapp_seminovo_watch) result.whatsapp_seminovo_watch = labels._whatsapp_seminovo_watch;
   if (labels._whatsapp_vendedores) result.whatsapp_vendedores = labels._whatsapp_vendedores;
   if (labels._whatsapp_vendedores_nomes) result.whatsapp_vendedores_nomes = labels._whatsapp_vendedores_nomes;
   if (labels._whatsapp_vendedores_recebe_links) result.whatsapp_vendedores_recebe_links = labels._whatsapp_vendedores_recebe_links;
@@ -41,18 +48,28 @@ export async function PUT(req: NextRequest) {
   if (body.origens !== undefined) updates.origens = body.origens;
 
   // Salvar whatsapp config dentro do campo labels (JSONB) pra não depender de colunas novas
-  if (body.whatsapp_principal !== undefined || body.whatsapp_formularios !== undefined || body.whatsapp_formularios_seminovos !== undefined || body.whatsapp_vendedores !== undefined || body.whatsapp_vendedores_nomes !== undefined || body.whatsapp_vendedores_recebe_links !== undefined || body.whatsapp_vendedores_ativo !== undefined || body.labels !== undefined) {
+  const whatsappFields = [
+    "whatsapp_principal",
+    "whatsapp_formularios",
+    "whatsapp_formularios_seminovos",
+    "whatsapp_seminovo_iphone",
+    "whatsapp_seminovo_ipad",
+    "whatsapp_seminovo_macbook",
+    "whatsapp_seminovo_watch",
+    "whatsapp_vendedores",
+    "whatsapp_vendedores_nomes",
+    "whatsapp_vendedores_recebe_links",
+    "whatsapp_vendedores_ativo",
+  ] as const;
+  const hasAnyWaField = whatsappFields.some((k) => body[k] !== undefined);
+  if (hasAnyWaField || body.labels !== undefined) {
     const { data: current } = await supabase.from("tradein_config").select("labels").limit(1).single();
     const currentLabels = (current?.labels && typeof current.labels === "object") ? current.labels as Record<string, unknown> : {};
     const newLabels = { ...currentLabels };
     if (body.labels !== undefined) Object.assign(newLabels, body.labels);
-    if (body.whatsapp_principal !== undefined) newLabels._whatsapp_principal = body.whatsapp_principal;
-    if (body.whatsapp_formularios !== undefined) newLabels._whatsapp_formularios = body.whatsapp_formularios;
-    if (body.whatsapp_formularios_seminovos !== undefined) newLabels._whatsapp_formularios_seminovos = body.whatsapp_formularios_seminovos;
-    if (body.whatsapp_vendedores !== undefined) newLabels._whatsapp_vendedores = body.whatsapp_vendedores;
-    if (body.whatsapp_vendedores_nomes !== undefined) newLabels._whatsapp_vendedores_nomes = body.whatsapp_vendedores_nomes;
-    if (body.whatsapp_vendedores_recebe_links !== undefined) newLabels._whatsapp_vendedores_recebe_links = body.whatsapp_vendedores_recebe_links;
-    if (body.whatsapp_vendedores_ativo !== undefined) newLabels._whatsapp_vendedores_ativo = body.whatsapp_vendedores_ativo;
+    for (const k of whatsappFields) {
+      if (body[k] !== undefined) newLabels[`_${k}`] = body[k];
+    }
     updates.labels = newLabels;
   }
 

--- a/app/api/tradein-config/route.ts
+++ b/app/api/tradein-config/route.ts
@@ -45,6 +45,11 @@ export async function GET() {
     if (labels._whatsapp_principal) result.whatsapp_principal = labels._whatsapp_principal;
     if (labels._whatsapp_formularios) result.whatsapp_formularios = labels._whatsapp_formularios;
     if (labels._whatsapp_formularios_seminovos) result.whatsapp_formularios_seminovos = labels._whatsapp_formularios_seminovos;
+    // WhatsApp por categoria de seminovo (fallback: whatsapp_formularios_seminovos).
+    if (labels._whatsapp_seminovo_iphone) result.whatsapp_seminovo_iphone = labels._whatsapp_seminovo_iphone;
+    if (labels._whatsapp_seminovo_ipad) result.whatsapp_seminovo_ipad = labels._whatsapp_seminovo_ipad;
+    if (labels._whatsapp_seminovo_macbook) result.whatsapp_seminovo_macbook = labels._whatsapp_seminovo_macbook;
+    if (labels._whatsapp_seminovo_watch) result.whatsapp_seminovo_watch = labels._whatsapp_seminovo_watch;
     if (labels._whatsapp_vendedores) result.whatsapp_vendedores = labels._whatsapp_vendedores;
 
     // Backfill defensivo: garante que todo seminovo tenha categoria (fallback iphone).

--- a/components/StepNewDevice.tsx
+++ b/components/StepNewDevice.tsx
@@ -17,6 +17,13 @@ interface StepNewDeviceProps {
   usedStorage?: string;
   usedColor?: string;
   whatsappNumber?: string;
+  // WhatsApp por categoria de seminovo (iPhone/iPad/MacBook/Watch). Se a
+  // categoria selecionada tiver config especifica, ganha do whatsappNumber
+  // generico. Sobrescrito por vendedorOverride quando cliente veio via ?ref=.
+  whatsappSeminovoByCat?: Record<SeminovoCategoria, string>;
+  // true quando o usuario veio via ?ref=<vendedor> — nesse caso whatsappNumber
+  // ja foi resolvido pro vendedor e o override por categoria NAO deve valer.
+  vendedorOverride?: boolean;
   condition?: AnyConditionData;
   deviceType?: DeviceType;
   tradeinConfig?: TradeInConfig | null;
@@ -62,7 +69,7 @@ const SEMINOVOS_DEFAULT: { modelo: string; variantes: SeminovoVariante[]; ativo:
   { modelo: "iPhone 16 Pro Max", variantes: [{ storage: "256GB", ativo: true }], ativo: true, categoria: "iphone" },
 ];
 
-export default function StepNewDevice({ products, tradeInValue, onNext, onBack, usedModel, usedStorage, usedColor, whatsappNumber, condition, deviceType, tradeinConfig, usedModel2, usedStorage2, usedColor2, condition2, deviceType2, tradeInValue1, tradeInValue2 }: StepNewDeviceProps) {
+export default function StepNewDevice({ products, tradeInValue, onNext, onBack, usedModel, usedStorage, usedColor, whatsappNumber, whatsappSeminovoByCat, vendedorOverride, condition, deviceType, tradeinConfig, usedModel2, usedStorage2, usedColor2, condition2, deviceType2, tradeInValue1, tradeInValue2 }: StepNewDeviceProps) {
   const [mode, setMode] = useState<"" | "lacrado" | "seminovo">("");
   const [category, setCategory] = useState<ProductCategory | "">("");
   const [line, setLine] = useState(""); const [model, setModel] = useState(""); const [storage, setStorage] = useState("");
@@ -484,12 +491,16 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
                   // Salvar simulação seminovo no banco de dados (com dados completos de condição)
                   const condLines = condition && deviceType ? getAnyConditionLines(deviceType, condition) : [];
                   const condLines2 = condition2 && deviceType2 ? getAnyConditionLines(deviceType2, condition2) : [];
-                  // whatsappNumber eh passado pelo TradeInCalculator ja com a
-                  // logica correta pra seminovos (prefere vendedor selecionado;
-                  // senao tradeinConfig.whatsapp_formularios_seminovos; senao
-                  // principal). O fallback WHATSAPP_SEMINOVO so entra se o prop
-                  // nao foi passado (componente usado standalone).
-                  const waNum = whatsappNumber || WHATSAPP_SEMINOVO;
+                  // Cascata de roteamento pra seminovos:
+                  //  1. vendedor via ?ref= na URL (parent ja resolveu em whatsappNumber
+                  //     + marcou vendedorOverride=true) → usa, independente da categoria
+                  //  2. whatsapp da categoria selecionada (whatsappSeminovoByCat[semiCat])
+                  //     → permite iPhone Seminovo -> Nicolas, iPad Seminovo -> outro
+                  //  3. whatsappNumber (fallback geral: whatsapp_formularios_seminovos)
+                  //  4. WHATSAPP_SEMINOVO hardcoded (stand-alone use)
+                  const cat = semiCatEffective || "iphone";
+                  const waFromCat = !vendedorOverride && whatsappSeminovoByCat ? whatsappSeminovoByCat[cat] : "";
+                  const waNum = (vendedorOverride && whatsappNumber) || waFromCat || whatsappNumber || WHATSAPP_SEMINOVO;
                   fetch("/api/leads", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },

--- a/components/TradeInCalculator.tsx
+++ b/components/TradeInCalculator.tsx
@@ -92,7 +92,7 @@ export default function TradeInCalculator({ vendedor: vendedorProp, temaParam }:
 
   const [questionsConfig, setQuestionsConfig] = useState<TradeInQuestion[] | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios?: string; whatsapp_formularios_seminovos?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
+  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios?: string; whatsapp_formularios_seminovos?: string; whatsapp_seminovo_iphone?: string; whatsapp_seminovo_ipad?: string; whatsapp_seminovo_macbook?: string; whatsapp_seminovo_watch?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
   // Mapa dinâmico de WhatsApp por vendedor — usa DB se disponível (normaliza keys pra lowercase)
   const VENDEDOR_WHATSAPP = useMemo(() => {
     const dbMap = tradeinConfig?.whatsapp_vendedores;
@@ -107,6 +107,13 @@ export default function TradeInCalculator({ vendedor: vendedorProp, temaParam }:
   const whatsappPrincipal: string = tradeinConfig?.whatsapp_principal || config.whatsappNumero;
   const whatsappFormulariosLacrados: string = tradeinConfig?.whatsapp_formularios || whatsappPrincipal;
   const whatsappFormulariosSeminovos: string = tradeinConfig?.whatsapp_formularios_seminovos || whatsappPrincipal;
+  // Override por categoria de seminovo (vazio = usa o fallback geral).
+  const whatsappSeminovoByCat: Record<"iphone" | "ipad" | "macbook" | "watch", string> = {
+    iphone: tradeinConfig?.whatsapp_seminovo_iphone || whatsappFormulariosSeminovos,
+    ipad: tradeinConfig?.whatsapp_seminovo_ipad || whatsappFormulariosSeminovos,
+    macbook: tradeinConfig?.whatsapp_seminovo_macbook || whatsappFormulariosSeminovos,
+    watch: tradeinConfig?.whatsapp_seminovo_watch || whatsappFormulariosSeminovos,
+  };
   const [deviceType, setDeviceType] = useState<DeviceType>("iphone");
   const [usedModel, setUsedModel] = useState("");
   const [usedStorage, setUsedStorage] = useState("");
@@ -399,7 +406,7 @@ export default function TradeInCalculator({ vendedor: vendedorProp, temaParam }:
           )}
 
           {step === 2 && (
-            <StepNewDevice products={products} tradeInValue={totalTradeInValue} onNext={handleStep2Complete} onBack={() => setStep(hasSecondDevice ? 1.7 : 1)} usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormulariosSeminovos} condition={condition} deviceType={deviceType} tradeinConfig={tradeinConfig}
+            <StepNewDevice products={products} tradeInValue={totalTradeInValue} onNext={handleStep2Complete} onBack={() => setStep(hasSecondDevice ? 1.7 : 1)} usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormulariosSeminovos} whatsappSeminovoByCat={whatsappSeminovoByCat} vendedorOverride={!!(vendedor && VENDEDOR_WHATSAPP[vendedor])} condition={condition} deviceType={deviceType} tradeinConfig={tradeinConfig}
               usedModel2={hasSecondDevice ? usedModel2 : undefined} usedStorage2={hasSecondDevice ? usedStorage2 : undefined} usedColor2={hasSecondDevice ? usedColor2 : undefined}
               condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined}
               tradeInValue1={hasSecondDevice ? tradeInValue : undefined} tradeInValue2={hasSecondDevice ? tradeInValue2 : undefined}

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -103,7 +103,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
   const [questionsConfig, setQuestionsConfig] = useState<TradeInQuestion[] | null>(null);
   const [catConfigs, setCatConfigs] = useState<{ categoria: string; modo: string; ativo: boolean }[]>([]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios_seminovos?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
+  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios_seminovos?: string; whatsapp_seminovo_iphone?: string; whatsapp_seminovo_ipad?: string; whatsapp_seminovo_macbook?: string; whatsapp_seminovo_watch?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
   // Mapa dinamico de WhatsApp por vendedor — usa DB se disponivel
   const VENDEDOR_WHATSAPP = useMemo(() => {
     const dbMap = tradeinConfig?.whatsapp_vendedores;
@@ -114,6 +114,13 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
   // WhatsApp destino dos formularios de seminovo — Nicolas por padrao,
   // configurado em /admin/configuracoes. Fallback pro principal.
   const whatsappFormulariosSeminovos: string = tradeinConfig?.whatsapp_formularios_seminovos || whatsappPrincipal;
+  // Override por categoria (iPhone Seminovo pro Nicolas, iPad pro Rodrigo, etc).
+  const whatsappSeminovoByCat: Record<"iphone" | "ipad" | "macbook" | "watch", string> = {
+    iphone: tradeinConfig?.whatsapp_seminovo_iphone || whatsappFormulariosSeminovos,
+    ipad: tradeinConfig?.whatsapp_seminovo_ipad || whatsappFormulariosSeminovos,
+    macbook: tradeinConfig?.whatsapp_seminovo_macbook || whatsappFormulariosSeminovos,
+    watch: tradeinConfig?.whatsapp_seminovo_watch || whatsappFormulariosSeminovos,
+  };
   const [deviceType, setDeviceType] = useState<DeviceType>("iphone");
   const [usedModel, setUsedModel] = useState("");
   const [usedStorage, setUsedStorage] = useState("");
@@ -503,7 +510,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
           )}
 
           {step === 2 && (
-            <StepNewDevice products={products} tradeInValue={totalTradeInValue} onNext={handleStep2Complete} onBack={() => setStep(hasSecondDevice ? 1.7 : 1)} usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormulariosSeminovos} condition={condition} deviceType={deviceType} tradeinConfig={tradeinConfig} usedModel2={hasSecondDevice ? usedModel2 : undefined} usedStorage2={hasSecondDevice ? usedStorage2 : undefined} usedColor2={hasSecondDevice ? usedColor2 : undefined} condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined} tradeInValue1={hasSecondDevice ? tradeInValue : undefined} tradeInValue2={hasSecondDevice ? tradeInValue2 : undefined} />
+            <StepNewDevice products={products} tradeInValue={totalTradeInValue} onNext={handleStep2Complete} onBack={() => setStep(hasSecondDevice ? 1.7 : 1)} usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} whatsappNumber={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappFormulariosSeminovos} whatsappSeminovoByCat={whatsappSeminovoByCat} vendedorOverride={!!(vendedor && VENDEDOR_WHATSAPP[vendedor])} condition={condition} deviceType={deviceType} tradeinConfig={tradeinConfig} usedModel2={hasSecondDevice ? usedModel2 : undefined} usedStorage2={hasSecondDevice ? usedStorage2 : undefined} usedColor2={hasSecondDevice ? usedColor2 : undefined} condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined} tradeInValue1={hasSecondDevice ? tradeInValue : undefined} tradeInValue2={hasSecondDevice ? tradeInValue2 : undefined} />
           )}
 
           {step === 3 && (


### PR DESCRIPTION
## Summary
Permite escolher um WhatsApp **diferente por categoria** de seminovo (iPhone, iPad, MacBook, Apple Watch). Hoje existe só um "WhatsApp Formulários Seminovos" único pra todos.

Cenário alvo: começa com tudo no Nicolas, e quando outro funcionário for receber avaliações de iPhone Seminovo, basta trocar só essa categoria sem mexer nas outras.

## Cascata de roteamento (nova → antiga em ordem de prioridade)
1. \`?ref=<vendedor>\` na URL (link de referral) → vai pro WhatsApp daquele vendedor, **independente da categoria**
2. \`whatsapp_seminovo_<categoria>\` (config específica dessa categoria)
3. \`whatsapp_formularios_seminovos\` (fallback geral — comportamento atual)
4. \`whatsapp_principal\` (Bianca)

## O que muda pra você
- Em \`/admin/configuracoes\` aparece uma seção nova **"WhatsApp Seminovos por Categoria"** com 4 linhas (iPhone / iPad / MacBook / Apple Watch)
- Cada linha: botão "Usar padrão" + um botão por vendedor cadastrado + input manual
- Deixando vazio (Usar padrão), segue o fallback geral — nada muda vs hoje
- Preenchendo uma categoria, aquele WhatsApp passa a valer **só pra avaliações daquele tipo de seminovo**

## Arquivos mexidos
- [app/api/admin/tradein-config/route.ts](app/api/admin/tradein-config/route.ts) — GET/PUT lêem/gravam \`_whatsapp_seminovo_{iphone,ipad,macbook,watch}\` em \`labels\` (JSONB, sem migration)
- [app/api/tradein-config/route.ts](app/api/tradein-config/route.ts) — mesmo para a API pública lida pelo cliente
- [app/admin/configuracoes/page.tsx](app/admin/configuracoes/page.tsx) — UI nova
- [components/TradeInCalculator.tsx](components/TradeInCalculator.tsx) + [components/TradeInCalculatorMulti.tsx](components/TradeInCalculatorMulti.tsx) — computam \`whatsappSeminovoByCat\` e passam pro Step
- [components/StepNewDevice.tsx](components/StepNewDevice.tsx) — escolhe \`waNum\` baseado na categoria do seminovo selecionado

## Backwards-compat
- Sem migration (campo JSONB livre)
- Se os 4 novos campos estiverem vazios, cai no fallback atual
- Quem veio via \`?ref=\` segue caindo no vendedor indicado (prioridade máxima, não mudou)

## Test plan
- [ ] Abrir \`/admin/configuracoes\` → ver seção "WhatsApp Seminovos por Categoria"
- [ ] Clicar "Nicolas" em **iPhone Seminovo** → salvar → recarregar → valor persistiu
- [ ] Entrar no site como cliente (sem \`?ref=\`), escolher um seminovo iPhone, clicar "Consultar no WhatsApp" → URL abre com número do Nicolas
- [ ] Voltar em \`/admin/configuracoes\`, colocar outro número em **iPhone Seminovo** mas deixar MacBook vazio
- [ ] Testar: iPhone vai pro novo número / MacBook ainda vai pro fallback (Nicolas ou quem estiver configurado)
- [ ] Testar com \`?ref=bianca\` — ignora tudo e vai pra Bianca (comportamento preservado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)