### PR TITLE
fix(pendencias): sync serial/IMEI de pendencia pra venda + fix Maria Fernanda

### DIFF
--- a/app/api/estoque/route.ts
+++ b/app/api/estoque/route.ts
@@ -564,6 +564,69 @@ export async function PATCH(req: NextRequest) {
     }).eq("id", antes.encomenda_id).in("status", ["PENDENTE", "COMPRADO", "A CAMINHO"]);
   }
 
+  // ── Sync serial/IMEI de PENDENCIA/SEMINOVO pra venda original ──
+  // Quando usuario edita serial/IMEI de um item vindo de troca (aba Pendencias),
+  // propagar pra vendas.troca_serial/troca_imei. Senao o Termo de Procedencia,
+  // que monta aparelhos a partir da venda, sai com dado antigo.
+  const editouSerialOuImei = fields.serial_no !== undefined || fields.imei !== undefined;
+  const vindoDeTroca = antes?.tipo === "PENDENCIA" || antes?.tipo === "SEMINOVO";
+  if (editouSerialOuImei && vindoDeTroca && antes?.cliente) {
+    try {
+      const novoSerial = fields.serial_no !== undefined ? (fields.serial_no as string | null) : (antes.serial_no as string | null);
+      const novoImei = fields.imei !== undefined ? (fields.imei as string | null) : (antes.imei as string | null);
+      const oldSerial = antes.serial_no as string | null;
+      const oldImei = antes.imei as string | null;
+
+      let vendaAlvo: { id: string; slot: 1 | 2 } | null = null;
+
+      // 1) Match deterministico pelos valores antigos (caso o sync nunca tenha rodado antes
+      //    os valores antigos do estoque podem nao estar na venda — ai cai no fallback).
+      const findByCol = async (col: string, value: string): Promise<string | null> => {
+        const { data } = await supabase.from("vendas").select("id").eq(col, value).limit(1).maybeSingle();
+        return (data?.id as string) || null;
+      };
+      if (oldSerial) {
+        const v1 = await findByCol("troca_serial", oldSerial); if (v1) vendaAlvo = { id: v1, slot: 1 };
+        if (!vendaAlvo) { const v2 = await findByCol("troca_serial2", oldSerial); if (v2) vendaAlvo = { id: v2, slot: 2 }; }
+      }
+      if (!vendaAlvo && oldImei) {
+        const v1 = await findByCol("troca_imei", oldImei); if (v1) vendaAlvo = { id: v1, slot: 1 };
+        if (!vendaAlvo) { const v2 = await findByCol("troca_imei2", oldImei); if (v2) vendaAlvo = { id: v2, slot: 2 }; }
+      }
+
+      // 2) Fallback: cliente + valor da troca (±50) — cobre quando serial/imei
+      //    estavam vazios antes ou quando o sync nao rodou na primeira edicao.
+      if (!vendaAlvo) {
+        const custo = Number(antes.custo_unitario || 0);
+        const { data: vs } = await supabase
+          .from("vendas")
+          .select("id, produto_na_troca, produto_na_troca2, created_at")
+          .ilike("cliente", antes.cliente as string)
+          .order("created_at", { ascending: false })
+          .limit(20);
+        for (const v of vs || []) {
+          const val1 = Number(v.produto_na_troca || 0);
+          const val2 = Number((v as Record<string, unknown>).produto_na_troca2 || 0);
+          if (custo > 0 && val1 > 0 && Math.abs(val1 - custo) < 50) { vendaAlvo = { id: v.id as string, slot: 1 }; break; }
+          if (custo > 0 && val2 > 0 && Math.abs(val2 - custo) < 50) { vendaAlvo = { id: v.id as string, slot: 2 }; break; }
+        }
+      }
+
+      if (vendaAlvo) {
+        const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+        if (vendaAlvo.slot === 1) {
+          if (fields.serial_no !== undefined) patch.troca_serial = novoSerial;
+          if (fields.imei !== undefined) patch.troca_imei = novoImei;
+        } else {
+          if (fields.serial_no !== undefined) patch.troca_serial2 = novoSerial;
+          if (fields.imei !== undefined) patch.troca_imei2 = novoImei;
+        }
+        await supabase.from("vendas").update(patch).eq("id", vendaAlvo.id);
+        await logActivity(usuario, "Sync serial/IMEI pendencia->venda", `Venda ${vendaAlvo.id} (slot ${vendaAlvo.slot}): serial=${novoSerial || "—"}, imei=${novoImei || "—"}`, "vendas", vendaAlvo.id).catch(() => {});
+      }
+    } catch { /* silent — nao bloqueia o PATCH principal */ }
+  }
+
   // ── Sincronizar com Mostruário: estoque zerou ou voltou ──
   if (fields.qnt !== undefined) {
     const newQnt = Number(fields.qnt);

--- a/supabase/migrations/20260423b_sync_troca_maria_fernanda.sql
+++ b/supabase/migrations/20260423b_sync_troca_maria_fernanda.sql
@@ -1,0 +1,12 @@
+-- Sync retroativo: venda da MARIA FERNANDA QUINTANILHA GRUNERT tem troca_serial/imei
+-- antigos (FNPMWF7V46 / 350056836065126) porque foram salvos no momento da venda.
+-- O serial/IMEI corretos foram atualizados na aba Pendencias (estoque) mas nao propagaram
+-- pra venda — bug corrigido em paralelo no PATCH /api/estoque.
+-- Essa migration faz o sync manual desse caso especifico.
+
+UPDATE vendas
+SET troca_serial = 'J3WPGWRP2H',
+    troca_imei   = '358824780919628',
+    updated_at   = NOW()
+WHERE troca_serial = 'FNPMWF7V46'
+  AND troca_imei   = '350056836065126';


### PR DESCRIPTION
## Problema

Quando o usuario edita serial/IMEI de um item na aba **Pendencias** (estoque), o dado atualiza na tabela \`estoque\` mas **nao propaga** pra venda original. A venda guarda \`troca_serial\` / \`troca_imei\` em colunas proprias — gravadas no momento que a venda foi criada — e ficam desatualizadas.

Isso quebra o **Termo de Procedencia**, que monta o array \`aparelhos\` a partir de \`v.troca_serial\` / \`v.troca_imei\` ([app/admin/vendas/page.tsx:5810-5811](app/admin/vendas/page.tsx:5810)). O cliente recebe termo com serial/IMEI errados.

Exemplo real: venda da MARIA FERNANDA QUINTANILHA GRUNERT — estoque corrigido pra \`J3WPGWRP2H\` / \`358824780919628\`, venda ficou com \`FNPMWF7V46\` / \`350056836065126\`.

## Fix

1. \`PATCH /api/estoque\`: quando \`serial_no\` ou \`imei\` de um item \`tipo IN (PENDENCIA, SEMINOVO)\` eh editado, acha a venda correspondente e sincroniza \`troca_serial\` / \`troca_imei\` (slot 1 ou 2).

   **Matching:**
   - 1º: deterministico pelos valores antigos (\`troca_serial = antes.serial_no\` etc.)
   - 2º (fallback): \`cliente\` ilike + \`produto_na_troca\` ~ \`custo_unitario\` (±50), mais recente primeiro.

2. Migration \`20260423b_sync_troca_maria_fernanda.sql\`: corrige retroativamente a venda da Maria Fernanda pra permitir envio do termo agora, sem precisar re-editar a pendencia depois do deploy.

## Test plan

- [ ] Preview do Vercel sobe sem erro
- [ ] \`/admin/migrations\` → achar \`20260423b_sync_troca_maria_fernanda\` pendente → Rodar → ✅
- [ ] Abrir venda da Maria Fernanda: painel "Produto na Troca" deve mostrar \`J3WPGWRP2H\` / \`358824780919628\`
- [ ] Enviar Termo de Procedencia da venda → conferir que sai com serial/IMEI atualizados
- [ ] (Regressao) Editar serial/IMEI de outra pendencia qualquer na aba Pendencias → conferir que a venda correspondente atualiza automaticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)