### PR TITLE
fix(pendencias): remover updated_at do sync (vendas nao tem coluna)

### DIFF
--- a/app/api/estoque/route.ts
+++ b/app/api/estoque/route.ts
@@ -613,7 +613,7 @@ export async function PATCH(req: NextRequest) {
       }
 
       if (vendaAlvo) {
-        const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
+        const patch: Record<string, unknown> = {};
         if (vendaAlvo.slot === 1) {
           if (fields.serial_no !== undefined) patch.troca_serial = novoSerial;
           if (fields.imei !== undefined) patch.troca_imei = novoImei;
@@ -621,7 +621,9 @@ export async function PATCH(req: NextRequest) {
           if (fields.serial_no !== undefined) patch.troca_serial2 = novoSerial;
           if (fields.imei !== undefined) patch.troca_imei2 = novoImei;
         }
-        await supabase.from("vendas").update(patch).eq("id", vendaAlvo.id);
+        if (Object.keys(patch).length > 0) {
+          await supabase.from("vendas").update(patch).eq("id", vendaAlvo.id);
+        }
         await logActivity(usuario, "Sync serial/IMEI pendencia->venda", `Venda ${vendaAlvo.id} (slot ${vendaAlvo.slot}): serial=${novoSerial || "—"}, imei=${novoImei || "—"}`, "vendas", vendaAlvo.id).catch(() => {});
       }
     } catch { /* silent — nao bloqueia o PATCH principal */ }

--- a/supabase/migrations/20260423b_sync_troca_maria_fernanda.sql
+++ b/supabase/migrations/20260423b_sync_troca_maria_fernanda.sql
@@ -6,7 +6,6 @@
 
 UPDATE vendas
 SET troca_serial = 'J3WPGWRP2H',
-    troca_imei   = '358824780919628',
-    updated_at   = NOW()
+    troca_imei   = '358824780919628'
 WHERE troca_serial = 'FNPMWF7V46'
   AND troca_imei   = '350056836065126';


### PR DESCRIPTION
## Problema

PR #681 foi mergeado mas o sync de serial/IMEI usa \`updated_at: new Date().toISOString()\` em \`vendas.update(...)\`, e a **migration 20260423b** tambem tem \`updated_at = NOW()\`. A tabela \`vendas\` nao tem essa coluna — a migration falhou ao rodar com \`column "updated_at" of relation "vendas" does not exist\`, e qualquer edicao de serial/IMEI pela aba Pendencias tambem vai falhar no sync (silenciosamente no try/catch).

## Fix

- [app/api/estoque/route.ts](app/api/estoque/route.ts:613): tirar \`updated_at\` do patch, so atualizar se houver campo real pra mudar.
- [supabase/migrations/20260423b_sync_troca_maria_fernanda.sql](supabase/migrations/20260423b_sync_troca_maria_fernanda.sql): remover linha \`updated_at = NOW()\`.

## Test plan

- [ ] Apos merge e deploy do preview, abrir \`/admin/migrations\` → \`20260423b_sync_troca_maria_fernanda\` → Rodar → ✅
- [ ] Abrir venda da Maria Fernanda: "Produto na Troca" mostra \`J3WPGWRP2H\` / \`358824780919628\`
- [ ] Enviar termo da venda → conferir serial/IMEI corretos

🤖 Generated with [Claude Code](https://claude.com/claude-code)