### PR TITLE
feat(admin): ambiente de teste do simulador (/admin/simulador-teste)

### DIFF
--- a/app/admin/simulador-teste/page.tsx
+++ b/app/admin/simulador-teste/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import TradeInCalculatorMulti from "@/components/TradeInCalculatorMulti";
+
+/**
+ * Ambiente de teste do simulador de troca — acessivel apenas via /admin/*
+ * (autenticacao herdada do AdminShell). Diferenca pro simulador publico em
+ * /troca:
+ *   - previewMode=true → bypass do filtro `ativo=false` nas categorias
+ *     (admin ve iPad/MacBook/Watch mesmo com modo desligado pro cliente)
+ *   - Banner no topo pra deixar claro que esta em modo teste
+ *   - Categorias, perguntas e precos vem do mesmo DB de producao — edite
+ *     em /admin/simulacoes e /admin/precos e veja o resultado aqui na hora
+ */
+export default function SimuladorTestePage() {
+  return (
+    <div className="min-h-screen bg-[#F5F5F7]">
+      <div className="bg-[#FFF7ED] border-b-2 border-[#E8740E] px-4 py-3 sticky top-0 z-10">
+        <div className="max-w-2xl mx-auto flex items-center gap-3 flex-wrap">
+          <span className="text-xl">🧪</span>
+          <div className="flex-1 min-w-[200px]">
+            <p className="font-bold text-sm text-[#1D1D1F]">Modo de Teste — só admin</p>
+            <p className="text-xs text-[#86868B]">
+              Mostra todas as categorias (inclusive as <b>desativadas</b> pro cliente).
+              Edita as perguntas em <a href="/admin/simulacoes" className="underline text-[#E8740E]">/admin/simulacoes</a> e
+              os preços em <a href="/admin/precos" className="underline text-[#E8740E]">/admin/precos</a>.
+            </p>
+          </div>
+          <a
+            href="/troca"
+            className="text-xs font-semibold text-[#86868B] hover:text-[#1D1D1F] underline whitespace-nowrap"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Abrir /troca (produção)
+          </a>
+        </div>
+      </div>
+      <TradeInCalculatorMulti previewMode={true} />
+    </div>
+  );
+}

--- a/app/admin/usados/page.tsx
+++ b/app/admin/usados/page.tsx
@@ -554,6 +554,20 @@ export function UsadosContent() {
             {currentCatConfig.ativo ? "Aparece no formulário público" : "Escondido do cliente"}
           </span>
         </div>
+        {/* Link pro ambiente de teste — mostra mesmo quando categoria esta
+            desativada pro cliente. Quando ja esta ativa, o admin pode testar
+            no /troca publico; o botao aqui atalha pro ambiente que NAO respeita
+            o filtro de ativo, util pra testar antes de ligar. */}
+        <div className="h-5 w-px bg-[#D2D2D7]" />
+        <a
+          href="/admin/simulador-teste"
+          target="_blank"
+          rel="noreferrer"
+          className="px-3 py-1.5 rounded-lg text-xs font-bold bg-[#FFF7ED] text-[#E8740E] border border-[#E8740E]/40 hover:bg-[#FFEFE0] transition-colors whitespace-nowrap"
+          title="Abre o simulador em modo teste (admin-only), ignorando o filtro de desativado"
+        >
+          🧪 Testar como cliente
+        </a>
       </div>
 
       {/* Sub-tabs: Valores Base / Descontos / Excluidos */}

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -38,7 +38,7 @@ const DEVICE_OPTIONS: { type: MultiDeviceType; emoji: string; label: string }[] 
   { type: "watch", emoji: "\u{231A}", label: "Apple Watch" },
 ];
 
-export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaParam }: { vendedor?: string | null; temaParam?: string | null }) {
+export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaParam, previewMode = false }: { vendedor?: string | null; temaParam?: string | null; previewMode?: boolean }) {
   const [vendedor] = useState<string | null>(() => {
     if (typeof window !== "undefined") {
       const ref = new URLSearchParams(window.location.search).get("ref")?.toLowerCase();
@@ -426,6 +426,10 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
               </div>
               <div className="grid grid-cols-2 gap-3">
                 {DEVICE_OPTIONS.filter(d => {
+                  // previewMode (route admin /admin/simulador-teste): bypassa o
+                  // filtro de ativo pra admin ver categorias ainda nao ligadas.
+                  // Cliente publico em / continua respeitando cfg.ativo.
+                  if (previewMode) return true;
                   const catMap: Record<string, string> = { iphone: "IPHONE", ipad: "IPAD", macbook: "MACBOOK", watch: "APPLE_WATCH" };
                   const cfg = catConfigs.find(c => c.categoria === catMap[d.type]);
                   return !cfg || cfg.ativo; // se não tem config ou está ativo, mostra


### PR DESCRIPTION
## Summary
Rota nova \`/admin/simulador-teste\` pra admin testar o fluxo completo do simulador de troca — **inclusive de categorias desativadas** (iPad, MacBook, Apple Watch) — sem expor pro cliente.

## Como funciona
- Herda autenticação do \`AdminShell\` (mesma senha que protege o resto do painel), então só admin logado acessa
- Reusa o \`TradeInCalculatorMulti\` com prop nova \`previewMode={true}\` que bypassa o filtro \`tradein_cat_config.ativo\`
- Cliente público em \`/troca\` continua respeitando o filtro — se MacBook está desativado, cliente não vê
- Lê **o mesmo DB de produção**: perguntas editadas em \`/admin/simulacoes\`, preços em \`/admin/precos\`, tudo aparece aqui na hora

## Banner fixo no topo
- Avisa que é modo teste
- Atalhos pra editar perguntas e preços
- Link pra abrir \`/troca\` de produção em aba nova (comparação)

## Atalho em \`/admin/usados\`
Ao lado do toggle Ativo/Desativado da categoria, aparece um botão **"🧪 Testar como cliente"** que abre o ambiente de teste direto.

## Test plan
- [ ] Login em \`/admin\` → abrir \`/admin/simulador-teste\`
- [ ] Conferir banner no topo e categorias (todas as 4 devem aparecer no step 0, mesmo as desativadas)
- [ ] Em \`/admin/usados\` → MacBooks → clicar em "🧪 Testar como cliente" → abre em aba nova
- [ ] Simular uma troca completa de MacBook (categoria desativada) → fluxo funciona
- [ ] Abrir \`/troca\` público sem login → MacBook continua **não aparecendo** (filtro preservado)
- [ ] Ativar MacBook em \`/admin/usados\` → cliente público passa a ver normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)