### PR TITLE
chore(meta): verificacao de dominio do Meta Business

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,11 @@ export const metadata: Metadata = {
     description: "Simule o valor do seu iPhone usado na troca por um novo. Cotação instantânea.",
     images: ["https://tigrao-tradein.vercel.app/og-image.png"],
   },
+  // Verificacao de dominio do Meta Business — necessario pra configurar
+  // Eventos Prioritarios (Aggregated Event Measurement) e melhorar matching iOS.
+  other: {
+    "facebook-domain-verification": "j5bbljyri0x7yea766ygamf06j9rau",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## O que muda

Adiciona a metatag `facebook-domain-verification` no `<head>` do site (via `metadata.other` do Next.js no `app/layout.tsx`) com o token gerado pelo Meta Business: `j5bbljyri0x7yea766ygamf06j9rau`.

## Por que

Permite verificar o domínio `tigraoimports.com` no Meta Business Suite. Isso é pré-requisito pra:
- **Configurar Eventos Prioritários** (Aggregated Event Measurement) — sem isso, conversões em iOS 14+ não otimizam direito
- Melhorar Advanced Matching e qualidade dos Lookalikes

## Próximo passo (depois do deploy)

1. Aguardar deploy automático do Vercel (~1-2 min)
2. Confirmar que a metatag está visível: ver código-fonte de `tigraoimports.com` e procurar `facebook-domain-verification`
3. No Meta Business Suite → Configurações → Domínios → tigraoimports.com → clicar em **"Verificar domínio"**

🤖 Generated with [Claude Code](https://claude.com/claude-code)