### PR TITLE
fix(estoque): balanço Mac Mini misturava RAM 16GB/24GB no mesmo modelo

### DIFF
--- a/lib/produto-display.ts
+++ b/lib/produto-display.ts
@@ -234,10 +234,15 @@ export function getModeloBase(produto: string, categoria: string, observacao?: s
     return `MacBook${chip}${memPair}`;
   }
   if (baseCat === "MAC_MINI") {
-    const mem = getMem();
+    const all = [...p.matchAll(/(\d+)\s*(GB|TB)/gi)];
+    const vals = all.map(m => ({ raw: `${m[1]}${m[2].toUpperCase()}`, gb: m[2].toUpperCase() === "TB" ? parseInt(m[1]) * 1024 : parseInt(m[1]) }));
+    const sorted = [...vals].sort((a, b) => a.gb - b.gb);
+    const ram = sorted.length >= 2 ? ` ${sorted[0].raw}` : "";
+    const ssd = sorted.length >= 1 ? ` ${sorted[sorted.length - 1].raw}` : "";
+    const memPair = `${ram}${ssd}`;
     const chipMatch = p.match(/M(\d+)(\s*PRO)?/i);
     const chip = chipMatch ? ` M${chipMatch[1]}${chipMatch[2] ? " Pro" : ""}` : "";
-    return `Mac Mini${chip}${mem}`;
+    return `Mac Mini${chip}${memPair}`;
   }
   if (baseCat === "APPLE_WATCH") {
     // Apple Watch SE só existe em 40/44mm. Se nome tem 46mm ou 49mm, "SE" é lixo → Series 11.


### PR DESCRIPTION
## Summary
- \`getModeloBase\` pra Mac Mini usava só o maior GB (SSD), então 16GB/512GB e 24GB/512GB colapsavam na chave \`Mac Mini M4 512GB\`
- \`recalcBalancos()\` agrupava os dois e sobrescrevia o balanço manual com a média unificada — por isso editar o preço médio do 24GB não persistia
- Espelha a lógica do MACBOOK: extrai RAM + SSD como par distinto

## Como reproduzir o bug (antes)
1. Ter 1 Mac Mini 24GB/512GB + vários 16GB/512GB em estoque
2. Editar balanço do 24GB pra R\$ X no modal → salvar
3. Valor volta pra média ponderada do grupo inteiro

## Test plan
- [ ] No Vercel preview: /admin/estoque → Mac Mini → editar balanço do H07G4V02QQ (24GB/512GB) → salvar → recarregar → valor persiste
- [ ] Balanço do 16GB/512GB NÃO muda
- [ ] Clicar "Recalc Balanços" e confirmar que os dois grupos permanecem independentes

Substitui #691 (que estava conflitado por divergência do dev-nicolas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)