### PR TITLE
fix(admin): aumentar limite da aba Simulacoes de 500 pra 5000

### DIFF
--- a/app/api/admin/stats/route.ts
+++ b/app/api/admin/stats/route.ts
@@ -16,7 +16,7 @@ export async function GET(req: NextRequest) {
     .from("simulacoes")
     .select("*")
     .order("created_at", { ascending: false })
-    .limit(500);
+    .limit(5000);
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });


### PR DESCRIPTION
## Summary
- `/api/admin/stats` tinha `.limit(500)` hard-coded
- Já temos **736 simulações reais** — 236 não apareciam no admin
- Aumentado para 5000 (~10x o volume atual, dá folga pra meses)

## Test plan
- [x] API retorna 736 simulações (antes 500)
- [x] Aba Simulações mostra todos os 736 registros no preview local (Total, Fecharam, Saíram e Conversão atualizam)
- [ ] Verificar no preview do Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)