### PR TITLE
feat(troca): perguntas dinamicas por categoria (iPad/MacBook/Watch) + fix Watch

### DIFF
--- a/components/StepManualHandoff.tsx
+++ b/components/StepManualHandoff.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { getAnyConditionLines, type AnyConditionData, type DeviceType } from "@/lib/calculations";
+import type { TradeInQuestion } from "@/lib/types";
 import { getHoneypotValue } from "@/lib/honeypot-client";
 
 interface StepManualHandoffProps {
@@ -10,12 +11,19 @@ interface StepManualHandoffProps {
   usedColor?: string;
   condition: AnyConditionData;
   deviceType: DeviceType;
+  // Perguntas dinamicas respondidas no Step 1 (cadastradas via /admin/simulacoes
+  // com slug fora dos hardcoded). Usado pra montar a mensagem do WhatsApp e o
+  // resumo visual com TODAS as respostas — operador precisa disso pra avaliar.
+  extraAnswers?: Record<string, unknown>;
+  extraQuestions?: TradeInQuestion[];
   // 2o aparelho opcional
   usedModel2?: string;
   usedStorage2?: string;
   usedColor2?: string;
   condition2?: AnyConditionData;
   deviceType2?: DeviceType;
+  extraAnswers2?: Record<string, unknown>;
+  extraQuestions2?: TradeInQuestion[];
   // Produto novo escolhido
   newModel: string;
   newStorage: string;
@@ -32,6 +40,26 @@ interface StepManualHandoffProps {
   onGoToStep?: (step: number) => void;
 }
 
+// Formata uma resposta dinamica em string human-readable.
+function formatExtraAnswer(q: TradeInQuestion, value: unknown): string {
+  if (value === undefined || value === null || value === "") return "—";
+  if (Array.isArray(value)) {
+    const labels = value.map((v) => q.opcoes.find((o) => o.value === v)?.label || String(v));
+    return labels.length > 0 ? labels.join(", ") : "—";
+  }
+  if (typeof value === "boolean") return value ? "Sim" : "Nao";
+  const opt = q.opcoes.find((o) => o.value === value);
+  return opt?.label || String(value);
+}
+
+// Converte respostas dinamicas em pares { label, value } pra renderizar/exibir.
+function formatExtraLines(questions: TradeInQuestion[] | undefined, answers: Record<string, unknown> | undefined): { label: string; value: string }[] {
+  if (!questions || !answers) return [];
+  return questions
+    .map((q) => ({ label: q.titulo || q.slug, value: formatExtraAnswer(q, answers[q.slug]) }))
+    .filter((l) => l.value !== "—");
+}
+
 /**
  * Handoff pra avaliacao manual via WhatsApp. Renderizado em vez do StepQuote
  * quando o modelo usado nao tem preco base cadastrado (ou a categoria esta
@@ -40,7 +68,9 @@ interface StepManualHandoffProps {
 export default function StepManualHandoff(p: StepManualHandoffProps) {
   const {
     usedModel, usedStorage, usedColor, condition, deviceType,
+    extraAnswers, extraQuestions,
     usedModel2, usedStorage2, usedColor2, condition2, deviceType2,
+    extraAnswers2, extraQuestions2,
     newModel, newStorage, newPrice,
     clienteNome, clienteWhatsApp, clienteInstagram, clienteOrigem,
     whatsappNumero, vendedor, onReset, onGoToStep,
@@ -50,6 +80,10 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
 
   const hasSecond = !!(usedModel2 && usedStorage2);
   const fmt = (v: number) => `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
+
+  // Linhas das perguntas dinamicas pra resumo UI + mensagem WhatsApp
+  const extraLines1 = formatExtraLines(extraQuestions, extraAnswers);
+  const extraLines2 = formatExtraLines(extraQuestions2, extraAnswers2);
 
   function buildWhatsAppMsg(): string {
     const lines: string[] = [];
@@ -72,6 +106,8 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
     if (usedColor) lines.push(`Cor: ${usedColor}`);
     const condLines = getAnyConditionLines(deviceType, condition);
     if (condLines.length > 0) lines.push(`Condição: ${condLines.join(", ")}`);
+    // Perguntas dinamicas (cadastradas via /admin/simulacoes)
+    for (const l of extraLines1) lines.push(`${l.label}: ${l.value}`);
 
     if (hasSecond && condition2 && deviceType2) {
       lines.push("", `*Aparelho 2:*`);
@@ -79,6 +115,7 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
       if (usedColor2) lines.push(`Cor: ${usedColor2}`);
       const condLines2 = getAnyConditionLines(deviceType2, condition2);
       if (condLines2.length > 0) lines.push(`Condição: ${condLines2.join(", ")}`);
+      for (const l of extraLines2) lines.push(`${l.label}: ${l.value}`);
     }
 
     lines.push("");
@@ -92,6 +129,10 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
     try {
       const condLines = getAnyConditionLines(deviceType, condition);
       const condLines2 = hasSecond && condition2 && deviceType2 ? getAnyConditionLines(deviceType2, condition2) : [];
+      // Respostas dinamicas viram linhas "Label: Valor" e entram em condicaoLinhas
+      // pra chegar no admin junto com as condicoes hardcoded.
+      const extraLinesStr1 = extraLines1.map((l) => `${l.label}: ${l.value}`);
+      const extraLinesStr2 = extraLines2.map((l) => `${l.label}: ${l.value}`);
       await fetch("/api/leads", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -110,7 +151,7 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
           diferenca: 0,
           status: "AVALIACAO_MANUAL",
           formaPagamento: "WhatsApp Avaliacao Manual",
-          condicaoLinhas: condLines,
+          condicaoLinhas: [...condLines, ...extraLinesStr1],
           whatsappDestino: whatsappNumero,
           vendedor: vendedor || null,
           ...(hasSecond ? {
@@ -118,7 +159,7 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
             storageUsado2: usedStorage2,
             corUsado2: usedColor2 || "",
             avaliacaoUsado2: 0,
-            condicaoLinhas2: condLines2,
+            condicaoLinhas2: [...condLines2, ...extraLinesStr2],
           } : {}),
           website: getHoneypotValue(),
         }),
@@ -164,11 +205,31 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
             {usedModel} {usedStorage}
             {usedColor ? ` · ${usedColor}` : ""}
           </p>
+          {extraLines1.length > 0 && (
+            <div className="mt-2 space-y-0.5">
+              {extraLines1.map((l, i) => (
+                <p key={i} className="text-[12px]" style={{ color: "var(--ti-muted)" }}>
+                  <span className="font-medium">{l.label}:</span> {l.value}
+                </p>
+              ))}
+            </div>
+          )}
           {hasSecond && (
-            <p className="text-[14px] mt-1" style={{ color: "var(--ti-text)" }}>
-              {usedModel2} {usedStorage2}
-              {usedColor2 ? ` · ${usedColor2}` : ""}
-            </p>
+            <>
+              <p className="text-[14px] mt-3" style={{ color: "var(--ti-text)" }}>
+                {usedModel2} {usedStorage2}
+                {usedColor2 ? ` · ${usedColor2}` : ""}
+              </p>
+              {extraLines2.length > 0 && (
+                <div className="mt-2 space-y-0.5">
+                  {extraLines2.map((l, i) => (
+                    <p key={i} className="text-[12px]" style={{ color: "var(--ti-muted)" }}>
+                      <span className="font-medium">{l.label}:</span> {l.value}
+                    </p>
+                  ))}
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -17,8 +17,31 @@ interface StepUsedDeviceMultiProps {
   modelDiscounts?: Record<string, ModelDiscounts>;
   questionsConfig?: TradeInQuestion[] | null;
   deviceType: MultiDeviceType;
-  onNext: (data: { usedModel: string; usedStorage: string; usedColor: string; condition: AnyConditionData; tradeInValue: number; deviceType: DeviceType }) => void;
+  onNext: (data: { usedModel: string; usedStorage: string; usedColor: string; condition: AnyConditionData; tradeInValue: number; deviceType: DeviceType; extraAnswers?: Record<string, unknown> }) => void;
   onTrackQuestion?: (step: number, question: string) => void;
+}
+
+// Slugs que ja sao renderizados pela UI hardcoded. Qualquer pergunta do
+// questionsConfig cujo slug esteja fora dessa lista entra no bloco dinamico
+// "Perguntas adicionais" no final — permite admin adicionar perguntas novas
+// (ex: "Ciclos" pra MacBook, "Pulseira" pra Watch) via /admin/simulacoes sem
+// precisar mexer no componente.
+const HARDCODED_SLUGS = new Set([
+  "battery", "hasDamage", "hasOriginalBox", "hasWarranty", "hasWearMarks",
+  "partsReplaced", "peeling", "screenScratch", "sideScratch",
+  "warrantyMonth", "wearMarks",
+]);
+
+// Formata uma resposta dinamica pra exibir no resumo/WhatsApp.
+function formatExtraAnswer(q: TradeInQuestion, value: unknown): string {
+  if (value === undefined || value === null || value === "") return "—";
+  if (Array.isArray(value)) {
+    const labels = value.map((v) => q.opcoes.find((o) => o.value === v)?.label || String(v));
+    return labels.join(", ");
+  }
+  if (typeof value === "boolean") return value ? "Sim" : "Nao";
+  const opt = q.opcoes.find((o) => o.value === value);
+  return opt?.label || String(value);
 }
 
 // Helper to get question config by slug
@@ -154,6 +177,10 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   const [hasOriginalBox, setHasOriginalBox] = useState<boolean|null>(null);
   const [cor, setCor] = useState("");
   const [coresDisponiveis, setCoresDisponiveis] = useState<Record<string, string[]>>({});
+  // Respostas das perguntas dinamicas (slugs fora do HARDCODED_SLUGS). Chave
+  // e o slug, valor depende do `tipo`: string pra selection/yesno,
+  // string[] pra multiselect, number pra numeric.
+  const [extraAnswers, setExtraAnswers] = useState<Record<string, unknown>>({});
 
   // Busca cores do catálogo/estoque quando muda o deviceType
   const fetchCores = useCallback(async () => {
@@ -249,6 +276,24 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [baseValue, screenScratch, sideScratch, peeling, battery, hasDamage, partsReplaced, hasWarranty, warrantyMonth, warrantyYear, md, hasOriginalBox, hasWearMarks, wearMarksDiscount, calcDeviceType]);
 
+  // Perguntas dinamicas ativas: qualquer pergunta do DB com slug fora dos
+  // hardcoded. Ordena por `ordem` pra respeitar a sequencia configurada no admin.
+  const dynamicQuestions = useMemo(() => {
+    if (!qc) return [];
+    return qc
+      .filter((q) => q.ativo !== false && !HARDCODED_SLUGS.has(q.slug))
+      .sort((a, b) => (a.ordem ?? 0) - (b.ordem ?? 0));
+  }, [qc]);
+
+  // Valida: toda pergunta dinamica precisa ter resposta (exceto multiselect,
+  // que pode ficar vazio). Pra simplificar, considera "nao respondida" se a
+  // chave nao existe em extraAnswers. Multiselect com [] conta como respondida.
+  const dynamicOk = dynamicQuestions.every((q) => {
+    const v = extraAnswers[q.slug];
+    if (q.tipo === "multiselect") return v !== undefined;
+    return v !== undefined && v !== null && v !== "";
+  });
+
   const isExcluded = excludedModels.some((m) => model.toLowerCase().includes(m.toLowerCase()));
   const batteryFilled = !isQActive(qc, "battery") || (battery !== null && battery >= 1 && battery <= 100);
   // New wear marks system: if hasWearMarks is active, skip old screenScratch/sideScratch/peeling checks
@@ -261,7 +306,7 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   const warrantyFilled = !isQActive(qc, "hasWarranty") || hasWarranty === false || (hasWarranty === true && (!isQActive(qc, "warrantyMonth") || warrantyMonth !== null));
   const partsOk = !isQActive(qc, "partsReplaced") || partsReplaced === "no" || partsReplaced === "apple";
   const boxOk = !isQActive(qc, "hasOriginalBox") || hasOriginalBox !== null;
-  const canProceed = model && storage && cor && baseValue !== null && !isExcluded && damageOk && partsOk && allCond && warrantyFilled && boxOk;
+  const canProceed = model && storage && cor && baseValue !== null && !isExcluded && damageOk && partsOk && allCond && warrantyFilled && boxOk && dynamicOk;
 
   const tq = (q: string) => onTrackQuestion?.(1, q);
   function handleLineChange(l: string) { setLine(l); setSubLine(""); setModel(""); setStorage(""); setHasDamage(null); tq("line"); }
@@ -681,8 +726,78 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
         </>
       )}
 
+      {/* Perguntas adicionais — cadastradas via /admin/simulacoes com slug
+          diferente dos hardcoded. Renderizacao generica por `tipo`. Admin
+          pode adicionar/editar/remover pra qualquer device_type sem precisar
+          mexer no codigo. */}
+      {model && !isExcluded && dynamicQuestions.length > 0 && dynamicQuestions.map((q) => {
+        const val = extraAnswers[q.slug];
+        const setVal = (v: unknown) => setExtraAnswers((prev) => ({ ...prev, [q.slug]: v }));
+        return (
+          <Section key={q.id || q.slug} title={q.titulo}>
+            {q.tipo === "yesno" && (
+              <div className="flex gap-2">
+                {(q.opcoes.length > 0 ? q.opcoes : [{ value: "yes", label: "Sim" }, { value: "no", label: "Nao" }]).map((opt) => (
+                  <Btn key={opt.value} sel={val === opt.value} onClick={() => { setVal(opt.value); tq(q.slug); }} className="flex-1">
+                    {opt.label}
+                  </Btn>
+                ))}
+              </div>
+            )}
+            {q.tipo === "selection" && (
+              <div className={`grid gap-2 ${q.opcoes.length <= 2 ? "grid-cols-2" : q.opcoes.length === 3 ? "grid-cols-3" : "grid-cols-2"}`}>
+                {q.opcoes.map((opt) => (
+                  <Btn key={opt.value} sel={val === opt.value} onClick={() => { setVal(opt.value); tq(q.slug); }}>
+                    {opt.label}
+                  </Btn>
+                ))}
+              </div>
+            )}
+            {q.tipo === "multiselect" && (
+              <div className="grid grid-cols-2 gap-2">
+                {q.opcoes.map((opt) => {
+                  const arr = Array.isArray(val) ? (val as string[]) : [];
+                  const sel = arr.includes(opt.value);
+                  return (
+                    <Btn key={opt.value} sel={sel} onClick={() => {
+                      const next = sel ? arr.filter((v) => v !== opt.value) : [...arr, opt.value];
+                      setVal(next); tq(q.slug);
+                    }}>
+                      {sel ? "✓ " : ""}{opt.label}
+                    </Btn>
+                  );
+                })}
+                {/* Inicializa array vazio quando usuario nao marcou nada ainda, pra validacao saber que ja interagiu */}
+                {val === undefined && (
+                  <button onClick={() => setVal([])} className="col-span-2 text-[11px] text-[#86868B] underline py-1">Nenhum</button>
+                )}
+              </div>
+            )}
+            {q.tipo === "numeric" && (
+              <input
+                type="number"
+                inputMode="numeric"
+                value={typeof val === "number" ? String(val) : (typeof val === "string" ? val : "")}
+                onChange={(e) => {
+                  const raw = e.target.value.trim();
+                  const num = raw === "" ? undefined : Number(raw);
+                  setVal(Number.isFinite(num as number) ? (num as number) : undefined);
+                  tq(q.slug);
+                }}
+                className="w-full px-4 py-3 rounded-xl text-[15px]"
+                style={{ backgroundColor: "var(--ti-input-bg)", color: "var(--ti-text)", border: "1px solid var(--ti-input-border)" }}
+                placeholder="Ex: 500"
+              />
+            )}
+          </Section>
+        );
+      })}
+
       {canProceed && (
-        <button onClick={() => onNext({ usedModel: model, usedStorage: storage, usedColor: cor, condition: cond, tradeInValue, deviceType: calcDeviceType })}
+        <button onClick={() => onNext({
+          usedModel: model, usedStorage: storage, usedColor: cor, condition: cond, tradeInValue, deviceType: calcDeviceType,
+          extraAnswers: dynamicQuestions.length > 0 ? extraAnswers : undefined,
+        })}
           className="w-full py-4 rounded-2xl text-[17px] font-semibold text-white transition-all duration-200 active:scale-[0.98] shadow-lg"
           style={{ backgroundColor: "#22c55e" }}>
           Ver minha avaliacao {"\u2192"}

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -180,8 +180,11 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
     !hasPriceFor(usedModel, usedStorage) ||
     (hasSecondDevice && (catForcesManual(deviceType2) || !hasPriceFor(usedModel2, usedStorage2)));
 
-  // Map MultiDeviceType to API device_type param
-  const apiDeviceType: DeviceType = selectedDeviceType === "watch" ? "iphone" : (selectedDeviceType || "iphone");
+  // Map MultiDeviceType ao device_type da API. A API /api/tradein-perguntas
+  // suporta "watch" nativamente (DEFAULT_QUESTIONS tem bloco proprio), entao
+  // nao coerce pra "iphone" como antes — isso fazia o Watch carregar
+  // perguntas do iPhone e ignorar as especificas cadastradas em /admin/simulacoes.
+  const apiDeviceType: MultiDeviceType = selectedDeviceType || "iphone";
 
   useEffect(() => {
     async function load() {
@@ -253,20 +256,41 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
 
   const [usedColor, setUsedColor] = useState("");
   const [usedColor2, setUsedColor2] = useState("");
+  // Respostas das perguntas dinamicas (criadas via /admin/simulacoes pra
+  // categorias nao-iPhone). Separado do `condition` hardcoded pra nao mexer
+  // no tipo `AnyConditionData`. Passa adiante pro StepManualHandoff e pro
+  // StepQuote (quando a avaliacao for manual — onde a info realmente importa).
+  const [extraAnswers, setExtraAnswers] = useState<Record<string, unknown> | undefined>(undefined);
+  const [extraAnswers2, setExtraAnswers2] = useState<Record<string, unknown> | undefined>(undefined);
+  // Snapshot das perguntas usadas em cada aparelho (pra formatar depois)
+  const [extraQuestions, setExtraQuestions] = useState<TradeInQuestion[]>([]);
+  const [extraQuestions2, setExtraQuestions2] = useState<TradeInQuestion[]>([]);
 
   function handleStep1Complete(data: {
     usedModel: string; usedStorage: string; usedColor: string; condition: AnyConditionData; tradeInValue: number; deviceType: DeviceType;
+    extraAnswers?: Record<string, unknown>;
   }) {
     trackComplete(1);
     fbq("track", "ViewContent", { content_name: `${data.usedModel} ${data.usedStorage}`, content_category: "trade-in-usado" });
+    // Snapshot das perguntas dinamicas ativas no momento do submit — usa o
+    // questionsConfig atual, filtrado por slugs fora dos hardcoded.
+    const dynamicQs = (questionsConfig ?? []).filter(
+      (q) => q.ativo !== false && !["battery","hasDamage","hasOriginalBox","hasWarranty","hasWearMarks","partsReplaced","peeling","screenScratch","sideScratch","warrantyMonth","wearMarks"].includes(q.slug)
+    );
     if (step === 1) {
       setDeviceType(data.deviceType); setUsedModel(data.usedModel); setUsedStorage(data.usedStorage);
       setUsedColor(data.usedColor || "");
-      setCondition(data.condition); setTradeInValue(data.tradeInValue); setStep(1.5);
+      setCondition(data.condition); setTradeInValue(data.tradeInValue);
+      setExtraAnswers(data.extraAnswers);
+      setExtraQuestions(dynamicQs);
+      setStep(1.5);
     } else {
       setDeviceType2(data.deviceType); setUsedModel2(data.usedModel); setUsedStorage2(data.usedStorage);
       setUsedColor2(data.usedColor || "");
-      setCondition2(data.condition); setTradeInValue2(data.tradeInValue); setHasSecondDevice(true); setStep(2);
+      setCondition2(data.condition); setTradeInValue2(data.tradeInValue); setHasSecondDevice(true);
+      setExtraAnswers2(data.extraAnswers);
+      setExtraQuestions2(dynamicQs);
+      setStep(2);
     }
     window.scrollTo({ top: 0, behavior: "smooth" });
   }
@@ -593,6 +617,8 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
               usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} condition={condition} deviceType={deviceType}
               usedModel2={hasSecondDevice ? usedModel2 : undefined} usedStorage2={hasSecondDevice ? usedStorage2 : undefined} usedColor2={hasSecondDevice ? usedColor2 : undefined}
               condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined}
+              extraAnswers={extraAnswers} extraQuestions={extraQuestions}
+              extraAnswers2={hasSecondDevice ? extraAnswers2 : undefined} extraQuestions2={hasSecondDevice ? extraQuestions2 : undefined}
               newModel={newModel} newStorage={newStorage} newPrice={newPrice}
               clienteNome={clienteNome} clienteWhatsApp={clienteWhatsApp} clienteInstagram={clienteInstagram} clienteOrigem={clienteOrigem}
               whatsappNumero={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappPrincipal}


### PR DESCRIPTION
## Summary
Libera controle total das perguntas por categoria em \`/admin/simulacoes\` sem mexer no fluxo do iPhone.

## O que muda

### 1. Fix do bug do Apple Watch
\`TradeInCalculatorMulti\` convertia \`selectedDeviceType=watch\` em \`"iphone"\` quando pedia as perguntas da API. Resultado: Watch sempre carregava perguntas de iPhone e **ignorava** as cadastradas pra Watch. Agora usa \`"watch"\` nativo (a API já suporta).

### 2. Perguntas dinâmicas em \`StepUsedDeviceMulti\`
Após as perguntas hardcoded (bateria, arranhão, caixa...), renderiza uma nova seção **"Perguntas adicionais"** com **qualquer** pergunta do \`questionsConfig\` cujo slug esteja fora dos hardcoded. Renderização genérica por \`tipo\`:

| tipo | UI |
|---|---|
| \`yesno\` | 2 botões Sim/Não |
| \`selection\` | N botões, 1 por opção |
| \`multiselect\` | N botões toggle (seleciona vários) |
| \`numeric\` | input numérico |

Isso significa que agora o admin pode **adicionar/editar/remover qualquer pergunta** pra iPad/MacBook/Watch em \`/admin/simulacoes\` e o cliente renderiza sozinho, sem precisar mexer no código.

**iPhone não muda em nada.** Se não tem pergunta cadastrada com slug novo, a seção "Perguntas adicionais" não aparece.

### 3. Handoff WhatsApp com resumo completo
\`StepManualHandoff\` agora:
- Mostra todas as respostas dinâmicas no card de resumo
- Inclui elas na mensagem do WhatsApp (pro operador)
- Salva em \`condicaoLinhas\` no lead (pra ficar gravado em \`/admin/simulacoes\`)

## Arquivos
- [components/TradeInCalculatorMulti.tsx](components/TradeInCalculatorMulti.tsx) — fix Watch + receber/passar \`extraAnswers\`
- [components/StepUsedDeviceMulti.tsx](components/StepUsedDeviceMulti.tsx) — seção de perguntas dinâmicas + validação
- [components/StepManualHandoff.tsx](components/StepManualHandoff.tsx) — resumo + WhatsApp + lead payload

## Test plan
- [ ] Em \`/admin/simulacoes\`, criar pergunta "Pulseira original?" com \`device_type=watch\`, \`tipo=yesno\`, \`slug=pulseira\`
- [ ] Abrir \`/admin/simulador-teste\`, selecionar Apple Watch, preencher fluxo
- [ ] Chegar no step 1 (condição) → pergunta "Pulseira original?" aparece após as hardcoded
- [ ] Responder → habilita botão "Ver minha avaliação"
- [ ] Chegar no step 4 → Handoff mostra "Pulseira original: Sim" no resumo
- [ ] Clicar "Receber orçamento no WhatsApp" → mensagem tem a linha "Pulseira original: Sim"
- [ ] Conferir que iPhone NÃO mudou nada visualmente no fluxo
- [ ] Conferir no /admin/simulacoes (histórico de leads) que o lead tem \`condicaoLinhas\` com a resposta

🤖 Generated with [Claude Code](https://claude.com/claude-code)