### PR TITLE
fix(vendas): botao Recriar Pendencia apos pendencia deletada

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -5979,7 +5979,7 @@ export default function VendasPage() {
                                               fetch("/api/vendas", {
                                                 method: "PATCH",
                                                 headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
-                                                body: JSON.stringify({ id: v.id, troca_produto: v.troca_produto, produto_na_troca: v.produto_na_troca }),
+                                                body: JSON.stringify({ id: v.id, troca_produto: v.troca_produto, produto_na_troca: v.produto_na_troca, _recriar_pendencia: true }),
                                               }).then(r => { if (r.ok) setMsg("Pendência recriada!"); else r.json().then(j => setMsg("Erro: " + (j.error || "falha"))); }).catch(() => setMsg("Erro ao recriar"));
                                             }}
                                             className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-yellow-500 text-white hover:bg-yellow-600 transition-colors"

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -800,6 +800,11 @@ export async function PATCH(req: NextRequest) {
   const patchCreditoLoja = Number(fields.usar_credito_loja || 0);
   const patchLojistaId = fields._lojista_id || null;
 
+  // Flag do botão "Recriar Pendência": força criação mesmo quando a venda
+  // ja tinha troca antes (caso em que o admin deletou manualmente a pendencia
+  // do estoque pra editar e quer recriar).
+  const forceRecriarPendencia = fields._recriar_pendencia === true;
+
   // Remover campos internos que não existem na tabela vendas
   delete fields._seminovo;
   delete fields._seminovo2;
@@ -807,6 +812,7 @@ export async function PATCH(req: NextRequest) {
   delete fields.forma_sinal;
   delete fields.usar_credito_loja;
   delete fields._lojista_id;
+  delete fields._recriar_pendencia;
 
   // Se tem crédito de lojista, salvar na coluna correta
   if (patchCreditoLoja > 0) {
@@ -1029,8 +1035,10 @@ export async function PATCH(req: NextRequest) {
         // (provavelmente foi movida pra estoque como seminovo), NAO criar uma
         // nova. Antes, toda edicao de venda com troca criava uma pendencia
         // duplicada, obrigando o admin a deletar manualmente.
-        if (!p1 && jaTinhaTroca1Antes) {
+        if (!p1 && jaTinhaTroca1Antes && !forceRecriarPendencia) {
           // no-op: troca ja foi processada numa edicao/criacao anterior
+          // (forceRecriarPendencia=true quando o botao "Recriar Pendencia"
+          // foi clicado — admin deletou a pendencia e quer recria-la)
         } else if (p1) {
           // UPDATE
           const upd1: Record<string, unknown> = {};
@@ -1110,7 +1118,7 @@ export async function PATCH(req: NextRequest) {
           : (hasTroca1 ? undefined : existing[0]);
         // Mesmo tratamento da troca 1: se venda ja tinha troca2 antes e nao
         // achou pendencia, a troca ja foi processada — nao duplicar.
-        if (!p2 && jaTinhaTroca2Antes) {
+        if (!p2 && jaTinhaTroca2Antes && !forceRecriarPendencia) {
           // no-op
         } else if (p2) {
           const upd2: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary
- Botao **🔄 Recriar Pendência** nao funcionava quando o admin deletava a pendencia do estoque (pra editar os dados) e depois tentava recriar
- Guard `jaTinhaTroca1Antes` bloqueava a criacao achando que a troca ja tinha sido processada
- Frontend agora envia flag explicita `_recriar_pendencia: true` e a API pula o guard quando ela vem

## Caso que reproduziu o bug
Venda da cliente Marcella (IPHONE 17 PRO MAX + troca IPHONE 11 64GB Branco R\$ 500). Admin deletou a pendencia no estoque pra editar, clicou Recriar Pendencia → nada acontecia.

## Test plan
- [ ] Abrir uma venda com troca, deletar a pendencia correspondente no estoque
- [ ] Clicar **🔄 Recriar Pendência** na venda
- [ ] Confirmar que a pendencia reaparece no estoque da cliente com os dados da troca
- [ ] Testar tambem que edicoes normais de venda com troca (sem clicar o botao) continuam respeitando o guard e nao criam duplicata

🤖 Generated with [Claude Code](https://claude.com/claude-code)