### PR TITLE
feat(contrato): adicionar 3 clausulas (trade-in definitivo, vicios ocultos, procedencia)

### DIFF
--- a/lib/pdf-contrato.ts
+++ b/lib/pdf-contrato.ts
@@ -183,6 +183,9 @@ export async function gerarContratoPDF(dados: ContratoData): Promise<Buffer> {
       "4. A TigraoImports garante que o produto novo e lacrado, com garantia Apple de 1 ano e nota fiscal.",
       "5. Este contrato tem validade de 24 horas a partir da data de emissao.",
       "6. Em caso de desistencia apos a troca, taxas de restocking poderao ser aplicadas.",
+      "7. Compras realizadas com entrega de aparelho usado na troca (trade-in) sao DEFINITIVAS e nao admitem arrependimento, desistencia ou cancelamento. O direito previsto no art. 49 do Codigo de Defesa do Consumidor nao se aplica a esta modalidade, pois o aparelho recebido e imediatamente recolocado a venda, tornando impossivel a reversao da operacao.",
+      "8. O cliente declara que o aparelho entregue na troca nao possui vicios ocultos, defeitos de funcionamento, danos internos ou historico de reparos nao informados.",
+      "9. O cliente e integralmente responsavel pela PROCEDENCIA licita do aparelho entregue na troca. Em caso de apreensao, reivindicacao por terceiros ou qualquer prejuizo decorrente de origem ilicita (furto, roubo, receptacao etc.), o cliente se obriga a reembolsar a TigraoImports por todos os valores envolvidos, inclusive o ressarcimento ao comprador do aparelho revendido.",
     ];
 
     doc.fontSize(8.5).font("Helvetica").fillColor(C.textLight);


### PR DESCRIPTION
## Summary
Adiciona 3 clausulas novas no contrato de trade-in ([lib/pdf-contrato.ts](lib/pdf-contrato.ts)):

### 7. Trade-in e DEFINITIVO
> Compras realizadas com entrega de aparelho usado na troca (trade-in) sao DEFINITIVAS e nao admitem arrependimento, desistencia ou cancelamento. O direito previsto no art. 49 do Codigo de Defesa do Consumidor nao se aplica a esta modalidade, pois o aparelho recebido e imediatamente recolocado a venda, tornando impossivel a reversao da operacao.

### 8. Sem vicios ocultos
> O cliente declara que o aparelho entregue na troca nao possui vicios ocultos, defeitos de funcionamento, danos internos ou historico de reparos nao informados.

### 9. Responsabilidade pela procedencia
> O cliente e integralmente responsavel pela PROCEDENCIA licita do aparelho entregue na troca. Em caso de apreensao, reivindicacao por terceiros ou qualquer prejuizo decorrente de origem ilicita (furto, roubo, receptacao etc.), o cliente se obriga a reembolsar a TigraoImports por todos os valores envolvidos, inclusive o ressarcimento ao comprador do aparelho revendido.

## Motivação
- **#7**: evitar cliente pedir reversao citando CDC art. 49 depois da loja ja ter revendido o usado
- **#8**: proteger contra aparelho com problema funcional que so aparece depois
- **#9**: proteger a loja financeiramente caso o aparelho seja fruto de crime e a policia aparecer no endereco do comprador final

## Test plan
- [x] PDF gera sem erro (testado via `POST /api/admin/contrato`, 200, 4.7KB)
- [x] Contrato tem 3 pags (antes 2) — clausulas novas empurraram pra pagina extra
- [ ] Revisar texto das clausulas no preview do Vercel
- [ ] Conferir se vale a pena revisar clausula 6 (ficou meio redundante com 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)