### PR TITLE
fix(vendas): deduzir estoque ao vincular venda por serial

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -5979,7 +5979,7 @@ export default function VendasPage() {
                                               fetch("/api/vendas", {
                                                 method: "PATCH",
                                                 headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
-                                                body: JSON.stringify({ id: v.id, troca_produto: v.troca_produto, produto_na_troca: v.produto_na_troca }),
+                                                body: JSON.stringify({ id: v.id, troca_produto: v.troca_produto, produto_na_troca: v.produto_na_troca, _recriar_pendencia: true }),
                                               }).then(r => { if (r.ok) setMsg("Pendência recriada!"); else r.json().then(j => setMsg("Erro: " + (j.error || "falha"))); }).catch(() => setMsg("Erro ao recriar"));
                                             }}
                                             className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-yellow-500 text-white hover:bg-yellow-600 transition-colors"

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -821,11 +821,39 @@ export async function PATCH(req: NextRequest) {
 
   // Buscar venda anterior para comparar estoque_id (devolver produto se trocou)
   // e status_pagamento (evitar reenvio de NF/Telegram em edicoes posteriores).
-  const { data: vendaAnterior } = await supabase.from("vendas").select("estoque_id, serial_no, produto, status_pagamento, troca_produto, produto_na_troca, troca_produto2, produto_na_troca2").eq("id", id).single();
+  const { data: vendaAnterior } = await supabase.from("vendas").select("estoque_id, serial_no, produto, status_pagamento, troca_produto, produto_na_troca, troca_produto2, produto_na_troca2, troca_serial, troca_imei, troca_serial2, troca_imei2, cliente").eq("id", id).single();
   const estoqueIdAnterior = vendaAnterior?.estoque_id || null;
   const statusPagamentoAnterior = (vendaAnterior as unknown as { status_pagamento?: string } | null)?.status_pagamento || null;
   const jaTinhaTroca1Antes = !!((vendaAnterior as unknown as { troca_produto?: string; produto_na_troca?: string } | null)?.troca_produto || (vendaAnterior as unknown as { troca_produto?: string; produto_na_troca?: string } | null)?.produto_na_troca);
   const jaTinhaTroca2Antes = !!((vendaAnterior as unknown as { troca_produto2?: string; produto_na_troca2?: string } | null)?.troca_produto2 || (vendaAnterior as unknown as { troca_produto2?: string; produto_na_troca2?: string } | null)?.produto_na_troca2);
+
+  // Guard do botao "Recriar Pendencia": so deixa recriar se o produto da troca
+  // NAO estiver ja no estoque (nem como PENDENTE, nem como EM ESTOQUE). Evita
+  // duplicata quando a troca ja virou seminovo ou ja tem pendencia ativa.
+  if (forceRecriarPendencia) {
+    const vA = vendaAnterior as unknown as {
+      troca_produto?: string; troca_serial?: string; troca_imei?: string; cliente?: string;
+    } | null;
+    const tSerial = vA?.troca_serial ? String(vA.troca_serial).toUpperCase() : null;
+    const tImei = vA?.troca_imei ? String(vA.troca_imei).toUpperCase() : null;
+    const tProduto = vA?.troca_produto || null;
+    const tCliente = vA?.cliente ? String(vA.cliente).toUpperCase() : null;
+
+    let q = supabase.from("estoque").select("id, produto, status, tipo, serial_no, imei, fornecedor")
+      .in("status", ["PENDENTE", "EM ESTOQUE"]);
+    if (tSerial) q = q.eq("serial_no", tSerial);
+    else if (tImei) q = q.eq("imei", tImei);
+    else if (tProduto && tCliente) q = q.ilike("produto", tProduto).ilike("fornecedor", tCliente);
+    else q = q.eq("id", "__NO_MATCH__"); // sem identificador, nao bloqueia
+
+    const { data: existe } = await q.limit(1);
+    if (existe && existe.length > 0) {
+      const found = existe[0];
+      return NextResponse.json({
+        error: `Produto ja esta no estoque (status: ${found.status}${found.tipo === "PENDENCIA" ? ", pendencia" : ""}). Apague o item do estoque antes de recriar a pendencia.`,
+      }, { status: 400 });
+    }
+  }
 
   // Se o admin enviou _estoque_id (mesmo null), atualizar o vinculo na venda
   if (estoqueIdFoiEnviado) {

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -800,6 +800,11 @@ export async function PATCH(req: NextRequest) {
   const patchCreditoLoja = Number(fields.usar_credito_loja || 0);
   const patchLojistaId = fields._lojista_id || null;
 
+  // Flag do botão "Recriar Pendência": força criação mesmo quando a venda
+  // ja tinha troca antes (caso em que o admin deletou manualmente a pendencia
+  // do estoque pra editar e quer recriar).
+  const forceRecriarPendencia = fields._recriar_pendencia === true;
+
   // Remover campos internos que não existem na tabela vendas
   delete fields._seminovo;
   delete fields._seminovo2;
@@ -807,6 +812,7 @@ export async function PATCH(req: NextRequest) {
   delete fields.forma_sinal;
   delete fields.usar_credito_loja;
   delete fields._lojista_id;
+  delete fields._recriar_pendencia;
 
   // Se tem crédito de lojista, salvar na coluna correta
   if (patchCreditoLoja > 0) {
@@ -1029,8 +1035,10 @@ export async function PATCH(req: NextRequest) {
         // (provavelmente foi movida pra estoque como seminovo), NAO criar uma
         // nova. Antes, toda edicao de venda com troca criava uma pendencia
         // duplicada, obrigando o admin a deletar manualmente.
-        if (!p1 && jaTinhaTroca1Antes) {
+        if (!p1 && jaTinhaTroca1Antes && !forceRecriarPendencia) {
           // no-op: troca ja foi processada numa edicao/criacao anterior
+          // (forceRecriarPendencia=true quando o botao "Recriar Pendencia"
+          // foi clicado — admin deletou a pendencia e quer recria-la)
         } else if (p1) {
           // UPDATE
           const upd1: Record<string, unknown> = {};
@@ -1110,7 +1118,7 @@ export async function PATCH(req: NextRequest) {
           : (hasTroca1 ? undefined : existing[0]);
         // Mesmo tratamento da troca 1: se venda ja tinha troca2 antes e nao
         // achou pendencia, a troca ja foi processada — nao duplicar.
-        if (!p2 && jaTinhaTroca2Antes) {
+        if (!p2 && jaTinhaTroca2Antes && !forceRecriarPendencia) {
           // no-op
         } else if (p2) {
           const upd2: Record<string, unknown> = {};

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -929,15 +929,26 @@ export async function PATCH(req: NextRequest) {
     let vendaEstoqueId = data[0].estoque_id;
     const { data: estoqueItems } = await supabase
       .from("estoque")
-      .select("id")
+      .select("id, qnt")
       .eq("serial_no", serialU)
       .eq("status", "EM ESTOQUE");
     if (estoqueItems && estoqueItems.length > 0) {
       if (!vendaEstoqueId) {
-        vendaEstoqueId = estoqueItems[0].id;
+        const primeiro = estoqueItems[0];
+        vendaEstoqueId = primeiro.id;
         await supabase.from("vendas").update({ estoque_id: vendaEstoqueId }).eq("id", id);
         data[0].estoque_id = vendaEstoqueId; // sync pros blocos seguintes (finalizacao)
-        await logActivity(usuario, "Venda vinculada ao estoque (auto por serial)", `serial=${serialU}`, "vendas", id);
+        // Vincular o serial ja compromete o item: deduzir agora. Se a venda for
+        // cancelada/trocada depois, a logica de DELETE/estoque_id restaura.
+        // (Sem essa deducao, a venda ficava ligada mas o estoque continuava
+        // "EM ESTOQUE" ate a finalizacao, permitindo double-booking.)
+        const novaQnt = Math.max(0, Number(primeiro.qnt || 0) - 1);
+        await supabase.from("estoque").update({
+          qnt: novaQnt,
+          status: novaQnt === 0 ? "ESGOTADO" : "EM ESTOQUE",
+          updated_at: new Date().toISOString(),
+        }).eq("id", primeiro.id);
+        await logActivity(usuario, "Venda vinculada + estoque deduzido (auto por serial)", `serial=${serialU}, qnt restante=${novaQnt}`, "vendas", id);
       }
       const idsParaEsgotar = estoqueItems
         .filter(e => e.id !== vendaEstoqueId)

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -917,26 +917,36 @@ export async function PATCH(req: NextRequest) {
     }
   }
 
-  // Se serial_no foi atualizado, marcar estoque correspondente como ESGOTADO
-  // (previne itens vendidos que ficam "EM ESTOQUE" por falta de vínculo)
+  // Se serial_no veio no PATCH, resolver vinculo venda↔estoque.
+  // Antes: quando a venda nao tinha estoque_id, o codigo marcava TODOS os items
+  // do estoque com esse serial como ESGOTADO — isso destruia o estoque real em
+  // edicoes triviais de vendas vindas do formulario (ex: trocar nome do cliente
+  // pelo completo re-enviava serial_no e o bloco nukeava o iPhone correspondente).
+  // Agora: se venda nao tem estoque_id, LIGAR ao primeiro item achado. Esgotar
+  // apenas duplicatas reais (2+ items com mesmo serial, caso raro de dados sujos).
   if (fields.serial_no && data && data.length > 0) {
     const serialU = String(fields.serial_no).toUpperCase();
-    const vendaEstoqueId = data[0].estoque_id;
+    let vendaEstoqueId = data[0].estoque_id;
     const { data: estoqueItems } = await supabase
       .from("estoque")
       .select("id")
       .eq("serial_no", serialU)
       .eq("status", "EM ESTOQUE");
     if (estoqueItems && estoqueItems.length > 0) {
+      if (!vendaEstoqueId) {
+        vendaEstoqueId = estoqueItems[0].id;
+        await supabase.from("vendas").update({ estoque_id: vendaEstoqueId }).eq("id", id);
+        data[0].estoque_id = vendaEstoqueId; // sync pros blocos seguintes (finalizacao)
+        await logActivity(usuario, "Venda vinculada ao estoque (auto por serial)", `serial=${serialU}`, "vendas", id);
+      }
       const idsParaEsgotar = estoqueItems
         .filter(e => e.id !== vendaEstoqueId)
         .map(e => e.id);
-      // Se a venda não tem estoque_id, esgotar TODOS com esse serial
-      const ids = vendaEstoqueId ? idsParaEsgotar : estoqueItems.map(e => e.id);
-      if (ids.length > 0) {
+      if (idsParaEsgotar.length > 0) {
         await supabase.from("estoque")
           .update({ qnt: 0, status: "ESGOTADO", updated_at: new Date().toISOString() })
-          .in("id", ids);
+          .in("id", idsParaEsgotar);
+        await logActivity(usuario, "Duplicidade de serial resolvida (edicao)", `serial=${serialU}: ${idsParaEsgotar.length} item(s) ESGOTADO`, "estoque");
       }
     }
   }


### PR DESCRIPTION
## Bug (relatado por Nicolas)

Sequência:
1. iPhone 17 256GB WHITE (serial FQ23QDX7HM) foi ESGOTADO pelo bug do PR #703
2. Nicolas restaurou manualmente no /admin/estoque (qnt=1, status=EM ESTOQUE)
3. Colocou a venda novamente (editando a venda da Beatriz Napoli com o serial)
4. A venda ficou vinculada, **mas o estoque continuou EM ESTOQUE** — permitindo que o mesmo item aparecesse disponível enquanto já tinha venda em aberto

## Causa

No PR #703 mudei o bloco de dedupe pra **vincular** a venda ao estoque em vez de nukear — mas deixei a dedução pro bloco de finalização (`status_pagamento === "FINALIZADO"`). Se a venda fica em `AGUARDANDO` (caminho comum quando admin edita a venda do formulário), o estoque nunca deduzia.

## Fix

Quando o vínculo automático acontece (venda sem `estoque_id` + `serial_no` bate com item EM ESTOQUE), deduzir `qnt` na hora e marcar `ESGOTADO` se zerou. Assim:
- Impede double-booking (item não fica "disponível" pra outra venda)
- Cancelamento (DELETE venda) restaura via lógica existente em [app/api/vendas/route.ts:1397](app/api/vendas/route.ts:1397)
- Troca de produto (PATCH com `_estoque_id` novo) restaura o item antigo via [:834](app/api/vendas/route.ts:834)

## Test plan
- [ ] Editar venda vinda de formulário com o serial de um item em estoque → venda.estoque_id liga + item vira ESGOTADO na hora
- [ ] Cancelar essa venda → item volta pra EM ESTOQUE qnt=1
- [ ] Editar uma venda que **já** tinha estoque_id (ex: re-save sem mudar nada) → estoque não é deduzido de novo
- [ ] Finalizar venda depois do link → bloco de finalização vê `status=ESGOTADO` e pula (sem double-deduct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)