### PR TITLE
fix(vendas): deduzir estoque em _estoque_id e ligacao legada (#703)

### DIFF
--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -877,6 +877,24 @@ export async function PATCH(req: NextRequest) {
       console.log(`[Vendas PATCH] Produto anterior devolvido ao estoque: ${estoqueIdAnterior} (novo: ${novoEstoqueId || "nenhum"})`);
     }
   }
+
+  // Se o admin vinculou um item NOVO do estoque (via _estoque_id), deduzir
+  // esse item. Cobre o caminho "aba Formularios Preenchidos → editar venda →
+  // selecionar produto do dropdown do estoque → salvar": o frontend manda
+  // _estoque_id mas nao sabia deduzir. A restauracao do item antigo acima
+  // cuida do lado contrario (produto trocado ou desvinculado).
+  if (!error && estoqueIdFoiEnviado && novoEstoqueId && novoEstoqueId !== estoqueIdAnterior) {
+    const { data: itemNovo } = await supabase.from("estoque").select("id, qnt, status, produto").eq("id", novoEstoqueId).single();
+    if (itemNovo && itemNovo.status === "EM ESTOQUE" && Number(itemNovo.qnt) > 0) {
+      const novaQnt = Math.max(0, Number(itemNovo.qnt) - 1);
+      await supabase.from("estoque").update({
+        qnt: novaQnt,
+        status: novaQnt === 0 ? "ESGOTADO" : "EM ESTOQUE",
+        updated_at: new Date().toISOString(),
+      }).eq("id", novoEstoqueId);
+      await logActivity(usuario, "Estoque deduzido (vinculo via _estoque_id)", `${itemNovo.produto || "?"} — restam ${novaQnt} un.`, "estoque", novoEstoqueId);
+    }
+  }
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
   // Debitar crédito de lojista (se enviado no PATCH)
@@ -949,6 +967,21 @@ export async function PATCH(req: NextRequest) {
           updated_at: new Date().toISOString(),
         }).eq("id", primeiro.id);
         await logActivity(usuario, "Venda vinculada + estoque deduzido (auto por serial)", `serial=${serialU}, qnt restante=${novaQnt}`, "vendas", id);
+      } else {
+        // Venda ja ligada, mas o item linkado ainda aparece EM ESTOQUE — legado
+        // do PR #703 (ligou sem deduzir). Deduzir agora pra evitar double-booking.
+        // Como o SELECT filtra por status=EM ESTOQUE, se o item ja foi deduzido
+        // antes ele nao aparece aqui e esse bloco nao roda de novo.
+        const linkado = estoqueItems.find(e => e.id === vendaEstoqueId);
+        if (linkado) {
+          const novaQnt = Math.max(0, Number(linkado.qnt || 0) - 1);
+          await supabase.from("estoque").update({
+            qnt: novaQnt,
+            status: novaQnt === 0 ? "ESGOTADO" : "EM ESTOQUE",
+            updated_at: new Date().toISOString(),
+          }).eq("id", linkado.id);
+          await logActivity(usuario, "Estoque deduzido (venda ja ligada, legado)", `serial=${serialU}, qnt restante=${novaQnt}`, "vendas", id);
+        }
       }
       const idsParaEsgotar = estoqueItems
         .filter(e => e.id !== vendaEstoqueId)


### PR DESCRIPTION
## Bug (relatado por Nicolas)

> "todos os clientes que vieram do formulario preenchido, da aba, quando adiciona o produto na compra e move para andamento, o produto continua em estoque"

Depois do PR #704, vendas vindas da aba **📝 Formulários Preenchidos** ainda não deduzem o estoque quando o admin adiciona o produto e move pra andamento.

## Causas

Dois caminhos de vínculo venda↔estoque no PATCH, e nenhum dos dois estava deduzindo:

### 1. Caminho `_estoque_id` (principal)
Quando o admin edita a venda e **seleciona o produto do dropdown do estoque**, o frontend manda `_estoque_id` no PATCH. O código em [app/api/vendas/route.ts:868](app/api/vendas/route.ts:868) só **restaura** o item antigo (quando havia vínculo anterior), mas **nunca deduzia o item novo**. A dedução ficava delegada ao bloco de finalização — mas o fluxo normal é editar → mover pra andamento (AGUARDANDO), e só finalizar depois.

### 2. Caminho legado do PR #703
Vendas que foram vinculadas entre o PR #703 (linkou sem deduzir) e o PR #704 (passou a deduzir) ficaram num estado órfão: `venda.estoque_id` apontando pro item, item ainda `EM ESTOQUE qnt=1`. Em PATCHs seguintes, o bloco de dedupe via `vendaEstoqueId` já setado e pulava a dedução.

## Fix

**Caminho 1 (`_estoque_id`):** depois do UPDATE, se `_estoque_id` foi enviado com vínculo novo (diferente do anterior), deduzir o item novo se ainda estiver `EM ESTOQUE` e qnt > 0. Restauração do antigo continua como antes.

**Caminho 2 (legado):** no bloco de dedupe por serial, adicionar um `else` — se a venda já está ligada mas o item linkado aparece no SELECT (filtro `status=EM ESTOQUE`), deduzir. Como o filtro exclui ESGOTADO, não há risco de double-deduct em PATCHs posteriores.

## Ação manual pra limpar dados antigos

Vendas da Beatriz (e outras que passaram pelo mesmo caminho antes desse fix): depois do merge, editar a venda (qualquer campo) pra disparar o PATCH — o bloco legado vai pegar e deduzir. Ou manualmente em /admin/estoque.

## Test plan
- [ ] Aba Formulários Preenchidos → editar venda → selecionar produto do dropdown → salvar → item vai pra ESGOTADO na hora
- [ ] Editar venda que ja tinha `estoque_id` mas estoque `EM ESTOQUE` (legado #703) → deduz
- [ ] Editar venda que ja tinha estoque_id E item ja ESGOTADO (caso normal pos-fix) → **não** deduz de novo (item nao aparece no SELECT filtrado)
- [ ] Cancelar venda → item volta EM ESTOQUE qnt=1
- [ ] Trocar produto (PATCH com novo `_estoque_id`) → item antigo restaura, item novo deduz

🤖 Generated with [Claude Code](https://claude.com/claude-code)