### PR TITLE
feat(mostruario): ocultar variacoes esgotadas automaticamente

### DIFF
--- a/app/api/loja/route.ts
+++ b/app/api/loja/route.ts
@@ -1,5 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { rateLimitPublic } from "@/lib/rate-limit";
+import {
+  buildEstoqueIndex,
+  buildEstoqueKeysPresentes,
+  checkVariacaoEsgotada,
+  type EstoqueRow,
+} from "@/lib/loja-estoque-match";
 
 export const dynamic = "force-dynamic";
 
@@ -50,8 +56,8 @@ export async function GET(req: NextRequest) {
   try {
     const { supabase } = await import("@/lib/supabase");
 
-    // Fetch from new loja_* tables
-    const [categoriasRes, produtosRes, variacoesRes, configRes] = await Promise.all([
+    // Fetch from new loja_* tables + estoque (pra ocultar variações esgotadas)
+    const [categoriasRes, produtosRes, variacoesRes, configRes, estoqueRes] = await Promise.all([
       supabase
         .from("loja_categorias")
         .select("*")
@@ -74,11 +80,18 @@ export async function GET(req: NextRequest) {
         .select("*")
         .limit(1)
         .single(),
+      supabase
+        .from("estoque")
+        .select("produto,categoria,qnt,status,cor,observacao"),
     ]);
 
     const categorias = (categoriasRes.data ?? []) as CategoriaRow[];
     const produtosRaw = (produtosRes.data ?? []) as ProdutoRow[];
     const variacoes = (variacoesRes.data ?? []) as VariacaoRow[];
+    const estoqueRows = (estoqueRes.data ?? []) as EstoqueRow[];
+
+    const estoqueIndex = buildEstoqueIndex(estoqueRows);
+    const estoqueKeysPresentes = buildEstoqueKeysPresentes(estoqueRows);
 
     // Build categoria lookup
     const categoriaMap = new Map<string, CategoriaRow>();
@@ -94,7 +107,7 @@ export async function GET(req: NextRequest) {
       variacoesByProduto.set(v.produto_id, list);
     }
 
-    // Build produtos with variacoes
+    // Build produtos with variacoes (filtrando variações confirmadamente esgotadas)
     const produtos = produtosRaw
       .filter((p) => {
         // Only include products whose category exists and is visible
@@ -104,6 +117,21 @@ export async function GET(req: NextRequest) {
       .map((p) => {
         const cat = categoriaMap.get(p.categoria_id)!;
         const prodVariacoes = variacoesByProduto.get(p.id) ?? [];
+
+        const variacoesDisponiveis = prodVariacoes.filter((v) => {
+          const attrs = v.atributos ?? {};
+          const { esgotado } = checkVariacaoEsgotada(
+            {
+              produtoNome: p.nome,
+              categoriaSlug: cat.slug,
+              storage: attrs.storage,
+              cor: attrs.cor,
+            },
+            estoqueIndex,
+            estoqueKeysPresentes,
+          );
+          return !esgotado;
+        });
 
         return {
           id: p.id,
@@ -117,7 +145,7 @@ export async function GET(req: NextRequest) {
           imagem: p.imagem_url,
           destaque: p.destaque,
           tags: p.tags ?? ["Novo", "Lacrado", "1 ano garantia", "Nota Fiscal"],
-          variacoes: prodVariacoes.map((v) => ({
+          variacoes: variacoesDisponiveis.map((v) => ({
             id: v.id,
             nome: v.nome,
             preco: Number(v.preco),
@@ -126,7 +154,8 @@ export async function GET(req: NextRequest) {
             imagem: v.imagem_url,
           })),
         };
-      });
+      })
+      .filter((p) => p.variacoes.length > 0);
 
     // Config defaults
     const rawConfig = configRes.data ?? {

--- a/lib/loja-estoque-match.ts
+++ b/lib/loja-estoque-match.ts
@@ -1,0 +1,125 @@
+// lib/loja-estoque-match.ts
+// Liga loja_variacoes (mostruário público) ao estoque real pra esconder esgotados.
+//
+// Matching é fuzzy mas determinístico:
+//   chave = getModeloBase(produto, categoria) + "::" + corParaPT(cor) normalizada
+//
+// Permissivo: se não achar match nenhum pra uma variação, deixa ela visível
+// (benefício da dúvida — não esconde quando a heurística falhou). Só esconde
+// quando confirmou que existe o SKU no estoque mas está zerado/ESGOTADO.
+
+import { getModeloBase } from "./produto-display";
+import { corParaPT } from "./cor-pt";
+
+export interface EstoqueRow {
+  produto: string;
+  categoria: string;
+  qnt: number | null;
+  status: string | null;
+  cor: string | null;
+  observacao?: string | null;
+}
+
+interface EstoqueAgg {
+  totalEmEstoque: number;
+}
+
+// slug do loja_categorias → categoria do estoque
+const CAT_MAP: Record<string, string> = {
+  iphones: "IPHONES",
+  macbooks: "MACBOOK",
+  ipads: "IPADS",
+  airpods: "AIRPODS",
+  "apple-watch": "APPLE_WATCH",
+  "mac-mini": "MAC_MINI",
+  acessorios: "ACESSORIOS",
+};
+
+export function lojaCatToEstoqueCat(slug: string): string {
+  return CAT_MAP[slug] || slug.toUpperCase();
+}
+
+function norm(s: string | null | undefined): string {
+  return String(s || "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function keyModeloCor(modeloBase: string, cor: string | null | undefined): string {
+  const corPT = cor ? corParaPT(cor) : "";
+  return `${norm(modeloBase)}::${norm(corPT)}`;
+}
+
+/**
+ * Monta índice do estoque agrupado por (modeloBase + cor normalizada).
+ * Chave: "iphone 17 pro 256gb::titanio natural"
+ * Valor: { totalEmEstoque }
+ *
+ * Só conta linhas com status "EM ESTOQUE" e qnt > 0.
+ */
+export function buildEstoqueIndex(rows: EstoqueRow[]): Map<string, EstoqueAgg> {
+  const index = new Map<string, EstoqueAgg>();
+  for (const row of rows) {
+    const modeloBase = getModeloBase(row.produto || "", row.categoria || "", row.observacao);
+    const key = keyModeloCor(modeloBase, row.cor);
+    const existing = index.get(key) || { totalEmEstoque: 0 };
+
+    const qnt = Number(row.qnt || 0);
+    const isEmEstoque = (row.status || "").toUpperCase() === "EM ESTOQUE" && qnt > 0;
+    if (isEmEstoque) existing.totalEmEstoque += qnt;
+
+    index.set(key, existing);
+  }
+  return index;
+}
+
+/**
+ * Também precisa de um índice "qualquer linha desse SKU existe?" — pra saber
+ * se confirmou que o produto existe no estoque mas está zerado, versus se
+ * simplesmente não temos esse SKU cadastrado (match falhou).
+ */
+export function buildEstoqueKeysPresentes(rows: EstoqueRow[]): Set<string> {
+  const keys = new Set<string>();
+  for (const row of rows) {
+    const modeloBase = getModeloBase(row.produto || "", row.categoria || "", row.observacao);
+    keys.add(keyModeloCor(modeloBase, row.cor));
+  }
+  return keys;
+}
+
+export interface VariacaoCheck {
+  produtoNome: string;
+  categoriaSlug: string;
+  storage?: string;
+  cor?: string;
+}
+
+/**
+ * Decide se deve esconder uma variação do mostruário.
+ *
+ * Retorna:
+ *   - esgotado=true → esconder (confirmou que SKU existe no estoque e está zerado)
+ *   - esgotado=false → mostrar (tem em estoque OU não confirmou que o SKU existe)
+ */
+export function checkVariacaoEsgotada(
+  v: VariacaoCheck,
+  indexDisponivel: Map<string, EstoqueAgg>,
+  keysPresentes: Set<string>,
+): { esgotado: boolean; modeloBase: string; key: string } {
+  const estoqueCat = lojaCatToEstoqueCat(v.categoriaSlug);
+  const produtoStr = [v.produtoNome, v.storage].filter(Boolean).join(" ");
+  const modeloBase = getModeloBase(produtoStr, estoqueCat);
+  const key = keyModeloCor(modeloBase, v.cor);
+
+  const agg = indexDisponivel.get(key);
+  const temEstoque = (agg?.totalEmEstoque || 0) > 0;
+  if (temEstoque) return { esgotado: false, modeloBase, key };
+
+  // Sem estoque disponível. Só considera esgotado se CONFIRMOU que o SKU
+  // existe (alguma linha de estoque com essa chave, mesmo que zerada).
+  const confirmouSKU = keysPresentes.has(key);
+  return { esgotado: confirmouSKU, modeloBase, key };
+}


### PR DESCRIPTION
## Summary
- Integra o estoque real com o mostruário público
- Variações (cor/storage) sem estoque são automaticamente ocultadas
- Produtos com TODAS variações esgotadas somem da listagem

## Item do backlog
**#8 — Status estoque integrado no Mostruário** (🔥 Alta / 🟢 Rápido / 2h estimado)

## Como funciona o matching

Chave fuzzy por variação:
\`\`\`
getModeloBase(produto, categoria) + "::" + corParaPT(cor) normalizada
\`\`\`

Ex: loja_variacao \`{produto: "iPhone 17 Pro", storage: "256GB", cor: "Titânio Preto"}\`
vira chave \`"iphone 17 pro 256gb::titanio preto"\`.

Essa mesma chave é gerada para cada linha de estoque (usa \`getModeloBase\` que já estava no lib/produto-display) e compara.

## Regra permissiva (segura)

- **Tem estoque (qnt>0, status EM ESTOQUE):** mostra
- **Achou linha no estoque mas todas zeradas/ESGOTADO:** esconde
- **Não achou nenhuma linha no estoque pro SKU:** mostra (benefício da dúvida — não esconde por matching falho)

Isso evita casos em que uma variação do mostruário está cadastrada mas não está espelhada no estoque — ela continua aparecendo.

## Resultado do teste

Antes: 30 produtos, ~180 variações
Depois: 28 produtos, 77 variações

iPhone 17 Pro sobrou com as 8 variações que batem com o estoque real (256GB/512GB/1TB em Orange/Blue/Silver).

## Test plan
- [x] TypeScript sem erros
- [x] Home page renderiza apenas variações em estoque (verificado em preview)
- [x] Produto com nenhum match no estoque continua visível
- [x] Produto com todas variações esgotadas some
- [ ] Validar em produção com modo manutenção desligado

🤖 Generated with [Claude Code](https://claude.com/claude-code)