### PR TITLE
feat(gerar-link): tag de campanha/origem por link

### DIFF
--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -212,6 +212,10 @@ export default function GerarLinkPage() {
   }, [carrinhoLink]);
 
   const [vendedorNome, setVendedorNome] = useState("");
+  // Tag de campanha/origem do link (ex: "Instagram Stories", "Anuncio Meta",
+  // "Indicacao") — fica em link_compras.campanha pra agrupar conversoes em
+  // analytics. Texto livre + presets rapidos.
+  const [campanha, setCampanha] = useState("");
   // Lista dinâmica de vendedores (editável em /admin/configuracoes).
   const vendedoresList = useVendedores(adminPw);
   const [forma, setForma] = useState("");
@@ -352,6 +356,7 @@ export default function GerarLinkPage() {
     troca_condicao2: string | null;
     troca_cor2: string | null;
     vendedor: string | null;
+    campanha: string | null;
     operador: string | null;
     status: string | null;
     cliente_dados_preenchidos: Record<string, unknown> | null;
@@ -656,6 +661,7 @@ export default function GerarLinkPage() {
           troca_condicao2: temSegundaTroca ? trocaCondicao2 || null : null,
           troca_cor2: temSegundaTroca ? trocaCor2 || null : null,
           vendedor: vendedorNome || null,
+          campanha: campanha.trim() || null,
           cliente_nome: cliNome.trim() || null,
           cliente_telefone: cliTelefone.trim() || null,
           cliente_cpf: cliCpf.trim() || null,
@@ -680,6 +686,7 @@ export default function GerarLinkPage() {
         if (rawPreco && rawPreco !== "0") shortData.v = rawPreco;
         if (descontoNum > 0) shortData.dc = String(descontoNum);
         shortData.s = vendedorNome || "";
+        if (campanha.trim()) shortData.cm = campanha.trim();
         shortData.w = whatsappDestino;
         if (forma) shortData.f = forma;
         if (parcelas) shortData.x = parcelas;
@@ -777,6 +784,7 @@ export default function GerarLinkPage() {
     if (l.entrada) setEntradaPix(Number(l.entrada).toLocaleString("pt-BR"));
     if (l.desconto) setDesconto(Number(l.desconto).toLocaleString("pt-BR"));
     if (l.vendedor) setVendedorNome(l.vendedor);
+    if (l.campanha) setCampanha(l.campanha);
     if (l.taxa_entrega) setTaxaEntrega(Number(l.taxa_entrega).toLocaleString("pt-BR"));
     if (l.cliente_nome || l.cliente_telefone || l.cliente_cpf) {
       setIncluirDadosCliente(true);
@@ -926,6 +934,7 @@ export default function GerarLinkPage() {
     // Link gerado
     setGeneratedLink(""); setCopied(false); setPasteMsg("");
     setVendedorNome("");
+    setCampanha("");
     setEditingLinkId(null); setEditingShortCode(null);
   }
 
@@ -1011,6 +1020,7 @@ export default function GerarLinkPage() {
     if (rawPreco && rawPreco !== "0") shortData.v = rawPreco;
     if (descontoNum > 0) shortData.dc = String(descontoNum);
     shortData.s = vendedorNome || "";
+    if (campanha.trim()) shortData.cm = campanha.trim();
     shortData.w = whatsappDestino;
     if (forma) shortData.f = forma;
     if (parcelas) shortData.x = parcelas;
@@ -1090,6 +1100,7 @@ export default function GerarLinkPage() {
               troca_condicao2: temSegundaTroca ? trocaCondicao2 || null : null,
               troca_cor2: temSegundaTroca ? trocaCor2 || null : null,
               vendedor: vendedorNome || null,
+              campanha: campanha.trim() || null,
               simulacao_id: simulacaoId,
               pagamento_pago: pagamentoPago || null,
               taxa_entrega: Number(rawTaxaEntrega) || 0,
@@ -2790,6 +2801,30 @@ export default function GerarLinkPage() {
               <option key={v.nome} value={v.nome}>{v.nome}</option>
             ))}
           </select>
+        </div>
+
+        <div>
+          <label className={labelCls}>Campanha / Origem do link <span className="text-[10px] font-normal opacity-60">(opcional)</span></label>
+          <input
+            type="text"
+            value={campanha}
+            onChange={(e) => setCampanha(e.target.value)}
+            placeholder="Ex: Instagram Stories, Anuncio Meta, Indicacao..."
+            className={inputCls}
+          />
+          <div className="flex flex-wrap gap-1.5 mt-1.5">
+            {["Instagram Stories", "Instagram Direct", "Anuncio Meta", "WhatsApp Status", "Indicacao", "Funcionario"].map(p => (
+              <button
+                key={p}
+                type="button"
+                onClick={() => setCampanha(p)}
+                className={`px-2 py-1 rounded-full text-[10px] font-semibold transition-colors ${campanha === p ? "bg-[#E8740E] text-white" : dm ? "bg-[#2C2C2E] text-[#98989D] hover:bg-[#3A3A3C]" : "bg-[#F5F5F7] text-[#86868B] hover:bg-[#E5E5EA]"}`}
+              >
+                {p}
+              </button>
+            ))}
+          </div>
+          <p className="text-[10px] text-[#86868B] mt-1">Pra rastrear conversoes por origem nos relatorios.</p>
         </div>
 
         {/* Resumo do valor total */}

--- a/app/api/admin/link-compras/route.ts
+++ b/app/api/admin/link-compras/route.ts
@@ -211,6 +211,7 @@ export async function POST(request: Request) {
     troca_cor2: body.troca_cor2 || null,
     desconto: Number(body.desconto) || 0,
     vendedor: body.vendedor || null,
+    campanha: body.campanha || null,
     operador: getUser(request),
     simulacao_id: body.simulacao_id || null,
     observacao: body.observacao || null,
@@ -259,7 +260,7 @@ export async function PATCH(request: Request) {
     "produtos_extras",
     "troca_produto", "troca_valor", "troca_condicao", "troca_cor",
     "troca_produto2", "troca_valor2", "troca_condicao2", "troca_cor2",
-    "vendedor", "entrega_id", "cliente_dados_preenchidos", "cliente_preencheu_em",
+    "vendedor", "campanha", "entrega_id", "cliente_dados_preenchidos", "cliente_preencheu_em",
     "pagamento_pago", "taxa_entrega",
     "mp_link", "mp_preference_id",
   ];

--- a/app/c/[d]/page.tsx
+++ b/app/c/[d]/page.tsx
@@ -7,6 +7,7 @@ import { Metadata } from "next";
 const KEY_MAP: Record<string, string> = {
   p: "produto", v: "preco", w: "whatsapp", f: "forma",
   x: "parcelas", e: "entrada_pix", l: "local", s: "vendedor",
+  cm: "campanha",
   sh: "shopping", h: "horario", dt: "data_entrega", dc: "desconto",
   tp: "troca_produto", tv: "troca_valor", tc: "troca_cor", tcd: "troca_cond",
   tp2: "troca_produto2", tv2: "troca_valor2", tc2: "troca_cor2", tcd2: "troca_cond2",

--- a/supabase/migrations/20260423c_link_compras_campanha.sql
+++ b/supabase/migrations/20260423c_link_compras_campanha.sql
@@ -1,0 +1,9 @@
+-- Adiciona coluna `campanha` em link_compras pra rastrear origem dos links
+-- (ex: "Instagram Stories", "Anúncio Meta - Lookalike 1%", "Indicação Carlos").
+-- Cada link gerado em /admin/gerar-link pode receber uma tag livre que vendedor
+-- preenche, e analytics futuras podem agrupar vendas por campanha.
+
+ALTER TABLE link_compras
+  ADD COLUMN IF NOT EXISTS campanha TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_link_compras_campanha ON link_compras(campanha) WHERE campanha IS NOT NULL;


### PR DESCRIPTION
## Summary
- Novo campo "Campanha / Origem do link" no `/admin/gerar-link`
- Texto livre + presets rápidos: Instagram Stories, Instagram Direct, Anúncio Meta, WhatsApp Status, Indicação, Funcionário
- Persiste em \`link_compras.campanha\` (nova coluna + index)
- Vai pela URL curta (key \`cm\`) e volta mapeada no \`/c/[d]\`
- Carrega ao reutilizar/editar link existente

## Item do backlog
**#16 — Tag de campanha/origem nos links** (🔥 Alta / 🟡 Médio / 5h estimado) — fecha a Sprint 1

## Como funciona

**1. Vendedor preenche tag ao gerar link:**
\`\`\`
Campanha / Origem do link  (opcional)
[Ex: Instagram Stories, Anuncio Meta, Indicacao...]

[Instagram Stories] [Instagram Direct] [Anuncio Meta]
[WhatsApp Status]   [Indicacao]        [Funcionario]
\`\`\`

**2. Tag salva em \`link_compras.campanha\`** + propaga pela URL curta como \`cm=...\`

**3. Cliente abre o link → /compra → finaliza:** \`vendas.short_code\` aponta pro \`link_compras.short_code\`

**4. Relatórios podem agrupar:**
\`\`\`sql
SELECT campanha, COUNT(*) vendas, SUM(valor_pago) faturamento
FROM vendas v
JOIN link_compras l ON v.short_code = l.short_code
WHERE v.created_at >= NOW() - INTERVAL '30 days'
GROUP BY campanha
ORDER BY faturamento DESC;
\`\`\`

## Decisão de design

Não adicionei coluna em \`vendas\` — a venda já está ligada ao link via \`short_code\`. Single source of truth: a campanha mora no \`link_compras\`, e qualquer query de analytics faz JOIN. Mantém schema enxuto.

## Migration

\`\`\`sql
ALTER TABLE link_compras ADD COLUMN IF NOT EXISTS campanha TEXT;
CREATE INDEX IF NOT EXISTS idx_link_compras_campanha
  ON link_compras(campanha) WHERE campanha IS NOT NULL;
\`\`\`

Já apliquei no banco do preview pra validar. Quando esse PR mergear, lembrar de rodar em produção via \`/admin/migrations\`.

## Test plan
- [x] TypeScript sem erros
- [x] Migration aplica sem erro
- [x] Campo aparece no form com presets
- [x] Tag salva em link_compras quando link é gerado
- [x] Tag carrega ao "reutilizar link" do histórico
- [ ] Validar end-to-end com link real → cliente → venda em produção

🤖 Generated with [Claude Code](https://claude.com/claude-code)