### PR TITLE
feat(tracking): UTM end-to-end (Meta Ads/Google/Instagram → simulacao → venda)

### DIFF
--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -43,6 +43,10 @@ export async function POST(req: NextRequest) {
     if (body.condicaoLinhas2) row.condicao_linhas2 = body.condicaoLinhas2;
     // Numero de WhatsApp destino: rastreio de para quem foi o formulario
     if (body.whatsappDestino) row.whatsapp_destino = String(body.whatsappDestino).replace(/\D/g, "") || null;
+    // UTM tracking — incluido pelo client via withUTMs() de lib/utm-tracker
+    for (const k of ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"]) {
+      if (body[k]) row[k] = String(body[k]).slice(0, 200);
+    }
 
     // Checagem de duplicidade real: mesmo whatsapp + produto novo + produto usado nos últimos 2 minutos
     const twoMinAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();

--- a/app/api/vendas/from-formulario/route.ts
+++ b/app/api/vendas/from-formulario/route.ts
@@ -75,6 +75,12 @@ interface BodyIn {
   horarioEntrega?: string;
   vendedor?: string;
   origem?: string;
+  // UTM tracking — passado pelo client via withUTMs() de lib/utm-tracker
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_content?: string;
+  utm_term?: string;
   // Honeypot
   website?: string;
 }
@@ -180,6 +186,11 @@ export async function POST(req: NextRequest) {
     origem_detalhe: body.origem || null,
     vendedor: body.vendedor || null,
     estoque_id: null,
+    utm_source: body.utm_source ? String(body.utm_source).slice(0, 200) : null,
+    utm_medium: body.utm_medium ? String(body.utm_medium).slice(0, 200) : null,
+    utm_campaign: body.utm_campaign ? String(body.utm_campaign).slice(0, 200) : null,
+    utm_content: body.utm_content ? String(body.utm_content).slice(0, 200) : null,
+    utm_term: body.utm_term ? String(body.utm_term).slice(0, 200) : null,
   };
 
   // Produto principal: recebe o desconto, troca e sinal_antecipado.

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, useMemo, useRef, Suspense } from "react";
 import { WHATSAPP_FORMULARIO } from "@/lib/whatsapp-config";
 import { corParaPT } from "@/lib/cor-pt";
 import { getAgendamentoBounds } from "@/lib/date-utils";
+import { withUTMs } from "@/lib/utm-tracker";
 
 function maskCPF(value: string) {
   const digits = value.replace(/\D/g, "").slice(0, 11);
@@ -949,7 +950,7 @@ function CompraForm() {
       // Cria/atualiza venda em status FORMULARIO_PREENCHIDO — equipe vê na aba
       // "📝 Formulários Preenchidos" de /admin/vendas, confere e envia pra
       // "Vendas Pendentes" manualmente. Fire-and-forget via sendBeacon/keepalive.
-      const vendaPayload = JSON.stringify({
+      const vendaPayload = JSON.stringify(withUTMs({
         shortCode,
         nome, pessoa, cpf, cnpj, email, telefone, instagram,
         cep, endereco, numero, complemento, bairro,
@@ -976,7 +977,7 @@ function CompraForm() {
         localEntrega: localStr, dataEntrega, horarioEntrega: horario,
         vendedor, origem,
         website: honeypot,
-      });
+      }));
       const vendaUrl = "/api/vendas/from-formulario";
       let vendaBeaconOk = false;
       if (typeof navigator !== "undefined" && "sendBeacon" in navigator) {
@@ -1164,7 +1165,7 @@ function CompraForm() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           keepalive: true,
-          body: JSON.stringify({
+          body: JSON.stringify(withUTMs({
             shortCode,
             nome, pessoa, cpf, cnpj, email, telefone, instagram,
             cep, endereco, numero, complemento, bairro,
@@ -1187,7 +1188,7 @@ function CompraForm() {
             trocaImei2: trocaImei2.trim() || undefined,
             vendedor, origem,
             website: honeypot,
-          }),
+          })),
         });
       } catch { /* não bloqueia redirect */ }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import UTMCapture from "@/components/UTMCapture";
 
 export const metadata: Metadata = {
   title: "TigraoImports - Trade-In",
@@ -66,6 +67,7 @@ export default function RootLayout({
         {metaPixelId && (
           <noscript><img height="1" width="1" style={{ display: "none" }} src={`https://www.facebook.com/tr?id=${metaPixelId}&ev=PageView&noscript=1`} alt="" /></noscript>
         )}
+        <UTMCapture />
         {children}
         <script
           dangerouslySetInnerHTML={{

--- a/components/StepQuote.tsx
+++ b/components/StepQuote.tsx
@@ -7,6 +7,7 @@ import type { NewProduct } from "@/lib/types";
 import { calculateQuote, getWhatsAppUrl, getAnyConditionLines, formatBRL } from "@/lib/calculations";
 import { getHoneypotValue } from "@/lib/honeypot-client";
 import { getPublicBaseUrl } from "@/lib/public-url";
+import { withUTMs } from "@/lib/utm-tracker";
 import FlexiblePaymentSimulator, { type PaymentBlock, type PaymentSummary, calculatePaymentSummary } from "./FlexiblePaymentSimulator";
 
 const PARCELAS_OPCOES = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21];
@@ -28,7 +29,7 @@ interface StepQuoteProps {
 
 async function salvarLead(lead: LeadSaiu & { formaPagamento?: string; origem?: string; motivoSaida?: string }) {
   try {
-    const payload = { ...lead, website: getHoneypotValue() };
+    const payload = withUTMs({ ...lead, website: getHoneypotValue() });
     const res = await fetch("/api/leads", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
     if (res.status === 429) { console.warn("[salvarLead] Rate limit atingido, mas prosseguindo"); return; }
     const json = await res.json();

--- a/components/UTMCapture.tsx
+++ b/components/UTMCapture.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { captureAndPersistUTMs } from "@/lib/utm-tracker";
+
+/**
+ * Componente invisivel que captura UTMs da URL na primeira renderizacao do
+ * cliente. Plugado no app/layout.tsx pra rodar em qualquer pagina de entrada.
+ *
+ * Atribuicao "last-touch": se cliente chega 2x via URLs diferentes, vale a
+ * mais recente. UTMs ficam em localStorage por 30 dias e sao incluidas
+ * automaticamente em todo POST de simulacao/venda via withUTMs() de
+ * lib/utm-tracker.
+ */
+export default function UTMCapture() {
+  useEffect(() => {
+    captureAndPersistUTMs();
+  }, []);
+  return null;
+}

--- a/lib/utm-tracker.ts
+++ b/lib/utm-tracker.ts
@@ -1,0 +1,97 @@
+// lib/utm-tracker.ts
+// Captura UTM parameters da URL de entrada e persiste em localStorage por 30
+// dias. Usado pra atribuir cada simulacao/venda a uma origem (Meta Ads,
+// Instagram, Google, indicacao etc.).
+//
+// Fluxo:
+//   1. Cliente chega via /troca?utm_source=meta&utm_campaign=lookalike
+//   2. <UTMCapture/> roda no layout e chama captureAndPersistUTMs() que:
+//      - Le UTMs da URL atual
+//      - Se tem ao menos 1 UTM, salva no localStorage (sobrescreve qualquer
+//        UTM antigo — atribuicao "last touch")
+//   3. Em qualquer ponto (ao submeter simulacao, fechar venda etc.) chama
+//      getStoredUTMs() pra incluir no payload da API.
+
+export const UTM_KEYS = ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"] as const;
+
+export type UTMKey = typeof UTM_KEYS[number];
+export type UTMs = Partial<Record<UTMKey, string>>;
+
+const STORAGE_KEY = "tigrao_utm_v1";
+const TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 dias
+
+interface StoredUTMs {
+  utms: UTMs;
+  capturedAt: number; // timestamp ms
+}
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof localStorage !== "undefined";
+}
+
+export function captureFromURL(search?: string): UTMs {
+  if (!isBrowser() && !search) return {};
+  const query = search ?? window.location.search;
+  const params = new URLSearchParams(query);
+  const utms: UTMs = {};
+  for (const key of UTM_KEYS) {
+    const v = params.get(key);
+    if (v && v.trim()) utms[key] = v.trim().slice(0, 200); // trunca por seguranca
+  }
+  return utms;
+}
+
+export function getStoredUTMs(): UTMs {
+  if (!isBrowser()) return {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as StoredUTMs;
+    if (!parsed || typeof parsed !== "object") return {};
+    if (Date.now() - parsed.capturedAt > TTL_MS) {
+      localStorage.removeItem(STORAGE_KEY);
+      return {};
+    }
+    return parsed.utms || {};
+  } catch {
+    return {};
+  }
+}
+
+export function setStoredUTMs(utms: UTMs): void {
+  if (!isBrowser()) return;
+  if (Object.keys(utms).length === 0) return;
+  const payload: StoredUTMs = { utms, capturedAt: Date.now() };
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch { /* quota / safari private mode */ }
+}
+
+/**
+ * Captura UTMs da URL atual. Se houver, sobrescreve o que estava salvo
+ * (atribuicao last-touch). Se a URL nao tiver UTMs, mantem o valor antigo.
+ * Retorna o conjunto efetivo (nova URL ou o que ja estava salvo).
+ */
+export function captureAndPersistUTMs(): UTMs {
+  if (!isBrowser()) return {};
+  const fromURL = captureFromURL();
+  if (Object.keys(fromURL).length > 0) {
+    setStoredUTMs(fromURL);
+    return fromURL;
+  }
+  return getStoredUTMs();
+}
+
+/**
+ * Helper para includar UTMs no body de uma chamada de API. Filtra undefined
+ * pra nao mandar campos vazios.
+ */
+export function withUTMs<T extends object>(body: T): T & UTMs {
+  const utms = getStoredUTMs();
+  const filtered: UTMs = {};
+  for (const k of UTM_KEYS) {
+    const v = utms[k];
+    if (v) filtered[k] = v;
+  }
+  return { ...body, ...filtered };
+}

--- a/supabase/migrations/20260423d_utm_tracking.sql
+++ b/supabase/migrations/20260423d_utm_tracking.sql
@@ -1,0 +1,41 @@
+-- Adiciona colunas UTM em simulacoes (tradein_leads), vendas e link_compras pra
+-- rastrear de onde veio o cliente (Meta Ads, Google, Instagram orgânico, etc).
+--
+-- Regra: capturado client-side via lib/utm-tracker quando cliente chega em
+-- qualquer pagina de entrada (/, /troca, /compra, /produto/[slug]). Persistido
+-- em localStorage por 30 dias e injetado em todo POST de simulacao/venda.
+
+-- simulacoes (tabela tradein_leads — guarda cada simulacao trade-in finalizada)
+ALTER TABLE simulacoes
+  ADD COLUMN IF NOT EXISTS utm_source TEXT,
+  ADD COLUMN IF NOT EXISTS utm_medium TEXT,
+  ADD COLUMN IF NOT EXISTS utm_campaign TEXT,
+  ADD COLUMN IF NOT EXISTS utm_content TEXT,
+  ADD COLUMN IF NOT EXISTS utm_term TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_simulacoes_utm_source
+  ON simulacoes(utm_source, created_at DESC) WHERE utm_source IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_simulacoes_utm_campaign
+  ON simulacoes(utm_campaign, created_at DESC) WHERE utm_campaign IS NOT NULL;
+
+-- vendas
+ALTER TABLE vendas
+  ADD COLUMN IF NOT EXISTS utm_source TEXT,
+  ADD COLUMN IF NOT EXISTS utm_medium TEXT,
+  ADD COLUMN IF NOT EXISTS utm_campaign TEXT,
+  ADD COLUMN IF NOT EXISTS utm_content TEXT,
+  ADD COLUMN IF NOT EXISTS utm_term TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_vendas_utm_source
+  ON vendas(utm_source, created_at DESC) WHERE utm_source IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_vendas_utm_campaign
+  ON vendas(utm_campaign, created_at DESC) WHERE utm_campaign IS NOT NULL;
+
+-- link_compras: util quando vendedor mandar link pra cliente que ja foi
+-- atribuido a uma campanha de aquisicao
+ALTER TABLE link_compras
+  ADD COLUMN IF NOT EXISTS utm_source TEXT,
+  ADD COLUMN IF NOT EXISTS utm_medium TEXT,
+  ADD COLUMN IF NOT EXISTS utm_campaign TEXT,
+  ADD COLUMN IF NOT EXISTS utm_content TEXT,
+  ADD COLUMN IF NOT EXISTS utm_term TEXT;


### PR DESCRIPTION
## Summary
- Captura \`utm_source/medium/campaign/content/term\` quando cliente chega via campanha
- Persiste em localStorage por 30 dias (atribuição last-touch)
- Propaga até as tabelas \`simulacoes\`, \`vendas\` e \`link_compras\` automaticamente
- Analytics futuras podem agrupar por origem pra saber o que converte

## Item do backlog
**#26 — Tracking UTM end-to-end** (🔥 Alta / 🔴 Grande / 2 dias estimado) — Sprint 2, complementa #16 (Tag campanha)

## Como funciona

**1. Cliente chega com UTM na URL:**
\`\`\`
https://tigraoimports.com/troca?utm_source=meta&utm_campaign=lookalike-1pct&utm_medium=cpc
\`\`\`

**2. \`<UTMCapture/>\` (plugado no \`app/layout.tsx\`) roda ao montar:**
- Lê UTMs da URL
- Salva em \`localStorage\` com TTL 30 dias
- Atribuição **last-touch** — se cliente chegar 2x via URLs diferentes, vale a mais recente

**3. Cliente navega livre pelo app** (Home → /troca → /compra) — UTMs persistem sem precisar ficar na URL.

**4. Ao submeter qualquer POST** (simulação, venda), \`withUTMs()\` injeta os UTMs salvos no body.

**5. Backend salva nas tabelas:**
- \`simulacoes\` (via \`/api/leads\`) — toda simulação trade-in
- \`vendas\` (via \`/api/vendas/from-formulario\`) — venda finalizada
- \`link_compras\` já tem as colunas (pra quando cliente abrir link direto)

## API nova

\`\`\`ts
import { withUTMs, getStoredUTMs, captureAndPersistUTMs } from "@/lib/utm-tracker";

// Injetar em qualquer POST:
fetch("/api/minha-rota", { body: JSON.stringify(withUTMs({ foo: "bar" })) });
\`\`\`

## Migration

\`\`\`sql
ALTER TABLE simulacoes   ADD COLUMN utm_source/medium/campaign/content/term TEXT;
ALTER TABLE vendas       ADD COLUMN utm_source/medium/campaign/content/term TEXT;
ALTER TABLE link_compras ADD COLUMN utm_source/medium/campaign/content/term TEXT;

CREATE INDEX idx_simulacoes_utm_source  ON simulacoes(utm_source, created_at DESC);
CREATE INDEX idx_simulacoes_utm_campaign ON simulacoes(utm_campaign, created_at DESC);
CREATE INDEX idx_vendas_utm_source       ON vendas(utm_source, created_at DESC);
CREATE INDEX idx_vendas_utm_campaign     ON vendas(utm_campaign, created_at DESC);
\`\`\`

Apliquei em dev — quando mergeado, rodar em produção via \`/admin/migrations\`.

## Query de exemplo pós-merge

\`\`\`sql
-- Conversão por campanha (últimos 30 dias)
SELECT
  utm_source,
  utm_campaign,
  COUNT(DISTINCT s.id) AS simulacoes,
  COUNT(DISTINCT v.id) AS vendas,
  ROUND(100.0 * COUNT(DISTINCT v.id) / NULLIF(COUNT(DISTINCT s.id), 0), 1) AS conversao_pct,
  SUM(v.valor_pago) AS faturamento
FROM simulacoes s
LEFT JOIN vendas v
  ON v.utm_source = s.utm_source
  AND v.utm_campaign = s.utm_campaign
  AND v.created_at BETWEEN s.created_at AND s.created_at + INTERVAL '30 days'
WHERE s.created_at >= NOW() - INTERVAL '30 days'
  AND s.utm_source IS NOT NULL
GROUP BY utm_source, utm_campaign
ORDER BY faturamento DESC NULLS LAST;
\`\`\`

## Próximo passo sugerido (follow-up)

Configurar URL parameters nas campanhas Meta Ads:
- No Business Manager → Campaign → Ad Set → URL Parameters
- Padrão: \`utm_source=meta&utm_medium=cpc&utm_campaign={{campaign.name}}&utm_content={{ad.name}}\`

E no #27 (Cruzamento Meta Ads × região) usamos essa tabela + mapa de bairros pra cruzar dados.

## Test plan
- [x] TypeScript sem erros
- [x] UTMs capturados da URL e persistidos no localStorage
- [x] UTMs persistem entre páginas (navegação intra-app)
- [x] POST \`/api/leads\` salva UTMs em \`simulacoes\` (testado via eval no preview)
- [x] Atribuição last-touch (URL nova sobrescreve storage antigo)
- [ ] Validar em produção com campanha real Meta Ads

🤖 Generated with [Claude Code](https://claude.com/claude-code)