### PR TITLE
feat(mapa-vendas): cruzamento Meta Ads × região via UTM

### DIFF
--- a/app/admin/mapa-vendas/page.tsx
+++ b/app/admin/mapa-vendas/page.tsx
@@ -41,6 +41,23 @@ interface DiaSemanaData {
   receita: number;
 }
 
+interface CampanhaBucket {
+  nome: string;
+  qty: number;
+  receita: number;
+}
+
+interface CampanhaStat {
+  campanha: string;
+  source: string;
+  qty: number;
+  receita: number;
+  lucro: number;
+  ticket: number;
+  topBairros: CampanhaBucket[];
+  topCidades: CampanhaBucket[];
+}
+
 interface MapaData {
   totalVendas: number;
   totalReceita: number;
@@ -51,6 +68,7 @@ interface MapaData {
   estados: GeoData[];
   topClientes: ClienteData[];
   porDiaSemana: DiaSemanaData[];
+  campanhas?: CampanhaStat[];
 }
 
 type RangeOption = "7" | "month" | "30" | "90" | "all" | "custom";
@@ -399,6 +417,121 @@ export default function MapaVendasPage() {
           </div>
         )}
       </div>
+
+      {/* Cruzamento Meta Ads × região (UTM) */}
+      <CampanhasSection campanhas={data.campanhas ?? []} />
+    </div>
+  );
+}
+
+function CampanhasSection({ campanhas }: { campanhas: CampanhaStat[] }) {
+  const [aberta, setAberta] = useState<string | null>(null);
+  const totalComUTM = campanhas.filter(c => c.source !== "direct").reduce((s, c) => s + c.qty, 0);
+  const direct = campanhas.find(c => c.source === "direct");
+  const comUTM = campanhas.filter(c => c.source !== "direct");
+
+  return (
+    <div className="bg-white border border-[#D2D2D7] rounded-2xl p-4 sm:p-6 shadow-sm">
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-base font-semibold text-[#1D1D1F]">🎯 Campanhas × Região</h2>
+        <span className="text-xs text-[#86868B]">{totalComUTM} vendas com UTM</span>
+      </div>
+      <p className="text-xs text-[#86868B] mb-4">
+        Onde cada campanha (Meta Ads, Instagram, etc.) converteu. Clique pra ver os bairros específicos.
+      </p>
+
+      {comUTM.length === 0 ? (
+        <div className="rounded-xl p-4 bg-[#F5F5F7] text-center">
+          <p className="text-sm text-[#86868B]">
+            Nenhuma venda com UTM registrada ainda.
+          </p>
+          <p className="text-xs text-[#B0B0B0] mt-1">
+            Configure <span className="font-semibold">Parâmetros de URL</span> nas campanhas Meta Ads pra começar a rastrear.
+          </p>
+          {direct && direct.qty > 0 && (
+            <p className="text-xs text-[#86868B] mt-3">{direct.qty} vendas sem atribuição (direct)</p>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {comUTM.map((c) => {
+            const isOpen = aberta === `${c.source}::${c.campanha}`;
+            const pct = totalComUTM > 0 ? (c.qty / totalComUTM) * 100 : 0;
+            return (
+              <div key={`${c.source}::${c.campanha}`} className="border border-[#E8E8ED] rounded-xl overflow-hidden">
+                <button
+                  onClick={() => setAberta(isOpen ? null : `${c.source}::${c.campanha}`)}
+                  className="w-full px-4 py-3 flex items-center justify-between hover:bg-[#FAFAFA] transition-colors text-left"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-[#FFF5EB] text-[#E8740E]">{c.source}</span>
+                      <span className="text-sm font-semibold text-[#1D1D1F] truncate">{c.campanha}</span>
+                    </div>
+                    <div className="h-1.5 bg-[#F5F5F7] rounded-full overflow-hidden">
+                      <div className="h-full bg-[#E8740E]" style={{ width: `${Math.max(pct, 2)}%` }} />
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-4 ml-4 shrink-0 text-right">
+                    <div>
+                      <div className="text-xs text-[#86868B]">vendas</div>
+                      <div className="text-sm font-bold text-[#1D1D1F]">{c.qty}</div>
+                    </div>
+                    <div>
+                      <div className="text-xs text-[#86868B]">receita</div>
+                      <div className="text-sm font-bold text-[#1D1D1F]">{fmt(c.receita)}</div>
+                    </div>
+                    <div>
+                      <div className="text-xs text-[#86868B]">ticket</div>
+                      <div className="text-sm font-bold text-[#1D1D1F]">{fmt(c.ticket)}</div>
+                    </div>
+                    <span className="text-[#86868B] text-xs">{isOpen ? "▲" : "▼"}</span>
+                  </div>
+                </button>
+                {isOpen && (
+                  <div className="px-4 py-3 bg-[#FAFAFA] border-t border-[#E8E8ED] grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wider text-[#86868B] mb-2">Top bairros</p>
+                      {c.topBairros.length === 0 ? (
+                        <p className="text-xs text-[#B0B0B0]">Sem bairros informados</p>
+                      ) : (
+                        <ul className="space-y-1.5">
+                          {c.topBairros.map(b => (
+                            <li key={b.nome} className="flex items-center justify-between text-sm">
+                              <span className="text-[#1D1D1F] truncate max-w-[60%]">{b.nome}</span>
+                              <span className="text-[#86868B] shrink-0">{b.qty}x · {fmt(b.receita)}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                    <div>
+                      <p className="text-xs font-semibold uppercase tracking-wider text-[#86868B] mb-2">Top cidades</p>
+                      {c.topCidades.length === 0 ? (
+                        <p className="text-xs text-[#B0B0B0]">Sem cidades informadas</p>
+                      ) : (
+                        <ul className="space-y-1.5">
+                          {c.topCidades.map(cid => (
+                            <li key={cid.nome} className="flex items-center justify-between text-sm">
+                              <span className="text-[#1D1D1F] truncate max-w-[60%]">{cid.nome}</span>
+                              <span className="text-[#86868B] shrink-0">{cid.qty}x · {fmt(cid.receita)}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+          {direct && direct.qty > 0 && (
+            <p className="text-xs text-[#86868B] text-center pt-2">
+              + {direct.qty} vendas sem atribuição (direct/orgânico sem UTM)
+            </p>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/api/admin/mapa-vendas/route.ts
+++ b/app/api/admin/mapa-vendas/route.ts
@@ -448,6 +448,9 @@ export async function GET(req: NextRequest) {
       bairro: string | null;
       cidade: string | null;
       uf: string | null;
+      utm_source: string | null;
+      utm_campaign: string | null;
+      utm_medium: string | null;
     }[];
 
     // --- Aggregate by bairro (top 20) ---
@@ -616,6 +619,74 @@ export async function GET(req: NextRequest) {
       receita: receitaDia[i],
     }));
 
+    // --- Cruzamento Meta Ads x região (UTM) ---
+    // Agrega vendas com utm_source/utm_campaign preenchidos, mostrando
+    // onde cada campanha converteu. Vendas sem UTM caem no bucket "direct".
+    interface CampanhaStat {
+      campanha: string;      // utm_campaign (ou "(sem campanha)" se null)
+      source: string;        // utm_source
+      qty: number;
+      receita: number;
+      lucro: number;
+      ticket: number;
+      porBairro: Record<string, { qty: number; receita: number }>;
+      porCidade: Record<string, { qty: number; receita: number }>;
+    }
+    const porCampanhaRaw: Record<string, CampanhaStat> = {};
+    for (const v of rows) {
+      const source = (v.utm_source || "").trim() || "direct";
+      const campaign = (v.utm_campaign || "").trim() || "(sem campanha)";
+      const key = `${source}::${campaign}`;
+      if (!porCampanhaRaw[key]) {
+        porCampanhaRaw[key] = {
+          campanha: campaign,
+          source,
+          qty: 0,
+          receita: 0,
+          lucro: 0,
+          ticket: 0,
+          porBairro: {},
+          porCidade: {},
+        };
+      }
+      const entry = porCampanhaRaw[key];
+      entry.qty++;
+      entry.receita += Number(v.preco_vendido || 0);
+      entry.lucro += Number(v.lucro || 0);
+
+      const bairro = (v.bairro || "").trim() || "Nao informado";
+      const cidade = (v.cidade || "").trim() || "Nao informado";
+      const bairroKey = bairro === "Nao informado" ? bairro : `${bairro}, ${cidade}`;
+      if (!entry.porBairro[bairroKey]) entry.porBairro[bairroKey] = { qty: 0, receita: 0 };
+      entry.porBairro[bairroKey].qty++;
+      entry.porBairro[bairroKey].receita += Number(v.preco_vendido || 0);
+
+      if (!entry.porCidade[cidade]) entry.porCidade[cidade] = { qty: 0, receita: 0 };
+      entry.porCidade[cidade].qty++;
+      entry.porCidade[cidade].receita += Number(v.preco_vendido || 0);
+    }
+
+    const campanhas = Object.values(porCampanhaRaw)
+      .map(c => ({
+        ...c,
+        ticket: c.qty > 0 ? Math.round(c.receita / c.qty) : 0,
+        topBairros: Object.entries(c.porBairro)
+          .map(([nome, d]) => ({ nome, qty: d.qty, receita: d.receita }))
+          .sort((a, b) => b.qty - a.qty)
+          .slice(0, 5),
+        topCidades: Object.entries(c.porCidade)
+          .map(([nome, d]) => ({ nome, qty: d.qty, receita: d.receita }))
+          .sort((a, b) => b.qty - a.qty)
+          .slice(0, 5),
+      }))
+      .map(c => {
+        // Remove nested maps do payload final (já temos topBairros/Cidades)
+        const { porBairro: _pb, porCidade: _pc, ...rest } = c;
+        void _pb; void _pc;
+        return rest;
+      })
+      .sort((a, b) => b.qty - a.qty);
+
     // --- Totals ---
     const totalVendas = rows.length;
     const totalReceita = rows.reduce((s, v) => s + Number(v.preco_vendido || 0), 0);
@@ -632,6 +703,7 @@ export async function GET(req: NextRequest) {
       estados,
       topClientes,
       porDiaSemana,
+      campanhas,
     });
   } catch (err) {
     console.error("Erro mapa-vendas:", err);


### PR DESCRIPTION
## Summary
- Nova seção em \`/admin/mapa-vendas\`: **"🎯 Campanhas × Região"**
- Agrupa vendas por \`utm_source/utm_campaign\` e mostra onde cada campanha converteu
- Card expansível mostra top 5 bairros e top 5 cidades por campanha

## Item do backlog
**#27 — Cruzamento com Meta Ads (qual região respondeu melhor à campanha)** (🔥 Alta / 🔴 Grande / 2 dias estimado) — Sprint 2, fecha junto com #26

## Como fica

**Estado inicial (sem UTMs ainda):**
\`\`\`
🎯 Campanhas × Região                        0 vendas com UTM
Onde cada campanha (Meta Ads, Instagram, etc.) converteu.

┌────────────────────────────────────────────┐
│ Nenhuma venda com UTM registrada ainda.   │
│ Configure Parâmetros de URL nas campanhas  │
│ Meta Ads pra começar a rastrear.          │
│                                            │
│ 372 vendas sem atribuição (direct)        │
└────────────────────────────────────────────┘
\`\`\`

**Estado populado (dias depois, campanhas rodando):**
\`\`\`
🎯 Campanhas × Região                        42 vendas com UTM

┌─ meta · lookalike-1pct-brasil ─────────────┐
│ [██████████░░] vendas: 23  R$ 145k  ticket R$ 6.3k │
│                                           ▼│
│   Top bairros:        Top cidades:        │
│   • Barra       8     • Rio de Janeiro 18│
│   • Recreio     5     • Niterói         3│
│   • Tijuca      3     • São Gonçalo     2│
└────────────────────────────────────────────┘

┌─ instagram · organic-stories ──────────────┐
│ [███████░░░░░] vendas: 14  R$ 89k   ticket R$ 6.4k │
└────────────────────────────────────────────┘

+ 8 vendas sem atribuição (direct/orgânico sem UTM)
\`\`\`

## Como funciona

Na API \`/api/admin/mapa-vendas\`:
- Seleciona \`utm_source\` e \`utm_campaign\` das vendas
- Agrupa em \`Record<\`\${source}::\${campaign}\`, { qty, receita, lucro, porBairro, porCidade }>\`
- Vendas sem UTM: source = "direct" (separado visualmente como atribuição ausente)
- Retorna lista ordenada por volume (\`campanhas\` no payload)

Na UI:
- Componente \`CampanhasSection\` recebe a lista
- Filtra "direct" pra seção principal, mostra como footer
- Cada campanha é um card collapsável — click expande top 5 bairros/cidades
- Respeita o filtro de período já existente (\`range\` = 7/30/90/mês/tudo/custom)

## Dependências

- **#26 Tracking UTM** (merged em #714) — sem ele, todas as vendas caem em "direct"
- **Configuração de URL parameters no Meta Business Manager** — André já tem na lista de lembretes pendentes

## Test plan
- [x] TypeScript sem erros
- [x] Seção renderiza no final da página com empty state
- [x] API retorna \`campanhas\` agregadas por source/campaign + top regiões
- [x] Respeita filtro de período
- [ ] Validar em produção após campanhas Meta Ads serem reconfiguradas

🤖 Generated with [Claude Code](https://claude.com/claude-code)