### PR TITLE
fix(vendas): recriar pendencia por serial/imei + colar link termo assinado

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -5972,6 +5972,67 @@ export default function VendasPage() {
                                               </a>
                                             );
                                           })()}
+                                          {/* Colar link do PDF assinado — caso webhook ZapSign tenha falhado
+                                              (ex: admin reenviou termo e o link assinado ficou orfao). Aparece
+                                              quando nao ha termo ligado ou o termo atual nao esta ASSINADO. */}
+                                          {(() => {
+                                            const termo = termosPorVenda[v.id];
+                                            if (termo?.status === "ASSINADO") return null;
+                                            return (
+                                              <button
+                                                onClick={async (e) => {
+                                                  e.stopPropagation();
+                                                  const link = prompt("Cole o link do PDF assinado (copiado do ZapSign ou grupo do WhatsApp):");
+                                                  if (link === null) return;
+                                                  const url = link.trim();
+                                                  if (!url) return;
+                                                  if (!/^https?:\/\//i.test(url)) { setMsg("Link invalido — precisa comecar com http(s)://"); return; }
+                                                  const signedAt = new Date().toISOString();
+                                                  try {
+                                                    let termoId = termo?.id || null;
+                                                    if (!termoId) {
+                                                      // Nao existia termo — cria um minimo, ja como ASSINADO
+                                                      const aparelhos: { modelo: string; cor: string; imei: string; serial: string; condicao: string }[] = [];
+                                                      if (v.troca_produto) aparelhos.push({
+                                                        modelo: v.troca_produto, cor: v.troca_cor || "",
+                                                        imei: v.troca_imei || "", serial: v.troca_serial || "",
+                                                        condicao: v.troca_bateria ? `Bateria ${v.troca_bateria}%` : "",
+                                                      });
+                                                      if (v.troca_produto2) aparelhos.push({
+                                                        modelo: v.troca_produto2, cor: v.troca_cor2 || "",
+                                                        imei: v.troca_imei2 || "", serial: v.troca_serial2 || "",
+                                                        condicao: v.troca_bateria2 ? `Bateria ${v.troca_bateria2}%` : "",
+                                                      });
+                                                      if (aparelhos.length === 0) aparelhos.push({ modelo: "Produto da troca", cor: "", imei: "", serial: "", condicao: "" });
+                                                      const resCreate = await fetch("/api/admin/termo-procedencia", {
+                                                        method: "POST",
+                                                        headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
+                                                        body: JSON.stringify({ venda_id: v.id, aparelhos, gerar_pdf: false }),
+                                                      });
+                                                      const jsonCreate = await resCreate.json();
+                                                      if (!resCreate.ok || !jsonCreate.data?.id) { setMsg("Erro ao criar termo: " + (jsonCreate.error || "falha")); return; }
+                                                      termoId = jsonCreate.data.id;
+                                                    }
+                                                    const resPatch = await fetch("/api/admin/termo-procedencia", {
+                                                      method: "PATCH",
+                                                      headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
+                                                      body: JSON.stringify({ id: termoId, signed_pdf_url: url, status: "ASSINADO", signed_at: signedAt, venda_id: v.id }),
+                                                    });
+                                                    const jsonPatch = await resPatch.json();
+                                                    if (!resPatch.ok) { setMsg("Erro ao salvar: " + (jsonPatch.error || "falha")); return; }
+                                                    setTermosPorVenda(prev => ({ ...prev, [v.id]: { id: termoId!, status: "ASSINADO", zapsign_sign_url: prev[v.id]?.zapsign_sign_url || null, signed_pdf_url: url } }));
+                                                    setMsg("Link do termo assinado vinculado!");
+                                                  } catch {
+                                                    setMsg("Erro ao vincular link");
+                                                  }
+                                                }}
+                                                className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-purple-100 text-purple-700 border border-purple-300 hover:bg-purple-200 transition-colors"
+                                                title="Se o cliente ja assinou mas o link nao ficou na venda (ex: reenvio), cole aqui o PDF assinado"
+                                              >
+                                                🔗 Colar Link Assinado
+                                              </button>
+                                            );
+                                          })()}
                                           <button
                                             onClick={(e) => {
                                               e.stopPropagation();

--- a/app/api/admin/termo-procedencia/route.ts
+++ b/app/api/admin/termo-procedencia/route.ts
@@ -223,7 +223,7 @@ export async function PATCH(req: NextRequest) {
   const { id, ...fields } = await req.json();
   if (!id) return NextResponse.json({ error: "id obrigatório" }, { status: 400 });
 
-  const allowed = ["status", "observacao", "cidade", "aparelhos", "cliente_nome", "cliente_cpf", "pdf_url"];
+  const allowed = ["status", "observacao", "cidade", "aparelhos", "cliente_nome", "cliente_cpf", "pdf_url", "signed_pdf_url", "signed_at", "venda_id"];
   const patch: Record<string, unknown> = { updated_at: new Date().toISOString() };
   for (const k of allowed) {
     if (k in fields) patch[k] = fields[k];

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -1101,7 +1101,7 @@ export async function PATCH(req: NextRequest) {
       // Buscar pendências existentes do cliente
       const { data: pendencias } = await supabase
         .from("estoque")
-        .select("id, produto, data_compra")
+        .select("id, produto, data_compra, serial_no, imei")
         .ilike("fornecedor", venda.cliente)
         .eq("status", "PENDENTE")
         .eq("tipo", "PENDENCIA")
@@ -1109,10 +1109,34 @@ export async function PATCH(req: NextRequest) {
 
       const existing = pendencias || [];
 
+      // Match por serial/imei primeiro (distingue produtos diferentes do mesmo cliente).
+      // Se a venda tem identificador unico (serial/imei) mas nao acha match, retorna
+      // null — forca INSERT em vez de reaproveitar pendencia de outro produto.
+      // Sem serial/imei na venda, fallback para match por data (comportamento antigo).
+      const findMatch = (
+        pool: typeof existing,
+        serial: string | null,
+        imei: string | null,
+      ): typeof existing[number] | null => {
+        if (serial) {
+          const bySerial = pool.find(p => p.serial_no === serial);
+          if (bySerial) return bySerial;
+        }
+        if (imei) {
+          const byImei = pool.find(p => p.imei === imei);
+          if (byImei) return byImei;
+        }
+        if (serial || imei) return null;
+        return pool.find(p => p.data_compra === venda.data) || pool[0] || null;
+      };
+
       // ── TROCA 1 ──
       const hasTroca1 = !!(venda.troca_produto || venda.produto_na_troca);
+      const serial1 = venda.troca_serial ? String(venda.troca_serial).toUpperCase() : null;
+      const imei1 = venda.troca_imei ? String(venda.troca_imei).toUpperCase() : null;
+      let p1: typeof existing[number] | null = null;
       if (hasTroca1) {
-        const p1 = existing.find(p => p.data_compra === venda.data) || existing[0];
+        p1 = findMatch(existing, serial1, imei1);
         // Se venda JA tinha troca antes desta edicao E nao encontrou pendencia
         // (provavelmente foi movida pra estoque como seminovo), NAO criar uma
         // nova. Antes, toda edicao de venda com troca criava uma pendencia
@@ -1194,10 +1218,10 @@ export async function PATCH(req: NextRequest) {
       // ── TROCA 2 ──
       const hasTroca2 = !!(venda.troca_produto2 || venda.produto_na_troca2);
       if (hasTroca2) {
-        // Segunda pendência = segunda na lista (ou primeira se não existir troca 1)
-        const p2 = existing.length >= 2
-          ? (existing.find(p => p.data_compra === venda.data && p.id !== existing[0]?.id) || existing[1])
-          : (hasTroca1 ? undefined : existing[0]);
+        const serial2 = venda.troca_serial2 ? String(venda.troca_serial2).toUpperCase() : null;
+        const imei2 = venda.troca_imei2 ? String(venda.troca_imei2).toUpperCase() : null;
+        const pool2 = p1 ? existing.filter(e => e.id !== p1!.id) : existing;
+        const p2 = findMatch(pool2, serial2, imei2);
         // Mesmo tratamento da troca 1: se venda ja tinha troca2 antes e nao
         // achou pendencia, a troca ja foi processada — nao duplicar.
         if (!p2 && jaTinhaTroca2Antes && !forceRecriarPendencia) {


### PR DESCRIPTION
## Summary
- **Recriar Pendencia**: duas vendas do mesmo cliente no mesmo dia (cada uma com sua troca) colidiam — a segunda click de "Recriar Pendencia" atualizava a pendencia da primeira em vez de criar nova. Agora o sync faz match por serial/imei primeiro e so cai no match por data quando a venda nao tem identificador unico.
- **Colar Link Assinado**: novo botao roxo na linha da venda pra colar manualmente o URL do PDF assinado quando o webhook ZapSign falhou (ex: reenvio de termo). Cria termo minimo se nao existir, ou faz PATCH no existente, ja marcando como ASSINADO.

## Test plan
- [ ] Criar duas vendas do mesmo cliente na mesma data, cada uma com uma troca (seriais/IMEIs diferentes). Apagar as pendencias e clicar "Recriar Pendencia" em cada venda — ambas devem aparecer no estoque como itens separados.
- [ ] Numa venda com troca, clicar "Colar Link Assinado", colar uma URL valida, conferir que o badge "✅ Termo Assinado" aparece logo depois e abre o PDF no clique.
- [ ] Numa venda que ja tinha termo com status ENVIADO, usar o mesmo botao pra forcar ASSINADO. Conferir que o termo antigo foi atualizado (nao duplicou).

🤖 Generated with [Claude Code](https://claude.com/claude-code)