### PR TITLE
feat(entregas): foto comprovante inline + bulk "marcar entregues" mais visivel

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -37,6 +37,7 @@ interface Entrega {
   regiao: string | null;
   finalizada?: boolean | null;
   comprovante_lancado?: boolean | null;
+  comprovante_url?: string | null;
 }
 
 type EntregaStatus = Entrega["status"];
@@ -289,6 +290,8 @@ export default function EntregasPage() {
 
   // Seleção em massa para finalizar várias entregas
   const [modoSelecao, setModoSelecao] = useState(false);
+  // Lightbox de imagem do comprovante (foto anexada por venda)
+  const [comprovanteLightbox, setComprovanteLightbox] = useState<string | null>(null);
   const [entregasSelecionadas, setEntregasSelecionadas] = useState<Set<string>>(new Set());
   const [selectedEntrega, setSelectedEntrega] = useState<Entrega | null>(null);
   const [saving, setSaving] = useState(false);
@@ -2187,9 +2190,10 @@ export default function EntregasPage() {
         ))}
         <button
           onClick={() => { setModoSelecao(!modoSelecao); setEntregasSelecionadas(new Set()); }}
-          className={`ml-auto px-3 py-1 rounded-full text-[11px] font-semibold transition-colors ${modoSelecao ? "bg-blue-500 text-white" : "bg-white border border-[#D2D2D7] text-[#1D1D1F] hover:border-blue-400"}`}
+          className={`ml-auto px-3 py-1 rounded-full text-[11px] font-semibold transition-colors ${modoSelecao ? "bg-blue-500 text-white" : "bg-white border-2 border-blue-400 text-blue-700 hover:bg-blue-50"}`}
+          title="Ative pra marcar várias entregas como entregues, atribuir motoboy ou mudar status em lote"
         >
-          {modoSelecao ? "✖️ Sair da seleção" : "☑️ Selecionar várias"}
+          {modoSelecao ? "✖️ Sair da seleção" : "☑️ Marcar várias entregues"}
         </button>
       </div>
 
@@ -2715,6 +2719,42 @@ export default function EntregasPage() {
                     <span className={`text-xs font-semibold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>🧾 Comprovante lançado</span>
                   </label>
                 </div>
+                {/* Foto/imagem do comprovante — paste URL */}
+                <div className="mt-3 space-y-2">
+                  <div className="flex items-center gap-2">
+                    <span className={`text-[11px] font-semibold uppercase tracking-wider ${dm ? "text-[#86868B]" : "text-[#86868B]"}`}>📸 Foto comprovante</span>
+                    {e.comprovante_url && (
+                      <button
+                        onClick={() => quickPatchEntrega(e.id, { comprovante_url: null })}
+                        className="text-[10px] text-red-500 hover:underline"
+                      >Remover</button>
+                    )}
+                  </div>
+                  <input
+                    type="url"
+                    defaultValue={e.comprovante_url || ""}
+                    onBlur={(ev) => {
+                      const v = ev.target.value.trim();
+                      if (v !== (e.comprovante_url || "")) quickPatchEntrega(e.id, { comprovante_url: v || null });
+                    }}
+                    placeholder="Cole link da imagem (Drive, WhatsApp, etc.)"
+                    className={`w-full text-[11px] px-2 py-1.5 rounded border ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"} focus:border-[#E8740E] focus:outline-none`}
+                  />
+                  {e.comprovante_url && (
+                    <button
+                      onClick={() => setComprovanteLightbox(e.comprovante_url || null)}
+                      className="block w-full"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={e.comprovante_url}
+                        alt="Comprovante"
+                        className="w-full max-h-48 object-contain rounded-lg border border-[#D2D2D7] hover:border-[#E8740E] transition-colors cursor-zoom-in"
+                        onError={(ev) => { (ev.target as HTMLImageElement).style.display = "none"; }}
+                      />
+                    </button>
+                  )}
+                </div>
               </div>
 
               {/* Detalhes */}
@@ -3106,6 +3146,28 @@ export default function EntregasPage() {
           </div>
         );
       })()}
+
+      {/* Lightbox de comprovante — imagem em tela cheia */}
+      {comprovanteLightbox && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/90 cursor-zoom-out p-4"
+          onClick={() => setComprovanteLightbox(null)}
+        >
+          <button
+            onClick={(ev) => { ev.stopPropagation(); setComprovanteLightbox(null); }}
+            className="absolute top-4 right-4 w-10 h-10 rounded-full bg-white/10 text-white text-xl font-bold hover:bg-white/20"
+          >
+            ✕
+          </button>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={comprovanteLightbox}
+            alt="Comprovante (tamanho real)"
+            className="max-w-full max-h-full object-contain"
+            onClick={(ev) => ev.stopPropagation()}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/supabase/migrations/20260423e_entregas_comprovante_url.sql
+++ b/supabase/migrations/20260423e_entregas_comprovante_url.sql
@@ -1,0 +1,10 @@
+-- Adiciona coluna `comprovante_url` em entregas pra anexar foto/imagem do
+-- comprovante (recibo, ticket, foto da assinatura, etc.) e mostrar inline
+-- no card em vez de so um link.
+--
+-- A flag booleana `comprovante_lancado` continua sendo o checkbox manual
+-- ("a Bia confirmou que recebeu o comprovante"). A nova URL e opcional —
+-- vendedor cola um link de imagem (Drive, WhatsApp, etc.) ou deixa vazio.
+
+ALTER TABLE entregas
+  ADD COLUMN IF NOT EXISTS comprovante_url TEXT;


### PR DESCRIPTION
## Summary
- **#4:** Foto do comprovante anexada inline no card (URL → thumbnail → lightbox)
- **#3:** Bulk "marcar entregues" — UX mais clara (botão renomeado e destacado)

## Items do backlog
- **#3 — Bulk "marcar múltiplas como entregues"** (⚡ Média / 🟢 Rápido / 2h estimado)
- **#4 — Foto do comprovante anexada no card** (⚡ Média / 🟢 Rápido / 3h estimado)

## #4 Foto comprovante — implementação completa

**Migration:** nova coluna \`entregas.comprovante_url TEXT NULL\` (já apliquei em dev — rodar em prod via /admin/migrations).

**Modal de detalhes da entrega:**
\`\`\`
✅ Finalizada    🧾 Comprovante lançado
📸 FOTO COMPROVANTE                      [Remover]
[https://drive.google.com/...                       ]
┌──────────────────────────────────┐
│  [thumbnail max 192px de altura]  │  ← click = lightbox
└──────────────────────────────────┘
\`\`\`

- Cole link de imagem (Drive, WhatsApp Web, etc.)
- Salva no \`onBlur\` (sem botão "salvar")
- Thumbnail mostra automaticamente (com fallback se URL quebrada)
- Click na thumb → lightbox tela cheia
- Botão "Remover" → limpa o URL

**Decisão pragmática:** sem upload direto pra storage por agora — só URL de imagem pública. Se a equipe quiser upload no Vercel/Supabase Storage depois, é uma extensão simples.

## #3 Bulk entregas — descobrimento

A infra de bulk **já existia** (toggle "Selecionar várias" → marca múltiplas → bulk action bar com 4 status, 4 motoboys, "Finalizar" e "Comprovante"). O problema era visibilidade.

**Mudanças:**
- Botão "☑️ Selecionar várias" → "☑️ Marcar várias entregues" (mais action-oriented)
- Borda mais grossa azul pra destacar
- Tooltip explica que cobre mais ações (motoboy, etc.)

A funcionalidade em si (marcar N entregas como ENTREGUE de uma vez) já estava 100% lá via:
1. Click "☑️ Marcar várias entregues"
2. Click nos cards desejados (ou "Selecionar todas")
3. Click "🟢 Entregue" (status) ou "✅ Finalizar" (status + flag finalizada)

## Test plan
- [x] TypeScript sem erros
- [x] Migration aplica
- [x] Modal mostra "📸 Foto comprovante" + input URL
- [x] Botão bulk renomeado "Marcar várias entregues"
- [ ] Validar thumbnail render + lightbox em produção com URLs reais
- [ ] Confirmar que comprovante_url salva via onBlur

🤖 Generated with [Claude Code](https://claude.com/claude-code)