### PR TITLE
feat: sprint rapido — 6 itens verdes (etiquetas, gerar-link x2, relatorios, analytics, sazonalidade)

### DIFF
--- a/app/admin/analytics-vendas/page.tsx
+++ b/app/admin/analytics-vendas/page.tsx
@@ -174,12 +174,16 @@ export default function AnalyticsVendasPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [range, setRange] = useState<"1m" | "3m" | "6m">("1m");
+  // Filtro por canal/origem (FORMULARIO, INSTAGRAM, INDICACAO, OUTROS, etc.)
+  const [origemFiltro, setOrigemFiltro] = useState<string>("");
+  const [origensDisponiveis, setOrigensDisponiveis] = useState<string[]>([]);
 
   const fetchData = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/admin/analytics-vendas?range=${range}`, {
+      const url = `/api/admin/analytics-vendas?range=${range}${origemFiltro ? `&origem=${encodeURIComponent(origemFiltro)}` : ""}`;
+      const res = await fetch(url, {
         headers: apiHeaders(),
       });
       if (!res.ok) throw new Error(`Erro ${res.status}`);
@@ -237,11 +241,14 @@ export default function AnalyticsVendasPage() {
         coresPorModelo: json.coresPorModelo || [],
       };
       setData(transformed);
+      if (Array.isArray(json.origensDisponiveis)) {
+        setOrigensDisponiveis(json.origensDisponiveis);
+      }
     } catch (err: any) {
       setError(err.message || "Erro ao carregar dados");
     }
     setLoading(false);
-  }, [range, apiHeaders]);
+  }, [range, origemFiltro, apiHeaders]);
 
   useEffect(() => {
     fetchData();
@@ -283,7 +290,7 @@ export default function AnalyticsVendasPage() {
           <h1 className="text-2xl font-bold text-[#1D1D1F]">Analytics de Vendas</h1>
           <p className="text-sm text-[#86868B]">{rangeLabel()}</p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
           <div className="flex bg-[#E5E5EA] rounded-xl p-1">
             {(["1m", "3m", "6m"] as const).map((r) => (
               <button
@@ -299,6 +306,17 @@ export default function AnalyticsVendasPage() {
               </button>
             ))}
           </div>
+          <select
+            value={origemFiltro}
+            onChange={(e) => setOrigemFiltro(e.target.value)}
+            className="px-3 py-1.5 rounded-xl border border-[#D2D2D7] text-sm font-medium text-[#1D1D1F] focus:border-[#E8740E] focus:outline-none"
+            title="Filtrar projeção e KPIs por canal/origem"
+          >
+            <option value="">📊 Todos canais</option>
+            {origensDisponiveis.map((o) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
           <button
             onClick={fetchData}
             disabled={loading}

--- a/app/admin/etiquetas/page.tsx
+++ b/app/admin/etiquetas/page.tsx
@@ -170,6 +170,8 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
   const [histLoading, setHistLoading] = useState(false);
   const [selecionadas, setSelecionadas] = useState<Set<string>>(new Set());
   const [excluindoId, setExcluindoId] = useState<string | null>(null);
+  // Busca pra reimprimir rapido por codigo/produto/serial
+  const [buscaHistorico, setBuscaHistorico] = useState("");
 
   const headers = useCallback(() => ({
     "Content-Type": "application/json",
@@ -1084,11 +1086,18 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
                 <option value="EM_ESTOQUE">Em Estoque</option>
                 <option value="SAIU">Saiu</option>
               </select>
+              <input
+                type="text"
+                value={buscaHistorico}
+                onChange={(e) => setBuscaHistorico(e.target.value)}
+                placeholder="🔍 Buscar por código, produto, serial, IMEI..."
+                className="flex-1 min-w-[220px] border border-gray-300 rounded-lg px-3 py-2 text-sm focus:border-orange-500 focus:outline-none"
+              />
               <button onClick={carregarHistorico} className="bg-orange-500 hover:bg-orange-600 text-white font-bold px-4 py-2 rounded-lg text-sm">Atualizar</button>
               <span className="text-sm text-gray-500">{etiquetas.length} etiquetas</span>
               {selecionadas.size > 0 && (
                 <button onClick={handlePrintBatch} className="ml-auto bg-gray-800 hover:bg-gray-700 text-white font-bold px-4 py-2 rounded-lg text-sm flex items-center gap-2">
-                  🖨️ Imprimir {selecionadas.size} selecionada{selecionadas.size > 1 ? "s" : ""}
+                  🖨️ Reimprimir {selecionadas.size} selecionada{selecionadas.size > 1 ? "s" : ""}
                 </button>
               )}
             </div>
@@ -1113,7 +1122,14 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-50">
-                    {etiquetas.map((et) => {
+                    {etiquetas.filter((et) => {
+                      if (!buscaHistorico.trim()) return true;
+                      const q = buscaHistorico.trim().toLowerCase();
+                      return (et.codigo_barras || "").toLowerCase().includes(q)
+                        || (et.produto || "").toLowerCase().includes(q)
+                        || (et.serial_no || "").toLowerCase().includes(q)
+                        || (et.imei || "").toLowerCase().includes(q);
+                    }).map((et) => {
                       const st = STATUS_ETIQUETA[et.status as keyof typeof STATUS_ETIQUETA];
                       return (
                         <tr key={et.id} className={`hover:bg-gray-50 ${selecionadas.has(et.id) ? "bg-orange-50" : ""}`}>
@@ -1145,7 +1161,7 @@ export function EtiquetasContent({ embedded = false }: { embedded?: boolean }) {
                           </td>
                           <td className="px-4 py-3 text-center">
                             <div className="flex gap-1.5 justify-center">
-                              <button onClick={() => handlePrint(et)} className="text-xs bg-gray-800 hover:bg-gray-700 text-white px-3 py-1 rounded-lg">Imprimir</button>
+                              <button onClick={() => handlePrint(et)} className="text-xs bg-gray-800 hover:bg-gray-700 text-white px-3 py-1 rounded-lg" title="Reimprimir mantendo o mesmo código">🖨️ Reimprimir</button>
                               {et.status === "AGUARDANDO_ENTRADA" && (
                                 <button onClick={() => handleExcluir(et)} disabled={excluindoId === et.id} className="text-xs bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded-lg disabled:opacity-50">
                                   {excluindoId === et.id ? "..." : "Excluir"}

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -376,6 +376,8 @@ export default function GerarLinkPage() {
   const [histArquivado, setHistArquivado] = useState<"0" | "1">("0");
   const [histStatus, setHistStatus] = useState<"" | "ATIVO" | "PREENCHIDO" | "ENCAMINHADO">("");
   const [histOperador, setHistOperador] = useState<string>("");
+  // Vendedor designado no link (separado do operador que criou)
+  const [histVendedor, setHistVendedor] = useState<string>("");
 
   // Lista de operadores unicos extraida dos links carregados. Alimenta o
   // dropdown "Vendedor que criou" na aba Historico. Ordena alfabeticamente,
@@ -385,6 +387,15 @@ export default function GerarLinkPage() {
     const set = new Set<string>();
     for (const l of histLinks) {
       if (l.operador && l.operador.trim()) set.add(l.operador.trim());
+    }
+    return Array.from(set).sort((a, b) => a.localeCompare(b, "pt-BR"));
+  }, [histLinks]);
+
+  // Lista de vendedores designados extraida dos links carregados.
+  const vendedoresDisponiveis = useMemo(() => {
+    const set = new Set<string>();
+    for (const l of histLinks) {
+      if (l.vendedor && l.vendedor.trim()) set.add(l.vendedor.trim());
     }
     return Array.from(set).sort((a, b) => a.localeCompare(b, "pt-BR"));
   }, [histLinks]);
@@ -1929,11 +1940,23 @@ export default function GerarLinkPage() {
               onChange={(e) => setHistOperador(e.target.value)}
               className={inputCls}
               style={{ maxWidth: 200 }}
-              title="Filtrar por quem criou o link"
+              title="Quem criou o link no admin"
             >
-              <option value="">👤 Todos vendedores</option>
+              <option value="">🛠️ Todos operadores</option>
               {operadoresDisponiveis.map((op) => (
                 <option key={op} value={op}>{op}</option>
+              ))}
+            </select>
+            <select
+              value={histVendedor}
+              onChange={(e) => setHistVendedor(e.target.value)}
+              className={inputCls}
+              style={{ maxWidth: 200 }}
+              title="Vendedor designado no link (campo Vendedor do form)"
+            >
+              <option value="">👤 Todos vendedores</option>
+              {vendedoresDisponiveis.map((v) => (
+                <option key={v} value={v}>{v}</option>
               ))}
             </select>
             <button
@@ -1948,16 +1971,33 @@ export default function GerarLinkPage() {
 
           {histLoading && <p className="text-xs text-[#86868B] text-center py-4">Carregando...</p>}
           {!histLoading && histLinks.length === 0 && <p className="text-xs text-[#86868B] text-center py-6">Nenhum link encontrado.</p>}
-          {!histLoading && histLinks.length > 0 && histOperador && histLinks.filter((l) => (l.operador || "") === histOperador).length === 0 && (
-            <p className="text-xs text-[#86868B] text-center py-6">Nenhum link de <strong>{histOperador}</strong> nos filtros atuais.</p>
-          )}
+          {!histLoading && histLinks.length > 0 && (() => {
+            const filtrados = histLinks.filter((l) => {
+              if (histOperador && (l.operador || "") !== histOperador) return false;
+              if (histVendedor && (l.vendedor || "") !== histVendedor) return false;
+              return true;
+            });
+            if (filtrados.length === 0 && (histOperador || histVendedor)) {
+              const labels: string[] = [];
+              if (histOperador) labels.push(`operador: ${histOperador}`);
+              if (histVendedor) labels.push(`vendedor: ${histVendedor}`);
+              return (
+                <p className="text-xs text-[#86868B] text-center py-6">
+                  Nenhum link encontrado pra <strong>{labels.join(" + ")}</strong>.
+                </p>
+              );
+            }
+            return null;
+          })()}
 
           {(() => {
             // Mostra TODOS os links (Aguardando, Preenchido, Entrega criada).
-            // Operador filtra via os dropdowns em cima (Status / Vendedor que criou).
-            const visiveis = histOperador
-              ? histLinks.filter((l) => (l.operador || "") === histOperador)
-              : histLinks;
+            // Filtros aplicados: operador (quem criou) + vendedor (designado).
+            const visiveis = histLinks.filter((l) => {
+              if (histOperador && (l.operador || "") !== histOperador) return false;
+              if (histVendedor && (l.vendedor || "") !== histVendedor) return false;
+              return true;
+            });
             return (
           <div className="space-y-2">
             {visiveis.map((l) => (
@@ -2991,6 +3031,26 @@ export default function GerarLinkPage() {
           <div className="bg-[#F5F5F7] rounded-lg p-3 break-all text-xs text-[#1D1D1F] font-mono border border-[#D2D2D7]">
             {generatedLink}
           </div>
+
+          {/* Pre-visualizacao WhatsApp — bubble que simula como cliente vai ver */}
+          <div className="space-y-1">
+            <p className="text-[10px] font-semibold uppercase tracking-wider text-[#86868B]">📱 Como vai aparecer no WhatsApp:</p>
+            <div className="bg-[#E5DDD5] rounded-lg p-3" style={{ backgroundImage: "radial-gradient(circle at 1px 1px, rgba(0,0,0,0.03) 1px, transparent 0)", backgroundSize: "12px 12px" }}>
+              <div className="ml-auto max-w-[85%] bg-[#DCF8C6] rounded-lg rounded-tr-none p-2 shadow-sm">
+                {/* Card de preview do link (simula rich preview do WhatsApp) */}
+                <div className="bg-white/80 rounded border-l-4 border-[#25D366] p-2 mb-1.5">
+                  <p className="text-[10px] font-bold text-[#075E54]">TigraoImports</p>
+                  <p className="text-[10px] text-[#3B4A54] line-clamp-2">Finalize sua compra com troca em 1 minuto</p>
+                  <p className="text-[9px] text-[#667781] mt-0.5 truncate">{generatedLink.replace(/^https?:\/\//, "")}</p>
+                </div>
+                <p className="text-[11px] text-[#1F2937] break-all">{generatedLink}</p>
+                <p className="text-[9px] text-[#667781] text-right mt-1">
+                  {new Date().toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })} ✓✓
+                </p>
+              </div>
+            </div>
+          </div>
+
           <div className="flex gap-2">
             <button
               onClick={copiar}

--- a/app/admin/relatorios/page.tsx
+++ b/app/admin/relatorios/page.tsx
@@ -37,7 +37,7 @@ interface Gasto {
   data: string; descricao: string; valor: number; banco: string; usuario: string;
 }
 
-type Periodo = "semana" | "mes";
+type Periodo = "semana" | "mes" | "custom";
 
 export default function RelatoriosPage() {
   const { password, user, darkMode: dm } = useAdmin();
@@ -47,6 +47,11 @@ export default function RelatoriosPage() {
   const [loading, setLoading] = useState(true);
   const [weekOffset, setWeekOffset] = useState(0);
   const [monthOffset, setMonthOffset] = useState(0);
+  // Periodo customizado (de/ate) — valores default: ultimo mes
+  const todayISO = new Date().toISOString().split("T")[0];
+  const lastMonthISO = (() => { const d = new Date(); d.setDate(d.getDate() - 30); return d.toISOString().split("T")[0]; })();
+  const [customFrom, setCustomFrom] = useState(lastMonthISO);
+  const [customTo, setCustomTo] = useState(todayISO);
 
   // Estado para envio de relatórios PDF por email
   const [sendingSemanal, setSendingSemanal] = useState(false);
@@ -74,7 +79,13 @@ export default function RelatoriosPage() {
   const hoje = new Date();
   const range = periodo === "semana"
     ? (() => { const d = new Date(hoje); d.setDate(d.getDate() + weekOffset * 7); return getWeekRange(d); })()
-    : (() => { const d = new Date(hoje.getFullYear(), hoje.getMonth() + monthOffset, 1); return getMonthRange(d.getFullYear(), d.getMonth() + 1); })();
+    : periodo === "mes"
+    ? (() => { const d = new Date(hoje.getFullYear(), hoje.getMonth() + monthOffset, 1); return getMonthRange(d.getFullYear(), d.getMonth() + 1); })()
+    : (() => {
+        // Custom range: usa customFrom e customTo direto
+        const fmtBR = (iso: string) => { const [y, m, d] = iso.split("-"); return `${d}/${m}/${y.slice(2)}`; };
+        return { start: customFrom, end: customTo, label: `${fmtBR(customFrom)} – ${fmtBR(customTo)}` };
+      })();
 
   const fetchData = useCallback(async () => {
     setLoading(true);
@@ -173,18 +184,42 @@ export default function RelatoriosPage() {
         <h1 className={`text-2xl font-bold ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>Relatorios</h1>
         <div className="flex items-center gap-2">
           <div className="flex rounded-xl overflow-hidden border border-[#D2D2D7]">
-            {(["semana", "mes"] as const).map(p => (
+            {(["semana", "mes", "custom"] as const).map(p => (
               <button key={p} onClick={() => { setPeriodo(p); setWeekOffset(0); setMonthOffset(0); }}
                 className={`px-4 py-2 text-sm font-semibold ${periodo === p ? "bg-[#E8740E] text-white" : `${dm ? "bg-[#1C1C1E] text-[#98989D]" : "bg-white text-[#86868B]"}`}`}>
-                {p === "semana" ? "Semanal" : "Mensal"}
+                {p === "semana" ? "Semanal" : p === "mes" ? "Mensal" : "Personalizado"}
               </button>
             ))}
           </div>
-          <button onClick={() => periodo === "semana" ? setWeekOffset(o => o - 1) : setMonthOffset(o => o - 1)}
-            className={`px-3 py-2 rounded-lg text-sm ${dm ? "bg-[#2C2C2E] text-[#F5F5F7]" : "bg-[#F5F5F7]"}`}>◀</button>
-          <span className={`text-sm font-medium min-w-[140px] text-center ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{range.label}</span>
-          <button onClick={() => periodo === "semana" ? setWeekOffset(o => o + 1) : setMonthOffset(o => o + 1)}
-            className={`px-3 py-2 rounded-lg text-sm ${dm ? "bg-[#2C2C2E] text-[#F5F5F7]" : "bg-[#F5F5F7]"}`}>▶</button>
+          {periodo !== "custom" && (
+            <>
+              <button onClick={() => periodo === "semana" ? setWeekOffset(o => o - 1) : setMonthOffset(o => o - 1)}
+                className={`px-3 py-2 rounded-lg text-sm ${dm ? "bg-[#2C2C2E] text-[#F5F5F7]" : "bg-[#F5F5F7]"}`}>◀</button>
+              <span className={`text-sm font-medium min-w-[140px] text-center ${dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`}>{range.label}</span>
+              <button onClick={() => periodo === "semana" ? setWeekOffset(o => o + 1) : setMonthOffset(o => o + 1)}
+                className={`px-3 py-2 rounded-lg text-sm ${dm ? "bg-[#2C2C2E] text-[#F5F5F7]" : "bg-[#F5F5F7]"}`}>▶</button>
+            </>
+          )}
+          {periodo === "custom" && (
+            <div className="flex items-center gap-2">
+              <input
+                type="date"
+                value={customFrom}
+                onChange={(e) => setCustomFrom(e.target.value)}
+                max={customTo}
+                className={`px-2.5 py-1.5 rounded-lg border text-sm ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"} focus:border-[#E8740E] focus:outline-none`}
+              />
+              <span className={`text-xs ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>até</span>
+              <input
+                type="date"
+                value={customTo}
+                onChange={(e) => setCustomTo(e.target.value)}
+                min={customFrom}
+                max={todayISO}
+                className={`px-2.5 py-1.5 rounded-lg border text-sm ${dm ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7]" : "bg-white border-[#D2D2D7] text-[#1D1D1F]"} focus:border-[#E8740E] focus:outline-none`}
+              />
+            </div>
+          )}
         </div>
       </div>
 

--- a/app/admin/sazonalidade/page.tsx
+++ b/app/admin/sazonalidade/page.tsx
@@ -62,9 +62,20 @@ interface KPIs {
   totalFaturamento: number;
 }
 
+interface DiaHoraCell {
+  hora: number;
+  vendas: number;
+}
+interface DiaHoraRow {
+  dia: string;
+  diaFull: string;
+  horas: DiaHoraCell[];
+}
+
 interface SazonalidadeData {
   porDiaSemana: DiaSemanaData[];
   porHora: HoraData[];
+  diaHora?: DiaHoraRow[];
   topProdutos: TopProduto[];
   faturamentoSemanal: SemanaData[];
   produtosPorMes: ProdutosPorMes[];
@@ -354,6 +365,63 @@ export default function SazonalidadePage() {
               </ResponsiveContainer>
             </Section>
           </div>
+
+          {/* Heatmap dia × hora — cruzamento pra descobrir picos especificos */}
+          {data.diaHora && data.diaHora.length > 0 && (() => {
+            const maxVendas = Math.max(
+              1,
+              ...data.diaHora.flatMap(row => row.horas.map(h => h.vendas)),
+            );
+            const colorFor = (n: number) => {
+              if (n === 0) return darkMode ? "#1F1F22" : "#F5F5F7";
+              const intensity = n / maxVendas; // 0..1
+              const alpha = Math.max(0.2, intensity);
+              return `rgba(232, 116, 14, ${alpha})`;
+            };
+            const horas = data.diaHora[0].horas.map(h => h.hora);
+            return (
+              <Section title="Heatmap Dia × Hora" darkMode={darkMode}>
+                <p className={`text-xs mb-3 ${darkMode ? "text-[#98989D]" : "text-[#86868B]"}`}>
+                  Cruzamento de vendas por dia da semana × hora do dia. Quanto mais escuro, mais vendas (max: {maxVendas}).
+                </p>
+                <div className="overflow-x-auto">
+                  <table className="text-[11px] border-collapse" style={{ minWidth: 720 }}>
+                    <thead>
+                      <tr>
+                        <th className={`px-2 py-1 text-left font-semibold ${darkMode ? "text-[#98989D]" : "text-[#86868B]"}`}>Dia / Hora</th>
+                        {horas.map(h => (
+                          <th key={h} className={`px-1.5 py-1 text-center font-semibold ${darkMode ? "text-[#98989D]" : "text-[#86868B]"}`}>{h}h</th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.diaHora.map(row => (
+                        <tr key={row.dia}>
+                          <td className={`px-2 py-1 font-semibold ${darkMode ? "text-[#F5F5F7]" : "text-[#1D1D1F]"}`} title={row.diaFull}>{row.dia}</td>
+                          {row.horas.map(c => (
+                            <td
+                              key={c.hora}
+                              className="text-center font-mono text-[10px]"
+                              style={{
+                                backgroundColor: colorFor(c.vendas),
+                                color: c.vendas / maxVendas > 0.5 ? "#fff" : (darkMode ? "#86868B" : "#86868B"),
+                                width: 36,
+                                height: 28,
+                                border: darkMode ? "1px solid #1A1A1C" : "1px solid #FAFAFB",
+                              }}
+                              title={`${row.diaFull} ${c.hora}h: ${c.vendas} venda${c.vendas !== 1 ? "s" : ""}`}
+                            >
+                              {c.vendas || ""}
+                            </td>
+                          ))}
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </Section>
+            );
+          })()}
 
           {/* Faturamento por Semana */}
           <Section title="Faturamento por Semana" darkMode={darkMode}>

--- a/app/api/admin/analytics-vendas/route.ts
+++ b/app/api/admin/analytics-vendas/route.ts
@@ -49,6 +49,9 @@ export async function GET(req: NextRequest) {
   // Support both "meses" and "range" (frontend sends "range=1m")
   const rangeParam = searchParams.get("range") || searchParams.get("meses") || "3";
   const meses = Math.min(Math.max(parseInt(rangeParam.replace(/[^0-9]/g, "")) || 3, 1), 24);
+  // Filtro opcional por canal/origem (FORMULARIO, INSTAGRAM, INDICACAO, etc.)
+  // Quando vazio = todas as origens.
+  const origemFilter = (searchParams.get("origem") || "").trim();
 
   // Use São Paulo timezone to avoid UTC date mismatches on Vercel
   const spNow = new Date(new Date().toLocaleString("en-US", { timeZone: "America/Sao_Paulo" }));
@@ -89,9 +92,15 @@ export async function GET(req: NextRequest) {
       offset += PAGE_SIZE;
     }
 
-    // Excluir brindes dos cálculos financeiros
-    const rows = allRows.filter(v => !v.is_brinde);
-    console.log(`[analytics-vendas] meses=${meses} dataInicio=${dataInicioStr} hoje=${hojeStr} totalRows=${rows.length} (excl. brindes)`);
+    // Excluir brindes dos cálculos financeiros + aplicar filtro de origem (se houver)
+    let rows = allRows.filter(v => !v.is_brinde);
+    if (origemFilter) {
+      rows = rows.filter(v => (v.origem || "OUTROS") === origemFilter);
+    }
+    console.log(`[analytics-vendas] meses=${meses} dataInicio=${dataInicioStr} hoje=${hojeStr} totalRows=${rows.length} (excl. brindes${origemFilter ? `, origem=${origemFilter}` : ""})`);
+
+    // Lista de origens disponíveis no dataset (pra popular o filtro do front)
+    const origensDisponiveis = Array.from(new Set(allRows.filter(v => !v.is_brinde).map(v => v.origem || "OUTROS"))).sort();
 
     // ---------------------------------------------------------------
     // 1. COMPARATIVO MENSAL
@@ -477,6 +486,8 @@ export async function GET(req: NextRequest) {
       vendasPorRegiao,
       projecao,
       coresPorModelo,
+      origensDisponiveis,
+      origemFiltrada: origemFilter || null,
     });
   } catch (err) {
     console.error("Erro analytics-vendas:", err);

--- a/app/api/admin/sazonalidade/route.ts
+++ b/app/api/admin/sazonalidade/route.ts
@@ -127,6 +127,35 @@ export async function GET(req: NextRequest) {
     porHora.push({ hora: `${h}h`, vendas: horaMap[h] || 0 });
   }
 
+  // ─── 2b. Heatmap Dia da Semana × Hora do Dia ───
+  // Matrix [dow][hour] com qtd de vendas. Util pra ver picos especificos
+  // (ex: "sexta as 19h vende muito mais que segunda as 14h").
+  const diaHoraMap: Record<number, Record<number, number>> = {};
+  for (const dow of [0, 1, 2, 3, 4, 5, 6]) {
+    diaHoraMap[dow] = {};
+    for (let h = 8; h <= 21; h++) diaHoraMap[dow][h] = 0;
+  }
+  for (const v of rows) {
+    if (!v.created_at) continue;
+    const d = new Date(v.created_at);
+    const dow = d.getDay();
+    const h = d.getHours();
+    if (h < 8 || h > 21) continue;
+    diaHoraMap[dow][h] += 1;
+  }
+  const diaHora: { dia: string; diaFull: string; horas: { hora: number; vendas: number }[] }[] = [];
+  for (const dow of diaOrder) {
+    const horas: { hora: number; vendas: number }[] = [];
+    for (let h = 8; h <= 21; h++) {
+      horas.push({ hora: h, vendas: diaHoraMap[dow][h] });
+    }
+    diaHora.push({
+      dia: DIAS_SEMANA_LABELS[dow],
+      diaFull: DIAS_SEMANA_FULL[dow],
+      horas,
+    });
+  }
+
   // ─── 3. Top Produtos por Periodo ───
   const produtoMap: Record<string, { qtd: number; receita: number }> = {};
   for (const v of rows) {
@@ -239,6 +268,7 @@ export async function GET(req: NextRequest) {
   return NextResponse.json({
     porDiaSemana,
     porHora,
+    diaHora,
     topProdutos,
     faturamentoSemanal,
     produtosPorMes,


### PR DESCRIPTION
## Summary
Bundle de 6 melhorias rápidas do backlog "verdes". Cada uma toca uma página diferente, todas focadas e mínimas.

## Items do backlog (todos ⚡ Média ou 💤 Baixa, 🟢 Rápidos)

| # | Item | Página | Tempo |
|---|------|--------|-------|
| #2 | Reimprimir etiqueta sem regenerar | /admin/etiquetas | 1h |
| #6 | Preview WhatsApp antes de copiar | /admin/gerar-link | 1h |
| #7 | Histórico links + filtro vendedor | /admin/gerar-link | 3h |
| #9 | Filtro período customizado | /admin/relatorios | 2h |
| #10 | Filtro canal/origem | /admin/analytics-vendas | 2h |
| #11 | Sazonalidade dia × hora | /admin/sazonalidade | 3h |

## Detalhes

### #2 Reimprimir etiqueta
A função \`handlePrint\` já preservava o código original. Faltava UX:
- Adicionei input de busca no histórico (código, produto, serial, IMEI)
- Renomeei "Imprimir" → "🖨️ Reimprimir" (deixa explícito)

### #6 Preview WhatsApp
Bubble que simula como o link aparece no chat do cliente — fundo verde claro estilo WhatsApp, mockup de rich link preview, hora e dois ticks azuis.

### #7 Histórico + filtro vendedor
Distingue **operador** (quem criou no admin) de **vendedor** (designado no link). 2 selects separados, lista dinâmica derivada dos links carregados.

### #9 Filtro período customizado
Terceiro modo "Personalizado" com inputs de/até. Default: últimos 30 dias.

### #10 Filtro canal/origem
- API aceita \`?origem=\` que filtra **todos** os agregados (KPIs, projeção, ranking, região)
- API retorna \`origensDisponiveis\` pra popular o select
- UI: select com lista dinâmica das origens existentes

### #11 Sazonalidade dia × hora
Heatmap tabela 7 dias × 14 horas (8h-21h). Quanto mais escuro o laranja, mais vendas. Tooltip mostra dia completo + qtd. Rolagem horizontal pra mobile.

## Test plan
- [x] TypeScript sem erros (todos 6)
- [x] Heatmap renderiza com dados reais
- [x] Botão "Reimprimir" mostra label clara
- [x] Preview WhatsApp aparece quando link é gerado
- [x] Filtro vendedor lista vendedores reais dos links
- [x] Filtro custom em Relatórios aceita range arbitrário
- [x] Filtro origem em Analytics filtra a projeção
- [ ] Validar em produção

🤖 Generated with [Claude Code](https://claude.com/claude-code)