### PR TITLE
feat: previews visuais — produto (mostruario) + carrossel (instagram)

### DIFF
--- a/app/admin/instagram/[id]/page.tsx
+++ b/app/admin/instagram/[id]/page.tsx
@@ -80,6 +80,9 @@ export default function InstagramPostPage() {
   const [slidesEdit, setSlidesEdit] = useState<Slide[]>([]);
   const [legendaEdit, setLegendaEdit] = useState("");
   const [hashtagsEdit, setHashtagsEdit] = useState("");
+  // Preview do carrossel como vai aparecer no Instagram (modal swipeable)
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewIdx, setPreviewIdx] = useState(0);
 
   // PR 2: imagens
   const [ilustrando, setIlustrando] = useState(false);
@@ -679,6 +682,22 @@ export default function InstagramPostPage() {
             </div>
           )}
 
+          {/* Botao de preview Instagram */}
+          {slidesEdit.length > 0 && (
+            <div className="flex items-center justify-between mb-3 bg-gradient-to-r from-[#833AB4] via-[#FD1D1D] to-[#FCB045] rounded-2xl p-3">
+              <div className="text-white">
+                <p className="text-sm font-bold">📱 Preview Instagram</p>
+                <p className="text-[11px] opacity-90">Veja o carrossel como vai aparecer no feed</p>
+              </div>
+              <button
+                onClick={() => { setPreviewIdx(0); setPreviewOpen(true); }}
+                className="px-4 py-2 rounded-xl bg-white text-[#833AB4] text-sm font-bold hover:bg-white/90 transition-colors"
+              >
+                Abrir preview
+              </button>
+            </div>
+          )}
+
           {/* Cards de edição de slide */}
           <div className="grid gap-3 mb-6">
             {slidesEdit.map((slide, idx) => (
@@ -949,6 +968,116 @@ export default function InstagramPostPage() {
           )}
         </>
       )}
+
+      {/* Modal de preview do carrossel Instagram */}
+      {previewOpen && slidesEdit.length > 0 && (() => {
+        const total = slidesEdit.length;
+        const slide = slidesEdit[previewIdx] || slidesEdit[0];
+        const go = (dir: 1 | -1) => {
+          setPreviewIdx((i) => Math.min(Math.max(i + dir, 0), total - 1));
+        };
+        return (
+          <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/90 p-4" onClick={() => setPreviewOpen(false)}>
+            <button
+              onClick={() => setPreviewOpen(false)}
+              className="absolute top-4 right-4 w-10 h-10 rounded-full bg-white/10 text-white text-xl font-bold hover:bg-white/20 z-10"
+            >
+              ✕
+            </button>
+            <div className="max-w-md w-full" onClick={(e) => e.stopPropagation()}>
+              <p className="text-center text-white text-xs mb-2 opacity-70">📱 Preview Instagram — slide {previewIdx + 1} de {total}</p>
+              {/* Instagram post frame */}
+              <div className="bg-white rounded-2xl overflow-hidden shadow-2xl">
+                {/* Header estilo Instagram */}
+                <div className="flex items-center gap-2 px-3 py-2 border-b border-[#EFEFEF]">
+                  <div className="w-8 h-8 rounded-full bg-gradient-to-br from-[#833AB4] via-[#FD1D1D] to-[#FCB045] p-0.5">
+                    <div className="w-full h-full rounded-full bg-white flex items-center justify-center text-sm">🐯</div>
+                  </div>
+                  <div className="flex-1">
+                    <p className="text-sm font-bold text-[#1F2937]">tigraoimports</p>
+                    <p className="text-[10px] text-[#667781]">Rio de Janeiro · Brasil</p>
+                  </div>
+                  <span className="text-[#1F2937]">⋯</span>
+                </div>
+                {/* Slide (quadrado 1080x1080) */}
+                <div className="aspect-square bg-[#1C1C1E] relative flex flex-col items-center justify-center p-6 text-center overflow-hidden">
+                  {slide.imagem_url ? (
+                    <>
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={slide.imagem_url} alt="" className="absolute inset-0 w-full h-full object-cover" />
+                      <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent" />
+                    </>
+                  ) : (
+                    <div className="absolute inset-0 bg-gradient-to-br from-[#E8740E] via-[#FD1D1D] to-[#833AB4]" />
+                  )}
+                  {slide.destaque && (
+                    <p className="relative text-white text-7xl font-black drop-shadow-2xl mb-3">{slide.destaque}</p>
+                  )}
+                  <h3 className="relative text-white text-2xl font-black leading-tight drop-shadow-lg mb-2">{slide.titulo || "(sem título)"}</h3>
+                  <p className="relative text-white/90 text-sm leading-relaxed whitespace-pre-wrap drop-shadow-md">{slide.texto || "(sem texto)"}</p>
+                  {/* Dots indicador de slides */}
+                  <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex gap-1">
+                    {slidesEdit.map((_, i) => (
+                      <span key={i} className={`w-1.5 h-1.5 rounded-full ${i === previewIdx ? "bg-white" : "bg-white/40"}`} />
+                    ))}
+                  </div>
+                  {/* Navegação */}
+                  {previewIdx > 0 && (
+                    <button
+                      onClick={() => go(-1)}
+                      className="absolute left-2 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-black/30 text-white text-xl hover:bg-black/50"
+                    >‹</button>
+                  )}
+                  {previewIdx < total - 1 && (
+                    <button
+                      onClick={() => go(1)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-black/30 text-white text-xl hover:bg-black/50"
+                    >›</button>
+                  )}
+                </div>
+                {/* Ações do post */}
+                <div className="flex items-center gap-3 px-3 py-2">
+                  <span className="text-xl">♡</span>
+                  <span className="text-xl">💬</span>
+                  <span className="text-xl">✈️</span>
+                  <span className="ml-auto text-xl">🔖</span>
+                </div>
+                {/* Legenda */}
+                {legendaEdit && (
+                  <div className="px-3 pb-3 text-xs">
+                    <p className="text-[#1F2937] leading-relaxed whitespace-pre-wrap">
+                      <span className="font-bold">tigraoimports </span>
+                      {legendaEdit.length > 150 ? legendaEdit.slice(0, 150) + "..." : legendaEdit}
+                    </p>
+                    {hashtagsEdit && (
+                      <p className="text-[#00376B] text-[11px] mt-1 leading-snug">{hashtagsEdit}</p>
+                    )}
+                  </div>
+                )}
+              </div>
+              {/* Thumbnails pra navegar */}
+              <div className="flex gap-1.5 mt-3 overflow-x-auto pb-2">
+                {slidesEdit.map((s, i) => (
+                  <button
+                    key={i}
+                    onClick={() => setPreviewIdx(i)}
+                    className={`shrink-0 w-12 h-12 rounded-lg border-2 flex items-center justify-center text-xs font-bold overflow-hidden ${
+                      i === previewIdx ? "border-white" : "border-white/30"
+                    }`}
+                  >
+                    {s.imagem_url ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={s.imagem_url} alt="" className="w-full h-full object-cover" />
+                    ) : (
+                      <span className="text-white bg-gradient-to-br from-[#833AB4] to-[#FCB045] w-full h-full flex items-center justify-center">{i + 1}</span>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        );
+      })()}
 
     </div>
   );

--- a/app/admin/mostruario/page.tsx
+++ b/app/admin/mostruario/page.tsx
@@ -124,6 +124,8 @@ export default function MostruarioPage() {
   const [editingCategory, setEditingCategory] = useState<Categoria | null>(null);
   const [editingProduct, setEditingProduct] = useState<Produto | null>(null);
   const [editingVariacao, setEditingVariacao] = useState<Variacao | null>(null);
+  // Preview do produto como o cliente ve (modal com card estilo loja)
+  const [previewProduct, setPreviewProduct] = useState<Produto | null>(null);
 
   const showToast = useCallback((msg: string) => {
     setToast(msg);
@@ -277,6 +279,7 @@ export default function MostruarioPage() {
               onToggleField={async (field, value) => { await apiCall("PATCH", { action: "update_produto", id: produto.id, [field]: value }); await fetchData(); showToast("Salvo!"); }}
               onDelete={async () => { if (!confirm(`Deletar "${produto.nome}" e todas suas variacoes?`)) return; await apiCall("DELETE", { action: "delete_produto", id: produto.id }); await fetchData(); showToast("Produto deletado!"); }}
               onEdit={() => setEditingProduct(produto)}
+              onPreview={() => setPreviewProduct(produto)}
               onUploadImage={(file) => uploadImage("produto_id", produto.id, file)}
               onAddVariacao={() => setShowNewVariacao(produto.id)}
               onEditVariacao={(v) => setEditingVariacao(v)}
@@ -309,6 +312,86 @@ export default function MostruarioPage() {
       {editingProduct && <EditProductModal produto={editingProduct} categorias={categorias} onClose={() => setEditingProduct(null)} onSave={async (data) => { await apiCall("PATCH", { action: "update_produto", id: editingProduct.id, ...data }); setEditingProduct(null); await fetchData(); showToast("Produto atualizado!"); }} />}
       {showNewVariacao && <NewVariacaoModal produtoId={showNewVariacao} onClose={() => setShowNewVariacao(null)} onSave={async (data) => { await apiCall("POST", { action: "create_variacao", ...data }); setShowNewVariacao(null); await fetchData(); showToast("Variacao criada!"); }} />}
       {editingVariacao && <EditVariacaoModal variacao={editingVariacao} onClose={() => setEditingVariacao(null)} onSave={async (data) => { await apiCall("PATCH", { action: "update_variacao", id: editingVariacao.id, ...data }); setEditingVariacao(null); await fetchData(); showToast("Variacao atualizada!"); }} />}
+      {previewProduct && (
+        <CustomerPreviewModal
+          produto={previewProduct}
+          categorias={categorias}
+          onClose={() => setPreviewProduct(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ── Customer Preview Modal — mostra o produto como o cliente ve no /troca ── */
+function CustomerPreviewModal({ produto, categorias, onClose }: { produto: Produto; categorias: Categoria[]; onClose: () => void }) {
+  const cat = categorias.find((c) => c.id === produto.categoria_id);
+  const variacoesVisiveis = (produto.variacoes || []).filter(v => v.preco > 0);
+  const minPreco = variacoesVisiveis.length > 0
+    ? Math.min(...variacoesVisiveis.map(v => Number(v.preco)))
+    : 0;
+  const parcela12 = minPreco > 0 ? Math.round((minPreco * 1.13) / 12) : 0;
+  // Storages unicos (caso variacoes tenham campo storage no atributos)
+  const storages = Array.from(new Set(variacoesVisiveis.map(v => v.atributos?.storage).filter(Boolean))) as string[];
+  // Cores unicas
+  const cores = Array.from(new Set(variacoesVisiveis.map(v => v.atributos?.cor).filter(Boolean))) as string[];
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-4" onClick={onClose}>
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 w-10 h-10 rounded-full bg-white/10 text-white text-xl font-bold hover:bg-white/20 z-10"
+      >
+        ✕
+      </button>
+      <div className="max-w-sm w-full" onClick={(e) => e.stopPropagation()}>
+        <p className="text-center text-white text-xs mb-3 opacity-70">📱 Como o cliente vê no site (mock)</p>
+        {/* Card simulando o do home page */}
+        <div className="bg-[#1C1C1E] rounded-3xl overflow-hidden shadow-2xl">
+          {/* Imagem */}
+          <div className="aspect-square bg-gradient-to-br from-[#2C2C2E] to-[#1C1C1E] flex items-center justify-center relative">
+            {produto.imagem_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={produto.imagem_url} alt={produto.nome} className="w-full h-full object-cover" />
+            ) : (
+              <span className="text-7xl">{cat?.emoji || "📦"}</span>
+            )}
+            <button className="absolute top-3 right-3 w-9 h-9 rounded-full bg-black/40 backdrop-blur-sm text-white/80 hover:bg-black/60 flex items-center justify-center text-sm">
+              🤍
+            </button>
+          </div>
+          {/* Info */}
+          <div className="p-4 space-y-1">
+            <h3 className="text-lg font-bold text-white">{produto.nome}</h3>
+            {storages.length > 0 && (
+              <p className="text-sm text-white/60">{storages.join(" | ")}</p>
+            )}
+            {minPreco > 0 ? (
+              <>
+                <p className="text-xs text-white/50 mt-2">a partir de</p>
+                <p className="text-2xl font-bold text-white">R$ {minPreco.toLocaleString("pt-BR")}</p>
+                <p className="text-xs text-white/50">ou 12x de <span className="text-white/80 font-semibold">R$ {parcela12.toLocaleString("pt-BR")}</span></p>
+              </>
+            ) : (
+              <p className="text-sm text-white/50 mt-2">Consulte o preço</p>
+            )}
+            {cores.length > 0 && (
+              <div className="flex gap-1.5 mt-3">
+                {cores.slice(0, 6).map(c => (
+                  <span key={c} className="text-[10px] px-2 py-0.5 rounded-full bg-white/10 text-white/70">{c}</span>
+                ))}
+              </div>
+            )}
+            <button className="w-full mt-3 py-3 rounded-2xl bg-[#34C759] text-white font-semibold text-sm">
+              Comprar
+            </button>
+          </div>
+        </div>
+        <p className="text-center text-white/50 text-[10px] mt-3">
+          {variacoesVisiveis.length} variação{variacoesVisiveis.length !== 1 ? "ões" : ""} ativa{variacoesVisiveis.length !== 1 ? "s" : ""}
+          {!produto.visivel && " · ⚠️ Produto OCULTO no site"}
+        </p>
+      </div>
     </div>
   );
 }
@@ -486,7 +569,7 @@ function TemaAccordion({ label, sublabel, children }: { label: string; sublabel:
 }
 
 /* ── Product Card ── */
-function ProductCard({ produto, categorias, expanded, onToggleExpand, onToggleField, onDelete, onEdit, onUploadImage, onAddVariacao, onEditVariacao, onDeleteVariacao, onUploadVariacaoImage }: { produto: Produto; categorias: Categoria[]; expanded: boolean; onToggleExpand: () => void; onToggleField: (field: string, value: unknown) => void; onDelete: () => void; onEdit: () => void; onUploadImage: (file: File) => void; onAddVariacao: () => void; onEditVariacao: (v: Variacao) => void; onDeleteVariacao: (id: string) => void; onUploadVariacaoImage: (varId: string, file: File) => void }) {
+function ProductCard({ produto, categorias, expanded, onToggleExpand, onToggleField, onDelete, onEdit, onPreview, onUploadImage, onAddVariacao, onEditVariacao, onDeleteVariacao, onUploadVariacaoImage }: { produto: Produto; categorias: Categoria[]; expanded: boolean; onToggleExpand: () => void; onToggleField: (field: string, value: unknown) => void; onDelete: () => void; onEdit: () => void; onPreview: () => void; onUploadImage: (file: File) => void; onAddVariacao: () => void; onEditVariacao: (v: Variacao) => void; onDeleteVariacao: (id: string) => void; onUploadVariacaoImage: (varId: string, file: File) => void }) {
   const fileRef = useRef<HTMLInputElement>(null);
   const cat = categorias.find((c) => c.id === produto.categoria_id);
   const minPreco = produto.variacoes.length > 0 ? Math.min(...produto.variacoes.map((v) => Number(v.preco)).filter((p) => p > 0)) : 0;
@@ -529,6 +612,7 @@ function ProductCard({ produto, categorias, expanded, onToggleExpand, onToggleFi
               <div className="flex items-center gap-2 flex-wrap">
                 <button onClick={() => onToggleField("visivel", !produto.visivel)} className={`flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-medium transition-colors ${produto.visivel ? "bg-[#34C759]/10 text-[#34C759]" : "bg-[#F5F5F7] text-[#AEAEB2]"}`}>{produto.visivel ? "👁️ Visivel" : "👁️‍🗨️ Oculto"}</button>
                 <button onClick={() => onToggleField("destaque", !produto.destaque)} className={`flex items-center gap-1 px-2 py-1 rounded-lg text-[11px] font-medium transition-colors ${produto.destaque ? "bg-[#FF9500]/10 text-[#FF9500]" : "bg-[#F5F5F7] text-[#AEAEB2]"}`}>{produto.destaque ? "⭐ Destaque" : "☆ Destaque"}</button>
+                <button onClick={onPreview} className="px-2 py-1 rounded-lg text-[11px] font-medium bg-[#007AFF]/10 text-[#007AFF] hover:bg-[#007AFF]/20">👁️ Preview cliente</button>
                 <button onClick={onEdit} className="px-2 py-1 rounded-lg text-[11px] font-medium bg-[#F5F5F7] text-[#86868B] hover:text-[#1D1D1F]">✏️ Editar</button>
                 <button onClick={onDelete} className="px-2 py-1 rounded-lg text-[11px] font-medium bg-[#F5F5F7] text-[#FF3B30] hover:bg-[#FF3B30]/10">🗑️ Deletar</button>
               </div>


### PR DESCRIPTION
## Summary
PR2 do sprint rápido — fecha as últimas 2 melhorias 🟢 verdes (cosméticas).

## Items do backlog
- **#18** Preview produto como o cliente vê (/admin/mostruario) — 💤 Baixa / 🟢 5h
- **#19** Preview slides Instagram carrossel (/admin/instagram/[id]) — 💤 Baixa / 🟢 6h

## #18 Preview produto — como fica

**Onde:** botão \"👁️ Preview cliente\" em cada ProductCard expandido.

**Modal:** card estilo /troca (dark theme)
- Imagem do produto (ou emoji da categoria se sem imagem)
- Título
- Storages disponíveis: \`256GB | 512GB | 1TB\`
- \"a partir de R$ X.XXX\" + \"ou 12x de R$ Y\" (cálculo com taxa 13%)
- Chips de cores (até 6)
- Botão \"Comprar\" verde (só mock, não funcional)
- Footer: \"N variações ativas · ⚠️ Produto OCULTO no site\" (se aplicável)

**Testado com iPhone 17 Pro Max** — renderiza exatamente como o cliente vê.

## #19 Preview Instagram — como fica

**Onde:** banner gradiente roxo→rosa→amarelo no topo dos slides, botão \"Abrir preview\".

**Modal:** mockup fiel do post Instagram
- Header: avatar da loja, handle \`tigraoimports\`, localização
- Slide quadrado 1:1 com imagem + overlay degradê
- Texto sobreposto: destaque 7xl + título 2xl + texto
- Dots indicadores (1 por slide)
- Setas laterais para navegar
- Thumbnails abaixo do frame (clique pra saltar direto)
- Ações do post (❤️ 💬 ✈️ 🔖)
- Legenda + hashtags formatados como no feed

**Testado com post real de iPads 2026** — navegação entre slides funciona, imagens carregam, texto renderiza com whitespace preservado.

## Test plan
- [x] TypeScript sem erros
- [x] Preview produto abre e fecha corretamente (mostruário)
- [x] Preview Instagram abre, navega entre slides e fecha (instagram/[id])
- [x] Indicador de produto OCULTO aparece quando \`visivel === false\`
- [x] Thumbnails do preview IG navegam corretamente
- [ ] Validar em produção

🤖 Generated with [Claude Code](https://claude.com/claude-code)