### PR TITLE
fix(troca): qcSorted inclui hardcoded slugs com ordem fallback

### DIFF
--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -33,6 +33,16 @@ const HARDCODED_SLUGS = new Set([
   "warrantyMonth", "wearMarks",
 ]);
 
+// Ordem fallback pros slugs hardcoded quando o admin nao configurou nada no
+// qc (config carregando, slug removido, ou qc vazio). Permite que o gate
+// `allPriorAnswered` funcione mesmo antes do qc chegar, evitando que a
+// pergunta "battery" apareca antes de "hasDamage" ser respondida.
+const HARDCODED_DEFAULT_ORDEM: Record<string, number> = {
+  hasDamage: 1, battery: 2, hasWearMarks: 3, wearMarks: 4,
+  screenScratch: 4.1, sideScratch: 4.2, peeling: 4.3,
+  partsReplaced: 5, hasWarranty: 6, warrantyMonth: 7, hasOriginalBox: 8,
+};
+
 // Formata uma resposta dinamica pra exibir no resumo/WhatsApp.
 function formatExtraAnswer(q: TradeInQuestion, value: unknown): string {
   if (value === undefined || value === null || value === "") return "—";
@@ -385,7 +395,23 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
       }
     }
   };
-  const qcSorted = (qc || []).filter(q => q.ativo !== false).sort((a, b) => (a.ordem ?? 0) - (b.ordem ?? 0));
+  // qcSorted inclui tanto slugs do admin (ativos) quanto hardcoded que faltam
+  // no qc — pros hardcoded missing, usa HARDCODED_DEFAULT_ORDEM como fallback.
+  // Isso garante que allPriorAnswered/isPriorRejecting funcionem mesmo quando o
+  // admin deletou o slug ou o qc ainda nao chegou (race condition no loading).
+  const qcSorted = (() => {
+    const list = (qc || []).filter(q => q.ativo !== false);
+    const seen = new Set(list.map(q => q.slug));
+    for (const slug of Object.keys(HARDCODED_DEFAULT_ORDEM)) {
+      if (!seen.has(slug) && isQActive(qc, slug)) {
+        list.push({
+          id: `hc-${slug}`, device_type: deviceType, slug, titulo: "", tipo: "yesno",
+          opcoes: [], ordem: HARDCODED_DEFAULT_ORDEM[slug], ativo: true, config: {},
+        } as TradeInQuestion);
+      }
+    }
+    return list.sort((a, b) => (a.ordem ?? 0) - (b.ordem ?? 0));
+  })();
   const allPriorAnswered = (slug: string): boolean => {
     const idx = qcSorted.findIndex(q => q.slug === slug);
     if (idx === -1) return true; // nao ordenado = sem bloqueio


### PR DESCRIPTION
## Summary
- Bug: se o admin deleta um slug hardcoded (ou se qc ainda esta carregando), qcSorted ficava sem o slug e allPriorAnswered da pergunta seguinte nao bloqueava.
- Fix: qcSorted agora mescla qc com HARDCODED_DEFAULT_ORDEM — slugs hardcoded ausentes entram com ordem default.
- Sequential reveal funciona em iPad/MacBook/Watch mesmo com qc parcial.

## Test plan
- [ ] /troca iPad → respondendo cada pergunta a proxima aparece (nao todas em cascata)
- [ ] Deletar 1 slug hardcoded em /admin/simulacoes → cliente continua bloqueando proximas ate pergunta anterior responder
- [ ] MacBook e Watch — mesmo comportamento sequencial

🤖 Generated with [Claude Code](https://claude.com/claude-code)