### PR TITLE
fix(troca): iPhone travava apos marcas de uso — excluir slugs legacy

### DIFF
--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -419,10 +419,17 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   // no qc — pros hardcoded missing, usa HARDCODED_DEFAULT_ORDEM como fallback.
   // Isso garante que allPriorAnswered/isPriorRejecting funcionem mesmo quando o
   // admin deletou o slug ou o qc ainda nao chegou (race condition no loading).
+  // Exceto: slugs do sistema antigo de marcas (screenScratch/sideScratch/peeling)
+  // nao entram no fallback quando useNewWearMarks=true, senao bloqueiam o reveal
+  // de partsReplaced/hasWarranty/hasOriginalBox (ficam "nao respondidos" pra sempre
+  // porque nao sao renderizados). Antes dessa excecao, o fluxo de iPhone travava
+  // apos "marcas de uso: Nao".
+  const LEGACY_WEAR_SLUGS = new Set(["screenScratch", "sideScratch", "peeling"]);
   const qcSorted = (() => {
     const list = (qc || []).filter(q => q.ativo !== false);
     const seen = new Set(list.map(q => q.slug));
     for (const slug of Object.keys(HARDCODED_DEFAULT_ORDEM)) {
+      if (useNewWearMarks && LEGACY_WEAR_SLUGS.has(slug)) continue;
       if (!seen.has(slug) && isQActive(qc, slug)) {
         list.push({
           id: `hc-${slug}`, device_type: deviceType, slug, titulo: "", tipo: "yesno",


### PR DESCRIPTION
## Resumo

Fix urgente: fluxo de iPhone em `/troca` travava após responder "marcas de uso: Não". O botão "Ver minha avaliação" nunca aparecia e as perguntas seguintes (peças trocadas, garantia, caixa) não renderizavam.

## Causa

O PR #739 (qcSorted sempre inclui hardcoded slugs) passou a adicionar `screenScratch/sideScratch/peeling` via `HARDCODED_DEFAULT_ORDEM` quando eles não estavam no qc. Esses slugs são do **sistema antigo** de marcas — quando `useNewWearMarks=true` (hasWearMarks ativo), eles não são renderizados, mas ficam no qcSorted com state `null` pra sempre. Isso fazia `isSlugAnswered` retornar `false` pra eles, bloqueando `allPriorAnswered` das perguntas seguintes.

## Fix

Pular slugs legacy (`screenScratch`, `sideScratch`, `peeling`) no fallback de qcSorted quando `useNewWearMarks=true`. Mínima mudança — 2 linhas novas.

## Validação

Testado em preview local o fluxo completo de iPhone:
- iPhone 11 → 128GB → cor Amarelo → trincado Não → bateria 70 → marcas Não → **peças Não (apareceu!)** → garantia Não → caixa Sim → **"Ver minha avaliação" aparece ✓**

## Test plan

- [x] Fluxo iPhone ponta-a-ponta funciona
- [ ] Verificar MacBook (ciclos → marcas → peças → …)
- [ ] Verificar iPad e Watch

🤖 Generated with [Claude Code](https://claude.com/claude-code)