### PR TITLE
feat(troca): rejeicao por valor minimo em perguntas numericas

### DIFF
--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -593,47 +593,81 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
 
       {model && !isExcluded && storages.length > 1 && (
         deviceType === "macbook" ? (
-          // MacBook: agrupar por RAM e mostrar SSD separado
+          // MacBook: aceitar tanto o formato antigo "256GB/8GB" (ssd/ram) quanto
+          // o novo "13\" | 8GB | 256GB" (tela | ram | ssd, vindo de /admin/usados).
+          // Renderiza steps sequenciais: tela (se tiver) → RAM → SSD — o cliente
+          // escolhe cada dimensao separadamente em vez de um botao por combinacao.
           (() => {
-            // storages são tipo "256GB/8GB", "512GB/8GB", "256GB/16GB" etc.
-            const parsed = storages.map(s => {
-              const parts = s.split("/");
-              const ssd = parts[0] || s;
-              const ram = parts[1] || "";
-              return { raw: s, ssd, ram };
-            });
-            // Agrupar por RAM
-            const byRam: Record<string, typeof parsed> = {};
-            for (const p of parsed) {
-              const key = p.ram || "default";
-              if (!byRam[key]) byRam[key] = [];
-              byRam[key].push(p);
-            }
-            const ramGroups = Object.entries(byRam).sort(([a], [b]) => {
-              const na = parseInt(a) || 0;
-              const nb = parseInt(b) || 0;
-              return na - nb;
-            });
+            const parseMac = (raw: string): { raw: string; tela: string; ram: string; ssd: string } => {
+              if (raw.includes("|")) {
+                // Formato novo do admin: "tela | ram | ssd"
+                const [tela = "", ram = "", ssd = ""] = raw.split("|").map(p => p.trim());
+                return { raw, tela, ram, ssd };
+              }
+              if (raw.includes("/")) {
+                // Formato antigo: "ssd/ram" (ordem invertida, legado)
+                const [ssd = "", ram = ""] = raw.split("/").map(p => p.trim());
+                return { raw, tela: "", ram, ssd };
+              }
+              // Sem separador: storage unico (pode ser so ssd)
+              return { raw, tela: "", ram: "", ssd: raw };
+            };
+            const specs = storages.map(parseMac);
+            const current = storage ? parseMac(storage) : { raw: "", tela: "", ram: "", ssd: "" };
+            const sortCapacidade = (a: string, b: string) => (parseInt(a) || 0) - (parseInt(b) || 0);
+            const uniq = (xs: string[]) => [...new Set(xs.filter(Boolean))];
+
+            const telaOpts = uniq(specs.map(s => s.tela));
+            const afterTela = specs.filter(s => !current.tela || s.tela === current.tela);
+            const ramOpts = uniq(afterTela.map(s => s.ram)).sort(sortCapacidade);
+            const afterRam = afterTela.filter(s => !current.ram || s.ram === current.ram);
+            const ssdOpts = uniq(afterRam.map(s => s.ssd)).sort(sortCapacidade);
+
+            const pickMac = (tela: string, ram: string, ssd: string) => {
+              const match = specs.find(s =>
+                (!tela || s.tela === tela) &&
+                (!ram || s.ram === ram) &&
+                (!ssd || s.ssd === ssd)
+              );
+              if (match) { setStorage(match.raw); tq("storage"); }
+            };
+
             return (
-              <Section title="Qual a configuracao do seu MacBook?">
-                <div className="space-y-4">
-                  {ramGroups.map(([ram, items]) => (
-                    <div key={ram}>
-                      {ram && ram !== "default" && ramGroups.length > 1 && (
-                        <p className="text-[13px] font-semibold mb-2 text-center" style={{ color: "var(--ti-text)" }}>{ram} RAM</p>
-                      )}
-                      <div className={`grid gap-2 ${items.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
-                        {items.map(({ raw, ssd, ram: r }) => (
-                          <Btn key={raw} sel={storage === raw} onClick={() => { setStorage(raw); tq("storage"); }}
-                            className="w-full text-center">
-                            {r ? <><span className="block font-bold">{r} RAM</span><span className="block text-[12px] opacity-80">{ssd} SSD</span></> : ssd}
-                          </Btn>
-                        ))}
-                      </div>
+              <>
+                {telaOpts.length > 1 && (
+                  <Section title="Tamanho da tela">
+                    <div className={`grid gap-2 ${telaOpts.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
+                      {telaOpts.map(t => (
+                        <Btn key={t} sel={current.tela === t}
+                          onClick={() => pickMac(t, "", "")}
+                          className="w-full text-center">{t}</Btn>
+                      ))}
                     </div>
-                  ))}
-                </div>
-              </Section>
+                  </Section>
+                )}
+                {(telaOpts.length <= 1 || current.tela) && ramOpts.length > 0 && (
+                  <Section title="Memoria RAM">
+                    <div className={`grid gap-2 ${ramOpts.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
+                      {ramOpts.map(r => (
+                        <Btn key={r} sel={current.ram === r}
+                          onClick={() => pickMac(current.tela, r, "")}
+                          className="w-full text-center">{r}</Btn>
+                      ))}
+                    </div>
+                  </Section>
+                )}
+                {(ramOpts.length === 0 || current.ram) && ssdOpts.length > 0 && (
+                  <Section title="Armazenamento SSD">
+                    <div className={`grid gap-2 ${ssdOpts.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
+                      {ssdOpts.map(s => (
+                        <Btn key={s} sel={current.ssd === s}
+                          onClick={() => pickMac(current.tela, current.ram, s)}
+                          className="w-full text-center">{s}</Btn>
+                      ))}
+                    </div>
+                  </Section>
+                )}
+              </>
             );
           })()
         ) : storages.some(hasStructuredStorage) ? (

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -634,7 +634,7 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
 
             return (
               <>
-                {telaOpts.length > 1 && (
+                {telaOpts.length > 0 && (
                   <Section title="Tamanho da tela">
                     <div className={`grid gap-2 ${telaOpts.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
                       {telaOpts.map(t => (
@@ -645,7 +645,7 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                     </div>
                   </Section>
                 )}
-                {(telaOpts.length <= 1 || current.tela) && ramOpts.length > 0 && (
+                {(telaOpts.length === 0 || current.tela) && ramOpts.length > 0 && (
                   <Section title="Memoria RAM">
                     <div className={`grid gap-2 ${ramOpts.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
                       {ramOpts.map(r => (

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -375,10 +375,17 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   // Valida: toda pergunta dinamica precisa ter resposta (exceto multiselect,
   // que pode ficar vazio). Pra simplificar, considera "nao respondida" se a
   // chave nao existe em extraAnswers. Multiselect com [] conta como respondida.
+  // Perguntas numericas com config.rejectBelow bloqueiam o avanco quando o valor
+  // e menor que o threshold (ex: bateria < 80%).
   const dynamicOk = dynamicQuestions.every((q) => {
     const v = extraAnswers[q.slug];
     if (q.tipo === "multiselect") return v !== undefined;
-    return v !== undefined && v !== null && v !== "";
+    if (v === undefined || v === null || v === "") return false;
+    if (q.tipo === "numeric" && typeof v === "number") {
+      const rb = (q.config as Record<string, unknown>)?.rejectBelow;
+      if (typeof rb === "number" && v < rb) return false;
+    }
+    return true;
   });
 
   const isExcluded = excludedSet.has(model.toLowerCase());
@@ -388,6 +395,22 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   const batteryMax = deviceType === "macbook" ? 9999 : 100;
   const batteryMin = deviceType === "macbook" ? 0 : 1;
   const batteryFilled = !isQActive(qc, "battery") || (battery !== null && battery >= batteryMin && battery <= batteryMax);
+  // Pergunta hardcoded "battery" tambem suporta rejeicao por valor minimo:
+  // admin cadastra config.rejectBelow (ex: 80) + config.rejectMessage. Quando
+  // bateria < rejectBelow, bloqueia canProceed e esconde perguntas seguintes.
+  // Pra MacBook, como o campo e ciclos (quanto maior, pior), o admin nao deve
+  // usar rejectBelow ali — deve criar dynamic question de saude % separada.
+  const batteryRejectBelow = (() => {
+    const cfg = getQ(qc, "battery")?.config as Record<string, unknown> | undefined;
+    const rb = cfg?.rejectBelow;
+    return typeof rb === "number" ? rb : undefined;
+  })();
+  const batteryRejectMessage = (() => {
+    const cfg = getQ(qc, "battery")?.config as Record<string, unknown> | undefined;
+    const rm = cfg?.rejectMessage;
+    return typeof rm === "string" ? rm : "";
+  })();
+  const batteryRejected = batteryRejectBelow !== undefined && battery !== null && battery < batteryRejectBelow;
 
   // Reveal progressivo: mostra pergunta N so quando todas as anteriores (na ordem
   // configurada pelo admin) estao respondidas. Sem isso, perguntas apareciam em
@@ -454,13 +477,19 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   // Verifica se alguma pergunta anterior (na ordem do admin) tem resposta com
   // `reject: true` selecionada. Se sim, perguntas posteriores nao renderizam —
   // substitui o wrap generico `hasDamage === false` que fixava a ordem no JSX.
+  // Suporta tambem perguntas numericas com config.rejectBelow (ex: bateria < 80%).
   const isPriorRejecting = (slug: string): boolean => {
     const myOrd = getOrdem(slug);
     if (myOrd === undefined) return false;
     return qcSorted.filter(p => (p.ordem ?? 0) < myOrd).some(prev => {
       if (prev.slug === "hasDamage" && hasDamage === true) return true;
       if (prev.slug === "partsReplaced" && partsReplaced === "thirdParty") return true;
+      if (prev.slug === "battery" && batteryRejected) return true;
       const v = extraAnswers[prev.slug];
+      if (prev.tipo === "numeric" && typeof v === "number") {
+        const rb = (prev.config as Record<string, unknown>)?.rejectBelow;
+        if (typeof rb === "number" && v < rb) return true;
+      }
       const opt = v !== undefined ? prev.opcoes.find(o => o.value === v) : undefined;
       return opt?.reject === true;
     });
@@ -475,7 +504,7 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   const warrantyFilled = !isQActive(qc, "hasWarranty") || hasWarranty === false || (hasWarranty === true && (!isQActive(qc, "warrantyMonth") || warrantyMonth !== null));
   const partsOk = !isQActive(qc, "partsReplaced") || partsReplaced === "no" || partsReplaced === "apple";
   const boxOk = !isQActive(qc, "hasOriginalBox") || hasOriginalBox !== null;
-  const canProceed = model && storageCompleto && cor && baseValue !== null && !isExcluded && damageOk && partsOk && allCond && warrantyFilled && boxOk && dynamicOk;
+  const canProceed = model && storageCompleto && cor && baseValue !== null && !isExcluded && damageOk && partsOk && allCond && !batteryRejected && warrantyFilled && boxOk && dynamicOk;
 
   const tq = (q: string) => onTrackQuestion?.(1, q);
   function handleLineChange(l: string) { setLine(l); setSubLine(""); setModel(""); setStorage(""); setHasDamage(null); tq("line"); }
@@ -754,24 +783,23 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                   <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[16px] font-bold" style={{ color: "var(--ti-muted)" }}>%</span>
                 )}
               </div>
-              {(deviceType === "ipad" || deviceType === "macbook") && (
+              {deviceType === "ipad" && (
                 <button
                   type="button"
                   onClick={() => {
-                    // iPad/MacBook as vezes so mostra "Normal" em vez de numero.
-                    // Cliente clica aqui pra liberar o fluxo assumindo que o aparelho
-                    // esta saudavel: iPad = 100% saude, MacBook = 0 ciclos (sem desconto).
-                    setBattery(deviceType === "macbook" ? 0 : 100);
+                    // iPad as vezes so mostra "Normal" em vez de numero — cliente
+                    // clica pra liberar assumindo aparelho saudavel (100%).
+                    setBattery(100);
                     tq("battery");
                   }}
                   className="w-full py-2 rounded-xl text-[13px] font-medium transition-colors"
                   style={{
-                    backgroundColor: battery === (deviceType === "macbook" ? 0 : 100) ? "var(--ti-success-light)" : "var(--ti-input-bg)",
-                    color: battery === (deviceType === "macbook" ? 0 : 100) ? "var(--ti-success)" : "var(--ti-muted)",
-                    border: `1px solid ${battery === (deviceType === "macbook" ? 0 : 100) ? "var(--ti-success)" : "var(--ti-card-border)"}`,
+                    backgroundColor: battery === 100 ? "var(--ti-success-light)" : "var(--ti-input-bg)",
+                    color: battery === 100 ? "var(--ti-success)" : "var(--ti-muted)",
+                    border: `1px solid ${battery === 100 ? "var(--ti-success)" : "var(--ti-card-border)"}`,
                   }}
                 >
-                  Aparece só &quot;Normal&quot; no meu {deviceType === "macbook" ? "Mac" : "iPad"}
+                  Aparece só &quot;Normal&quot; no meu iPad
                 </button>
               )}
               {deviceType === "iphone" && (
@@ -818,6 +846,11 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                     <p>4. Veja o valor em <strong style={{ color: "var(--ti-text)" }}>Capacidade Maxima</strong></p>
                   </div>
                 </details>
+              )}
+              {batteryRejected && batteryRejectMessage && (
+                <div className="rounded-2xl p-4 text-center" style={{ backgroundColor: "var(--ti-error-light)", border: "1px solid var(--ti-error)" }}>
+                  <p className="text-[15px] font-semibold" style={{ color: "var(--ti-error)" }}>{batteryRejectMessage}</p>
+                </div>
               )}
             </div>
           </Section>
@@ -1045,22 +1078,43 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                 )}
               </div>
             )}
-            {q.tipo === "numeric" && (
-              <input
-                type="number"
-                inputMode="numeric"
-                value={typeof val === "number" ? String(val) : (typeof val === "string" ? val : "")}
-                onChange={(e) => {
-                  const raw = e.target.value.trim();
-                  const num = raw === "" ? undefined : Number(raw);
-                  setVal(Number.isFinite(num as number) ? (num as number) : undefined);
-                  tq(q.slug);
-                }}
-                className="w-full px-4 py-3 rounded-xl text-[15px]"
-                style={{ backgroundColor: "var(--ti-input-bg)", color: "var(--ti-text)", border: "1px solid var(--ti-input-border)" }}
-                placeholder="Ex: 500"
-              />
-            )}
+            {q.tipo === "numeric" && (() => {
+              const cfg = (q.config || {}) as Record<string, unknown>;
+              const ph = typeof cfg.placeholder === "string" ? cfg.placeholder : "Ex: 500";
+              const help = typeof cfg.helpText === "string" ? cfg.helpText : "";
+              const rb = typeof cfg.rejectBelow === "number" ? cfg.rejectBelow : undefined;
+              const rm = typeof cfg.rejectMessage === "string" ? cfg.rejectMessage : "";
+              const isRejected = typeof val === "number" && rb !== undefined && val < rb;
+              return (
+                <div className="space-y-3">
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    value={typeof val === "number" ? String(val) : (typeof val === "string" ? val : "")}
+                    onChange={(e) => {
+                      const raw = e.target.value.trim();
+                      const num = raw === "" ? undefined : Number(raw);
+                      setVal(Number.isFinite(num as number) ? (num as number) : undefined);
+                      tq(q.slug);
+                    }}
+                    className="w-full px-4 py-3 rounded-xl text-[20px] font-bold text-center"
+                    style={{ backgroundColor: "var(--ti-input-bg)", color: "var(--ti-text)", border: "1px solid var(--ti-input-border)" }}
+                    placeholder={ph}
+                  />
+                  {help && (
+                    <details className="rounded-xl p-3" style={{ backgroundColor: "var(--ti-input-bg)", border: "1px solid var(--ti-card-border)" }}>
+                      <summary className="text-[12px] font-semibold cursor-pointer" style={{ color: "var(--ti-accent)" }}>Como descobrir?</summary>
+                      <p className="text-[11px] mt-2 whitespace-pre-line" style={{ color: "var(--ti-muted)" }}>{help}</p>
+                    </details>
+                  )}
+                  {isRejected && rm && (
+                    <div className="rounded-2xl p-4 text-center" style={{ backgroundColor: "var(--ti-error-light)", border: "1px solid var(--ti-error)" }}>
+                      <p className="text-[15px] font-semibold" style={{ color: "var(--ti-error)" }}>{rm}</p>
+                    </div>
+                  )}
+                </div>
+              );
+            })()}
           </Section>
         );
       })}

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -401,45 +401,101 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
 
                 {/* Numeric (battery) config */}
                 {q.tipo === "numeric" && (
-                  <div>
-                    <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">Thresholds de desconto</label>
-                    <div className="mt-2 space-y-2">
-                      {(Array.isArray((q.config as Record<string, unknown>).thresholds) ? (q.config.thresholds as Array<{ below: number; discount: number }>) : []).map((t, ti) => (
-                        <div key={ti} className="flex items-center gap-2 bg-[#F5F5F7] rounded-lg px-3 py-2">
-                          <span className="text-xs text-[#86868B]">Abaixo de</span>
-                          <input
-                            type="number"
-                            value={t.below}
-                            onChange={(e) => {
+                  <div className="space-y-4">
+                    <div>
+                      <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">Thresholds de desconto</label>
+                      <div className="mt-2 space-y-2">
+                        {(Array.isArray((q.config as Record<string, unknown>).thresholds) ? (q.config.thresholds as Array<{ below: number; discount: number }>) : []).map((t, ti) => (
+                          <div key={ti} className="flex items-center gap-2 bg-[#F5F5F7] rounded-lg px-3 py-2">
+                            <span className="text-xs text-[#86868B]">Abaixo de</span>
+                            <input
+                              type="number"
+                              value={t.below}
+                              onChange={(e) => {
+                                const thresholds = [...(q.config.thresholds as Array<{ below: number; discount: number }>)];
+                                thresholds[ti] = { ...thresholds[ti], below: Number(e.target.value) };
+                                updateConfig(q.id, "thresholds", thresholds);
+                              }}
+                              className="w-16 px-2 py-1 rounded border border-[#D2D2D7] text-sm text-center focus:outline-none focus:border-[#E8740E]"
+                            />
+                            <span className="text-xs text-[#86868B]">% → desconto R$</span>
+                            <input
+                              type="number"
+                              value={t.discount}
+                              onChange={(e) => {
+                                const thresholds = [...(q.config.thresholds as Array<{ below: number; discount: number }>)];
+                                thresholds[ti] = { ...thresholds[ti], discount: Number(e.target.value) };
+                                updateConfig(q.id, "thresholds", thresholds);
+                              }}
+                              className="w-20 px-2 py-1 rounded border border-[#D2D2D7] text-sm text-center focus:outline-none focus:border-[#E8740E]"
+                            />
+                            <button onClick={() => {
                               const thresholds = [...(q.config.thresholds as Array<{ below: number; discount: number }>)];
-                              thresholds[ti] = { ...thresholds[ti], below: Number(e.target.value) };
+                              thresholds.splice(ti, 1);
                               updateConfig(q.id, "thresholds", thresholds);
-                            }}
-                            className="w-16 px-2 py-1 rounded border border-[#D2D2D7] text-sm text-center focus:outline-none focus:border-[#E8740E]"
-                          />
-                          <span className="text-xs text-[#86868B]">% → desconto R$</span>
-                          <input
-                            type="number"
-                            value={t.discount}
-                            onChange={(e) => {
-                              const thresholds = [...(q.config.thresholds as Array<{ below: number; discount: number }>)];
-                              thresholds[ti] = { ...thresholds[ti], discount: Number(e.target.value) };
-                              updateConfig(q.id, "thresholds", thresholds);
-                            }}
-                            className="w-20 px-2 py-1 rounded border border-[#D2D2D7] text-sm text-center focus:outline-none focus:border-[#E8740E]"
-                          />
-                          <button onClick={() => {
-                            const thresholds = [...(q.config.thresholds as Array<{ below: number; discount: number }>)];
-                            thresholds.splice(ti, 1);
-                            updateConfig(q.id, "thresholds", thresholds);
-                          }} className="text-red-400 hover:text-red-600 text-xs">✕</button>
-                        </div>
-                      ))}
-                      <button onClick={() => {
-                        const current = Array.isArray((q.config as Record<string, unknown>).thresholds) ? [...(q.config.thresholds as Array<{ below: number; discount: number }>)] : [];
-                        current.push({ below: 80, discount: -200 });
-                        updateConfig(q.id, "thresholds", current);
-                      }} className="text-xs font-semibold text-[#E8740E] hover:underline mt-1">+ Adicionar threshold</button>
+                            }} className="text-red-400 hover:text-red-600 text-xs">✕</button>
+                          </div>
+                        ))}
+                        <button onClick={() => {
+                          const current = Array.isArray((q.config as Record<string, unknown>).thresholds) ? [...(q.config.thresholds as Array<{ below: number; discount: number }>)] : [];
+                          current.push({ below: 80, discount: -200 });
+                          updateConfig(q.id, "thresholds", current);
+                        }} className="text-xs font-semibold text-[#E8740E] hover:underline mt-1">+ Adicionar threshold</button>
+                      </div>
+                    </div>
+
+                    <div>
+                      <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">Placeholder do input</label>
+                      <input
+                        type="text"
+                        value={typeof (q.config as Record<string, unknown>).placeholder === "string" ? (q.config.placeholder as string) : ""}
+                        onChange={(e) => updateConfig(q.id, "placeholder", e.target.value)}
+                        placeholder="Ex: 87"
+                        className="mt-1 w-full px-3 py-2 rounded border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                      />
+                    </div>
+
+                    <div>
+                      <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">Texto de ajuda (&quot;Como descobrir?&quot;)</label>
+                      <textarea
+                        value={typeof (q.config as Record<string, unknown>).helpText === "string" ? (q.config.helpText as string) : ""}
+                        onChange={(e) => updateConfig(q.id, "helpText", e.target.value)}
+                        placeholder="Ajustes > Bateria > Saude da Bateria"
+                        rows={3}
+                        className="mt-1 w-full px-3 py-2 rounded border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                      />
+                      <p className="mt-1 text-[11px] text-[#86868B]">Aparece como painel expansivel &quot;Como descobrir?&quot; abaixo do input.</p>
+                    </div>
+
+                    <div className="border-t border-[#E5E5EA] pt-3">
+                      <label className="text-xs font-semibold text-red-600 uppercase tracking-wider">Rejeicao por valor minimo</label>
+                      <p className="mt-1 text-[11px] text-[#86868B]">Se o cliente digitar um valor menor que &quot;Rejeitar abaixo de&quot;, mostra a mensagem e bloqueia as perguntas seguintes.</p>
+                      <div className="mt-2 flex items-center gap-2">
+                        <span className="text-xs text-[#86868B]">Rejeitar abaixo de</span>
+                        <input
+                          type="number"
+                          value={typeof (q.config as Record<string, unknown>).rejectBelow === "number" ? String((q.config.rejectBelow as number)) : ""}
+                          onChange={(e) => {
+                            const raw = e.target.value.trim();
+                            if (raw === "") {
+                              const next = { ...q.config } as Record<string, unknown>;
+                              delete next.rejectBelow;
+                              updateQuestion(q.id, { config: next });
+                            } else {
+                              updateConfig(q.id, "rejectBelow", Number(raw));
+                            }
+                          }}
+                          placeholder="Ex: 80"
+                          className="w-24 px-2 py-1 rounded border border-[#D2D2D7] text-sm text-center focus:outline-none focus:border-red-500"
+                        />
+                      </div>
+                      <textarea
+                        value={typeof (q.config as Record<string, unknown>).rejectMessage === "string" ? (q.config.rejectMessage as string) : ""}
+                        onChange={(e) => updateConfig(q.id, "rejectMessage", e.target.value)}
+                        placeholder="Ex: Infelizmente nao aceitamos aparelhos com saude de bateria abaixo de 80%."
+                        rows={2}
+                        className="mt-2 w-full px-3 py-2 rounded border border-[#D2D2D7] text-sm focus:outline-none focus:border-red-500"
+                      />
                     </div>
                   </div>
                 )}


### PR DESCRIPTION
## Resumo

Implementa a feature pedida: admin pode configurar em `/admin/simulacoes` pra qualquer pergunta numerica uma rejeicao automatica por valor minimo, mostrando uma mensagem customizada e bloqueando o avanco.

Cobre os casos:
- Saude de bateria % pro **Apple Watch** (pergunta hardcoded `battery`)
- Saude de bateria % pro **MacBook** (pergunta dynamic criada no admin)
- Qualquer outra pergunta numerica custom

## Novos campos no admin (pergunta tipo numeric)

- **Placeholder do input** — texto que aparece quando campo vazio
- **Texto de ajuda** ("Como descobrir?") — painel expansivel abaixo do input
- **Rejeitar abaixo de** + **Mensagem de rejeicao** — threshold + texto em vermelho

## Comportamento no /troca

- Cliente digita valor `<` rejectBelow → mensagem em vermelho aparece
- `canProceed` fica false, botao "Ver minha avaliacao" some
- Perguntas posteriores nao renderizam (`isPriorRejecting` trata battery e dynamic numeric)

## Mudanca secundaria

Removido o botao "Aparece so Normal no meu Mac" da pergunta de ciclos do MacBook — ciclos vem sempre como numero; o botao so faz sentido em saude % (iPad), onde foi mantido.

## Test plan

- [x] Fluxo iPhone continua funcionando ponta-a-ponta (regressao)
- [x] Fluxo MacBook — ciclos nao tem mais botao "Normal", avanca pra marcas → pecas → garantia → caixa
- [ ] Cadastrar pergunta numeric nova em /admin/simulacoes com rejectBelow=80 + rejectMessage, testar no cliente com valor 70 (deve bloquear)
- [ ] Cadastrar saude de bateria pro Watch com rejectBelow=80, testar

🤖 Generated with [Claude Code](https://claude.com/claude-code)