### PR TITLE
feat(sku): Fase 2+3 — auto-populacao em POSTs + JOIN por SKU + dashboard top SKUs

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { TopSkusSection } from "@/components/admin/TopSkusSection";
 
 interface FunnelStep {
   step: number;
@@ -339,6 +340,9 @@ export default function AnalyticsPage() {
           </div>
         );
       })()}
+
+      {/* Top SKUs (vendas/simulacoes/encomendas por SKU canonico) */}
+      <TopSkusSection password={password} range={range} />
 
       {/* Daily chart (simple bar chart) */}
       {data.daily.length > 0 && (

--- a/app/api/admin/avisos-clientes/route.ts
+++ b/app/api/admin/avisos-clientes/route.ts
@@ -23,21 +23,29 @@ export async function GET(req: NextRequest) {
 
   const [{ data, error }, estoqueRes] = await Promise.all([
     q,
-    supabase.from("estoque").select("id,produto,cor,qnt,status,observacao,categoria").gt("qnt", 0).eq("status", "EM ESTOQUE"),
+    supabase.from("estoque").select("id,produto,cor,qnt,status,observacao,categoria,sku").gt("qnt", 0).eq("status", "EM ESTOQUE"),
   ]);
   if (error) return NextResponse.json({ error: error.message }, { status: 500, headers: noCache });
 
   const estoque = (estoqueRes.data || []) as EstoqueLinha[];
   const enriched = (data || []).map(a => {
-    const { matches, disponivel_qnt } = annotateAvisoComEstoque(a.produto_desejado || "", estoque);
+    // a.sku existe a partir da migration Fase 3a (coluna adicionada em avisos_clientes).
+    // Antes disso, fica undefined e o matching cai no fuzzy — funciona igual.
+    const { matches, disponivel_qnt, matchedBySku } = annotateAvisoComEstoque(
+      a.produto_desejado || "",
+      estoque,
+      a.sku as string | null | undefined,
+    );
     return {
       ...a,
       disponivel_qnt,
+      matched_by_sku: !!matchedBySku,
       estoque_matches: matches.slice(0, 5).map(m => ({
         id: m.id,
         produto: m.produto,
         cor: m.cor,
         qnt: m.qnt,
+        sku: m.sku,
       })),
     };
   });

--- a/app/api/admin/link-compras/route.ts
+++ b/app/api/admin/link-compras/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { logActivity } from "@/lib/activity-log";
 import { entregaFromLink } from "@/lib/entrega-from-link";
+import { gerarSkuSafe, detectarCategoriaPorTexto } from "@/lib/sku";
 
 function auth(request: Request) {
   const pw = request.headers.get("x-admin-password");
@@ -225,6 +226,17 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "short_code e produto são obrigatórios" }, { status: 400 });
   }
 
+  // Auto-popular SKU canonico. Detecta categoria pelo nome do produto
+  // (link_compras nao guarda categoria separada). Sempre tipo NOVO.
+  const sku = gerarSkuSafe({
+    produto: payload.produto,
+    categoria: detectarCategoriaPorTexto(payload.produto),
+    cor: payload.cor,
+    observacao: null,
+    tipo: "NOVO",
+  });
+  if (sku) (payload as Record<string, unknown>).sku = sku;
+
   // Idempotencia: se ja existe link com esse short_code, nao cria novo.
   // Protege contra caso do frontend perder `editingLinkId` e cair aqui em vez
   // do PATCH — resultado seria duplicacao. Em vez de criar, retornamos o
@@ -270,6 +282,21 @@ export async function PATCH(request: Request) {
   // produtos_extras deve ser salvo como JSON string
   if (allowed.produtos_extras && Array.isArray(allowed.produtos_extras)) {
     allowed.produtos_extras = JSON.stringify(allowed.produtos_extras);
+  }
+  // Regerar SKU se editou produto ou cor
+  if ("produto" in allowed || "cor" in allowed) {
+    const produtoFinal = String(allowed.produto || "");
+    const corFinal = (allowed.cor as string | null | undefined) ?? null;
+    if (produtoFinal) {
+      const novoSku = gerarSkuSafe({
+        produto: produtoFinal,
+        categoria: detectarCategoriaPorTexto(produtoFinal),
+        cor: corFinal,
+        observacao: null,
+        tipo: "NOVO",
+      });
+      if (novoSku) allowed.sku = novoSku;
+    }
   }
   allowed.updated_at = new Date().toISOString();
 

--- a/app/api/admin/mostruario/route.ts
+++ b/app/api/admin/mostruario/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { logActivity } from "@/lib/activity-log";
+import { gerarSkuSafe } from "@/lib/sku";
+import { lojaCatToEstoqueCat } from "@/lib/loja-estoque-match";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 function auth(req: NextRequest) {
   return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
@@ -12,6 +15,36 @@ function slugify(text: string): string {
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
+}
+
+// Gera SKU canonico pra uma variacao do mostruario. Faz JOIN com loja_produtos
+// pra pegar o nome do produto pai + categoria via slug. Retorna null se nao
+// conseguir gerar (input invalido). Mostruario sempre conta como NOVO/lacrado.
+async function gerarSkuVariacao(
+  supabase: SupabaseClient,
+  produtoId: string,
+  varNome: string,
+  atributos: Record<string, unknown> | null,
+): Promise<string | null> {
+  const { data: prod } = await supabase
+    .from("loja_produtos")
+    .select("nome, loja_categorias:categoria_id(slug)")
+    .eq("id", produtoId)
+    .single();
+  if (!prod) return null;
+  // categoria_id vem como objeto unico (FK 1-1), nao array
+  const cat = (prod as { loja_categorias?: { slug?: string } | null }).loja_categorias;
+  const slug = cat?.slug || "";
+  const categoria = lojaCatToEstoqueCat(slug);
+  const produtoNome = `${(prod as { nome?: string }).nome || ""} ${varNome || ""}`.trim();
+  const cor = (atributos?.cor as string | null) ?? null;
+  return gerarSkuSafe({
+    produto: produtoNome,
+    categoria,
+    cor,
+    observacao: null,
+    tipo: "NOVO",
+  });
 }
 
 // GET — list all data: categorias, produtos (with variacoes), config
@@ -203,6 +236,10 @@ export async function POST(req: NextRequest) {
     if (preco_parcelado !== undefined) row.preco_parcelado = preco_parcelado;
     if (imagem_url) row.imagem_url = imagem_url;
 
+    // Auto-popular SKU canonico
+    const sku = await gerarSkuVariacao(supabase, produto_id, nome, atributos ?? {});
+    if (sku) row.sku = sku;
+
     const { data, error } = await supabase
       .from("loja_variacoes")
       .insert(row)
@@ -286,6 +323,24 @@ export async function PATCH(req: NextRequest) {
     if (update.preco !== undefined) update.preco = Number(update.preco);
 
     if (Object.keys(update).length === 0) return NextResponse.json({ error: "No fields to update" }, { status: 400 });
+
+    // Regerar SKU se mudou nome ou atributos (cor). Busca produto_id atual da
+    // variacao pra resolver o pai. Se algo falhar, mantem o SKU antigo.
+    if ("nome" in update || "atributos" in update) {
+      try {
+        const { data: varAtual } = await supabase
+          .from("loja_variacoes")
+          .select("produto_id, nome, atributos")
+          .eq("id", id)
+          .single();
+        if (varAtual?.produto_id) {
+          const nomeFinal = (update.nome as string | undefined) ?? varAtual.nome;
+          const attrsFinal = (update.atributos as Record<string, unknown> | undefined) ?? varAtual.atributos ?? {};
+          const novoSku = await gerarSkuVariacao(supabase, varAtual.produto_id, nomeFinal, attrsFinal);
+          if (novoSku) update.sku = novoSku;
+        }
+      } catch { /* mantem SKU antigo */ }
+    }
 
     const { error } = await supabase.from("loja_variacoes").update(update).eq("id", id);
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/app/api/admin/sku/backfill/route.ts
+++ b/app/api/admin/sku/backfill/route.ts
@@ -6,14 +6,19 @@
 //   POST              → executa de verdade
 //   POST ?force=1     → sobrescreve SKUs já existentes
 //
-// Tabelas processadas: estoque, loja_variacoes, avaliacao_usados.
+// Tabelas processadas:
+//   Fase 1: estoque, loja_variacoes, avaliacao_usados
+//   Fase 3: vendas, encomendas, link_compras, simulacoes
+//
+// Pra vendas/encomendas, prefere copiar SKU do estoque vinculado quando
+// existe. Senao gera do texto livre via lib/sku.
 
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
-import { gerarSku, type ProdutoInput } from "@/lib/sku";
+import { gerarSku, detectarCategoriaPorTexto, type ProdutoInput } from "@/lib/sku";
 
 export const dynamic = "force-dynamic";
-export const maxDuration = 120; // 2 minutos pra processar tudo
+export const maxDuration = 300; // 5 minutos pra processar tudo (vendas/links podem ter muitas rows)
 
 function auth(req: NextRequest) {
   return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
@@ -30,16 +35,8 @@ interface BackfillStats {
   exemplosFalha: Array<{ id: string; produto: string; categoria: string }>;
 }
 
-function detectarCategoria(modelo: string): string {
-  const up = (modelo || "").toUpperCase();
-  if (/IPHONE/.test(up)) return "IPHONES";
-  if (/IPAD/.test(up)) return "IPADS";
-  if (/MAC.*MINI/.test(up)) return "MAC_MINI";
-  if (/MACBOOK/.test(up)) return "MACBOOK";
-  if (/WATCH/.test(up)) return "APPLE_WATCH";
-  if (/AIRPODS/.test(up)) return "AIRPODS";
-  return "OUTROS";
-}
+// Wrapper pra continuar funcionando — agora reaproveita o helper compartilhado
+const detectarCategoria = detectarCategoriaPorTexto;
 
 async function processarTabela(
   tabela: string,
@@ -196,7 +193,134 @@ async function rodarBackfill(opts: { dry: boolean; force: boolean }): Promise<Ba
     tipo: "SEMINOVO",
   }), opts));
 
+  // ─── Fase 3: tabelas transacionais ───────────────────────────────
+
+  // vendas: prefere SKU do estoque vinculado quando existe; senao gera do texto.
+  results.push(await processarTabelaComEstoqueLookup("vendas", (row) => ({
+    produto: row.produto,
+    categoria: row.categoria || detectarCategoria(row.produto || ""),
+    cor: row.cor,
+    observacao: null,
+    tipo: "NOVO",
+  }), opts));
+
+  // encomendas: idem vendas. Tem coluna estoque_id quando vinculado.
+  results.push(await processarTabelaComEstoqueLookup("encomendas", (row) => ({
+    produto: row.produto,
+    categoria: row.categoria || detectarCategoria(row.produto || ""),
+    cor: row.cor,
+    observacao: null,
+    tipo: "NOVO",
+  }), opts));
+
+  // link_compras: nao tem estoque_id direto, sempre gera do texto.
+  results.push(await processarTabela("link_compras", (row) => ({
+    produto: row.produto,
+    categoria: detectarCategoria(row.produto || ""),
+    cor: row.cor,
+    observacao: null,
+    tipo: "NOVO",
+  }), opts));
+
+  // simulacoes: SKU representa o produto NOVO desejado (foco da troca).
+  results.push(await processarTabela("simulacoes", (row) => ({
+    produto: `${row.modelo_novo || ""} ${row.storage_novo || ""}`.trim(),
+    categoria: detectarCategoria(row.modelo_novo || ""),
+    cor: null,
+    observacao: null,
+    tipo: "NOVO",
+  }), opts));
+
   return results;
+}
+
+// Variante de processarTabela pra vendas/encomendas: pra cada row com
+// estoque_id, tenta copiar SKU do estoque (mais confiavel — ja passou pelo
+// gerador validado). Se nao tem estoque_id ou estoque sem SKU, cai no mapper
+// generico (gera do texto).
+async function processarTabelaComEstoqueLookup(
+  tabela: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mapper: (row: any) => ProdutoInput | null,
+  opts: { dry: boolean; force: boolean },
+): Promise<BackfillStats> {
+  const stats: BackfillStats = {
+    tabela,
+    total: 0, sucesso: 0, falha: 0, baixaConfianca: 0, skusUnicos: 0,
+    topSkus: [], exemplosFalha: [],
+  };
+
+  let query = supabase.from(tabela).select("*");
+  if (!opts.force) query = query.is("sku", null);
+  const { data: rows, error } = await query;
+  if (error) throw new Error(`${tabela}: ${error.message}`);
+  if (!rows || rows.length === 0) return stats;
+
+  stats.total = rows.length;
+
+  // Coleta estoque_ids existentes pra um lookup batch
+  const estoqueIds = [...new Set(
+    rows.map((r) => (r as { estoque_id?: string | null }).estoque_id).filter(Boolean),
+  )] as string[];
+  const skuByEstoqueId = new Map<string, string>();
+  if (estoqueIds.length > 0) {
+    const { data: estItems } = await supabase
+      .from("estoque")
+      .select("id, sku")
+      .in("id", estoqueIds);
+    for (const e of estItems || []) {
+      if (e.sku) skuByEstoqueId.set(e.id, e.sku);
+    }
+  }
+
+  const updates: Array<{ id: string; sku: string }> = [];
+  const skuCount = new Map<string, number>();
+
+  for (const row of rows) {
+    const estId = (row as { estoque_id?: string | null }).estoque_id;
+    let sku: string | null = null;
+
+    // Path 1: copia do estoque vinculado
+    if (estId && skuByEstoqueId.has(estId)) {
+      sku = skuByEstoqueId.get(estId)!;
+      stats.sucesso++;
+    } else {
+      // Path 2: gera do texto via mapper
+      const input = mapper(row);
+      if (!input || !input.produto) {
+        stats.falha++;
+        if (stats.exemplosFalha.length < 5) {
+          stats.exemplosFalha.push({ id: row.id, produto: input?.produto || "(vazio)", categoria: input?.categoria || "" });
+        }
+        continue;
+      }
+      const result = gerarSku(input);
+      if (!result.sku) {
+        stats.falha++;
+        if (stats.exemplosFalha.length < 5) {
+          stats.exemplosFalha.push({ id: row.id, produto: (input.produto || "").slice(0, 80), categoria: input.categoria });
+        }
+        continue;
+      }
+      sku = result.sku;
+      stats.sucesso++;
+      if (result.confianca < 100) stats.baixaConfianca++;
+    }
+
+    skuCount.set(sku, (skuCount.get(sku) || 0) + 1);
+    updates.push({ id: row.id, sku });
+  }
+
+  stats.skusUnicos = skuCount.size;
+  stats.topSkus = [...skuCount.entries()]
+    .sort((a, b) => b[1] - a[1]).slice(0, 5)
+    .map(([sku, count]) => ({ sku, count }));
+
+  if (opts.dry) return stats;
+  for (const u of updates) {
+    await supabase.from(tabela).update({ sku: u.sku }).eq("id", u.id);
+  }
+  return stats;
 }
 
 export async function GET(req: NextRequest) {

--- a/app/api/admin/sku/sugerir/route.ts
+++ b/app/api/admin/sku/sugerir/route.ts
@@ -1,0 +1,54 @@
+// app/api/admin/sku/sugerir/route.ts
+// Endpoint que recebe os dados de um produto e retorna o SKU canonico
+// sugerido. Util pra UI mostrar o SKU em tempo real (ex: enquanto admin
+// digita um novo item de estoque, mostrar "vai virar IPHONE-17-PRO-256...").
+//
+// Uso:
+//   POST { produto, categoria, cor?, observacao?, tipo? } → SkuResult
+//   GET  ?produto=...&categoria=...&cor=...               → SkuResult
+
+import { NextRequest, NextResponse } from "next/server";
+import { gerarSku, type ProdutoInput } from "@/lib/sku";
+
+export const dynamic = "force-dynamic";
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+function processarInput(input: ProdutoInput) {
+  if (!input?.produto || typeof input.produto !== "string") {
+    return NextResponse.json({ error: "campo 'produto' obrigatorio" }, { status: 400 });
+  }
+  const result = gerarSku({
+    produto: input.produto,
+    categoria: input.categoria || "",
+    cor: input.cor ?? null,
+    observacao: input.observacao ?? null,
+    tipo: input.tipo ?? null,
+  });
+  return NextResponse.json({ ok: true, ...result });
+}
+
+export async function POST(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  let body: ProdutoInput;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "body invalido" }, { status: 400 });
+  }
+  return processarInput(body);
+}
+
+export async function GET(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const sp = req.nextUrl.searchParams;
+  return processarInput({
+    produto: sp.get("produto") || "",
+    categoria: sp.get("categoria") || "",
+    cor: sp.get("cor"),
+    observacao: sp.get("observacao"),
+    tipo: sp.get("tipo"),
+  });
+}

--- a/app/api/admin/sku/top-vendidos/route.ts
+++ b/app/api/admin/sku/top-vendidos/route.ts
@@ -1,0 +1,168 @@
+// app/api/admin/sku/top-vendidos/route.ts
+// Dashboard agregado por SKU canonico — mostra rapidamente quais produtos
+// estao saindo mais (vendas), quais clientes mais querem (simulacoes), e o
+// pipeline em aberto (encomendas pendentes).
+//
+// Uso:
+//   GET ?range=7d|30d|90d|all  (default 30d)
+//
+// Cada bucket retorna top 20 SKUs ordenados por volume.
+
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { parseSku } from "@/lib/sku";
+
+export const dynamic = "force-dynamic";
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+function getDateFrom(range: string): string | null {
+  const now = Date.now();
+  const days = range === "7d" ? 7 : range === "30d" ? 30 : range === "90d" ? 90 : null;
+  if (days === null) return null;
+  return new Date(now - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+interface SkuAggVenda {
+  sku: string;
+  total: number;
+  valor_total: number;
+  ticket_medio: number;
+  modelo: string;
+  seminovo: boolean;
+}
+
+interface SkuAggGenerico {
+  sku: string;
+  total: number;
+  modelo: string;
+  seminovo: boolean;
+}
+
+interface SkuAggEncomenda extends SkuAggGenerico {
+  pendentes: number;
+}
+
+function modeloLegivelDoSku(sku: string): { modelo: string; seminovo: boolean } {
+  const parsed = parseSku(sku);
+  if (!parsed) return { modelo: sku, seminovo: false };
+  // Modelo + primeira spec geralmente eh o suficiente pra display
+  // (ex: "IPHONE-17-PRO" + "256GB")
+  const modelo = [parsed.modelo, parsed.specs[0]].filter(Boolean).join(" ");
+  return { modelo, seminovo: parsed.seminovo };
+}
+
+export async function GET(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const range = req.nextUrl.searchParams.get("range") || "30d";
+  const dataFrom = getDateFrom(range);
+  const limit = 20;
+
+  try {
+    // ─── Vendas: agrega volume + faturamento por SKU ────────────────
+    let qVendas = supabase.from("vendas").select("sku, preco_vendido, data, status_pagamento").not("sku", "is", null);
+    if (dataFrom) qVendas = qVendas.gte("data", dataFrom.slice(0, 10));
+    const { data: vendasRows } = await qVendas;
+    const vendasMap = new Map<string, { total: number; valor: number }>();
+    for (const r of vendasRows || []) {
+      const sku = r.sku as string;
+      // Excluir vendas canceladas/estornadas do agregado
+      const status = String(r.status_pagamento || "").toUpperCase();
+      if (status === "CANCELADO" || status === "ESTORNADO") continue;
+      const cur = vendasMap.get(sku) || { total: 0, valor: 0 };
+      cur.total += 1;
+      cur.valor += Number(r.preco_vendido || 0);
+      vendasMap.set(sku, cur);
+    }
+    const vendas: SkuAggVenda[] = [...vendasMap.entries()]
+      .map(([sku, v]) => {
+        const { modelo, seminovo } = modeloLegivelDoSku(sku);
+        return {
+          sku,
+          total: v.total,
+          valor_total: v.valor,
+          ticket_medio: v.total > 0 ? Math.round(v.valor / v.total) : 0,
+          modelo,
+          seminovo,
+        };
+      })
+      .sort((a, b) => b.total - a.total)
+      .slice(0, limit);
+
+    // ─── Simulacoes: agrega volume por SKU (interesse de compra) ────
+    let qSim = supabase.from("simulacoes").select("sku, created_at").not("sku", "is", null);
+    if (dataFrom) qSim = qSim.gte("created_at", dataFrom);
+    const { data: simRows } = await qSim;
+    const simMap = new Map<string, number>();
+    for (const r of simRows || []) {
+      const sku = r.sku as string;
+      simMap.set(sku, (simMap.get(sku) || 0) + 1);
+    }
+    const simulacoes: SkuAggGenerico[] = [...simMap.entries()]
+      .map(([sku, total]) => {
+        const { modelo, seminovo } = modeloLegivelDoSku(sku);
+        return { sku, total, modelo, seminovo };
+      })
+      .sort((a, b) => b.total - a.total)
+      .slice(0, limit);
+
+    // ─── Encomendas: agrega volume + pendentes por SKU ──────────────
+    let qEnc = supabase.from("encomendas").select("sku, status, created_at").not("sku", "is", null);
+    if (dataFrom) qEnc = qEnc.gte("created_at", dataFrom);
+    const { data: encRows } = await qEnc;
+    const encMap = new Map<string, { total: number; pendentes: number }>();
+    for (const r of encRows || []) {
+      const sku = r.sku as string;
+      const status = String(r.status || "").toUpperCase();
+      const cur = encMap.get(sku) || { total: 0, pendentes: 0 };
+      cur.total += 1;
+      // Status "abertos" — ajuste conforme convencao das encomendas
+      if (status === "PENDENTE" || status === "COMPRADO" || status === "A CAMINHO") {
+        cur.pendentes += 1;
+      }
+      encMap.set(sku, cur);
+    }
+    const encomendas: SkuAggEncomenda[] = [...encMap.entries()]
+      .map(([sku, v]) => {
+        const { modelo, seminovo } = modeloLegivelDoSku(sku);
+        return { sku, total: v.total, pendentes: v.pendentes, modelo, seminovo };
+      })
+      .sort((a, b) => b.pendentes - a.pendentes || b.total - a.total)
+      .slice(0, limit);
+
+    // ─── Estoque atual por SKU (pra cruzar com vendas) ──────────────
+    const { data: estoqueRows } = await supabase
+      .from("estoque")
+      .select("sku, qnt, status")
+      .not("sku", "is", null)
+      .eq("status", "EM ESTOQUE");
+    const estoqueMap = new Map<string, number>();
+    for (const r of estoqueRows || []) {
+      const sku = r.sku as string;
+      estoqueMap.set(sku, (estoqueMap.get(sku) || 0) + Number(r.qnt || 0));
+    }
+    // Annotate vendas com qnt em estoque agora
+    const vendasComEstoque = vendas.map((v) => ({
+      ...v,
+      em_estoque: estoqueMap.get(v.sku) || 0,
+    }));
+
+    return NextResponse.json({
+      ok: true,
+      range,
+      vendas: vendasComEstoque,
+      simulacoes,
+      encomendas,
+      meta: {
+        vendas_unicas: vendasMap.size,
+        simulacoes_unicas: simMap.size,
+        encomendas_unicas: encMap.size,
+      },
+    });
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/app/api/admin/usados/route.ts
+++ b/app/api/admin/usados/route.ts
@@ -1,9 +1,28 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { fetchUsedValues, fetchExcludedModels, fetchDiscountRules, fetchModelDiscounts } from "@/lib/sheets";
+import { gerarSkuSafe, detectarCategoriaPorTexto } from "@/lib/sku";
 
 function auth(req: NextRequest) {
   return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+// Auto-popular SKU canonico em rows de avaliacao_usados.
+// Sempre tipo=SEMINOVO; categoria detectada pelo nome do modelo.
+// Sem cor (avaliacao_usados nao guarda cor — preco e o mesmo independente).
+function addSkuUsado(row: Record<string, unknown>): void {
+  if (row.sku) return;
+  const modelo = String(row.modelo || "");
+  const storage = String(row.armazenamento || "");
+  if (!modelo) return;
+  const sku = gerarSkuSafe({
+    produto: `${modelo} ${storage}`.trim(),
+    categoria: detectarCategoriaPorTexto(modelo),
+    cor: null,
+    observacao: null,
+    tipo: "SEMINOVO",
+  });
+  if (sku) row.sku = sku;
 }
 
 // PUT: Importar tudo do Google Sheets para o Supabase
@@ -26,12 +45,16 @@ export async function PUT(req: NextRequest) {
 
     // 1. Valores Base
     if (usedValues.length > 0) {
-      const rows = usedValues.map((v) => ({
-        modelo: v.modelo,
-        armazenamento: v.armazenamento,
-        valor_base: v.valorBase,
-        updated_at: now,
-      }));
+      const rows = usedValues.map((v) => {
+        const row: Record<string, unknown> = {
+          modelo: v.modelo,
+          armazenamento: v.armazenamento,
+          valor_base: v.valorBase,
+          updated_at: now,
+        };
+        addSkuUsado(row);
+        return row;
+      });
       const { error } = await supabase.from("avaliacao_usados").upsert(rows, { onConflict: "modelo,armazenamento" });
       if (!error) importedValores = rows.length;
     }
@@ -118,8 +141,10 @@ export async function POST(req: NextRequest) {
 
   if (action === "upsert_valor") {
     const { modelo, armazenamento, valor_base } = body;
+    const row: Record<string, unknown> = { modelo, armazenamento, valor_base, updated_at: new Date().toISOString() };
+    addSkuUsado(row);
     const { error } = await supabase.from("avaliacao_usados").upsert(
-      { modelo, armazenamento, valor_base, updated_at: new Date().toISOString() },
+      row,
       { onConflict: "modelo,armazenamento" }
     );
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
@@ -327,8 +352,13 @@ export async function POST(req: NextRequest) {
     const defaults = body.valores as { modelo: string; armazenamento: string; valor_base: number }[];
     if (!defaults?.length) return NextResponse.json({ error: "valores required" }, { status: 400 });
 
+    const rows = defaults.map((d) => {
+      const row: Record<string, unknown> = { ...d, updated_at: new Date().toISOString() };
+      addSkuUsado(row);
+      return row;
+    });
     const { error } = await supabase.from("avaliacao_usados").upsert(
-      defaults.map((d) => ({ ...d, updated_at: new Date().toISOString() })),
+      rows,
       { onConflict: "modelo,armazenamento" }
     );
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });

--- a/app/api/encomendas/route.ts
+++ b/app/api/encomendas/route.ts
@@ -1,9 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { logActivity } from "@/lib/activity-log";
+import { gerarSkuSafe, detectarCategoriaPorTexto } from "@/lib/sku";
 
 function auth(req: NextRequest) {
   return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+// Gera SKU pra encomenda. Se vinculada a estoque (estoque_id), usa o SKU
+// do estoque. Senao gera do texto livre.
+async function resolverSkuEncomenda(body: Record<string, unknown>): Promise<string | null> {
+  if (body.estoque_id) {
+    const { data } = await supabase.from("estoque").select("sku").eq("id", body.estoque_id).single();
+    if (data?.sku) return data.sku as string;
+  }
+  if (!body.produto) return null;
+  return gerarSkuSafe({
+    produto: String(body.produto),
+    categoria: String(body.categoria || detectarCategoriaPorTexto(body.produto as string)),
+    cor: (body.cor as string | null) ?? null,
+    observacao: null,
+    tipo: "NOVO",
+  });
 }
 
 export async function GET(req: NextRequest) {
@@ -17,6 +35,9 @@ export async function POST(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const body = await req.json();
   if (body.cliente) body.cliente = String(body.cliente).toUpperCase();
+  // Auto-popular SKU (do estoque vinculado OU do texto livre)
+  const sku = await resolverSkuEncomenda(body);
+  if (sku && !body.sku) body.sku = sku;
   const { data, error } = await supabase.from("encomendas").insert({ ...body, updated_at: new Date().toISOString() }).select().single();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
@@ -37,14 +58,14 @@ export async function PATCH(req: NextRequest) {
   if (!id) return NextResponse.json({ error: "id required" }, { status: 400 });
   if (fields.cliente) fields.cliente = String(fields.cliente).toUpperCase();
 
-  // Vincular: se estoque_id foi passado, sincroniza produto/cor/custo/fornecedor
+  // Vincular: se estoque_id foi passado, sincroniza produto/cor/custo/fornecedor/sku
   // da encomenda com o item de estoque. Senao admin corrige nome no estoque,
   // re-vincula, e a encomenda continua com o snapshot velho (ex: M4 no lugar
   // de M5 depois da correcao do modelo).
   if ("estoque_id" in fields && fields.estoque_id) {
     const { data: estItem } = await supabase
       .from("estoque")
-      .select("produto, cor, categoria, custo_compra, custo_unitario, fornecedor")
+      .select("produto, cor, categoria, custo_compra, custo_unitario, fornecedor, sku")
       .eq("id", fields.estoque_id)
       .single();
     if (estItem) {
@@ -52,9 +73,19 @@ export async function PATCH(req: NextRequest) {
       if (estItem.cor) fields.cor = estItem.cor;
       if (estItem.categoria) fields.categoria = estItem.categoria;
       if (estItem.fornecedor) fields.fornecedor = estItem.fornecedor;
+      if (estItem.sku) fields.sku = estItem.sku;
       const custoEst = Number(estItem.custo_compra || estItem.custo_unitario || 0);
       if (custoEst > 0) fields.custo = custoEst;
     }
+  }
+
+  // Regerar SKU se editou produto/cor/categoria sem re-vincular estoque
+  if (
+    !("estoque_id" in fields) &&
+    ("produto" in fields || "cor" in fields || "categoria" in fields)
+  ) {
+    const novoSku = await resolverSkuEncomenda(fields);
+    if (novoSku) fields.sku = novoSku;
   }
 
   const { error } = await supabase.from("encomendas").update({ ...fields, updated_at: new Date().toISOString() }).eq("id", id);

--- a/app/api/estoque/route.ts
+++ b/app/api/estoque/route.ts
@@ -4,6 +4,22 @@ import { logActivity } from "@/lib/activity-log";
 import { hasPermission } from "@/lib/permissions";
 import { recalcBalancos } from "@/lib/recalc-balancos";
 import { getModeloBase } from "@/lib/produto-display";
+import { gerarSkuSafe } from "@/lib/sku";
+
+// Auto-popular SKU canonico em rows novas/editadas. Centralizado pra
+// garantir que todo insert/upsert no estoque grave o SKU consistente.
+// Mutates row.sku in-place; nao sobrescreve se ja vier preenchido no body.
+function addSkuToRow(row: Record<string, unknown>): void {
+  if (row.sku) return;
+  const sku = gerarSkuSafe({
+    produto: String(row.produto || ""),
+    categoria: String(row.categoria || ""),
+    cor: (row.cor as string | null) ?? null,
+    observacao: (row.observacao as string | null) ?? null,
+    tipo: (row.tipo as string | null) ?? null,
+  });
+  if (sku) row.sku = sku;
+}
 
 function auth(req: NextRequest) {
   return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
@@ -246,6 +262,7 @@ export async function POST(req: NextRequest) {
     if (row.produto && typeof row.produto === "string") row.produto = normalizeProdutoNome(row.produto.trim());
     row.updated_at = new Date().toISOString();
     if (row.custo_compra == null) row.custo_compra = row.custo_unitario;
+    addSkuToRow(row);
     const { data, error } = await supabase.from("estoque").insert([row]).select();
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     const usuario = getUsuario(req);
@@ -276,6 +293,7 @@ export async function POST(req: NextRequest) {
         // Garante custo_compra no primeiro insert
         const base: Record<string, unknown> = { ...r, updated_at: new Date().toISOString() };
         if (base.custo_compra == null) base.custo_compra = base.custo_unitario;
+        addSkuToRow(base);
         seen.set(key, base);
       }
     }
@@ -312,6 +330,7 @@ export async function POST(req: NextRequest) {
       } else {
         const rowIns: Record<string, unknown> = { ...row };
         if (rowIns.custo_compra == null) rowIns.custo_compra = rowIns.custo_unitario;
+        addSkuToRow(rowIns);
         const { error: ie } = await supabase.from("estoque").insert(rowIns);
         if (ie) errors.push(`${produto}: ${ie.message}`);
         else imported++;
@@ -435,6 +454,7 @@ export async function POST(req: NextRequest) {
   if (insertBody.custo_compra == null && insertBody.custo_unitario != null) {
     insertBody.custo_compra = insertBody.custo_unitario;
   }
+  addSkuToRow(insertBody);
 
   const { data, error } = await supabase.from("estoque").insert(insertBody).select().single();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
@@ -527,6 +547,21 @@ export async function PATCH(req: NextRequest) {
   // Se tem serial_no, força qnt=1
   const serialFinal = fields.serial_no ?? antes?.serial_no;
   if (serialFinal) fields.qnt = 1;
+
+  // Regerar SKU se algum campo que afeta foi alterado. So sobrescreve
+  // se a regeracao funcionar — senao mantem o SKU antigo.
+  const camposQueAfetamSku = ["produto", "cor", "categoria", "observacao", "tipo"];
+  if (antes && camposQueAfetamSku.some((k) => k in fields)) {
+    const merged = { ...antes, ...fields } as Record<string, unknown>;
+    const novoSku = gerarSkuSafe({
+      produto: String(merged.produto || ""),
+      categoria: String(merged.categoria || ""),
+      cor: (merged.cor as string | null) ?? null,
+      observacao: (merged.observacao as string | null) ?? null,
+      tipo: (merged.tipo as string | null) ?? null,
+    });
+    if (novoSku) (fields as Record<string, unknown>).sku = novoSku;
+  }
 
   const { error } = await supabase.from("estoque").update({
     ...fields,

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { rateLimitSubmission } from "@/lib/rate-limit";
+import { gerarSkuSafe, detectarCategoriaPorTexto } from "@/lib/sku";
 
 export async function POST(req: NextRequest) {
   const limited = rateLimitSubmission(req);
@@ -47,6 +48,16 @@ export async function POST(req: NextRequest) {
     for (const k of ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"]) {
       if (body[k]) row[k] = String(body[k]).slice(0, 200);
     }
+    // SKU canonico do produto NOVO desejado (foco da simulacao). Permite
+    // dashboards tipo "Top SKUs simulados" e cruzamento com vendas.
+    const skuNovo = gerarSkuSafe({
+      produto: `${body.modeloNovo || ""} ${body.storageNovo || ""}`.trim(),
+      categoria: detectarCategoriaPorTexto(body.modeloNovo),
+      cor: null,
+      observacao: null,
+      tipo: "NOVO",
+    });
+    if (skuNovo) row.sku = skuNovo;
 
     // Checagem de duplicidade real: mesmo whatsapp + produto novo + produto usado nos últimos 2 minutos
     const twoMinAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
@@ -79,6 +90,12 @@ export async function POST(req: NextRequest) {
     if (error && /column\s+["']?whatsapp_destino/i.test(error.message || "")) {
       console.warn("[leads] coluna whatsapp_destino ausente, retry sem campo (rodar migration 20260421)");
       delete row.whatsapp_destino;
+      ({ error } = await supabase.from("simulacoes").insert([row]));
+    }
+    // Fallback: se sku ainda nao existe (migration Fase 3 nao rodou), tenta sem ela
+    if (error && /column\s+["']?sku/i.test(error.message || "")) {
+      console.warn("[leads] coluna sku ausente em simulacoes, retry sem campo (rodar migration 20260424c)");
+      delete row.sku;
       ({ error } = await supabase.from("simulacoes").insert([row]));
     }
 

--- a/app/api/loja/route.ts
+++ b/app/api/loja/route.ts
@@ -3,7 +3,9 @@ import { rateLimitPublic } from "@/lib/rate-limit";
 import {
   buildEstoqueIndex,
   buildEstoqueKeysPresentes,
+  buildEstoqueIndexBySku,
   checkVariacaoEsgotada,
+  checkVariacaoEsgotadaBySku,
   type EstoqueRow,
 } from "@/lib/loja-estoque-match";
 
@@ -21,6 +23,7 @@ interface VariacaoRow {
   imagem_url: string | null;
   visivel: boolean;
   ordem: number;
+  sku: string | null;
 }
 
 interface ProdutoRow {
@@ -82,7 +85,7 @@ export async function GET(req: NextRequest) {
         .single(),
       supabase
         .from("estoque")
-        .select("produto,categoria,qnt,status,cor,observacao"),
+        .select("produto,categoria,qnt,status,cor,observacao,sku"),
     ]);
 
     const categorias = (categoriasRes.data ?? []) as CategoriaRow[];
@@ -90,6 +93,8 @@ export async function GET(req: NextRequest) {
     const variacoes = (variacoesRes.data ?? []) as VariacaoRow[];
     const estoqueRows = (estoqueRes.data ?? []) as EstoqueRow[];
 
+    // Index por SKU (preferencial, 100% preciso) + index fuzzy (fallback)
+    const { disponivel: skuDisponivel, presentes: skuPresentes } = buildEstoqueIndexBySku(estoqueRows);
     const estoqueIndex = buildEstoqueIndex(estoqueRows);
     const estoqueKeysPresentes = buildEstoqueKeysPresentes(estoqueRows);
 
@@ -120,6 +125,11 @@ export async function GET(req: NextRequest) {
 
         const variacoesDisponiveis = prodVariacoes.filter((v) => {
           const attrs = v.atributos ?? {};
+          // Path 1: lookup exato por SKU (se variacao tem SKU). Retorna null
+          // quando nao pode decidir — ai cai no fuzzy.
+          const bySku = checkVariacaoEsgotadaBySku(v.sku, skuDisponivel, skuPresentes);
+          if (bySku) return !bySku.esgotado;
+          // Path 2: fallback fuzzy (pra variacoes ainda sem SKU populado)
           const { esgotado } = checkVariacaoEsgotada(
             {
               produtoNome: p.nome,

--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -1,6 +1,7 @@
 import { hojeBR } from "@/lib/date-utils";
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
+import { gerarSkuSafe, detectarCategoriaPorTexto } from "@/lib/sku";
 import { sendPaymentNotification, sendSaleNotification, sendCancelNotification } from "@/lib/telegram";
 import { logActivity } from "@/lib/activity-log";
 import { hasPermission } from "@/lib/permissions";
@@ -182,11 +183,12 @@ export async function POST(req: NextRequest) {
   let estoqueId = body._estoque_id;
   delete body._estoque_id;
 
-  // Se tem estoque_id, verificar se produto ainda está disponível e copiar IMEI/Serial
+  // Se tem estoque_id, verificar se produto ainda está disponível e copiar IMEI/Serial/SKU
   let imeiFromEstoque: string | null = null;
   let serialFromEstoque: string | null = null;
+  let skuFromEstoque: string | null = null;
   if (estoqueId) {
-    const { data: estoqueItem } = await supabase.from("estoque").select("imei, serial_no, qnt, status, tipo").eq("id", estoqueId).single();
+    const { data: estoqueItem } = await supabase.from("estoque").select("imei, serial_no, qnt, status, tipo, sku").eq("id", estoqueId).single();
     if (!estoqueItem) return NextResponse.json({ error: "Produto não encontrado no estoque" }, { status: 404 });
     if (estoqueItem.status === "ESGOTADO" || estoqueItem.qnt <= 0) {
       return NextResponse.json({ error: "Produto já foi vendido (ESGOTADO). Não é possível registrar outra venda." }, { status: 409 });
@@ -199,6 +201,7 @@ export async function POST(req: NextRequest) {
     }
     if (estoqueItem.imei && !body.imei) imeiFromEstoque = estoqueItem.imei;
     if (estoqueItem.serial_no && !body.serial_no) serialFromEstoque = estoqueItem.serial_no;
+    if (estoqueItem.sku) skuFromEstoque = estoqueItem.sku;
   }
 
   // Garantir nome do cliente em caixa alta
@@ -266,11 +269,23 @@ export async function POST(req: NextRequest) {
   // Remover campo virtual forma_sinal (não existe na tabela vendas)
   delete body.forma_sinal;
 
+  // SKU: prefere copiar do estoque vinculado (ja passou pelo gerador validado).
+  // Fallback: gera do texto livre produto+cor+categoria da venda. Sempre tipo
+  // NOVO (seminovo tem fluxo separado via campo produto_na_troca).
+  const skuVenda = skuFromEstoque || gerarSkuSafe({
+    produto: String(body.produto || ""),
+    categoria: String(body.categoria || detectarCategoriaPorTexto(body.produto)),
+    cor: body.cor ?? null,
+    observacao: null,
+    tipo: "NOVO",
+  });
+
   const { data, error } = await supabase.from("vendas").insert({
     ...body,
     estoque_id: estoqueId || null,
     ...(imeiFromEstoque ? { imei: imeiFromEstoque } : {}),
     ...(serialFromEstoque ? { serial_no: serialFromEstoque } : {}),
+    ...(skuVenda ? { sku: skuVenda } : {}),
   }).select().single();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 

--- a/components/admin/TopSkusSection.tsx
+++ b/components/admin/TopSkusSection.tsx
@@ -1,0 +1,209 @@
+// components/admin/TopSkusSection.tsx
+// Dashboard de Top SKUs — exibe os produtos canonicos mais vendidos, mais
+// simulados (interesse de compra) e mais pedidos (encomendas em aberto).
+//
+// Fonte: /api/admin/sku/top-vendidos
+// Compartilha o range selecionado pela pagina pai de analytics (7d/30d/all).
+
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface SkuAggVenda {
+  sku: string;
+  total: number;
+  valor_total: number;
+  ticket_medio: number;
+  modelo: string;
+  seminovo: boolean;
+  em_estoque: number;
+}
+
+interface SkuAggGenerico {
+  sku: string;
+  total: number;
+  modelo: string;
+  seminovo: boolean;
+}
+
+interface SkuAggEncomenda extends SkuAggGenerico {
+  pendentes: number;
+}
+
+interface TopSkusData {
+  range: string;
+  vendas: SkuAggVenda[];
+  simulacoes: SkuAggGenerico[];
+  encomendas: SkuAggEncomenda[];
+  meta: {
+    vendas_unicas: number;
+    simulacoes_unicas: number;
+    encomendas_unicas: number;
+  };
+}
+
+type Tab = "vendas" | "simulacoes" | "encomendas";
+
+// Range aceito: herdado da pagina pai. "all" nao manda filtro; outros traduzem
+// pra janela em dias (vide /api/admin/sku/top-vendidos).
+export function TopSkusSection({
+  password,
+  range,
+}: {
+  password: string;
+  range: "7d" | "30d" | "all";
+}) {
+  const [data, setData] = useState<TopSkusData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<Tab>("vendas");
+
+  useEffect(() => {
+    if (!password) return;
+    // Nao reseta loading ao trocar range — dados antigos ficam visiveis
+    // durante a transicao (melhor UX + agrada o lint set-state-in-effect).
+    let cancelled = false;
+    const rangeParam = range === "all" ? "all" : range;
+    fetch(`/api/admin/sku/top-vendidos?range=${rangeParam}`, {
+      headers: { "x-admin-password": password },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        if (cancelled) return;
+        setData(json);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setData(null);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [password, range]);
+
+  if (loading) {
+    return (
+      <div className="bg-white border border-[#D2D2D7] rounded-2xl p-6 shadow-sm">
+        <div className="animate-pulse space-y-3">
+          <div className="h-4 bg-[#F5F5F7] rounded w-1/3" />
+          <div className="h-4 bg-[#F5F5F7] rounded w-full" />
+          <div className="h-4 bg-[#F5F5F7] rounded w-5/6" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="bg-white border border-[#D2D2D7] rounded-2xl p-6 shadow-sm text-center text-sm text-[#86868B]">
+        Top SKUs indisponível (backend retornou erro).
+      </div>
+    );
+  }
+
+  const currentList: Array<SkuAggVenda | SkuAggEncomenda | SkuAggGenerico> =
+    tab === "vendas" ? data.vendas : tab === "simulacoes" ? data.simulacoes : data.encomendas;
+
+  const isVendas = tab === "vendas";
+  const isEncomendas = tab === "encomendas";
+
+  const maxTotal = Math.max(...currentList.map((r) => r.total), 1);
+
+  return (
+    <div className="bg-white border border-[#D2D2D7] rounded-2xl p-4 sm:p-6 shadow-sm">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
+        <div>
+          <h2 className="text-base font-semibold text-[#1D1D1F]">Top SKUs</h2>
+          <p className="text-xs text-[#86868B] mt-0.5">
+            Produtos canônicos com mais volume — {tab === "vendas" ? `${data.meta.vendas_unicas} SKUs vendidos` : tab === "simulacoes" ? `${data.meta.simulacoes_unicas} SKUs simulados` : `${data.meta.encomendas_unicas} SKUs encomendados`}
+          </p>
+        </div>
+        <div className="flex gap-1.5">
+          {(["vendas", "simulacoes", "encomendas"] as Tab[]).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                tab === t
+                  ? "bg-[#E8740E] text-white"
+                  : "bg-white border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E] hover:text-[#E8740E]"
+              }`}
+            >
+              {t === "vendas" ? "Vendas" : t === "simulacoes" ? "Simulações" : "Encomendas"}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {currentList.length === 0 ? (
+        <p className="text-sm text-[#86868B] text-center py-8">
+          Sem dados no período.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {currentList.map((r, idx) => {
+            const pct = (r.total / maxTotal) * 100;
+            const venda = r as SkuAggVenda;
+            const enc = r as SkuAggEncomenda;
+            return (
+              <div key={r.sku} className="flex items-center gap-3">
+                <span className="text-[11px] text-[#86868B] w-6 shrink-0 text-right font-mono">
+                  {idx + 1}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-[#1D1D1F] truncate">
+                      {r.modelo}
+                    </span>
+                    {r.seminovo && (
+                      <span className="text-[10px] bg-[#FFF5EB] text-[#E8740E] px-1.5 py-0.5 rounded font-medium shrink-0">
+                        seminovo
+                      </span>
+                    )}
+                    {isVendas && venda.em_estoque === 0 && (
+                      <span className="text-[10px] bg-[#FFF5F5] text-[#E74C3C] px-1.5 py-0.5 rounded font-medium shrink-0">
+                        esgotado
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2 mt-1">
+                    <div className="flex-1 h-2 bg-[#F5F5F7] rounded overflow-hidden">
+                      <div
+                        className="h-full bg-[#E8740E]/70 rounded transition-all duration-500"
+                        style={{ width: `${Math.max(pct, 2)}%` }}
+                      />
+                    </div>
+                    <span className="text-[10px] font-mono text-[#86868B] truncate max-w-[220px]" title={r.sku}>
+                      {r.sku}
+                    </span>
+                  </div>
+                </div>
+                <div className="text-right shrink-0">
+                  <p className="text-sm font-semibold text-[#1D1D1F]">
+                    {r.total}
+                  </p>
+                  {isVendas && (
+                    <p className="text-[10px] text-[#86868B]">
+                      R$ {venda.valor_total.toLocaleString("pt-BR")}
+                    </p>
+                  )}
+                  {isEncomendas && enc.pendentes > 0 && (
+                    <p className="text-[10px] text-[#E8740E] font-medium">
+                      {enc.pendentes} pendente{enc.pendentes > 1 ? "s" : ""}
+                    </p>
+                  )}
+                  {isVendas && venda.em_estoque > 0 && (
+                    <p className="text-[10px] text-[#2ECC71]">
+                      {venda.em_estoque} em estoque
+                    </p>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/avisos-match.ts
+++ b/lib/avisos-match.ts
@@ -2,14 +2,18 @@
 // Liga avisos_clientes (texto livre digitado pelo cliente, ex: "iPhone 17 Pro
 // Max 512GB Preto") com estoque real disponivel.
 //
-// Estrategia: tenta detectar a categoria do desejado pela palavra-chave (iphone,
-// ipad, macbook, etc), normaliza com getModeloBase em ambos os lados e compara
-// chave canonica (modelo + storage). Cor nao exclui match — se o modelo+storage
-// bate, mostra todas as cores disponiveis pro vendedor escolher.
+// Duas estrategias, em cascata:
 //
-// Fallback: se nao reconhecer categoria, usa matching por tokens (todas as
-// palavras do desejado devem estar no estoque + nao pode ter modificadores
-// extras tipo "max", "plus", "ultra" no estoque que nao estejam no desejado).
+//   1) JOIN por SKU canonico (quando disponivel):
+//      Se o aviso foi salvo com `sku` explicito (via dropdown do mostruario
+//      na UI admin), lookup direto em estoque.sku. Match 100% preciso.
+//
+//   2) Matching fuzzy (legado/padrao — aviso veio como texto livre):
+//      Detecta categoria pela palavra-chave (iphone, ipad, macbook, etc),
+//      normaliza com getModeloBase em ambos os lados e compara chave
+//      canonica (modelo + storage). Cor nao exclui match — se modelo+storage
+//      bate, mostra todas as cores disponiveis pro vendedor escolher.
+//      Fallback interno: matching por tokens com checagem de modificadores.
 
 import { getModeloBase } from "./produto-display";
 
@@ -21,6 +25,7 @@ export interface EstoqueLinha {
   status: string | null;
   observacao?: string | null;
   categoria?: string | null;
+  sku?: string | null;
 }
 
 function normalize(s: string | null | undefined): string {
@@ -104,15 +109,49 @@ export function findEstoqueMatch(
 export interface AvisoComEstoque {
   matches: EstoqueLinha[];
   disponivel_qnt: number;
+  matchedBySku?: boolean; // true quando o match veio via SKU canonico
+}
+
+// Lookup exato por SKU canonico. Retorna [] se o SKU nao bater nenhuma
+// row disponivel no estoque.
+export function findEstoqueMatchBySku(
+  skuDesejado: string,
+  estoque: EstoqueLinha[],
+): EstoqueLinha[] {
+  if (!skuDesejado || !skuDesejado.trim()) return [];
+  const sku = skuDesejado.trim().toUpperCase();
+  return estoque.filter(row => {
+    if (row.sku !== sku) return false;
+    const qnt = Number(row.qnt || 0);
+    if (qnt <= 0) return false;
+    if ((row.status || "").toUpperCase() !== "EM ESTOQUE") return false;
+    return true;
+  });
 }
 
 export function annotateAvisoComEstoque(
   produtoDesejado: string,
   estoque: EstoqueLinha[],
+  skuDesejado?: string | null,
 ): AvisoComEstoque {
+  // Path 1: lookup por SKU exato quando aviso tem sku explicito
+  if (skuDesejado && skuDesejado.trim()) {
+    const matches = findEstoqueMatchBySku(skuDesejado, estoque);
+    if (matches.length > 0) {
+      return {
+        matches,
+        disponivel_qnt: matches.reduce((s, m) => s + Number(m.qnt || 0), 0),
+        matchedBySku: true,
+      };
+    }
+    // Se SKU nao bateu, pode ser que o admin salvou SKU mas o texto
+    // livre ainda acha produtos similares — continua pro fuzzy.
+  }
+  // Path 2: fallback fuzzy pelo texto do aviso
   const matches = findEstoqueMatch(produtoDesejado, estoque);
   return {
     matches,
     disponivel_qnt: matches.reduce((s, m) => s + Number(m.qnt || 0), 0),
+    matchedBySku: false,
   };
 }

--- a/lib/loja-estoque-match.ts
+++ b/lib/loja-estoque-match.ts
@@ -1,12 +1,20 @@
 // lib/loja-estoque-match.ts
 // Liga loja_variacoes (mostruário público) ao estoque real pra esconder esgotados.
 //
-// Matching é fuzzy mas determinístico:
-//   chave = getModeloBase(produto, categoria) + "::" + corParaPT(cor) normalizada
+// Duas estrategias de match, usadas em cascata:
 //
-// Permissivo: se não achar match nenhum pra uma variação, deixa ela visível
-// (benefício da dúvida — não esconde quando a heurística falhou). Só esconde
-// quando confirmou que existe o SKU no estoque mas está zerado/ESGOTADO.
+//   1) JOIN por SKU canonico (preferencial, precisao 100%):
+//      Se a variacao tem sku E existe alguma row de estoque com o mesmo sku,
+//      usa lookup exato. Zero falsos positivos/negativos.
+//
+//   2) Fallback fuzzy (legado, pra rows sem SKU):
+//      chave = getModeloBase(produto, categoria) + "::" + corParaPT(cor)
+//      Permissivo: se nao achar match nenhum, deixa visivel (beneficio da
+//      duvida). So esconde quando confirmou existir SKU zerado.
+//
+// Transicao: conforme backfill popular SKUs, o (1) vira caminho principal
+// e o (2) so roda em rows orfas. Quando atingir 100% cobertura, podemos
+// remover o fuzzy.
 
 import { getModeloBase } from "./produto-display";
 import { corParaPT } from "./cor-pt";
@@ -18,6 +26,7 @@ export interface EstoqueRow {
   status: string | null;
   cor: string | null;
   observacao?: string | null;
+  sku?: string | null;
 }
 
 interface EstoqueAgg {
@@ -122,4 +131,51 @@ export function checkVariacaoEsgotada(
   // existe (alguma linha de estoque com essa chave, mesmo que zerada).
   const confirmouSKU = keysPresentes.has(key);
   return { esgotado: confirmouSKU, modeloBase, key };
+}
+
+// ─── Path preferencial: JOIN por SKU canonico ─────────────────────
+
+/**
+ * Indices por SKU. Separados em dois porque a semantica e diferente:
+ *   - disponivel: soma qnt quando status="EM ESTOQUE" e qnt>0 (pra saber se "tem")
+ *   - presentes: qualquer row (mesmo ESGOTADO) pra saber se o SKU existe no sistema
+ */
+export function buildEstoqueIndexBySku(rows: EstoqueRow[]): {
+  disponivel: Map<string, EstoqueAgg>;
+  presentes: Set<string>;
+} {
+  const disponivel = new Map<string, EstoqueAgg>();
+  const presentes = new Set<string>();
+  for (const row of rows) {
+    if (!row.sku) continue;
+    presentes.add(row.sku);
+    const qnt = Number(row.qnt || 0);
+    const isEmEstoque = (row.status || "").toUpperCase() === "EM ESTOQUE" && qnt > 0;
+    if (isEmEstoque) {
+      const existing = disponivel.get(row.sku) || { totalEmEstoque: 0 };
+      existing.totalEmEstoque += qnt;
+      disponivel.set(row.sku, existing);
+    }
+  }
+  return { disponivel, presentes };
+}
+
+/**
+ * Decide esgotado usando SKU canonico. Retorna null quando o lookup nao
+ * pode ser feito (variacao sem SKU) — nesse caso o caller deve cair no
+ * fallback fuzzy checkVariacaoEsgotada.
+ *
+ * Mesma semantica do fuzzy: so esconde se confirmou que SKU existe.
+ */
+export function checkVariacaoEsgotadaBySku(
+  variacaoSku: string | null | undefined,
+  disponivel: Map<string, EstoqueAgg>,
+  presentes: Set<string>,
+): { esgotado: boolean; matchedBySku: true } | null {
+  if (!variacaoSku) return null;
+  const agg = disponivel.get(variacaoSku);
+  const temEstoque = (agg?.totalEmEstoque || 0) > 0;
+  if (temEstoque) return { esgotado: false, matchedBySku: true };
+  const confirmou = presentes.has(variacaoSku);
+  return { esgotado: confirmou, matchedBySku: true };
 }

--- a/lib/sku.ts
+++ b/lib/sku.ts
@@ -357,3 +357,31 @@ export function isValidSku(sku: string): boolean {
   if (!sku || !sku.trim()) return false;
   return /^[A-Z0-9]+(-[A-Z0-9]+)+$/.test(sku.toUpperCase());
 }
+
+// ─── Helper: detectar categoria a partir do nome do produto ───────
+// Usado quando a row nao tem coluna `categoria` explicita (ex: avaliacao_usados,
+// simulacoes, avisos_clientes — guardam so o nome do modelo).
+// Retorna a categoria canonica do estoque (IPHONES, IPADS, MACBOOK, ...) ou OUTROS.
+export function detectarCategoriaPorTexto(texto: string | null | undefined): string {
+  const up = upper(texto);
+  if (/IPHONE/.test(up)) return "IPHONES";
+  if (/IPAD/.test(up)) return "IPADS";
+  if (/MAC.*MINI/.test(up)) return "MAC_MINI";
+  if (/MACBOOK/.test(up)) return "MACBOOK";
+  if (/WATCH/.test(up)) return "APPLE_WATCH";
+  if (/AIRPODS/.test(up)) return "AIRPODS";
+  return "OUTROS";
+}
+
+// ─── Helper conveniente: gera SKU sem disparar erro ─────────────
+// Wrapper que so retorna a string do SKU (ou null em caso de falha) — pra
+// uso em POSTs onde so queremos popular a coluna. Toda a lógica detalhada
+// (confianca, componentes) fica disponivel via gerarSku() pra UIs que queiram.
+export function gerarSkuSafe(produto: ProdutoInput): string | null {
+  try {
+    const r = gerarSku(produto);
+    return r.sku || null;
+  } catch {
+    return null;
+  }
+}

--- a/supabase/migrations/20260424c_sku_canonico_fase3.sql
+++ b/supabase/migrations/20260424c_sku_canonico_fase3.sql
@@ -1,0 +1,45 @@
+-- SKU canonico — Fase 3: estende a coluna `sku` (TEXT NULLABLE) pra todas as
+-- tabelas transacionais que registram um produto, fechando o circuito ponta-a-ponta:
+--
+--   vendas           — registro da venda fechada (entra no estoque por estoque_id)
+--   encomendas       — produto que cliente pediu pra trazer (estoque_id quando chega)
+--   link_compras     — link gerado pra cliente preencher dados/pagar (produto)
+--   simulacoes       — simulacao de troca (modelo_usado + storage_usado)
+--   avisos_clientes  — cliente pediu aviso quando produto X chegar
+--
+-- Backfill via /api/admin/sku/backfill (POST). Em vendas/encomendas, prefere
+-- copiar do estoque vinculado quando estoque.sku ja existe. Senao gera pelo
+-- texto livre do produto via lib/sku.ts.
+--
+-- Cobertura final esperada: ~95%+ em vendas/encomendas/link_compras/simulacoes
+-- (modelos Apple bem-cadastrados). Avisos pode ficar mais baixo (texto livre
+-- do cliente, sem garantia de formato).
+--
+-- Quando atingir 100% nas tabelas operacionais, avaliamos NOT NULL + UNIQUE
+-- onde fizer sentido.
+
+ALTER TABLE vendas
+  ADD COLUMN IF NOT EXISTS sku TEXT;
+
+ALTER TABLE encomendas
+  ADD COLUMN IF NOT EXISTS sku TEXT;
+
+ALTER TABLE link_compras
+  ADD COLUMN IF NOT EXISTS sku TEXT;
+
+ALTER TABLE simulacoes
+  ADD COLUMN IF NOT EXISTS sku TEXT;
+
+ALTER TABLE avisos_clientes
+  ADD COLUMN IF NOT EXISTS sku TEXT;
+
+-- Indices parciais (so linhas com sku) pra performance de:
+--   - dashboard "Top SKUs vendidos"     → vendas(sku)
+--   - lookup encomenda → estoque        → encomendas(sku)
+--   - relatorio funil por SKU           → link_compras(sku), simulacoes(sku)
+--   - matching aviso → estoque          → avisos_clientes(sku)
+CREATE INDEX IF NOT EXISTS idx_vendas_sku ON vendas(sku) WHERE sku IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_encomendas_sku ON encomendas(sku) WHERE sku IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_link_compras_sku ON link_compras(sku) WHERE sku IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_simulacoes_sku ON simulacoes(sku) WHERE sku IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_avisos_clientes_sku ON avisos_clientes(sku) WHERE sku IS NOT NULL;


### PR DESCRIPTION
## Summary

Fecha a trilogia do sistema de SKU canônico iniciada em #748. Agora todos os produtos novos cadastrados já nascem com SKU, o matching entre mostruário/estoque/avisos usa SKU preferencialmente (0 falsos positivos) e o painel tem um dashboard dos produtos mais vendidos/simulados/pedidos.

### Fase 2 — mostruário ↔ estoque
- **API `/api/admin/sku/sugerir`**: recebe um input e devolve o SKU previsto + componentes + confiança. Útil pra UI mostrar em tempo real o que vai ser gerado.
- **Auto-popular SKU em POSTs**: estoque (insert/import/add_to_pedido + PATCH regenera se mudou produto/cor/categoria/tipo), mostruário (create_variacao/update_variacao com JOIN na categoria do produto pai), usados (upsert_valor/import_defaults/PUT sempre tipo SEMINOVO).
- **`lib/loja-estoque-match`**: nova função `checkVariacaoEsgotadaBySku` + índice `buildEstoqueIndexBySku`. O caminho por SKU roda primeiro; fuzzy só quando variação ainda não tem SKU populado.
- **`lib/avisos-match`**: lookup exato por SKU quando aviso tem SKU explícito, fallback pro match atual por tokens.

### Fase 3 — tabelas transacionais
- **Migration `20260424c_sku_canonico_fase3.sql`**: coluna `sku TEXT` (nullable por enquanto) em `vendas`, `encomendas`, `link_compras`, `simulacoes` e `avisos_clientes`. Índices parciais em cada tabela.
- **Auto-popular SKU**:
  - `vendas`: prefere copiar de `estoque.sku` quando `estoque_id` vinculado, senão gera do texto.
  - `encomendas`: mesmo padrão; PATCH re-sincroniza quando muda vínculo com estoque.
  - `link_compras`: gera do texto + detecta categoria via `detectarCategoriaPorTexto`. Regenera no PATCH se mudou produto/cor.
  - `leads` (cria simulacoes): SKU do produto NOVO desejado (foco da simulação). Fallback graceful se coluna ainda não existe.
- **Backfill estendido** em `/api/admin/sku/backfill`: processa também vendas/encomendas (lookup prioritário em `estoque.sku` por `estoque_id`) e link_compras/simulacoes (via gerador). Timeout aumentado pra 5 min.
- **Dashboard Top SKUs** em `/admin/analytics`: novo endpoint `/api/admin/sku/top-vendidos` + componente `TopSkusSection` com 3 abas (vendas / simulações / encomendas), cruzamento com estoque atual pra destacar esgotados e pendentes.

### Como aplicar em prod (ordem)
1. Merge do PR
2. `/admin/migrations` → rodar `20260424c_sku_canonico_fase3.sql`
3. `POST /api/admin/sku/backfill` → popula SKUs nas linhas históricas de vendas/encomendas/link_compras/simulacoes (pode rodar com `?dry=1` primeiro pra ver o relatório)

## Test plan

- [ ] Cadastrar novo produto em /admin/estoque → conferir que gravou SKU canônico
- [ ] Criar variação no mostruário → conferir SKU populado (JOIN pegou categoria correta)
- [ ] Upsert valor em /admin/avaliacoes → conferir SKU com sufixo `-SEMINOVO`
- [ ] Registrar nova venda vinculada ao estoque → SKU da venda == SKU do estoque
- [ ] Criar link-compra → SKU gerado do texto
- [ ] Preencher simulação via funil público → SKU na tabela simulacoes
- [ ] Mostruário público `/loja`: variação esgotada no estoque some; variação com estoque aparece (lookup agora via SKU preferencialmente)
- [ ] Painel /admin/avisos: enriquecido com `matched_by_sku` quando aviso tem SKU
- [ ] `/admin/analytics`: nova seção "Top SKUs" renderiza nas 3 abas com dados agregados do período

🤖 Generated with [Claude Code](https://claude.com/claude-code)