### PR TITLE
fix: coleta whatsapp + precos seminovo/lacrado + entrega com troca info

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -91,6 +91,15 @@ function formatDateBR(dateStr: string) {
   return `${d}/${m}`;
 }
 
+// Formata telefone BR com DDI: "21976949939" -> "+55 (21) 97694-9939"
+function formatTelefoneBR(tel: string | null | undefined): string {
+  if (!tel) return "";
+  const digits = tel.replace(/\D/g, "").replace(/^55/, "");
+  if (digits.length === 11) return `+55 (${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+  if (digits.length === 10) return `+55 (${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`;
+  return tel;
+}
+
 // Tabela de taxas em nível de módulo pra reuso em formatPagamentoDisplay e no form
 const TAXAS_PARCELAS_MODULE: Record<number, number> = {
   1: 4, 2: 5, 3: 5.5, 4: 6, 5: 7, 6: 7.5,
@@ -927,7 +936,7 @@ export default function EntregasPage() {
       pagLine,
       ...(form.local_entrega === "RESIDÊNCIA" ? [`⚠️ PAGAMENTO ANTECIPADO`] : form.local_entrega === "SHOPPING" ? [`✅ PAGAR NA ENTREGA`] : []),
       `🧑 *CLIENTE:* ${form.cliente || "—"}`,
-      `📞 *CONTATO:* ${form.telefone || "—"}`,
+      `📞 *CONTATO:* ${formatTelefoneBR(form.telefone) || "—"}`,
       form.observacao ? `OBS: ${form.observacao}` : "",
       `💼 Vendedor: ${form.vendedor || "—"}`,
     ].filter(Boolean);
@@ -2976,25 +2985,22 @@ export default function EntregasPage() {
                     onClick={() => {
                       if (e.tipo === "COLETA") {
                         // Formulário de COLETA — sem valores financeiros
-                        const detalhesAparelho = e.detalhes_upgrade
-                          ? e.detalhes_upgrade.split("\n").filter(l => !l.toLowerCase().startsWith("avaliação") && !l.toLowerCase().startsWith("avaliacao")).join("\n• ")
-                          : "";
+                        const detalhesPartes = e.detalhes_upgrade
+                          ? e.detalhes_upgrade.split("\n").map(l => l.trim()).filter(l => l && !l.toLowerCase().startsWith("avaliação") && !l.toLowerCase().startsWith("avaliacao"))
+                          : [];
                         const obsLimpa = (e.observacao || "").split(" | ").filter(p => !p.startsWith("Endereço cadastro:")).join(" | ").trim();
                         const produtoFmtC = formatProdutoMotoboy(e.produto);
-                        const produtoLineC = produtoFmtC.startsWith("\n")
-                          ? `🍎 *PRODUTO:*${produtoFmtC}`
-                          : `🍎 *PRODUTO:* ${produtoFmtC}`;
+                        const produtoBase = produtoFmtC.startsWith("\n") ? produtoFmtC.replace(/\n\s*•\s*/g, " + ").trim() : produtoFmtC;
+                        const aparelhoLine = `📱 *APARELHO DA COLETA:* ${[produtoBase, ...detalhesPartes].filter(Boolean).join(" | ")}`;
                         const msg = [
                           `🛵 *COLETA* 🛵`,
                           ``,
                           `⏰ *HORÁRIO:* ${e.horario || "Horário a combinar"}`,
                           `📍 *LOCAL COLETA:* ${e.endereco || "A definir"}${e.bairro ? ` - ${e.bairro}` : ""}`,
-                          produtoLineC,
-                          ``,
-                          ...(detalhesAparelho ? [`📱 *APARELHO NA COLETA:*`, `• ${detalhesAparelho}`] : []),
+                          aparelhoLine,
                           ``,
                           `🧑 *CLIENTE:* ${e.cliente || ""}`,
-                          `📞 *CONTATO:* ${e.telefone || ""}`,
+                          `📞 *CONTATO:* ${formatTelefoneBR(e.telefone) || "—"}`,
                           obsLimpa ? `\nOBS: ${obsLimpa}` : "",
                           ``,
                           `💼 Vendedor: ${e.vendedor || ""}`,
@@ -3034,7 +3040,7 @@ export default function EntregasPage() {
                           ...(isUpgrade && trocaTexto ? [`🔄 *PRODUTO NA TROCA:* ${trocaTexto}`] : []),
                           pagLine,
                           `🧑 *CLIENTE:* ${e.cliente || ""}`,
-                          `📞 *CONTATO:* ${e.telefone || ""}`,
+                          `📞 *CONTATO:* ${formatTelefoneBR(e.telefone) || "—"}`,
                           obsLimpa ? `OBS: ${obsLimpa}` : "",
                           `💼 Vendedor: ${e.vendedor || ""}`,
                           "________________________________",

--- a/app/admin/precos/page.tsx
+++ b/app/admin/precos/page.tsx
@@ -211,7 +211,7 @@ function PrecosContent() {
       }),
     });
     setData((prev) => prev?.map((r) =>
-      r.modelo === row.modelo && r.armazenamento === row.armazenamento
+      r.modelo === row.modelo && r.armazenamento === row.armazenamento && (r.tipo ?? "TRADEIN") === (row.tipo ?? "TRADEIN")
         ? { ...r, preco_pix: newPrice }
         : r
     ) ?? null);
@@ -236,7 +236,7 @@ function PrecosContent() {
       }),
     });
     setData((prev) => prev?.map((r) =>
-      r.modelo === row.modelo && r.armazenamento === row.armazenamento
+      r.modelo === row.modelo && r.armazenamento === row.armazenamento && (r.tipo ?? "TRADEIN") === (row.tipo ?? "TRADEIN")
         ? { ...r, status: newStatus }
         : r
     ) ?? null);
@@ -247,10 +247,10 @@ function PrecosContent() {
     await fetch("/api/admin/precos", {
       method: "DELETE",
       headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
-      body: JSON.stringify({ modelo: row.modelo, armazenamento: row.armazenamento }),
+      body: JSON.stringify({ modelo: row.modelo, armazenamento: row.armazenamento, tipo: row.tipo ?? "TRADEIN" }),
     });
     setData((prev) => prev?.filter((r) =>
-      !(r.modelo === row.modelo && r.armazenamento === row.armazenamento)
+      !(r.modelo === row.modelo && r.armazenamento === row.armazenamento && (r.tipo ?? "TRADEIN") === (row.tipo ?? "TRADEIN"))
     ) ?? null);
   }
 

--- a/app/api/admin/link-compras/encaminhar-entrega/route.ts
+++ b/app/api/admin/link-compras/encaminhar-entrega/route.ts
@@ -95,14 +95,41 @@ export async function POST(request: Request) {
   const restanteComTaxa = taxaPct > 0 ? Math.ceil(restante * (1 + taxaPct / 100)) : restante;
   const valorFinal = entradaVal + restanteComTaxa;
 
+  // Fallback pra cor/condicao da troca: se o link esta incompleto (ex: foi criado
+  // como placeholder via upload-print com dados parciais), puxa da venda com
+  // mesmo short_code que foi salva pelo from-formulario — la o cliente submeteu
+  // os dados completos. Evita entregas saindo sem "Saude bateria X% | Sem marcas
+  // | ... | Tem a caixa original" quando o link original perdeu.
+  let trocaCorFb: string | null = link.troca_cor || null;
+  let trocaCondFb: string | null = link.troca_condicao || null;
+  let trocaCor2Fb: string | null = link.troca_cor2 || null;
+  let trocaCond2Fb: string | null = link.troca_condicao2 || null;
+  const precisaFallback = link.troca_produto && (!trocaCorFb || !trocaCondFb)
+    || link.troca_produto2 && (!trocaCor2Fb || !trocaCond2Fb);
+  if (precisaFallback && link.short_code) {
+    const { data: vendaSc } = await supabase
+      .from("vendas")
+      .select("troca_cor, troca_obs, troca_cor2, troca_obs2")
+      .eq("short_code", link.short_code)
+      .not("troca_produto", "is", null)
+      .limit(1)
+      .maybeSingle();
+    if (vendaSc) {
+      trocaCorFb = trocaCorFb || vendaSc.troca_cor || null;
+      trocaCondFb = trocaCondFb || vendaSc.troca_obs || null;
+      trocaCor2Fb = trocaCor2Fb || vendaSc.troca_cor2 || null;
+      trocaCond2Fb = trocaCond2Fb || vendaSc.troca_obs2 || null;
+    }
+  }
+
   // Campo detalhes_upgrade é usado pela aba de entregas pra listar trocas do pedido
   // (o texto do motoboy tem uma seção "PRODUTO NA TROCA" própria que lê desse campo).
   const trocaLinhas: string[] = [];
   if (link.troca_produto) {
     const t1 = [
       link.troca_produto,
-      link.troca_cor ? `cor ${link.troca_cor}` : null,
-      link.troca_condicao ? link.troca_condicao : null,
+      trocaCorFb ? `cor ${trocaCorFb}` : null,
+      trocaCondFb || null,
       Number(link.troca_valor) ? `R$ ${Number(link.troca_valor).toLocaleString("pt-BR")}` : null,
     ].filter(Boolean).join(" • ");
     trocaLinhas.push(t1);
@@ -110,8 +137,8 @@ export async function POST(request: Request) {
   if (link.troca_produto2) {
     const t2 = [
       link.troca_produto2,
-      link.troca_cor2 ? `cor ${link.troca_cor2}` : null,
-      link.troca_condicao2 ? link.troca_condicao2 : null,
+      trocaCor2Fb ? `cor ${trocaCor2Fb}` : null,
+      trocaCond2Fb || null,
       Number(link.troca_valor2) ? `R$ ${Number(link.troca_valor2).toLocaleString("pt-BR")}` : null,
     ].filter(Boolean).join(" • ");
     trocaLinhas.push(t2);

--- a/app/api/admin/precos/route.ts
+++ b/app/api/admin/precos/route.ts
@@ -67,26 +67,28 @@ export async function POST(req: NextRequest) {
 
   const { supabase } = await import("@/lib/supabase");
 
+  // Tipo sempre definido: LACRADO default = TRADEIN. Precisa ser NOT NULL pra
+  // o unique constraint (modelo, armazenamento, tipo) funcionar — Postgres
+  // trata NULL como distinto em unique, e dois NULLs conviveriam furando a regra.
+  const tipoFinal = tipo || "TRADEIN";
   const row: Record<string, unknown> = {
     modelo,
     armazenamento,
     preco_pix: Number(preco_pix),
     status: status ?? "ativo",
+    tipo: tipoFinal,
     updated_at: new Date().toISOString(),
   };
   // Só enviar categoria se a coluna existir (backwards-compatible)
   if (categoria) row.categoria = categoria;
-  // tipo: TRADEIN (default) | CATALOGO | AMBOS
-  if (tipo) row.tipo = tipo;
 
-  const { error } = await supabase.from("precos").upsert(row, { onConflict: "modelo,armazenamento" });
+  const { error } = await supabase.from("precos").upsert(row, { onConflict: "modelo,armazenamento,tipo" });
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
   await logActivity(usuario, "Alterou preco", `${modelo} ${armazenamento} -> R$ ${Number(preco_pix).toLocaleString("pt-BR")}`, "precos");
 
   // Notificar design via Telegram (apenas para produtos TRADEIN ou AMBOS)
-  const tipoFinal = tipo ?? "TRADEIN";
   const shouldNotifyTelegram = tipoFinal === "TRADEIN" || tipoFinal === "AMBOS";
   if (shouldNotifyTelegram) try {
     const botToken = process.env.TELEGRAM_BOT_TOKEN;
@@ -188,12 +190,13 @@ export async function PUT(req: NextRequest) {
     preco_pix: p.precoPix,
     status: "ativo",
     categoria: "IPHONE",
+    tipo: "TRADEIN",
     updated_at: new Date().toISOString(),
   }));
 
   const { error } = await supabase
     .from("precos")
-    .upsert(rows, { onConflict: "modelo,armazenamento" });
+    .upsert(rows, { onConflict: "modelo,armazenamento,tipo" });
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
@@ -205,7 +208,7 @@ export async function DELETE(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body = await req.json();
-  const { modelo, armazenamento } = body;
+  const { modelo, armazenamento, tipo } = body;
 
   if (!modelo) {
     return NextResponse.json({ error: "Missing fields" }, { status: 400 });
@@ -213,11 +216,16 @@ export async function DELETE(req: NextRequest) {
 
   const { supabase } = await import("@/lib/supabase");
 
+  // tipo distingue LACRADO vs SEMINOVO no unique. Sem ele, deletar iPhone 16
+  // 128GB LACRADO tiraria tambem o SEMINOVO. Default TRADEIN pra frontend que
+  // ainda nao manda tipo (devem sempre mandar apos este fix).
+  const tipoFinal = tipo || "TRADEIN";
   const { error } = await supabase
     .from("precos")
     .delete()
     .eq("modelo", modelo)
-    .eq("armazenamento", armazenamento);
+    .eq("armazenamento", armazenamento)
+    .eq("tipo", tipoFinal);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 

--- a/app/api/cron/alerta-preco/route.ts
+++ b/app/api/cron/alerta-preco/route.ts
@@ -78,11 +78,17 @@ export async function GET(req: NextRequest) {
   }
 
   try {
-    // 1. Buscar precos atuais da tabela precos
+    // 1. Buscar precos atuais da tabela precos — SO LACRADO.
+    // Simulacoes vem do fluxo /troca (aparelho novo lacrado). Se cruzassemos
+    // com SEMINOVO, que tem mesmo modelo+armazenamento mas preco bem mais
+    // baixo, a conta de "baixou R$X" daria um valor enorme e o robo mandaria
+    // "queda" errada. Filtro no banco evita confusao mesmo com tipo LACRADO
+    // tendo varios valores (TRADEIN/CATALOGO/AMBOS).
     const { data: precos, error: errPrecos } = await supabase
       .from("precos")
       .select("modelo, armazenamento, preco_pix")
-      .neq("status", "esgotado");
+      .neq("status", "esgotado")
+      .neq("tipo", "SEMINOVO");
 
     if (errPrecos || !precos) {
       console.error("[AlertaPreco] Erro ao buscar precos:", errPrecos);

--- a/app/api/link-compras-auto/route.ts
+++ b/app/api/link-compras-auto/route.ts
@@ -25,19 +25,26 @@ export async function POST(req: NextRequest) {
     // 1. Por short_code exato
     const { data: existing } = await supabase
       .from("link_compras")
-      .select("id")
+      .select("id, short_code, url_curta")
       .eq("short_code", body.short_code)
       .maybeSingle();
-    if (existing) return NextResponse.json({ ok: true, exists: true });
+    if (existing) return NextResponse.json({ ok: true, exists: true, data: existing });
 
-    // 2. Mesmo cliente + mesmo produto nos últimos 30 minutos (evita múltiplos cliques)
+    // 2. Mesmo cliente + mesmo produto nos últimos 30 minutos (evita múltiplos cliques).
+    // Quando dedupa, retorna o short_code e url do link existente pro StepQuote
+    // redirecionar o cliente pra la — antes redirecionava pro shortCode novo
+    // (orfao) e o upload-print acabava criando um placeholder incompleto, gerando
+    // entregas sem cor/condicao da troca.
     if (body.cliente_telefone || body.cliente_nome) {
       const since = new Date(Date.now() - 30 * 60 * 1000).toISOString();
-      let q = supabase.from("link_compras").select("id").eq("produto", body.produto || "").gte("created_at", since);
+      let q = supabase.from("link_compras")
+        .select("id, short_code, url_curta")
+        .eq("produto", body.produto || "")
+        .gte("created_at", since);
       if (body.cliente_telefone) q = q.eq("cliente_telefone", body.cliente_telefone);
       else if (body.cliente_nome) q = q.ilike("cliente_nome", body.cliente_nome);
       const { data: recent } = await q.limit(1);
-      if (recent && recent.length > 0) return NextResponse.json({ ok: true, exists: true });
+      if (recent && recent.length > 0) return NextResponse.json({ ok: true, exists: true, data: recent[0] });
     }
 
     const payload = {

--- a/app/api/link-compras/upload-print/route.ts
+++ b/app/api/link-compras/upload-print/route.ts
@@ -62,6 +62,8 @@ export async function POST(req: NextRequest) {
       const cliente_telefone = formData.get("cliente_telefone") as string | null;
       const troca_produto = formData.get("troca_produto") as string | null;
       const troca_valor = formData.get("troca_valor") as string | null;
+      const troca_cor = formData.get("troca_cor") as string | null;
+      const troca_condicao = formData.get("troca_condicao") as string | null;
 
       const insertPayload = {
         short_code: shortCode,
@@ -72,6 +74,11 @@ export async function POST(req: NextRequest) {
         produto: produto || "(produto será preenchido no submit)",
         troca_produto: troca_produto || null,
         troca_valor: troca_valor ? Number(troca_valor) || 0 : null,
+        // Cor e condicao vem do simulador (StepQuote). Sem isso a entrega
+        // encaminhada desse placeholder sai sem as infos do aparelho da
+        // troca (perdeu a cor, bateria, marcas, pecas trocadas, caixa).
+        troca_cor: troca_cor || null,
+        troca_condicao: troca_condicao || null,
         status: "PENDENTE",
         arquivado: false,
       };

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -508,6 +508,8 @@ function CompraForm() {
       if (whatsappClienteParam) fd.append("cliente_telefone", whatsappClienteParam);
       if (trocaProdutoParam) fd.append("troca_produto", trocaProdutoParam);
       if (trocaValorParam) fd.append("troca_valor", trocaValorParam);
+      if (trocaCorParam) fd.append("troca_cor", trocaCorParam);
+      if (trocaCondParam) fd.append("troca_condicao", trocaCondParam);
       const res = await fetch("/api/link-compras/upload-print", { method: "POST", body: fd });
       const json = await res.json();
       if (json.ok) {

--- a/components/StepQuote.tsx
+++ b/components/StepQuote.tsx
@@ -398,35 +398,46 @@ export default function StepQuote(p: StepQuoteProps) {
               const shortRes = await fetch("/api/short-link", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ data: shortData }) });
               const shortJson = await shortRes.json();
               if (shortJson.code) {
-                // Criar link_compras (fire-and-forget) — evita bloquear navegação
-                fetch("/api/link-compras-auto", {
-                  method: "POST", headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({
-                    short_code: shortJson.code,
-                    url_curta: `${baseOrigin}/c/${shortJson.code}`,
-                    tipo: usedModel ? "TROCA" : "COMPRA",
-                    cliente_nome: clienteNome || null,
-                    cliente_telefone: clienteWhatsApp || null,
-                    produto: `${newModel} ${newStorage}`.trim(),
-                    // Simulador nao pede cor do produto novo ao cliente — fica null,
-                    // vendedor acerta a cor por WhatsApp depois e edita o link.
-                    cor: null,
-                    valor: Math.round(newPrice),
-                    troca_produto: usedModel ? `${usedModel} ${usedStorage || ""}`.trim() : null,
-                    troca_valor: Math.round(valor1),
-                    troca_condicao: condStr || null,
-                    troca_cor: usedColor || null,
-                    troca_produto2: hasSecond && usedModel2 ? `${usedModel2} ${usedStorage2 || ""}`.trim() : null,
-                    troca_valor2: hasSecond ? Math.round(valor2) : 0,
-                    troca_condicao2: cond2Lines || null,
-                    troca_cor2: hasSecond ? (usedColor2 || null) : null,
-                    vendedor: vendedor || null,
-                    website: getHoneypotValue(),
-                  }),
-                }).catch(() => {});
+                // Criar link_compras. Antes era fire-and-forget, mas precisamos
+                // do response: quando o endpoint dedupa (mesmo cliente+produto
+                // nos ultimos 30min), ele retorna o short_code ja existente.
+                // Redirecionar pro novo geraria um link orfao e o upload-print
+                // criava placeholder incompleto depois.
+                let codigoFinal = shortJson.code;
+                try {
+                  const lcRes = await fetch("/api/link-compras-auto", {
+                    method: "POST", headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({
+                      short_code: shortJson.code,
+                      url_curta: `${baseOrigin}/c/${shortJson.code}`,
+                      tipo: usedModel ? "TROCA" : "COMPRA",
+                      cliente_nome: clienteNome || null,
+                      cliente_telefone: clienteWhatsApp || null,
+                      produto: `${newModel} ${newStorage}`.trim(),
+                      // Simulador nao pede cor do produto novo ao cliente — fica null,
+                      // vendedor acerta a cor por WhatsApp depois e edita o link.
+                      cor: null,
+                      valor: Math.round(newPrice),
+                      troca_produto: usedModel ? `${usedModel} ${usedStorage || ""}`.trim() : null,
+                      troca_valor: Math.round(valor1),
+                      troca_condicao: condStr || null,
+                      troca_cor: usedColor || null,
+                      troca_produto2: hasSecond && usedModel2 ? `${usedModel2} ${usedStorage2 || ""}`.trim() : null,
+                      troca_valor2: hasSecond ? Math.round(valor2) : 0,
+                      troca_condicao2: cond2Lines || null,
+                      troca_cor2: hasSecond ? (usedColor2 || null) : null,
+                      vendedor: vendedor || null,
+                      website: getHoneypotValue(),
+                    }),
+                  });
+                  const lcJson = await lcRes.json().catch(() => null);
+                  if (lcJson?.exists && lcJson?.data?.short_code) {
+                    codigoFinal = lcJson.data.short_code;
+                  }
+                } catch { /* segue com shortJson.code (modo degradado) */ }
                 // Inclui ?short=<code> na URL de /compra pra que a submissão salve o preenchimento
                 const u = new URL(compraUrl);
-                u.searchParams.set("short", shortJson.code);
+                u.searchParams.set("short", codigoFinal);
                 finalUrl = u.toString();
               }
             } catch {

--- a/supabase/migrations/20260424b_precos_unique_por_tipo.sql
+++ b/supabase/migrations/20260424b_precos_unique_por_tipo.sql
@@ -1,0 +1,39 @@
+-- Separa precos LACRADO e SEMINOVO: antes o unique constraint era
+-- (modelo, armazenamento) e quando cadastravam um SEMINOVO com mesmo
+-- modelo+armazenamento do LACRADO ja existente, o upsert do POST
+-- /admin/precos sobrescrevia a row LACRADO (trocando tipo pra SEMINOVO
+-- e preco pro valor do seminovo). Consequencias em producao:
+--   1. Aba "Valores Lacrados" perde o modelo (porque virou SEMINOVO).
+--   2. Cron alerta-preco lia o preco SEMINOVO como se fosse o LACRADO,
+--      calculava "queda" gigante e disparava WhatsApp errado pros
+--      clientes que tinham simulado o LACRADO.
+--
+-- Fix: unique agora inclui tipo. Antes precisa backfillar NULL -> 'TRADEIN'
+-- porque NULL nao participa de unique constraint em Postgres (cada NULL
+-- e considerado distinto) e deixaria a constraint furada.
+
+-- 1) Backfill: tipo NULL vira TRADEIN (alinhado com default do frontend)
+UPDATE precos SET tipo = 'TRADEIN' WHERE tipo IS NULL;
+
+-- 2) Remove unique antigo (modelo, armazenamento). O nome padrao do
+--    Postgres quando criado via `UNIQUE (modelo, armazenamento)` inline
+--    e precos_modelo_armazenamento_key, mas cobrimos qualquer nome via
+--    pg_constraint pra nao quebrar se o schema foi renomeado.
+DO $$
+DECLARE
+  cname text;
+BEGIN
+  SELECT conname INTO cname
+  FROM pg_constraint
+  WHERE conrelid = 'precos'::regclass
+    AND contype = 'u'
+    AND pg_get_constraintdef(oid) ILIKE 'UNIQUE (modelo, armazenamento)';
+  IF cname IS NOT NULL THEN
+    EXECUTE 'ALTER TABLE precos DROP CONSTRAINT ' || quote_ident(cname);
+  END IF;
+END $$;
+
+-- 3) Novo unique incluindo tipo. SEMINOVO e LACRADO agora coexistem.
+ALTER TABLE precos
+  ADD CONSTRAINT precos_modelo_armazenamento_tipo_key
+  UNIQUE (modelo, armazenamento, tipo);


### PR DESCRIPTION
## Summary

Três correções pedidas pelo Nicolas juntas num PR só.

### 1. Coleta — formato da mensagem do motoboy
- Produto e detalhes do aparelho agora saem numa linha só:
  `📱 *APARELHO DA COLETA:* iPhone 13 128GB Estelar | Bateria: 77% | Com caixa`
- Telefone formatado com DDI BR: `+55 (21) 97694-9939`
- Aplicado em COLETA, ENTREGA copiada do card e ENTREGA recém-agendada.

### 2. Preços SEMINOVO e LACRADO separados
Causa raiz: unique constraint em `precos (modelo, armazenamento)` — quando adicionavam iPhone 16 128GB SEMINOVO, o upsert sobrescrevia o LACRADO existente. Isso:
- Sumia o modelo da aba "Valores Lacrados"
- Fazia o cron `alerta-preco` ler o preço SEMINOVO (bem menor) como se fosse o LACRADO, disparando WhatsApp de "queda" errada pros clientes.

Fix:
- **Migration** [20260424b_precos_unique_por_tipo.sql](supabase/migrations/20260424b_precos_unique_por_tipo.sql) — troca unique pra `(modelo, armazenamento, tipo)`. Backfilla `tipo` NULL → TRADEIN.
- **API** [/admin/precos](app/api/admin/precos/route.ts) — POST/PUT `onConflict: "modelo,armazenamento,tipo"`. DELETE filtra por tipo.
- **Cron** [alerta-preco](app/api/cron/alerta-preco/route.ts) — filtra `tipo != 'SEMINOVO'` ao montar mapa de preços.
- **Frontend** [admin/precos/page.tsx](app/admin/precos/page.tsx) — matches locais agora incluem tipo.

### 3. Entrega saindo sem info da troca (bug da Natália)
Causa raiz em 2 pontos:
- StepQuote criava `shortCode` novo a cada clique em "DESEJO FECHAR MEU PEDIDO". Quando `link-compras-auto` dedupava (mesmo cliente+produto em 30min), o cliente era redirecionado pro shortCode órfão mesmo assim.
- No `/compra`, quando o cliente subia print, o `upload-print` criava um placeholder só com `troca_produto` + `troca_valor` (sem cor, sem condicao). A entrega encaminhada desse placeholder saía sem os detalhes.

Fix em 4 camadas:
- **[upload-print](app/api/link-compras/upload-print/route.ts)**: placeholder agora salva `troca_cor` e `troca_condicao`.
- **[/compra](app/compra/page.tsx)**: envia `troca_cor` e `troca_condicao` pro upload-print.
- **[encaminhar-entrega](app/api/admin/link-compras/encaminhar-entrega/route.ts)**: se link tá incompleto, puxa fallback de `venda.troca_obs`/`troca_cor` pelo mesmo `short_code`.
- **[link-compras-auto](app/api/link-compras-auto/route.ts) + [StepQuote](components/StepQuote.tsx)**: dedup agora retorna o shortCode existente e o StepQuote redireciona pra ele, eliminando o link órfão na raiz.

## Pós-deploy (manual)

1. Rodar a migration `20260424b_precos_unique_por_tipo` em `/admin/migrations`.
2. **Re-cadastrar os LACRADO sobrescritos**: iPhone 16 128GB e iPhone 17 Pro 256GB (a data do LACRADO original foi perdida quando o SEMINOVO sobrescreveu).
3. Testar coleta: criar uma coleta de teste e copiar o formulário — confirmar linha única com `APARELHO DA COLETA` e telefone formatado.
4. Testar preços: editar um SEMINOVO e verificar que o LACRADO equivalente (depois de recadastrado) não é afetado.

## Test plan

- [ ] Migration roda sem erro
- [ ] Cadastrar iPhone 16 128GB LACRADO com SEMINOVO coexistindo — ambos aparecem nas abas corretas
- [ ] Editar preço do SEMINOVO não mexe no LACRADO
- [ ] Cron alerta-preco não dispara pra quem simulou LACRADO quando SEMINOVO do mesmo modelo baixou
- [ ] Coleta: formulário sai com linha única e telefone `+55 (XX) XXXXX-XXXX`
- [ ] /troca: clicar "DESEJO FECHAR" duas vezes redireciona pro mesmo shortCode (segunda vez reutiliza)
- [ ] Entrega encaminhada de placeholder upload-print sai com cor/condicao da troca

🤖 Generated with [Claude Code](https://claude.com/claude-code)