### PR TITLE
feat(sku): tier 1 — Cmd+K resumo 360°, Comprar Urgente, similares, QR+SKU e Reconciliacao

### DIFF
--- a/app/admin/comprar-urgente/page.tsx
+++ b/app/admin/comprar-urgente/page.tsx
@@ -1,0 +1,316 @@
+// app/admin/comprar-urgente/page.tsx
+// Dashboard de priorizacao de compra — mostra em ordem de urgencia quais SKUs
+// precisam ser comprados do fornecedor agora. Cada linha mostra o score, a
+// demanda (avisos + simulacoes + encomendas), a velocidade de venda e uma
+// sugestao de quantidade ja pronta pra colar no pedido.
+
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useAdmin } from "@/components/admin/AdminShell";
+import { SkuInfoModal } from "@/components/admin/SkuInfoModal";
+
+const fmt = (v: number | null) => (v === null || v === undefined ? "—" : `R$ ${Math.round(v).toLocaleString("pt-BR")}`);
+
+interface SkuUrgencia {
+  sku: string;
+  nome_canonico: string | null;
+  score: number;
+  em_estoque: number;
+  vendas_30d: number;
+  vendas_60d: number;
+  simulacoes_30d: number;
+  avisos_ativos: number;
+  encomendas_pendentes: number;
+  velocidade_semanal: number;
+  qnt_sugerida: number;
+  ultimo_custo: number | null;
+  ultima_venda_data: string | null;
+}
+
+// Categorias detectadas pelo prefixo do SKU (IPHONE-, IPAD-, MACBOOK-, etc)
+const CATEGORIAS: Array<{ label: string; prefixo: string }> = [
+  { label: "Todos", prefixo: "" },
+  { label: "iPhones", prefixo: "IPHONE-" },
+  { label: "iPads", prefixo: "IPAD" },
+  { label: "MacBooks", prefixo: "MACBOOK-" },
+  { label: "Mac Mini", prefixo: "MAC-MINI" },
+  { label: "Apple Watch", prefixo: "WATCH-" },
+  { label: "AirPods", prefixo: "AIRPODS" },
+];
+
+export default function ComprarUrgentePage() {
+  const { password } = useAdmin();
+  const [data, setData] = useState<SkuUrgencia[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [categoriaFiltro, setCategoriaFiltro] = useState("");
+  const [skuInfo, setSkuInfo] = useState<string | null>(null);
+  const [copiado, setCopiado] = useState(false);
+  const [minScore, setMinScore] = useState(2);
+
+  const fetchData = useCallback(() => {
+    if (!password) return;
+    setLoading(true);
+    fetch(`/api/admin/sku/comprar-urgente?min_score=${minScore}`, {
+      headers: { "x-admin-password": password },
+    })
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.ok) setData(json.resultados);
+        else setData([]);
+      })
+      .catch(() => setData([]))
+      .finally(() => setLoading(false));
+  }, [password, minScore]);
+
+  useEffect(() => {
+    // Mount + re-fetch quando password/periodo muda. fetchData chama
+    // setLoading internamente — padrao tipico aceitavel (eslint excessivo).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchData();
+  }, [fetchData]);
+
+  const filtrados = (data || []).filter((r) => {
+    if (!categoriaFiltro) return true;
+    return r.sku.startsWith(categoriaFiltro);
+  });
+
+  const copiarLista = () => {
+    const linhas = filtrados.map(
+      (r) => `${r.qnt_sugerida}x ${r.nome_canonico || r.sku}${r.ultimo_custo ? ` (último custo ${fmt(r.ultimo_custo)})` : ""}`,
+    );
+    const texto = `📦 Lista de compra — ${new Date().toLocaleDateString("pt-BR")}\n\n${linhas.join("\n")}`;
+    navigator.clipboard.writeText(texto);
+    setCopiado(true);
+    setTimeout(() => setCopiado(false), 2500);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-bold text-[#1D1D1F]">🚨 Comprar Urgente</h1>
+          <p className="text-sm text-[#86868B] mt-0.5">
+            SKUs ranqueados por urgência baseado em demanda real (vendas recentes, simulações, avisos, encomendas).
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={copiarLista}
+            disabled={filtrados.length === 0}
+            className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+              filtrados.length === 0
+                ? "bg-gray-100 text-gray-400 cursor-not-allowed"
+                : copiado
+                  ? "bg-green-500 text-white"
+                  : "bg-[#E8740E] text-white hover:bg-[#D06A0D]"
+            }`}
+          >
+            {copiado ? "✅ Copiado" : "📋 Copiar lista pro fornecedor"}
+          </button>
+          <button
+            onClick={fetchData}
+            className="px-3 py-1.5 rounded-lg text-xs font-medium bg-white border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E] hover:text-[#E8740E] transition-colors"
+          >
+            Atualizar
+          </button>
+        </div>
+      </div>
+
+      {/* Filtros */}
+      <div className="bg-white border border-[#D2D2D7] rounded-2xl p-4 shadow-sm flex flex-col sm:flex-row gap-3 items-start sm:items-center">
+        <div className="flex gap-2 flex-wrap">
+          {CATEGORIAS.map((c) => (
+            <button
+              key={c.label}
+              onClick={() => setCategoriaFiltro(c.prefixo)}
+              className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                categoriaFiltro === c.prefixo
+                  ? "bg-[#E8740E] text-white"
+                  : "bg-white border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E] hover:text-[#E8740E]"
+              }`}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2 ml-auto">
+          <label className="text-xs text-[#86868B]">Score mínimo:</label>
+          <select
+            value={minScore}
+            onChange={(e) => setMinScore(Number(e.target.value))}
+            className="px-2 py-1 rounded-lg border border-[#D2D2D7] text-xs"
+          >
+            <option value={1}>1 (tudo)</option>
+            <option value={2}>2 (padrão)</option>
+            <option value={5}>5 (importante)</option>
+            <option value={10}>10 (crítico)</option>
+          </select>
+        </div>
+      </div>
+
+      {/* KPIs topo */}
+      {!loading && data && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <KPICard label="SKUs urgentes" value={filtrados.length} accent="red" />
+          <KPICard
+            label="Demanda reprimida"
+            value={filtrados.reduce((s, r) => s + r.avisos_ativos + r.encomendas_pendentes, 0)}
+            sub="avisos + encomendas"
+            accent="orange"
+          />
+          <KPICard
+            label="Interesse recente"
+            value={filtrados.reduce((s, r) => s + r.simulacoes_30d, 0)}
+            sub="simulações 30d"
+            accent="purple"
+          />
+          <KPICard
+            label="Total sugerido"
+            value={filtrados.reduce((s, r) => s + r.qnt_sugerida, 0)}
+            sub="unidades a comprar"
+            accent="green"
+          />
+        </div>
+      )}
+
+      {/* Tabela */}
+      <div className="bg-white border border-[#D2D2D7] rounded-2xl overflow-hidden shadow-sm">
+        {loading ? (
+          <div className="py-16 text-center text-sm text-[#86868B]">Calculando urgências…</div>
+        ) : filtrados.length === 0 ? (
+          <div className="py-16 text-center">
+            <p className="text-4xl mb-2">🎉</p>
+            <p className="text-sm text-[#86868B]">Nenhum SKU com urgência crítica. Bom trabalho!</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs sm:text-sm">
+              <thead className="bg-[#F5F5F7] border-b border-[#D2D2D7]">
+                <tr>
+                  <th className="px-3 py-2.5 text-left font-semibold text-[#6E6E73]">#</th>
+                  <th className="px-3 py-2.5 text-left font-semibold text-[#6E6E73]">Produto</th>
+                  <th className="px-3 py-2.5 text-center font-semibold text-[#6E6E73]">Score</th>
+                  <th className="px-3 py-2.5 text-center font-semibold text-[#6E6E73]">Em estoque</th>
+                  <th className="px-3 py-2.5 text-center font-semibold text-[#6E6E73]" title="Simulações + Avisos + Encomendas">
+                    Demanda
+                  </th>
+                  <th className="px-3 py-2.5 text-center font-semibold text-[#6E6E73]">Velocidade/sem</th>
+                  <th className="px-3 py-2.5 text-center font-semibold text-[#E8740E]">Comprar</th>
+                  <th className="px-3 py-2.5 text-right font-semibold text-[#6E6E73]">Último custo</th>
+                  <th className="px-3 py-2.5"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtrados.map((r, idx) => {
+                  const urgenciaColor =
+                    r.score >= 15 ? "bg-red-50" : r.score >= 8 ? "bg-orange-50" : "bg-yellow-50";
+                  return (
+                    <tr key={r.sku} className={`border-b border-[#F0F0F5] hover:bg-[#FAFAFB] transition-colors ${idx < 3 ? urgenciaColor : ""}`}>
+                      <td className="px-3 py-2.5 font-mono text-[#86868B]">{idx + 1}</td>
+                      <td className="px-3 py-2.5">
+                        <div className="font-medium text-[#1D1D1F]">{r.nome_canonico || r.sku}</div>
+                        <div className="font-mono text-[10px] text-[#86868B] mt-0.5">{r.sku}</div>
+                      </td>
+                      <td className="px-3 py-2.5 text-center">
+                        <span className={`inline-block px-2 py-0.5 rounded-full text-[11px] font-bold ${
+                          r.score >= 15 ? "bg-red-100 text-red-700" :
+                          r.score >= 8 ? "bg-orange-100 text-orange-700" :
+                          "bg-yellow-100 text-yellow-700"
+                        }`}>
+                          {r.score}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2.5 text-center">
+                        <span className={r.em_estoque === 0 ? "text-red-600 font-bold" : "text-[#1D1D1F]"}>
+                          {r.em_estoque}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2.5 text-center">
+                        <div className="text-[11px] text-[#86868B]">
+                          {r.simulacoes_30d > 0 && <span title="Simulações 30d">{r.simulacoes_30d}s</span>}
+                          {r.simulacoes_30d > 0 && (r.avisos_ativos > 0 || r.encomendas_pendentes > 0) && " · "}
+                          {r.avisos_ativos > 0 && <span title="Avisos ativos">{r.avisos_ativos}a</span>}
+                          {r.avisos_ativos > 0 && r.encomendas_pendentes > 0 && " · "}
+                          {r.encomendas_pendentes > 0 && <span title="Encomendas pendentes" className="text-[#E8740E] font-semibold">{r.encomendas_pendentes}e</span>}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2.5 text-center text-[#86868B]">
+                        {r.velocidade_semanal > 0 ? `${r.velocidade_semanal}/sem` : "—"}
+                      </td>
+                      <td className="px-3 py-2.5 text-center">
+                        <span className="inline-block px-2.5 py-1 rounded-lg bg-[#FFF5EB] text-[#E8740E] font-bold border border-[#E8740E]/30">
+                          {r.qnt_sugerida}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2.5 text-right text-[#86868B]">{fmt(r.ultimo_custo)}</td>
+                      <td className="px-3 py-2.5">
+                        <button
+                          onClick={() => setSkuInfo(r.sku)}
+                          className="text-xs px-2 py-1 rounded border border-[#E8740E]/30 text-[#E8740E] hover:bg-[#FFF5EB] transition-colors"
+                          title="Ver resumo 360° do SKU"
+                        >
+                          📊
+                        </button>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Ajuda rápida */}
+      {!loading && filtrados.length > 0 && (
+        <div className="bg-[#F5F5F7] rounded-2xl p-4 text-xs text-[#6E6E73] space-y-1">
+          <p>
+            <strong>Score:</strong> avisos × 4 + encomendas × 3 + simulações × 2 + vendas × 2 (pontua só quando estoque ≤ 1).
+          </p>
+          <p>
+            <strong>Comprar:</strong> maior entre (avisos+encomendas), 2 semanas de velocidade histórica ou 15% das simulações.
+          </p>
+          <p>
+            <strong>Demanda:</strong> <code>s</code> = simulações, <code>a</code> = avisos, <code className="text-[#E8740E]">e</code> = encomendas pendentes.
+          </p>
+        </div>
+      )}
+
+      {skuInfo && <SkuInfoModal sku={skuInfo} onClose={() => setSkuInfo(null)} />}
+    </div>
+  );
+}
+
+function KPICard({
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  label: string;
+  value: number;
+  sub?: string;
+  accent: "red" | "orange" | "purple" | "green";
+}) {
+  const bgMap = {
+    red: "bg-red-50 border-red-200",
+    orange: "bg-[#FFF5EB] border-[#E8740E]/30",
+    purple: "bg-purple-50 border-purple-200",
+    green: "bg-green-50 border-green-200",
+  };
+  const textMap = {
+    red: "text-red-600",
+    orange: "text-[#E8740E]",
+    purple: "text-purple-600",
+    green: "text-green-600",
+  };
+  return (
+    <div className={`p-4 rounded-2xl border ${bgMap[accent]}`}>
+      <p className="text-[11px] font-medium uppercase tracking-wide text-[#86868B]">{label}</p>
+      <p className={`text-2xl font-bold mt-1 ${textMap[accent]}`}>{value}</p>
+      {sub && <p className="text-[10px] mt-0.5 text-[#86868B]">{sub}</p>}
+    </div>
+  );
+}

--- a/app/admin/reconciliacao-sku/page.tsx
+++ b/app/admin/reconciliacao-sku/page.tsx
@@ -1,0 +1,305 @@
+// app/admin/reconciliacao-sku/page.tsx
+// Auditoria operacional: detecta inconsistencias entre estoque e vendas que
+// indicam sumico, erro de registro ou divergencia de SKU. Rodar toda semana
+// pra pegar problemas cedo em vez de deixar crescer ate a auditoria anual.
+
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import { useAdmin } from "@/components/admin/AdminShell";
+import { SkuInfoModal } from "@/components/admin/SkuInfoModal";
+
+const fmt = (v: number | null | undefined) =>
+  v === null || v === undefined ? "—" : `R$ ${Math.round(Number(v)).toLocaleString("pt-BR")}`;
+
+type Severidade = "alta" | "media" | "baixa";
+type TipoInc = "SKU_DIVERGENTE_PERSISTIDO" | "ESGOTADO_SEM_VENDA" | "VENDA_SEM_ESTOQUE";
+
+interface Inconsistencia {
+  tipo: TipoInc;
+  severidade: Severidade;
+  descricao: string;
+  produto: string;
+  detalhes: Record<string, string | number | null>;
+  ids: { venda_id?: string; estoque_id?: string };
+}
+
+interface Resumo {
+  total: number;
+  por_tipo: Record<TipoInc, number>;
+  por_severidade: Record<Severidade, number>;
+  periodo: { from: string; until: string };
+}
+
+const TIPO_LABEL: Record<TipoInc, { titulo: string; icone: string; explicacao: string }> = {
+  SKU_DIVERGENTE_PERSISTIDO: {
+    titulo: "SKU divergente",
+    icone: "⚠️",
+    explicacao:
+      "Venda vinculada a item com SKU diferente — cliente pode ter recebido produto errado. Verifique e corrija.",
+  },
+  ESGOTADO_SEM_VENDA: {
+    titulo: "Sumiço",
+    icone: "🔍",
+    explicacao:
+      "Produto marcado como vendido/esgotado no estoque mas sem venda vinculada. Pode ser venda fora do sistema, erro de registro ou roubo.",
+  },
+  VENDA_SEM_ESTOQUE: {
+    titulo: "Venda sem baixa",
+    icone: "📦",
+    explicacao:
+      "Venda registrada sem vincular item do estoque — o estoque ainda pensa que tem. Dupla-contagem potencial.",
+  },
+};
+
+export default function ReconciliacaoSkuPage() {
+  const { password } = useAdmin();
+  const [inconsistencias, setInconsistencias] = useState<Inconsistencia[] | null>(null);
+  const [resumo, setResumo] = useState<Resumo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [tipoFiltro, setTipoFiltro] = useState<TipoInc | "todos">("todos");
+  const [skuInfo, setSkuInfo] = useState<string | null>(null);
+  const [periodoDias, setPeriodoDias] = useState(30);
+
+  const fetchData = useCallback(() => {
+    if (!password) return;
+    setLoading(true);
+    const fromDate = new Date(Date.now() - periodoDias * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    fetch(`/api/admin/sku/reconciliacao?from=${fromDate}`, {
+      headers: { "x-admin-password": password },
+    })
+      .then((r) => r.json())
+      .then((json) => {
+        if (json.ok) {
+          setInconsistencias(json.inconsistencias);
+          setResumo(json.resumo);
+        } else {
+          setInconsistencias([]);
+        }
+      })
+      .catch(() => setInconsistencias([]))
+      .finally(() => setLoading(false));
+  }, [password, periodoDias]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    fetchData();
+  }, [fetchData]);
+
+  const filtradas = (inconsistencias || []).filter((i) =>
+    tipoFiltro === "todos" ? true : i.tipo === tipoFiltro,
+  );
+
+  const severidadeColor = (s: Severidade): string =>
+    s === "alta" ? "bg-red-100 text-red-700 border-red-200"
+    : s === "media" ? "bg-orange-100 text-orange-700 border-orange-200"
+    : "bg-yellow-100 text-yellow-700 border-yellow-200";
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-bold text-[#1D1D1F]">🔁 Reconciliação SKU</h1>
+          <p className="text-sm text-[#86868B] mt-0.5">
+            Auditoria cruzando estoque × vendas × SKU — detecta sumiço, erro de registro e divergências.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <select
+            value={periodoDias}
+            onChange={(e) => setPeriodoDias(Number(e.target.value))}
+            className="px-3 py-1.5 rounded-lg text-xs font-medium bg-white border border-[#D2D2D7]"
+          >
+            <option value={7}>Últimos 7 dias</option>
+            <option value={30}>Últimos 30 dias</option>
+            <option value={90}>Últimos 90 dias</option>
+            <option value={365}>Último ano</option>
+          </select>
+          <button
+            onClick={fetchData}
+            className="px-3 py-1.5 rounded-lg text-xs font-medium bg-white border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E] hover:text-[#E8740E] transition-colors"
+          >
+            Atualizar
+          </button>
+        </div>
+      </div>
+
+      {/* Resumo */}
+      {resumo && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <KPICard
+            label="Total"
+            value={resumo.total}
+            sub={`${resumo.periodo.from} → ${resumo.periodo.until}`}
+            accent={resumo.total === 0 ? "green" : resumo.total > 10 ? "red" : "orange"}
+          />
+          <KPICard
+            label="Alta severidade"
+            value={resumo.por_severidade.alta}
+            sub="investigar urgente"
+            accent="red"
+          />
+          <KPICard
+            label="Divergências SKU"
+            value={resumo.por_tipo.SKU_DIVERGENTE_PERSISTIDO}
+            sub="produto errado"
+            accent="red"
+          />
+          <KPICard
+            label="Possíveis sumiços"
+            value={resumo.por_tipo.ESGOTADO_SEM_VENDA}
+            sub="esgotados sem venda"
+            accent="orange"
+          />
+        </div>
+      )}
+
+      {/* Filtros por tipo */}
+      <div className="flex gap-2 flex-wrap">
+        <button
+          onClick={() => setTipoFiltro("todos")}
+          className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+            tipoFiltro === "todos" ? "bg-[#E8740E] text-white" : "bg-white border border-[#D2D2D7] text-[#6E6E73]"
+          }`}
+        >
+          Todos ({inconsistencias?.length || 0})
+        </button>
+        {(Object.keys(TIPO_LABEL) as TipoInc[]).map((tipo) => (
+          <button
+            key={tipo}
+            onClick={() => setTipoFiltro(tipo)}
+            className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+              tipoFiltro === tipo ? "bg-[#E8740E] text-white" : "bg-white border border-[#D2D2D7] text-[#6E6E73]"
+            }`}
+          >
+            {TIPO_LABEL[tipo].icone} {TIPO_LABEL[tipo].titulo} ({resumo?.por_tipo[tipo] || 0})
+          </button>
+        ))}
+      </div>
+
+      {/* Lista de inconsistências */}
+      <div className="bg-white border border-[#D2D2D7] rounded-2xl overflow-hidden shadow-sm">
+        {loading ? (
+          <div className="py-16 text-center text-sm text-[#86868B]">Analisando…</div>
+        ) : filtradas.length === 0 ? (
+          <div className="py-16 text-center">
+            <p className="text-4xl mb-2">✅</p>
+            <p className="text-base font-bold text-green-700">Tudo em ordem!</p>
+            <p className="text-sm text-[#86868B] mt-1">
+              Nenhuma inconsistência detectada no período selecionado.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y divide-[#F0F0F5]">
+            {filtradas.map((inc, idx) => (
+              <div key={idx} className="p-4 hover:bg-[#FAFAFB] transition-colors">
+                <div className="flex items-start gap-3">
+                  <span className="text-2xl shrink-0">{TIPO_LABEL[inc.tipo].icone}</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-bold border ${severidadeColor(inc.severidade)}`}>
+                        {inc.severidade.toUpperCase()}
+                      </span>
+                      <span className="text-xs font-semibold text-[#E8740E]">
+                        {TIPO_LABEL[inc.tipo].titulo}
+                      </span>
+                    </div>
+                    <p className="text-sm font-medium text-[#1D1D1F] mt-1">{inc.produto}</p>
+                    <p className="text-xs text-[#86868B] mt-0.5">{inc.descricao}</p>
+
+                    {/* Detalhes */}
+                    <div className="mt-2 flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] text-[#6E6E73]">
+                      {Object.entries(inc.detalhes).map(([k, v]) => {
+                        if (v === null || v === undefined || v === "") return null;
+                        const fmtValue = k === "preco" || k === "custo" ? fmt(v as number) : String(v);
+                        return (
+                          <span key={k}>
+                            <strong className="text-[#86868B]">{k}:</strong> <span className={k === "sku" || k === "venda_sku" || k === "estoque_sku" ? "font-mono" : ""}>{fmtValue}</span>
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {/* Actions */}
+                  <div className="flex flex-col gap-1 shrink-0">
+                    {inc.detalhes.sku && typeof inc.detalhes.sku === "string" && inc.detalhes.sku !== "sem SKU" && (
+                      <button
+                        onClick={() => setSkuInfo(inc.detalhes.sku as string)}
+                        className="text-xs px-2 py-1 rounded border border-[#E8740E]/30 text-[#E8740E] hover:bg-[#FFF5EB] transition-colors"
+                      >
+                        📊 SKU
+                      </button>
+                    )}
+                    {inc.ids.venda_id && (
+                      <a
+                        href={`/admin/vendas?venda_id=${inc.ids.venda_id}`}
+                        className="text-xs px-2 py-1 rounded border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E] hover:text-[#E8740E] text-center transition-colors"
+                      >
+                        Ver venda
+                      </a>
+                    )}
+                    {inc.ids.estoque_id && (
+                      <a
+                        href={`/admin/estoque?id=${inc.ids.estoque_id}`}
+                        className="text-xs px-2 py-1 rounded border border-[#D2D2D7] text-[#6E6E73] hover:border-[#E8740E] hover:text-[#E8740E] text-center transition-colors"
+                      >
+                        Ver estoque
+                      </a>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Legenda */}
+      <div className="bg-[#F5F5F7] rounded-2xl p-4 space-y-2">
+        <p className="text-xs font-bold text-[#1D1D1F]">Legenda dos tipos</p>
+        {(Object.keys(TIPO_LABEL) as TipoInc[]).map((tipo) => (
+          <div key={tipo} className="flex gap-2 text-xs text-[#6E6E73]">
+            <span>{TIPO_LABEL[tipo].icone}</span>
+            <div>
+              <strong>{TIPO_LABEL[tipo].titulo}:</strong> {TIPO_LABEL[tipo].explicacao}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {skuInfo && <SkuInfoModal sku={skuInfo} onClose={() => setSkuInfo(null)} />}
+    </div>
+  );
+}
+
+function KPICard({
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  label: string;
+  value: number;
+  sub?: string;
+  accent: "red" | "orange" | "green";
+}) {
+  const bgMap = {
+    red: "bg-red-50 border-red-200",
+    orange: "bg-[#FFF5EB] border-[#E8740E]/30",
+    green: "bg-green-50 border-green-200",
+  };
+  const textMap = {
+    red: "text-red-600",
+    orange: "text-[#E8740E]",
+    green: "text-green-600",
+  };
+  return (
+    <div className={`p-4 rounded-2xl border ${bgMap[accent]}`}>
+      <p className="text-[11px] font-medium uppercase tracking-wide text-[#86868B]">{label}</p>
+      <p className={`text-2xl font-bold mt-1 ${textMap[accent]}`}>{value}</p>
+      {sub && <p className="text-[10px] mt-0.5 text-[#86868B]">{sub}</p>}
+    </div>
+  );
+}

--- a/app/api/admin/search/route.ts
+++ b/app/api/admin/search/route.ts
@@ -17,18 +17,20 @@ export async function GET(req: NextRequest) {
   const searchTerm = `%${q}%`;
 
   // ── 1. Buscar no estoque (produtos com serial/IMEI) ──
+  // Inclui busca por SKU canonico (ex: "IPHONE-17-PRO-MAX-256GB") alem dos
+  // campos de texto livre.
   const { data: estoqueResults } = await supabase
     .from("estoque")
-    .select("id, produto, categoria, cor, qnt, custo_unitario, status, tipo, fornecedor, data_compra, data_entrada, observacao, bateria, serial_no, imei, origem, garantia, troca_id")
-    .or(`produto.ilike.${searchTerm},fornecedor.ilike.${searchTerm},cliente.ilike.${searchTerm},cor.ilike.${searchTerm},serial_no.ilike.${searchTerm},imei.ilike.${searchTerm}`)
+    .select("id, produto, categoria, cor, qnt, custo_unitario, status, tipo, fornecedor, data_compra, data_entrada, observacao, bateria, serial_no, imei, origem, garantia, troca_id, sku")
+    .or(`produto.ilike.${searchTerm},fornecedor.ilike.${searchTerm},cliente.ilike.${searchTerm},cor.ilike.${searchTerm},serial_no.ilike.${searchTerm},imei.ilike.${searchTerm},sku.ilike.${searchTerm}`)
     .order("data_entrada", { ascending: false })
     .limit(30);
 
   // ── 2. Buscar nas vendas (inclui fornecedor para entradas/recompras) ──
   const { data: vendasResults } = await supabase
     .from("vendas")
-    .select("id, produto, cliente, fornecedor, preco_vendido, custo, data, forma, banco, status_pagamento, tipo, origem, serial_no, imei, cpf, email")
-    .or(`produto.ilike.${searchTerm},cliente.ilike.${searchTerm},serial_no.ilike.${searchTerm},imei.ilike.${searchTerm},fornecedor.ilike.${searchTerm}`)
+    .select("id, produto, cliente, fornecedor, preco_vendido, custo, data, forma, banco, status_pagamento, tipo, origem, serial_no, imei, cpf, email, sku")
+    .or(`produto.ilike.${searchTerm},cliente.ilike.${searchTerm},serial_no.ilike.${searchTerm},imei.ilike.${searchTerm},fornecedor.ilike.${searchTerm},sku.ilike.${searchTerm}`)
     .neq("status_pagamento", "CANCELADO")
     .order("data", { ascending: false })
     .limit(includeHistory ? 100 : 30);
@@ -184,6 +186,7 @@ export async function GET(req: NextRequest) {
     garantia: e.garantia,
     troca_id: e.troca_id,
     troca_info: e.troca_id ? trocasMap.get(e.troca_id) || null : null,
+    sku: e.sku,
   }));
 
   // ── 6. Montar resultados de vendas ──
@@ -212,6 +215,7 @@ export async function GET(req: NextRequest) {
       serial_no: v.serial_no,
       imei: v.imei,
       is_entrada: matchedByFornecedor,
+      sku: v.sku,
     };
   });
 

--- a/app/api/admin/sku/comprar-urgente/route.ts
+++ b/app/api/admin/sku/comprar-urgente/route.ts
@@ -1,0 +1,206 @@
+// app/api/admin/sku/comprar-urgente/route.ts
+// Ranking de SKUs que o Andre precisa comprar do fornecedor, baseado em dados
+// reais do negocio. Regra de prioridade:
+//
+//   estoque_agora = 0
+//   score = avisos * 4 + encomendas_pendentes * 3 + simulacoes_30d * 2 + vendas_30d * 2
+//
+// Ranqueado por score decrescente. Quanto maior, mais urgente comprar.
+//
+// Tambem calcula "sugestao de qnt a comprar" baseada na velocidade de
+// venda historica (ultimos 60d) + demanda reprimida atual:
+//
+//   velocidade_semanal = vendas_60d / ~8.6 (semanas em 60d)
+//   qnt_sugerida = max(
+//     avisos + encomendas_pendentes,            // demanda confirmada
+//     velocidade_semanal * 2,                   // cobre 2 semanas de vendas
+//     simulacoes_30d * 0.15                     // 15% das simulacoes viram venda
+//   )
+//
+// Uso:
+//   GET /api/admin/sku/comprar-urgente
+//   Query opcional: ?min_score=N (default 2) — filtra SKUs irrelevantes
+
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { skuToNomeCanonico } from "@/lib/sku-validator";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+interface SkuUrgencia {
+  sku: string;
+  nome_canonico: string | null;
+  score: number;
+  em_estoque: number;
+  vendas_30d: number;
+  vendas_60d: number;
+  simulacoes_30d: number;
+  avisos_ativos: number;
+  encomendas_pendentes: number;
+  velocidade_semanal: number;
+  qnt_sugerida: number;
+  ultimo_custo: number | null;
+  ultima_venda_data: string | null;
+}
+
+export async function GET(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const minScore = Number(req.nextUrl.searchParams.get("min_score") || "2");
+  const from30d = daysAgoIso(30);
+  const from60d = daysAgoIso(60);
+
+  try {
+    // Coleta em paralelo todos os SKUs com sinal de demanda ou estoque
+    const [vendas60dRes, simRes, avisosRes, encRes, estoqueRes] = await Promise.all([
+      supabase
+        .from("vendas")
+        .select("sku, data, preco_vendido, custo")
+        .not("sku", "is", null)
+        .gte("data", from60d.slice(0, 10))
+        .neq("status_pagamento", "CANCELADO"),
+      supabase
+        .from("simulacoes")
+        .select("sku")
+        .not("sku", "is", null)
+        .gte("created_at", from30d),
+      supabase
+        .from("avisos_clientes")
+        .select("sku")
+        .not("sku", "is", null)
+        .eq("status", "ATIVO"),
+      supabase
+        .from("encomendas")
+        .select("sku")
+        .not("sku", "is", null)
+        .in("status", ["PENDENTE", "COMPRADO", "A CAMINHO"]),
+      supabase
+        .from("estoque")
+        .select("sku, qnt, status, custo_compra, custo_unitario, data_entrada")
+        .not("sku", "is", null),
+    ]);
+
+    // Mapas por SKU
+    const vendas30Map = new Map<string, number>();
+    const vendas60Map = new Map<string, number>();
+    const ultimaVendaMap = new Map<string, string>();
+    const from30Date = from30d.slice(0, 10);
+    for (const v of vendas60dRes.data || []) {
+      const sku = v.sku as string;
+      vendas60Map.set(sku, (vendas60Map.get(sku) || 0) + 1);
+      if (v.data >= from30Date) vendas30Map.set(sku, (vendas30Map.get(sku) || 0) + 1);
+      const prev = ultimaVendaMap.get(sku);
+      if (!prev || (v.data && v.data > prev)) ultimaVendaMap.set(sku, v.data);
+    }
+
+    const simMap = new Map<string, number>();
+    for (const r of simRes.data || []) {
+      const sku = r.sku as string;
+      simMap.set(sku, (simMap.get(sku) || 0) + 1);
+    }
+
+    const avisosMap = new Map<string, number>();
+    for (const r of avisosRes.data || []) {
+      const sku = r.sku as string;
+      avisosMap.set(sku, (avisosMap.get(sku) || 0) + 1);
+    }
+
+    const encMap = new Map<string, number>();
+    for (const r of encRes.data || []) {
+      const sku = r.sku as string;
+      encMap.set(sku, (encMap.get(sku) || 0) + 1);
+    }
+
+    // Estoque: agrega qnt em EM ESTOQUE e pega ultimo custo conhecido
+    const estoqueMap = new Map<string, { qnt: number; ultimoCusto: number | null; ultimaEntrada: string | null }>();
+    for (const r of estoqueRes.data || []) {
+      const sku = r.sku as string;
+      const isEmEstoque = String(r.status || "").toUpperCase() === "EM ESTOQUE" && Number(r.qnt || 0) > 0;
+      const cur = estoqueMap.get(sku) || { qnt: 0, ultimoCusto: null, ultimaEntrada: null };
+      if (isEmEstoque) cur.qnt += Number(r.qnt || 0);
+      const custo = Number(r.custo_compra || r.custo_unitario || 0);
+      if (custo > 0) {
+        // Pega o MAIS RECENTE (comparando por data_entrada)
+        if (!cur.ultimaEntrada || (r.data_entrada && r.data_entrada > cur.ultimaEntrada)) {
+          cur.ultimoCusto = custo;
+          cur.ultimaEntrada = r.data_entrada || cur.ultimaEntrada;
+        }
+      }
+      estoqueMap.set(sku, cur);
+    }
+
+    // Gera lista de todos os SKUs que aparecem em qualquer mapa
+    const todosSkus = new Set<string>([
+      ...vendas60Map.keys(),
+      ...simMap.keys(),
+      ...avisosMap.keys(),
+      ...encMap.keys(),
+      ...estoqueMap.keys(),
+    ]);
+
+    const resultados: SkuUrgencia[] = [];
+
+    for (const sku of todosSkus) {
+      const est = estoqueMap.get(sku) || { qnt: 0, ultimoCusto: null, ultimaEntrada: null };
+      const vendas30 = vendas30Map.get(sku) || 0;
+      const vendas60 = vendas60Map.get(sku) || 0;
+      const sim = simMap.get(sku) || 0;
+      const avisos = avisosMap.get(sku) || 0;
+      const enc = encMap.get(sku) || 0;
+
+      // Score: so pontua forte quando estoque = 0. Com estoque, score baixo
+      // (o produto nao e urgencia imediata).
+      const multiplicadorEstoque = est.qnt === 0 ? 1 : est.qnt < 2 ? 0.5 : 0;
+      const score = Math.round(
+        (avisos * 4 + enc * 3 + sim * 2 + vendas30 * 2) * multiplicadorEstoque,
+      );
+
+      if (score < minScore) continue;
+
+      const velocidadeSemanal = Math.round((vendas60 / 8.6) * 10) / 10;
+      const qntSugerida = Math.max(
+        avisos + enc,
+        Math.ceil(velocidadeSemanal * 2),
+        Math.ceil(sim * 0.15),
+        1,
+      );
+
+      resultados.push({
+        sku,
+        nome_canonico: skuToNomeCanonico(sku),
+        score,
+        em_estoque: est.qnt,
+        vendas_30d: vendas30,
+        vendas_60d: vendas60,
+        simulacoes_30d: sim,
+        avisos_ativos: avisos,
+        encomendas_pendentes: enc,
+        velocidade_semanal: velocidadeSemanal,
+        qnt_sugerida: qntSugerida,
+        ultimo_custo: est.ultimoCusto,
+        ultima_venda_data: ultimaVendaMap.get(sku) || null,
+      });
+    }
+
+    // Ordena por score desc
+    resultados.sort((a, b) => b.score - a.score);
+
+    return NextResponse.json({
+      ok: true,
+      total: resultados.length,
+      gerado_em: new Date().toISOString(),
+      resultados: resultados.slice(0, 100),
+    });
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/app/api/admin/sku/info/route.ts
+++ b/app/api/admin/sku/info/route.ts
@@ -1,0 +1,370 @@
+// app/api/admin/sku/info/route.ts
+// Agregador de tudo sobre um SKU canonico — usado pelo Cmd+K pra dar uma
+// visao 360° do produto em 1 request so:
+//
+//   - Estoque atual (qnt + custo medio ponderado)
+//   - Vendas ultimos 30/90d (qtd, ticket medio, margem)
+//   - Simulacoes 30d (interesse de compra)
+//   - Avisos clientes ativos (demanda reprimida)
+//   - Encomendas em aberto (compra ja prometida ao cliente)
+//   - Mostruario: SKU aparece? qual preco?
+//
+// Uso:
+//   GET /api/admin/sku/info?sku=IPHONE-17-PRO-MAX-256GB-TITANIO-NATURAL
+//   Retorna tudo que voce precisa saber pra precificar/decidir naquele momento.
+
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { skuToNomeCanonico } from "@/lib/sku-validator";
+
+export const dynamic = "force-dynamic";
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+interface InfoEstoque {
+  total_unidades: number;
+  custo_medio: number;
+  custo_minimo: number;
+  custo_maximo: number;
+  items: Array<{
+    id: string;
+    produto: string;
+    cor: string | null;
+    serial_no: string | null;
+    imei: string | null;
+    custo_compra: number;
+    custo_unitario: number;
+    fornecedor: string | null;
+    data_entrada: string | null;
+    status: string;
+  }>;
+}
+
+interface InfoVendas {
+  total_30d: number;
+  total_90d: number;
+  total_geral: number;
+  ticket_medio_30d: number;
+  faturamento_30d: number;
+  margem_media: number;   // % lucro medio
+  lucro_total_30d: number;
+  ultima_venda_data: string | null;
+  ultimas: Array<{
+    id: string;
+    data: string;
+    cliente: string;
+    preco_vendido: number;
+    custo: number | null;
+    lucro: number | null;
+  }>;
+}
+
+interface SkuSimilar {
+  sku: string;
+  nome_canonico: string | null;
+  em_estoque: number;
+  custo_medio: number;
+  similaridade: number; // 0-100, quanto maior mais parecido
+  diferencas: string[]; // ex: ["storage diferente", "cor diferente"]
+}
+
+interface InfoSkuResponse {
+  sku: string;
+  nome_canonico: string | null;
+  estoque: InfoEstoque;
+  vendas: InfoVendas;
+  simulacoes_30d: number;
+  avisos_ativos: number;
+  encomendas_pendentes: number;
+  mostruario: {
+    visivel: boolean;
+    preco: number | null;
+    preco_parcelado: number | null;
+    produto_id: string | null;
+    variacao_id: string | null;
+  };
+  similares: SkuSimilar[];
+}
+
+// Extrai prefixo comum do SKU pra busca de similares. Regras:
+//   IPHONE-17-PRO-MAX-512GB-PRATA  →  prefixo = IPHONE-17-PRO-MAX
+//   IPAD-PRO-M4-13-256GB-PRATA     →  prefixo = IPAD-PRO-M4
+//   MACBOOK-AIR-M4-13-16GB-256GB   →  prefixo = MACBOOK-AIR-M4
+//   WATCH-S11-42MM-GPS-PRATA       →  prefixo = WATCH-S11
+// O prefixo captura modelo+variante+chip, deixando livre storage+cor+etc.
+function extrairPrefixoFamilia(sku: string): string {
+  const partes = sku.split("-");
+  // IPHONE-17 / IPHONE-17-PRO / IPHONE-17-PRO-MAX
+  if (partes[0] === "IPHONE") {
+    if (partes.length >= 4 && (partes[2] === "PRO" || partes[2] === "PLUS" || partes[2] === "AIR") && partes[3] === "MAX") {
+      return `${partes[0]}-${partes[1]}-${partes[2]}-${partes[3]}`;
+    }
+    if (partes.length >= 3 && (partes[2] === "PRO" || partes[2] === "PLUS" || partes[2] === "AIR" || partes[2] === "MINI")) {
+      return `${partes[0]}-${partes[1]}-${partes[2]}`;
+    }
+    return `${partes[0]}-${partes[1]}`;
+  }
+  // IPAD / IPAD-PRO-M4 / IPAD-AIR-M3 / IPAD-MINI
+  if (partes[0] === "IPAD") {
+    if (partes.length >= 3 && (partes[1] === "PRO" || partes[1] === "AIR")) {
+      return `${partes[0]}-${partes[1]}-${partes[2] || ""}`;
+    }
+    return partes.slice(0, 2).join("-");
+  }
+  // MACBOOK-AIR-M4 / MACBOOK-PRO-M4
+  if (partes[0] === "MACBOOK") {
+    return partes.slice(0, 3).join("-");
+  }
+  // MAC-MINI-M4
+  if (partes[0] === "MAC" && partes[1] === "MINI") {
+    return partes.slice(0, 3).join("-");
+  }
+  // WATCH-S11 / WATCH-ULTRA-2 / WATCH-SE
+  if (partes[0] === "WATCH") {
+    if (partes[1] === "ULTRA") return partes.slice(0, 3).join("-");
+    return partes.slice(0, 2).join("-");
+  }
+  // AIRPODS-PRO-2 / AIRPODS-MAX / AIRPODS-4
+  if (partes[0] === "AIRPODS") {
+    return partes.slice(0, 2).join("-");
+  }
+  // Fallback: primeiros 2 segmentos
+  return partes.slice(0, 2).join("-");
+}
+
+// Compara dois SKUs da mesma familia e devolve score 0-100 + diferencas
+// legiveis. Quanto mais componentes batem, maior o score.
+function calcularSimilaridade(skuA: string, skuB: string): { score: number; diferencas: string[] } {
+  const partesA = skuA.split("-");
+  const partesB = skuB.split("-");
+  const diferencas: string[] = [];
+
+  const storageA = partesA.find((p) => /^\d+(GB|TB)$/.test(p));
+  const storageB = partesB.find((p) => /^\d+(GB|TB)$/.test(p));
+  const sameStorage = storageA === storageB && storageA;
+
+  // Cor = concat dos segmentos nao-classificados no final (heuristica simples)
+  const isClassificavel = (p: string) =>
+    /^\d+(GB|TB|MM)$/.test(p) || /^M\d+/.test(p) || ["GPS", "GPSCEL", "WIFI", "CELL", "SEMINOVO", "ANC"].includes(p);
+  const corA = partesA.filter((p) => !isClassificavel(p)).slice(-2).join("-");
+  const corB = partesB.filter((p) => !isClassificavel(p)).slice(-2).join("-");
+  const sameCor = corA === corB && corA;
+
+  const sameSeminovo = partesA.includes("SEMINOVO") === partesB.includes("SEMINOVO");
+
+  let score = 50; // base: mesma familia
+  if (sameStorage) score += 30;
+  else diferencas.push("storage diferente");
+  if (sameCor) score += 15;
+  else diferencas.push("cor diferente");
+  if (sameSeminovo) score += 5;
+  else diferencas.push("condição diferente");
+
+  return { score, diferencas };
+}
+
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+export async function GET(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const sku = (req.nextUrl.searchParams.get("sku") || "").trim().toUpperCase();
+  if (!sku) return NextResponse.json({ error: "sku obrigatorio" }, { status: 400 });
+
+  const from30d = daysAgoIso(30);
+  const from90d = daysAgoIso(90);
+
+  try {
+    // Buscar tudo em paralelo pra ficar rapido
+    const [estoqueRes, vendas30dRes, vendas90dRes, vendasGeralCount, simulacoesRes, avisosRes, encomendasRes, variacaoRes] = await Promise.all([
+      // Estoque: todas as linhas com esse SKU (inclusive ESGOTADO pra historico)
+      supabase
+        .from("estoque")
+        .select("id, produto, cor, serial_no, imei, custo_compra, custo_unitario, fornecedor, data_entrada, qnt, status")
+        .eq("sku", sku),
+      // Vendas ultimos 30d
+      supabase
+        .from("vendas")
+        .select("id, data, cliente, preco_vendido, custo, lucro")
+        .eq("sku", sku)
+        .gte("data", from30d.slice(0, 10))
+        .order("data", { ascending: false }),
+      // Vendas ultimos 90d
+      supabase
+        .from("vendas")
+        .select("id", { count: "exact", head: true })
+        .eq("sku", sku)
+        .gte("data", from90d.slice(0, 10)),
+      // Vendas total geral (pra contexto historico)
+      supabase
+        .from("vendas")
+        .select("id", { count: "exact", head: true })
+        .eq("sku", sku),
+      // Simulacoes ultimos 30d
+      supabase
+        .from("simulacoes")
+        .select("id", { count: "exact", head: true })
+        .eq("sku", sku)
+        .gte("created_at", from30d),
+      // Avisos ativos (nao notificados/removidos)
+      supabase
+        .from("avisos_clientes")
+        .select("id", { count: "exact", head: true })
+        .eq("sku", sku)
+        .eq("status", "ATIVO"),
+      // Encomendas em aberto (PENDENTE, COMPRADO, A CAMINHO)
+      supabase
+        .from("encomendas")
+        .select("id", { count: "exact", head: true })
+        .eq("sku", sku)
+        .in("status", ["PENDENTE", "COMPRADO", "A CAMINHO"]),
+      // Mostruario: variacao com esse SKU
+      supabase
+        .from("loja_variacoes")
+        .select("id, produto_id, preco, preco_parcelado, visivel")
+        .eq("sku", sku)
+        .limit(1)
+        .maybeSingle(),
+    ]);
+
+    // ── Estoque agregado ──
+    const estoqueRows = estoqueRes.data || [];
+    const emEstoque = estoqueRows.filter(
+      (r) => String(r.status || "").toUpperCase() === "EM ESTOQUE" && Number(r.qnt || 0) > 0,
+    );
+    let totalUnidades = 0;
+    let somaCustoPonderado = 0;
+    let custoMin = Infinity;
+    let custoMax = 0;
+    for (const r of emEstoque) {
+      const qnt = Number(r.qnt || 0);
+      const custo = Number(r.custo_compra || r.custo_unitario || 0);
+      totalUnidades += qnt;
+      somaCustoPonderado += qnt * custo;
+      if (custo > 0 && custo < custoMin) custoMin = custo;
+      if (custo > custoMax) custoMax = custo;
+    }
+    const custoMedio = totalUnidades > 0 ? Math.round(somaCustoPonderado / totalUnidades) : 0;
+
+    const estoque: InfoEstoque = {
+      total_unidades: totalUnidades,
+      custo_medio: custoMedio,
+      custo_minimo: custoMin === Infinity ? 0 : Math.round(custoMin),
+      custo_maximo: Math.round(custoMax),
+      items: emEstoque.slice(0, 10).map((r) => ({
+        id: r.id,
+        produto: r.produto,
+        cor: r.cor,
+        serial_no: r.serial_no,
+        imei: r.imei,
+        custo_compra: Number(r.custo_compra || 0),
+        custo_unitario: Number(r.custo_unitario || 0),
+        fornecedor: r.fornecedor,
+        data_entrada: r.data_entrada,
+        status: r.status,
+      })),
+    };
+
+    // ── Vendas agregadas ──
+    const vendas30d = vendas30dRes.data || [];
+    const totalVendas30 = vendas30d.length;
+    const faturamento30 = vendas30d.reduce((s, v) => s + Number(v.preco_vendido || 0), 0);
+    const lucroTotal30 = vendas30d.reduce((s, v) => s + Number(v.lucro || 0), 0);
+    const ticketMedio = totalVendas30 > 0 ? Math.round(faturamento30 / totalVendas30) : 0;
+    const margemMedia = faturamento30 > 0 ? Math.round((lucroTotal30 / faturamento30) * 1000) / 10 : 0;
+    const ultimaVendaData = vendas30d[0]?.data || null;
+
+    const vendas: InfoVendas = {
+      total_30d: totalVendas30,
+      total_90d: vendas90dRes.count || 0,
+      total_geral: vendasGeralCount.count || 0,
+      ticket_medio_30d: ticketMedio,
+      faturamento_30d: Math.round(faturamento30),
+      margem_media: margemMedia,
+      lucro_total_30d: Math.round(lucroTotal30),
+      ultima_venda_data: ultimaVendaData,
+      ultimas: vendas30d.slice(0, 5).map((v) => ({
+        id: v.id,
+        data: v.data,
+        cliente: v.cliente,
+        preco_vendido: Number(v.preco_vendido || 0),
+        custo: v.custo !== null && v.custo !== undefined ? Number(v.custo) : null,
+        lucro: v.lucro !== null && v.lucro !== undefined ? Number(v.lucro) : null,
+      })),
+    };
+
+    // ── Mostruario ──
+    const varRow = variacaoRes.data;
+    const mostruario = {
+      visivel: !!varRow?.visivel,
+      preco: varRow?.preco ? Number(varRow.preco) : null,
+      preco_parcelado: varRow?.preco_parcelado ? Number(varRow.preco_parcelado) : null,
+      produto_id: varRow?.produto_id || null,
+      variacao_id: varRow?.id || null,
+    };
+
+    // ── Similares em estoque (sugestao de substituicao quando esgotado) ──
+    // So busca se o SKU atual esta com pouco/zero estoque — senao nao tem
+    // motivo pra mostrar alternativa. Ranqueia por similaridade + qnt.
+    let similares: SkuSimilar[] = [];
+    if (totalUnidades < 2) {
+      const prefixo = extrairPrefixoFamilia(sku);
+      const { data: similaresRaw } = await supabase
+        .from("estoque")
+        .select("sku, qnt, custo_compra, custo_unitario, status")
+        .like("sku", `${prefixo}%`)
+        .eq("status", "EM ESTOQUE")
+        .gt("qnt", 0);
+
+      // Agrega por SKU (varias unidades mesmo SKU viram 1 entrada com qnt total)
+      const simMap = new Map<string, { qnt: number; custoSum: number; custoCount: number }>();
+      for (const r of similaresRaw || []) {
+        if (!r.sku || r.sku === sku) continue; // pula o proprio SKU
+        const qnt = Number(r.qnt || 0);
+        const custo = Number(r.custo_compra || r.custo_unitario || 0);
+        const cur = simMap.get(r.sku) || { qnt: 0, custoSum: 0, custoCount: 0 };
+        cur.qnt += qnt;
+        if (custo > 0) {
+          cur.custoSum += custo;
+          cur.custoCount += 1;
+        }
+        simMap.set(r.sku, cur);
+      }
+
+      similares = [...simMap.entries()]
+        .map(([skuSim, agg]) => {
+          const { score, diferencas } = calcularSimilaridade(sku, skuSim);
+          return {
+            sku: skuSim,
+            nome_canonico: skuToNomeCanonico(skuSim),
+            em_estoque: agg.qnt,
+            custo_medio: agg.custoCount > 0 ? Math.round(agg.custoSum / agg.custoCount) : 0,
+            similaridade: score,
+            diferencas,
+          };
+        })
+        .sort((a, b) => b.similaridade - a.similaridade || b.em_estoque - a.em_estoque)
+        .slice(0, 6);
+    }
+
+    const resp: InfoSkuResponse = {
+      sku,
+      nome_canonico: skuToNomeCanonico(sku),
+      estoque,
+      vendas,
+      simulacoes_30d: simulacoesRes.count || 0,
+      avisos_ativos: avisosRes.count || 0,
+      encomendas_pendentes: encomendasRes.count || 0,
+      mostruario,
+      similares,
+    };
+
+    return NextResponse.json({ ok: true, data: resp });
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/app/api/admin/sku/reconciliacao/route.ts
+++ b/app/api/admin/sku/reconciliacao/route.ts
@@ -1,0 +1,193 @@
+// app/api/admin/sku/reconciliacao/route.ts
+// Detecta inconsistencias entre estoque e vendas usando SKU canonico como
+// chave de cruzamento. Projetado pra auditoria semanal/mensal — responde
+// "cade as coisas que nao batem?".
+//
+// 3 tipos de inconsistencia:
+//
+//   1. SKU_DIVERGENTE_PERSISTIDO:
+//      Venda com estoque_id vinculado, mas vendas.sku ≠ estoque.sku.
+//      Significa que o bloqueio falhou antes (pre-validacao) ou o admin
+//      editou depois. Risco: produto errado foi separado pro cliente.
+//
+//   2. ESGOTADO_SEM_VENDA:
+//      Item de estoque com status ESGOTADO/VENDIDO mas sem venda vinculada
+//      (nenhuma venda com estoque_id apontando pra ele). Possivel sumico/
+//      roubo/venda fora do sistema.
+//
+//   3. VENDA_SEM_ESTOQUE:
+//      Venda registrada sem estoque_id (nao deduziu de nenhum item).
+//      Possivel dupla-contagem — o estoque ainda pensa que tem.
+//
+// Uso:
+//   GET /api/admin/sku/reconciliacao?from=YYYY-MM-DD
+//   Default: ultimos 30 dias.
+
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+interface Inconsistencia {
+  tipo: "SKU_DIVERGENTE_PERSISTIDO" | "ESGOTADO_SEM_VENDA" | "VENDA_SEM_ESTOQUE";
+  severidade: "alta" | "media" | "baixa";
+  descricao: string;
+  produto: string;
+  detalhes: Record<string, string | number | null>;
+  ids: { venda_id?: string; estoque_id?: string };
+}
+
+function daysAgoIso(days: number): string {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+export async function GET(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const fromParam = req.nextUrl.searchParams.get("from");
+  const fromDate = fromParam || daysAgoIso(30).slice(0, 10);
+
+  try {
+    const resultados: Inconsistencia[] = [];
+
+    // ── 1. SKU divergente persistido ────────────────────────────────
+    // Vendas com estoque_id + sku diferente do estoque.sku
+    const { data: vendasComEstoque } = await supabase
+      .from("vendas")
+      .select("id, produto, sku, estoque_id, cliente, data, preco_vendido")
+      .not("estoque_id", "is", null)
+      .not("sku", "is", null)
+      .gte("data", fromDate)
+      .neq("status_pagamento", "CANCELADO");
+
+    if (vendasComEstoque && vendasComEstoque.length > 0) {
+      const estoqueIds = vendasComEstoque.map((v) => v.estoque_id!).filter(Boolean) as string[];
+      const { data: itensEstoque } = await supabase
+        .from("estoque")
+        .select("id, sku, produto")
+        .in("id", estoqueIds);
+      const estoqueMap = new Map<string, { sku: string | null; produto: string }>(
+        (itensEstoque || []).map((e) => [e.id, { sku: e.sku, produto: e.produto }]),
+      );
+
+      for (const v of vendasComEstoque) {
+        const est = estoqueMap.get(v.estoque_id!);
+        if (!est || !est.sku) continue; // se estoque nao tem SKU, pula
+        if (est.sku !== v.sku) {
+          resultados.push({
+            tipo: "SKU_DIVERGENTE_PERSISTIDO",
+            severidade: "alta",
+            descricao: "Venda vinculada a item de estoque com SKU diferente",
+            produto: v.produto || est.produto,
+            detalhes: {
+              venda_sku: v.sku,
+              estoque_sku: est.sku,
+              cliente: v.cliente || "?",
+              data: v.data || "?",
+              preco: Number(v.preco_vendido || 0),
+            },
+            ids: { venda_id: v.id, estoque_id: v.estoque_id! },
+          });
+        }
+      }
+    }
+
+    // ── 2. Esgotado sem venda (produto sumiu) ──────────────────────
+    // Itens de estoque com status=ESGOTADO no periodo mas sem venda vinculada.
+    // So checa os ESGOTADOS recentemente (updated_at >= fromDate) pra evitar
+    // lixo historico antigo.
+    const { data: esgotados } = await supabase
+      .from("estoque")
+      .select("id, produto, sku, cor, serial_no, imei, custo_unitario, updated_at")
+      .eq("status", "ESGOTADO")
+      .gte("updated_at", fromDate);
+
+    if (esgotados && esgotados.length > 0) {
+      const esgotadoIds = esgotados.map((e) => e.id);
+      const { data: vendasVinculadas } = await supabase
+        .from("vendas")
+        .select("estoque_id")
+        .in("estoque_id", esgotadoIds);
+      const vinculados = new Set((vendasVinculadas || []).map((v) => v.estoque_id));
+
+      for (const e of esgotados) {
+        if (vinculados.has(e.id)) continue;
+        resultados.push({
+          tipo: "ESGOTADO_SEM_VENDA",
+          severidade: "alta",
+          descricao: "Item marcado como ESGOTADO mas sem venda vinculada",
+          produto: e.produto,
+          detalhes: {
+            sku: e.sku || "sem SKU",
+            cor: e.cor,
+            serial: e.serial_no,
+            imei: e.imei,
+            custo: Number(e.custo_unitario || 0),
+            desde: e.updated_at ? e.updated_at.slice(0, 10) : "?",
+          },
+          ids: { estoque_id: e.id },
+        });
+      }
+    }
+
+    // ── 3. Venda sem estoque vinculado (nao deduziu estoque) ────────
+    // So sinaliza vendas com SKU populado (senao nao tem baseline pra validar)
+    // e que deveriam ter vinculacao (modelo conhecido com serial).
+    const { data: vendasSemEstoque } = await supabase
+      .from("vendas")
+      .select("id, produto, sku, cliente, data, preco_vendido, serial_no, imei")
+      .is("estoque_id", null)
+      .not("sku", "is", null)
+      .gte("data", fromDate)
+      .neq("status_pagamento", "CANCELADO")
+      .neq("status_pagamento", "FORMULARIO_PREENCHIDO"); // formulario preenchido ainda nao foi processado
+
+    if (vendasSemEstoque && vendasSemEstoque.length > 0) {
+      for (const v of vendasSemEstoque) {
+        // Se tem serial ou imei, provavelmente e aparelho rastreavel que deveria
+        // estar vinculado. Sem serial/imei (ex: AirPods unitarios), nao alerta.
+        if (!v.serial_no && !v.imei) continue;
+        resultados.push({
+          tipo: "VENDA_SEM_ESTOQUE",
+          severidade: "media",
+          descricao: "Venda registrada sem vincular item do estoque",
+          produto: v.produto,
+          detalhes: {
+            sku: v.sku,
+            cliente: v.cliente || "?",
+            data: v.data || "?",
+            serial: v.serial_no,
+            imei: v.imei,
+            preco: Number(v.preco_vendido || 0),
+          },
+          ids: { venda_id: v.id },
+        });
+      }
+    }
+
+    // Resumo
+    const resumo = {
+      total: resultados.length,
+      por_tipo: {
+        SKU_DIVERGENTE_PERSISTIDO: resultados.filter((r) => r.tipo === "SKU_DIVERGENTE_PERSISTIDO").length,
+        ESGOTADO_SEM_VENDA: resultados.filter((r) => r.tipo === "ESGOTADO_SEM_VENDA").length,
+        VENDA_SEM_ESTOQUE: resultados.filter((r) => r.tipo === "VENDA_SEM_ESTOQUE").length,
+      },
+      por_severidade: {
+        alta: resultados.filter((r) => r.severidade === "alta").length,
+        media: resultados.filter((r) => r.severidade === "media").length,
+        baixa: resultados.filter((r) => r.severidade === "baixa").length,
+      },
+      periodo: { from: fromDate, until: new Date().toISOString().slice(0, 10) },
+    };
+
+    return NextResponse.json({ ok: true, resumo, inconsistencias: resultados });
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/components/admin/SkuInfoModal.tsx
+++ b/components/admin/SkuInfoModal.tsx
@@ -1,0 +1,448 @@
+// components/admin/SkuInfoModal.tsx
+// Modal de visao 360° de um SKU — mostra em 1 tela tudo que voce precisa
+// saber pra decidir algo sobre aquele produto agora (precificar, dar desconto,
+// comprar mais, aceitar encomenda, etc).
+//
+// Aberto via:
+//   - Botao 📊 nos resultados do SuperSearch (Cmd+K)
+//   - Links diretos de outras telas (estoque, vendas, mostruario)
+//
+// Dados vem de /api/admin/sku/info?sku=X (endpoint agregador).
+
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useAdmin } from "@/components/admin/AdminShell";
+
+const fmt = (v: number) => `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
+const fmtDate = (iso: string | null) => {
+  if (!iso) return "—";
+  const [y, m, d] = iso.slice(0, 10).split("-");
+  return `${d}/${m}/${y}`;
+};
+
+interface SkuSimilar {
+  sku: string;
+  nome_canonico: string | null;
+  em_estoque: number;
+  custo_medio: number;
+  similaridade: number;
+  diferencas: string[];
+}
+
+interface Info {
+  sku: string;
+  nome_canonico: string | null;
+  estoque: {
+    total_unidades: number;
+    custo_medio: number;
+    custo_minimo: number;
+    custo_maximo: number;
+    items: Array<{
+      id: string;
+      produto: string;
+      cor: string | null;
+      serial_no: string | null;
+      imei: string | null;
+      custo_compra: number;
+      fornecedor: string | null;
+      data_entrada: string | null;
+    }>;
+  };
+  vendas: {
+    total_30d: number;
+    total_90d: number;
+    total_geral: number;
+    ticket_medio_30d: number;
+    faturamento_30d: number;
+    margem_media: number;
+    lucro_total_30d: number;
+    ultima_venda_data: string | null;
+    ultimas: Array<{
+      id: string;
+      data: string;
+      cliente: string;
+      preco_vendido: number;
+      lucro: number | null;
+    }>;
+  };
+  simulacoes_30d: number;
+  avisos_ativos: number;
+  encomendas_pendentes: number;
+  mostruario: {
+    visivel: boolean;
+    preco: number | null;
+    preco_parcelado: number | null;
+    variacao_id: string | null;
+  };
+  similares?: SkuSimilar[];
+}
+
+export function SkuInfoModal({ sku: initialSku, onClose }: { sku: string; onClose: () => void }) {
+  const { password, darkMode: dm } = useAdmin();
+  // currentSku permite "trocar" o SKU foco sem fechar o modal — ao clicar
+  // num similar, navegamos dentro da mesma view (breadcrumb historico).
+  const [currentSku, setCurrentSku] = useState(initialSku);
+  const [history, setHistory] = useState<string[]>([]);
+  const [info, setInfo] = useState<Info | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const sku = currentSku;
+  // loading = "o info atual nao corresponde ao SKU pedido" — derivado, sem
+  // setState (agrada o lint react-hooks/set-state-in-effect e dá UX ok:
+  // enquanto carrega o novo SKU, dados do anterior ficam visiveis ~1s).
+  const loading = !info || (info.sku !== sku.toUpperCase() && !error);
+
+  // Quando initialSku muda (consumidor abriu modal com outro SKU), reinicia.
+  // Padrao legitimo de sincronizacao props→state.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setCurrentSku(initialSku);
+    setHistory([]);
+    setError(null);
+  }, [initialSku]);
+
+  useEffect(() => {
+    if (!sku || !password) return;
+    let cancelled = false;
+    fetch(`/api/admin/sku/info?sku=${encodeURIComponent(sku)}`, {
+      headers: { "x-admin-password": password },
+    })
+      .then((r) => r.json())
+      .then((json) => {
+        if (cancelled) return;
+        if (json.ok) {
+          setInfo(json.data);
+          setError(null);
+        } else {
+          setError(json.error || "Erro ao buscar info");
+        }
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sku, password]);
+
+  const navigateToSku = (newSku: string) => {
+    setHistory((prev) => [...prev, currentSku]);
+    setCurrentSku(newSku);
+  };
+
+  const goBack = () => {
+    if (history.length === 0) return;
+    const last = history[history.length - 1];
+    setHistory((prev) => prev.slice(0, -1));
+    setCurrentSku(last);
+  };
+
+  // ESC pra fechar
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  const bgCard = dm ? "bg-[#1C1C1E]" : "bg-white";
+  const bgSection = dm ? "bg-[#2C2C2E] border-[#3A3A3C]" : "bg-[#F9F9FB] border-[#E8E8ED]";
+  const textPrimary = dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]";
+  const textSecondary = dm ? "text-[#98989D]" : "text-[#86868B]";
+  const divider = dm ? "border-[#3A3A3C]" : "border-[#E8E8ED]";
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      onClick={onClose}
+    >
+      <div
+        className={`w-full max-w-2xl ${bgCard} rounded-2xl shadow-2xl overflow-hidden max-h-[90vh] overflow-y-auto`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className={`flex items-center justify-between px-5 py-4 border-b ${divider}`}>
+          <div className="flex items-center gap-2 min-w-0">
+            {history.length > 0 && (
+              <button
+                onClick={goBack}
+                title="Voltar ao SKU anterior"
+                className={`text-sm px-2 py-1 rounded ${dm ? "hover:bg-[#3A3A3C]" : "hover:bg-[#F5F5F7]"} ${textSecondary}`}
+              >
+                ←
+              </button>
+            )}
+            <span className="text-2xl">📊</span>
+            <div className="min-w-0">
+              <h3 className={`text-sm font-bold ${textPrimary} truncate`}>
+                {info?.nome_canonico || sku}
+              </h3>
+              <p className={`text-[11px] font-mono ${textSecondary} truncate`}>{sku}</p>
+            </div>
+          </div>
+          <button onClick={onClose} className={`text-lg ${textSecondary} hover:text-[#E8740E] ml-2`}>
+            ✕
+          </button>
+        </div>
+
+        {loading && (
+          <div className={`py-12 text-center text-sm ${textSecondary}`}>Carregando…</div>
+        )}
+
+        {error && !loading && (
+          <div className="py-12 text-center text-sm text-red-500">{error}</div>
+        )}
+
+        {info && !loading && (
+          <>
+            {/* Alerta visual de esgotado / demanda / etc */}
+            {info.estoque.total_unidades === 0 && (info.simulacoes_30d > 0 || info.avisos_ativos > 0) && (
+              <div className={`mx-4 mt-4 p-3 rounded-xl border bg-red-50 border-red-200 ${dm ? "bg-red-950/30 border-red-900" : ""}`}>
+                <p className="text-sm font-bold text-red-700">⚠️ ESGOTADO com demanda</p>
+                <p className={`text-xs ${dm ? "text-red-300" : "text-red-600"} mt-0.5`}>
+                  {info.simulacoes_30d > 0 && `${info.simulacoes_30d} simulações (30d)`}
+                  {info.simulacoes_30d > 0 && info.avisos_ativos > 0 && " · "}
+                  {info.avisos_ativos > 0 && `${info.avisos_ativos} avisos ativos`}
+                  {" — comprar urgente"}
+                </p>
+              </div>
+            )}
+
+            {/* Grid de stats principais */}
+            <div className="mx-4 mt-4 grid grid-cols-2 sm:grid-cols-4 gap-2">
+              <StatCard
+                label="Em estoque"
+                value={info.estoque.total_unidades}
+                sub={info.estoque.total_unidades > 0 ? `${fmt(info.estoque.custo_medio)} médio` : undefined}
+                accent={info.estoque.total_unidades === 0 ? "red" : "green"}
+                dm={dm}
+              />
+              <StatCard
+                label="Vendas 30d"
+                value={info.vendas.total_30d}
+                sub={info.vendas.total_30d > 0 ? fmt(info.vendas.faturamento_30d) : undefined}
+                accent="orange"
+                dm={dm}
+              />
+              <StatCard
+                label="Margem média"
+                value={`${info.vendas.margem_media}%`}
+                sub={info.vendas.lucro_total_30d > 0 ? `+${fmt(info.vendas.lucro_total_30d)}` : undefined}
+                accent={info.vendas.margem_media >= 15 ? "green" : info.vendas.margem_media >= 8 ? "orange" : "red"}
+                dm={dm}
+              />
+              <StatCard
+                label="Demanda ativa"
+                value={info.simulacoes_30d + info.avisos_ativos}
+                sub={`${info.simulacoes_30d} sim · ${info.avisos_ativos} avisos`}
+                accent="purple"
+                dm={dm}
+              />
+            </div>
+
+            {/* Detalhes estoque */}
+            <div className={`mx-4 mt-3 p-4 rounded-xl border ${bgSection}`}>
+              <div className="flex items-center justify-between mb-2">
+                <p className={`text-xs font-bold ${textPrimary}`}>📦 Estoque atual</p>
+                {info.estoque.total_unidades > 0 && (
+                  <span className={`text-[11px] ${textSecondary}`}>
+                    Custo: {fmt(info.estoque.custo_minimo)} – {fmt(info.estoque.custo_maximo)}
+                  </span>
+                )}
+              </div>
+              {info.estoque.items.length === 0 ? (
+                <p className={`text-sm ${textSecondary}`}>Sem unidades disponíveis.</p>
+              ) : (
+                <div className="space-y-1">
+                  {info.estoque.items.map((item) => (
+                    <div key={item.id} className={`flex items-center gap-3 text-xs`}>
+                      <span className="text-green-500">●</span>
+                      <span className={`flex-1 truncate ${textPrimary}`}>
+                        {item.produto}
+                        {item.cor && <span className={textSecondary}> · {item.cor}</span>}
+                      </span>
+                      {(item.serial_no || item.imei) && (
+                        <span className={`font-mono text-[10px] ${textSecondary}`}>
+                          {item.serial_no || item.imei}
+                        </span>
+                      )}
+                      <span className={`font-semibold ${textPrimary}`}>{fmt(item.custo_compra)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Vendas recentes */}
+            <div className={`mx-4 mt-3 p-4 rounded-xl border ${bgSection}`}>
+              <div className="flex items-center justify-between mb-2">
+                <p className={`text-xs font-bold ${textPrimary}`}>💰 Últimas vendas</p>
+                <span className={`text-[11px] ${textSecondary}`}>
+                  Total: {info.vendas.total_geral} · 90d: {info.vendas.total_90d} · 30d: {info.vendas.total_30d}
+                </span>
+              </div>
+              {info.vendas.ultimas.length === 0 ? (
+                <p className={`text-sm ${textSecondary}`}>
+                  Nenhuma venda nos últimos 30 dias
+                  {info.vendas.total_geral > 0 && ` (histórico: ${info.vendas.total_geral})`}.
+                </p>
+              ) : (
+                <div className="space-y-1">
+                  {info.vendas.ultimas.map((v) => (
+                    <div key={v.id} className="flex items-center gap-3 text-xs">
+                      <span className={`w-20 shrink-0 ${textSecondary}`}>{fmtDate(v.data)}</span>
+                      <span className={`flex-1 truncate ${textPrimary}`}>{v.cliente}</span>
+                      <span className="font-semibold text-[#E8740E]">{fmt(v.preco_vendido)}</span>
+                      {v.lucro !== null && (
+                        <span className={`w-16 text-right font-semibold ${v.lucro >= 0 ? "text-green-600" : "text-red-500"}`}>
+                          {v.lucro >= 0 ? "+" : ""}
+                          {fmt(v.lucro)}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Mostruario + Encomendas */}
+            <div className="mx-4 mt-3 grid grid-cols-2 gap-3">
+              <div className={`p-4 rounded-xl border ${bgSection}`}>
+                <p className={`text-xs font-bold ${textPrimary} mb-1`}>🛒 Mostruário</p>
+                {info.mostruario.variacao_id ? (
+                  <>
+                    <p className={`text-[11px] ${textSecondary}`}>
+                      {info.mostruario.visivel ? "✅ Visível ao público" : "🔒 Oculto"}
+                    </p>
+                    {info.mostruario.preco && (
+                      <p className={`text-sm font-bold ${textPrimary} mt-1`}>{fmt(info.mostruario.preco)}</p>
+                    )}
+                  </>
+                ) : (
+                  <p className={`text-[11px] ${textSecondary}`}>SKU não cadastrado no mostruário</p>
+                )}
+              </div>
+              <div className={`p-4 rounded-xl border ${bgSection}`}>
+                <p className={`text-xs font-bold ${textPrimary} mb-1`}>📋 Encomendas pendentes</p>
+                <p className={`text-2xl font-bold ${info.encomendas_pendentes > 0 ? "text-[#E8740E]" : textPrimary}`}>
+                  {info.encomendas_pendentes}
+                </p>
+                <p className={`text-[11px] ${textSecondary}`}>
+                  {info.encomendas_pendentes > 0 ? "prometidas a clientes" : "nenhuma em aberto"}
+                </p>
+              </div>
+            </div>
+
+            {/* Similares em estoque (substituicao quando esgotado) */}
+            {info.similares && info.similares.length > 0 && (
+              <div className={`mx-4 mt-3 p-4 rounded-xl border ${bgSection}`}>
+                <div className="flex items-center justify-between mb-2">
+                  <p className={`text-xs font-bold ${textPrimary}`}>
+                    🔄 {info.estoque.total_unidades === 0 ? "Sugestão de substituição" : "Variantes em estoque"}
+                  </p>
+                  <span className={`text-[11px] ${textSecondary}`}>
+                    {info.estoque.total_unidades === 0 && "cliente pode levar uma dessas"}
+                  </span>
+                </div>
+                <div className="space-y-1.5">
+                  {info.similares.map((s) => (
+                    <button
+                      key={s.sku}
+                      onClick={() => navigateToSku(s.sku)}
+                      className={`w-full text-left flex items-center gap-3 p-2 rounded-lg transition-colors ${
+                        dm ? "hover:bg-[#3A3A3C]" : "hover:bg-white"
+                      }`}
+                    >
+                      <span className="text-lg">{s.similaridade >= 90 ? "🟢" : s.similaridade >= 70 ? "🟡" : "🟠"}</span>
+                      <div className="flex-1 min-w-0">
+                        <p className={`text-sm font-medium ${textPrimary} truncate`}>
+                          {s.nome_canonico || s.sku}
+                        </p>
+                        <p className={`text-[11px] ${textSecondary}`}>
+                          {s.diferencas.length > 0 ? `Diferença: ${s.diferencas.join(", ")}` : "Mesmo modelo"}
+                          {" · "}
+                          {s.custo_medio > 0 && `Custo ${fmt(s.custo_medio)}`}
+                        </p>
+                      </div>
+                      <span className={`text-sm font-bold text-green-600 shrink-0`}>{s.em_estoque}un</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Actions */}
+            <div className="mx-4 mt-3 mb-4 flex flex-wrap gap-2">
+              <a
+                href={`/admin/estoque?sku=${encodeURIComponent(sku)}`}
+                className="flex-1 min-w-[120px] text-center py-2 rounded-xl bg-[#E8740E] text-white text-xs font-semibold hover:bg-[#D06A0D] transition-colors"
+              >
+                Ver estoque
+              </a>
+              <a
+                href={`/admin/vendas?sku=${encodeURIComponent(sku)}`}
+                className={`flex-1 min-w-[120px] text-center py-2 rounded-xl border text-xs font-semibold transition-colors ${
+                  dm
+                    ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7] hover:bg-[#3A3A3C]"
+                    : "bg-white border-[#D2D2D7] text-[#1D1D1F] hover:bg-[#F5F5F7]"
+                }`}
+              >
+                Ver vendas
+              </a>
+              {info.mostruario.variacao_id && (
+                <a
+                  href={`/admin/mostruario?variacao=${info.mostruario.variacao_id}`}
+                  className={`flex-1 min-w-[120px] text-center py-2 rounded-xl border text-xs font-semibold transition-colors ${
+                    dm
+                      ? "bg-[#2C2C2E] border-[#3A3A3C] text-[#F5F5F7] hover:bg-[#3A3A3C]"
+                      : "bg-white border-[#D2D2D7] text-[#1D1D1F] hover:bg-[#F5F5F7]"
+                  }`}
+                >
+                  Mostruário
+                </a>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+  accent,
+  dm,
+}: {
+  label: string;
+  value: number | string;
+  sub?: string;
+  accent: "green" | "orange" | "red" | "purple";
+  dm: boolean;
+}) {
+  const bgMap = {
+    green: dm ? "bg-green-950/30 border-green-900" : "bg-green-50 border-green-200",
+    orange: dm ? "bg-orange-950/30 border-orange-900" : "bg-[#FFF5EB] border-[#E8740E]/30",
+    red: dm ? "bg-red-950/30 border-red-900" : "bg-red-50 border-red-200",
+    purple: dm ? "bg-purple-950/30 border-purple-900" : "bg-purple-50 border-purple-200",
+  };
+  const textMap = {
+    green: "text-green-600",
+    orange: "text-[#E8740E]",
+    red: "text-red-600",
+    purple: "text-purple-600",
+  };
+  return (
+    <div className={`p-3 rounded-xl border ${bgMap[accent]}`}>
+      <p className={`text-[10px] font-medium uppercase tracking-wide ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
+        {label}
+      </p>
+      <p className={`text-xl font-bold mt-0.5 ${textMap[accent]}`}>{value}</p>
+      {sub && <p className={`text-[10px] mt-0.5 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>{sub}</p>}
+    </div>
+  );
+}

--- a/components/admin/SuperSearch.tsx
+++ b/components/admin/SuperSearch.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { useAdmin } from "@/components/admin/AdminShell";
 import { corParaPT } from "@/lib/cor-pt";
+import { SkuInfoModal } from "@/components/admin/SkuInfoModal";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type SearchResult = Record<string, any>;
@@ -306,6 +307,14 @@ function DetailModal({ item, onClose, onSave, dm }: { item: SearchResult; onClos
                   const cor = item.cor ? corParaPT(item.cor) : "";
                   const serial = item.serial_no || "";
                   const imei = item.imei || "";
+                  const sku = item.sku || "";
+                  // QR payload: JSON com sku + codigo identificador individual
+                  // (serial ou imei). Scanner do estoque le os dois — identifica
+                  // exatamente qual produto (SKU) E qual unidade (serial) em
+                  // uma unica leitura.
+                  const qrPayload = sku
+                    ? JSON.stringify({ sku, c: codigo })
+                    : codigo;
                   win.document.write(`<!DOCTYPE html><html><head>
 <title>Etiqueta ${codigo}</title>
 <script src="https://cdn.jsdelivr.net/npm/qrcode-generator@1.4.4/qrcode.min.js"><\/script>
@@ -317,6 +326,7 @@ body{font-family:Arial,Helvetica,sans-serif}
 .produto{font-size:11pt;font-weight:bold;line-height:1.2}
 .cor{font-size:8pt;color:#333;margin-top:1mm}
 .extra{font-size:6pt;color:#444;margin-top:1mm}
+.sku{font-size:6.5pt;color:#E8740E;font-weight:bold;margin-top:1mm;word-break:break-all;line-height:1.1}
 .qr{margin:2mm auto 1mm;display:flex;justify-content:center}
 .cod{font-size:7pt;color:#333;font-weight:bold;margin-top:1mm;margin-bottom:2mm}
 @page{size:62mm 45mm;margin:0}
@@ -326,12 +336,13 @@ body{font-family:Arial,Helvetica,sans-serif}
 ${cor ? `<div class="cor">${cor}</div>` : ""}
 ${serial ? `<div class="extra">SN: ${serial}</div>` : ""}
 ${imei ? `<div class="extra">IMEI: ${imei}</div>` : ""}
+${sku ? `<div class="sku">SKU: ${sku}</div>` : ""}
 <div class="qr"><canvas id="qr"></canvas></div>
 <div class="cod">${codigo}</div>
 </div>
 <script>
 var qr = qrcode(0, 'M');
-qr.addData('${codigo}');
+qr.addData(${JSON.stringify(qrPayload)});
 qr.make();
 var canvas = document.getElementById('qr');
 var size = 150;
@@ -720,9 +731,21 @@ export default function SuperSearch({ open, onClose }: { open: boolean; onClose:
   const [detailItem, setDetailItem] = useState<SearchResult | null>(null);
   const [selectedOp, setSelectedOp] = useState<SearchResult | null>(null);
   const [selectedContato, setSelectedContato] = useState<SearchResult | null>(null);
+  const [skuInfo, setSkuInfo] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const hasResults = results.operacoes.length + results.contatos.length + results.estoque.length + results.vendas.length > 0;
+
+  // SKU unico compartilhado pelos resultados: quando estoque + vendas convergem
+  // no mesmo SKU, mostra um banner de "resumo desse SKU" no topo — 1 clique pra
+  // ver o agregador completo em vez de clicar item por item.
+  const skuComum = (() => {
+    const skus = new Set<string>();
+    for (const r of [...results.estoque, ...results.vendas]) {
+      if (r.sku) skus.add(r.sku);
+    }
+    return skus.size === 1 ? [...skus][0] : null;
+  })();
 
   useEffect(() => {
     if (open) {
@@ -848,6 +871,22 @@ export default function SuperSearch({ open, onClose }: { open: boolean; onClose:
               </div>
             ) : (
               <div>
+                {/* ── BANNER SKU (quando todos os resultados compartilham o mesmo SKU) ── */}
+                {skuComum && (
+                  <button
+                    onClick={() => setSkuInfo(skuComum)}
+                    className={`w-full text-left px-5 py-3 border-b ${dm ? "border-[#2C2C2E] bg-[#FFF5EB]/5" : "border-[#F0F0F5] bg-[#FFF5EB]"} hover:bg-[#E8740E]/10 transition-colors`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-xl">📊</span>
+                      <div className="flex-1 min-w-0">
+                        <p className={`text-sm font-bold text-[#E8740E]`}>Resumo completo do SKU</p>
+                        <p className={`text-[11px] font-mono ${textSecondary} truncate`}>{skuComum}</p>
+                      </div>
+                      <span className={`text-xs ${textSecondary}`}>clique para ver tudo →</span>
+                    </div>
+                  </button>
+                )}
                 {/* ── OPERAÇÕES ── */}
                 {results.operacoes.length > 0 && (
                   <>
@@ -933,6 +972,16 @@ export default function SuperSearch({ open, onClose }: { open: boolean; onClose:
                               {r.data_entrada && <span>{r.data_entrada}</span>}
                             </div>
                           </div>
+                          {/* Botao SKU (resumo 360°) quando item tem sku e nao e o skuComum do banner */}
+                          {r.sku && r.sku !== skuComum && (
+                            <button
+                              onClick={(e) => { e.stopPropagation(); setSkuInfo(r.sku); }}
+                              title={`Ver resumo do SKU: ${r.sku}`}
+                              className={`text-xs px-2 py-1 rounded border shrink-0 ${dm ? "border-[#3A3A3C] text-[#E8740E] hover:bg-[#3A3A3C]" : "border-[#E8740E]/30 text-[#E8740E] hover:bg-[#FFF5EB]"}`}
+                            >
+                              📊
+                            </button>
+                          )}
                           {r.custo ? <p className={`text-sm font-semibold ${textSecondary} shrink-0`}>{fmt(r.custo)}</p> : null}
                         </div>
                       </div>
@@ -975,6 +1024,16 @@ export default function SuperSearch({ open, onClose }: { open: boolean; onClose:
                               {r.serial_no && <span className="font-mono text-purple-500">SN: {r.serial_no}</span>}
                             </div>
                           </div>
+                          {/* Botao SKU (resumo 360°) */}
+                          {r.sku && r.sku !== skuComum && (
+                            <button
+                              onClick={(e) => { e.stopPropagation(); setSkuInfo(r.sku); }}
+                              title={`Ver resumo do SKU: ${r.sku}`}
+                              className={`text-xs px-2 py-1 rounded border shrink-0 ${dm ? "border-[#3A3A3C] text-[#E8740E] hover:bg-[#3A3A3C]" : "border-[#E8740E]/30 text-[#E8740E] hover:bg-[#FFF5EB]"}`}
+                            >
+                              📊
+                            </button>
+                          )}
                           <div className="text-right shrink-0 flex flex-col items-end gap-0.5">
                             {r.is_entrada ? (
                               /* Trade-in: mostrar valor recebido (custo) */
@@ -1036,6 +1095,9 @@ export default function SuperSearch({ open, onClose }: { open: boolean; onClose:
           dm={dm}
         />
       )}
+
+      {/* SKU Info Modal — visao 360° agregada de um SKU canonico */}
+      {skuInfo && <SkuInfoModal sku={skuInfo} onClose={() => setSkuInfo(null)} />}
     </>
   );
 }

--- a/components/admin/nav-config.ts
+++ b/components/admin/nav-config.ts
@@ -40,6 +40,7 @@ export const NAV: NavEntry[] = [
       { href: "/admin/recebiveis", label: "Recebiveis", icon: "\u{1F4B3}", pageKey: "recebiveis" },
       { href: "/admin/conciliacao", label: "Conciliacao", icon: "\u{1F50D}", pageKey: "conciliacao" },
       { href: "/admin/auditoria", label: "Auditoria", icon: "📋", pageKey: "saldos" },
+      { href: "/admin/reconciliacao-sku", label: "Reconciliação SKU", icon: "\u{1F501}", pageKey: "saldos" },
       { href: "/admin/trocas", label: "Trocas", icon: "\u{1F504}", pageKey: "trocas" },
     ],
   },
@@ -49,6 +50,7 @@ export const NAV: NavEntry[] = [
     label: "Produtos", icon: "\u{1F4E6}",
     items: [
       { href: "/admin/estoque", label: "Estoque", icon: "\u{1F4E6}", pageKey: "estoque" },
+      { href: "/admin/comprar-urgente", label: "Comprar Urgente", icon: "\u{1F6A8}", pageKey: "estoque" },
       { href: "/admin/produtos-funcionarios", label: "Produtos c/ Funcionários", icon: "\u{1F465}", pageKey: "produtos_funcionarios" },
       { href: "/admin/etiquetas", label: "Etiquetas", icon: "\u{1F3F7}\uFE0F", pageKey: "etiquetas" },
       { href: "/admin/etiquetas-preco", label: "Etiquetas de Preco", icon: "\u{1F4B0}", pageKey: "etiquetas_preco" },


### PR DESCRIPTION
## Summary

Implementa as 5 melhorias de SKU pedidas (#2, #3, #4, #6, #9) na ordem do André. Todas consomem os dados de SKU canônico já populados na Fase 2/3 — não há migration necessária.

---

### #2 — Cmd+K com resumo 360° de SKU
**O que mudou:**
- Quando você aperta ⌘K e busca algo que converge num único SKU (ex: "IPHONE-17-PRO-MAX-256GB"), aparece banner 📊 no topo — 1 clique abre o modal.
- Cada item de estoque/venda tem botão 📊 pra abrir o resumo do SKU dele.
- O endpoint de busca agora aceita SKU como termo também.

**O modal mostra em 1 tela:**
- 4 cards: em estoque, vendas 30d + faturamento, margem média, demanda ativa
- Lista de unidades em estoque com IMEI/serial/custo
- Últimas 5 vendas com cliente, preço e lucro
- Mostruário (visível? preço?) e encomendas pendentes
- **Similares em estoque** (feature #4 integrada aqui)
- Links pra `/admin/estoque?sku=X`, `/admin/vendas?sku=X` e mostruário

### #3 — Dashboard Comprar Urgente (`/admin/comprar-urgente`)
- Ranking de SKUs por urgência: **score = avisos × 4 + encomendas × 3 + simulações × 2 + vendas × 2** (pontua só quando estoque ≤ 1)
- Calcula **quantidade sugerida** por SKU baseada em velocidade histórica (vendas 60d ÷ 8.6 sem × 2 semanas) + demanda reprimida
- Filtro por categoria (iPhone, iPad, Mac, Watch, AirPods)
- **Botão "📋 Copiar lista pro fornecedor"** — gera texto pronto pra colar no WhatsApp do fornecedor
- Top 3 destacados em vermelho/laranja por severidade

### #4 — Sugestão de substituição
- Quando o cliente pede um SKU esgotado, o modal mostra "🔄 Sugestão de substituição" com SKUs similares disponíveis
- Algoritmo: mesma família (prefixo modelo+chip) ranqueado por similaridade (storage +30pts, cor +15pts, condição +5pts)
- Badge visual: 🟢 muito similar, 🟡 similar, 🟠 família
- Cada similar mostra qual é a diferença ("storage diferente", "cor diferente")
- **Clica no similar → modal muda pra ele** (com botão "←" pra voltar)

### #6 — Etiqueta QR com SKU
- Etiqueta de impressão agora inclui linha **SKU: IPHONE-17-PRO-MAX-256GB...** em laranja
- QR code codifica JSON `{sku, c: codigo}` em vez de só serial — scanner lê SKU + unidade em 1 leitura
- Tamanho mantido (62×45mm), compatível com impressoras térmicas atuais

### #9 — Reconciliação SKU (`/admin/reconciliacao-sku`)
Auditoria que detecta 3 tipos de inconsistência usando SKU como chave:

| Tipo | O que é | Severidade |
|---|---|---|
| ⚠️ SKU_DIVERGENTE_PERSISTIDO | Venda com `estoque_id` mas `sku` ≠ `estoque.sku` | Alta |
| 🔍 ESGOTADO_SEM_VENDA | Item ESGOTADO sem venda vinculada (possível sumiço) | Alta |
| 📦 VENDA_SEM_ESTOQUE | Venda com serial/IMEI mas sem `estoque_id` (dupla-contagem) | Média |

Filtro por período (7d/30d/90d/ano), por tipo, e cada inconsistência tem links "Ver SKU / Ver venda / Ver estoque" pra investigar rápido.

---

## Sem migration
Todas as features leem colunas `sku` já existentes. Só deploy e usar.

## Como testar

- [ ] ⌘K e busca "iPhone 17 Pro" — deve aparecer banner 📊 se resultados convergirem num SKU
- [ ] Clicar botão 📊 em qualquer item do SuperSearch abre modal 360°
- [ ] No modal, ver similares em estoque quando qnt do SKU = 0
- [ ] Navegar entre similares com clique no card → seta voltar no header funciona
- [ ] Acessar `/admin/comprar-urgente` → lista ranqueada
- [ ] Clicar "📋 Copiar lista pro fornecedor" → texto no clipboard
- [ ] Imprimir etiqueta de qualquer item do estoque com SKU → mostra linha SKU + QR com JSON
- [ ] Acessar `/admin/reconciliacao-sku` → relatório de inconsistências dos últimos 30d

🤖 Generated with [Claude Code](https://claude.com/claude-code)