### PR TITLE
fix(sku): PRATEADO e PRATA eram tratados como cores diferentes (bug do Nicolas)

### DIFF
--- a/lib/produto-specs.ts
+++ b/lib/produto-specs.ts
@@ -308,6 +308,8 @@ export const COR_PT_TO_EN: Record<string, string> = {
   "PRETO ESPACIAL": "SPACE BLACK",
   "PRETO ONYX": "ONYX BLACK",
   "PRATA": "SILVER",
+  "PRATEADO": "SILVER",   // sinonimo — Apple Watch as vezes cadastrado assim
+  "PRATEADA": "SILVER",   // variacao feminina
   "ROSA": "PINK",
   "ROXO": "PURPLE",
   "ROXO PROFUNDO": "DEEP PURPLE",


### PR DESCRIPTION
## Problema

Nicolas tentou registrar venda de Apple Watch e o sistema bloqueou mesmo sendo o produto certo:

\`\`\`
🚫 PRODUTO ERRADO — venda bloqueada
Cliente pediu:    APPLE WATCH SERIES 11 GPS 46MM Prateado
Você selecionou:  APPLE WATCH Series 11 GPS 46MM PRATA
Diverge em: cor: — → PRATA
\`\`\`

## Causa

O mapa \`COR_PT_TO_EN\` em \`lib/produto-specs.ts\` tinha \`PRATA → SILVER\` mas **não** tinha \`PRATEADO → SILVER\`. O formulário do cliente envia \`cor="Prateado"\` (termo que a Apple usa em português pro Watch), e o gerador de SKU não consegue normalizar, então gera \`...-PRATEADO\`. O estoque (cadastrado como \`Prata\`) vira \`...-PRATA\`. SKUs diferentes → bloqueio.

## Fix

Adiciona \`PRATEADO\` e \`PRATEADA\` ao mapa, ambos apontando pra \`SILVER\`. Ambas formas agora viram a cor canônica e geram o mesmo SKU.

## Como vai funcionar após merge

1. **Merge do PR** — apenas mudança de código, sem migration
2. **Eu rodo o backfill com \`?force=1\`** — regenera todos os SKUs com o mapa atualizado. A venda do Nicolas volta a ter SKU \`...-PRATA\` e o bloqueio some.
3. Nicolas re-salva a venda e vai passar.

## Previne casos futuros

Outros sinônimos devem ser adicionados conforme forem descobertos. Por enquanto, \`PRATEADO/PRATEADA\` eram os mais prováveis — Apple usa esse termo pro Watch mas o sistema estava só com \`PRATA\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)