### PR TITLE
fix(sku): PATCH de venda perdia o SKU porque query nao lia a coluna

### DIFF
--- a/app/api/vendas/route.ts
+++ b/app/api/vendas/route.ts
@@ -863,7 +863,7 @@ export async function PATCH(req: NextRequest) {
 
   // Buscar venda anterior para comparar estoque_id (devolver produto se trocou)
   // e status_pagamento (evitar reenvio de NF/Telegram em edicoes posteriores).
-  const { data: vendaAnterior } = await supabase.from("vendas").select("estoque_id, serial_no, produto, status_pagamento, troca_produto, produto_na_troca, troca_produto2, produto_na_troca2, troca_serial, troca_imei, troca_serial2, troca_imei2, cliente").eq("id", id).single();
+  const { data: vendaAnterior } = await supabase.from("vendas").select("estoque_id, serial_no, produto, status_pagamento, troca_produto, produto_na_troca, troca_produto2, produto_na_troca2, troca_serial, troca_imei, troca_serial2, troca_imei2, cliente, sku").eq("id", id).single();
   const estoqueIdAnterior = vendaAnterior?.estoque_id || null;
   const statusPagamentoAnterior = (vendaAnterior as unknown as { status_pagamento?: string } | null)?.status_pagamento || null;
   const jaTinhaTroca1Antes = !!((vendaAnterior as unknown as { troca_produto?: string; produto_na_troca?: string } | null)?.troca_produto || (vendaAnterior as unknown as { troca_produto?: string; produto_na_troca?: string } | null)?.produto_na_troca);


### PR DESCRIPTION
## Problema

Mesmo com o SKU da venda gravado corretamente (\`WATCH-S11-46MM-GPS-PRATA\`), o bloqueio de venda continuava disparando com erro:

\`\`\`
Diverge em:
• cor: — → PRATA
\`\`\`

## Causa

No PATCH de \`/api/vendas\`, a query que busca \`vendaAnterior\` **não incluía a coluna \`sku\`** no SELECT:

\`\`\`ts
const { data: vendaAnterior } = await supabase.from(\"vendas\")
  .select(\"estoque_id, serial_no, produto, ...\")  // ← faltava \"sku\"
\`\`\`

Isso fazia \`vendaAnterior.sku\` ser sempre \`undefined\`, então \`vendaAtualSku = null\`, caindo no fallback que regera o SKU passando \`cor: null\`. Resultado: SKU regerado sem cor (\`WATCH-S11-46MM-GPS\`) divergia do estoque com cor (\`WATCH-S11-46MM-GPS-PRATA\`).

## Fix

1 caractere — adicionar \`\"sku\"\` no SELECT:

\`\`\`diff
- .select(\"estoque_id, serial_no, produto, ..., cliente\")
+ .select(\"estoque_id, serial_no, produto, ..., cliente, sku\")
\`\`\`

## Caso resolvido

Venda do André Martins Ismail (APPLE WATCH SERIES 11 GPS 46MM PRATA). Nicolas consegue vincular o estoque agora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)