### PR TITLE
fix(sku): inferir cor do texto do produto quando input.cor vem vazio

### DIFF
--- a/lib/sku.ts
+++ b/lib/sku.ts
@@ -107,6 +107,47 @@ function corParaSku(cor: string | null | undefined): string | null {
   return slugify(ptRaw);
 }
 
+// Quando o input.cor vem vazio mas o texto do produto contem uma cor
+// conhecida (ex: "APPLE WATCH SERIES 11 GPS 46MM PRATA"), tenta extrair.
+// Isso cobre casos onde o frontend envia o nome do produto ja com a cor
+// concatenada mas nao populou o campo cor separadamente — comum no fluxo
+// de formularios preenchidos pelo cliente.
+//
+// Estrategia conservadora: so retorna uma cor se encontrar match exato
+// (ignorando case/acento) com alguma cor conhecida no final do texto.
+// Evita falsos positivos como "BLACK" dentro de "BLACKBIRD" etc.
+const CORES_CONHECIDAS_PT = [
+  "TITANIO PRETO", "TITANIO NATURAL", "TITANIO AZUL", "TITANIO BRANCO",
+  "TITANIO DESERTO", "TITANIO PRATA",
+  "AZUL CEU", "AZUL NEVOA", "AZUL PROFUNDO", "AZUL PACIFICO", "AZUL SIERRA",
+  "PRETO ESPACIAL", "PRETO ONYX",
+  "VERDE ALPINO", "VERDE MEIANOITE",
+  "ROXO PROFUNDO",
+  "LARANJA COSMICO",
+  "DOURADO CLARO",
+  "MEIANOITE", "ESTELAR", "GRAFITE", "ARDOSIA",
+  "PRETO", "BRANCO", "AZUL", "VERDE", "ROXO", "ROSA", "AMARELO",
+  "VERMELHO", "LARANJA", "DOURADO", "CINZA",
+  "PRATA", "PRATEADO", "PRATEADA",
+  "LAVANDA", "TEAL", "SAGE", "INDIGO", "ULTRAMARINO", "BLUSH", "CITRUS",
+  "NATURAL",
+];
+
+function stripAccents(s: string): string {
+  return s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+function inferirCorDoTexto(texto: string): string | null {
+  const normalizado = stripAccents(upper(texto)).replace(/-/g, " ");
+  // Ordena por tamanho desc pra casar "TITANIO PRETO" antes de "PRETO"
+  const ordenadas = [...CORES_CONHECIDAS_PT].sort((a, b) => b.length - a.length);
+  for (const cor of ordenadas) {
+    const reWord = new RegExp(`\\b${cor.replace(/\s/g, "\\s+")}\\b`);
+    if (reWord.test(normalizado)) return cor;
+  }
+  return null;
+}
+
 // ─── Detectar variante de modelo (iPhone Pro / Plus / Max / Air / e) ──
 
 function extrairModeloIphone(texto: string): string | null {
@@ -203,7 +244,13 @@ export interface SkuResult {
 export function gerarSku(produto: ProdutoInput): SkuResult {
   const texto = [produto.produto, produto.observacao].filter(Boolean).join(" ");
   const cat = upper(produto.categoria);
-  const corSku = corParaSku(produto.cor);
+  // Cor: usa a explicitamente passada; senao tenta inferir do texto livre
+  // (cobre caso onde frontend envia cor concatenada no nome do produto).
+  let corSku = corParaSku(produto.cor);
+  if (!corSku) {
+    const corInferida = inferirCorDoTexto(texto);
+    if (corInferida) corSku = corParaSku(corInferida);
+  }
   const isSeminovo = upper(produto.tipo) === "SEMINOVO";
   const sfx = isSeminovo ? "-SEMINOVO" : "";
 


### PR DESCRIPTION
## Problema

Mesmo depois dos fixes #755 e #759, o Nicolas continuava recebendo bloqueio em vendas do Apple Watch:

\`\`\`
Cliente pediu:    APPLE WATCH SERIES 11 GPS 46MM PRATA
Você selecionou:  APPLE WATCH Series 11 GPS 46MM PRATA
Diverge em: cor: — → PRATA
\`\`\`

## Causa raiz

Quando o cliente preenche o formulário e o frontend processa a venda, o **nome do produto já vem com a cor concatenada no final** (\"...46MM PRATA\") mas o campo \`cor\` separado **nem sempre é populado**. Resultado:
- \`body.produto\` = \"APPLE WATCH SERIES 11 GPS 46MM PRATA\"
- \`body.cor\` = null

O gerador de SKU para Apple Watch só olhava \`input.cor\` pra extrair cor — com cor=null, gerava SKU sem cor (\`WATCH-S11-46MM-GPS\`) mesmo o texto claramente dizendo \"PRATA\".

Aí o estoque tem \`WATCH-S11-46MM-GPS-PRATA\` → diverge → bloqueia.

## Fix

\`gerarSku()\` agora tenta inferir a cor do texto do produto quando \`input.cor\` não foi passado:

1. Se \`input.cor\` presente → usa ele (comportamento antigo)
2. Senão → busca no texto do produto palavras conhecidas do mapa de cores (PRATA, PRATEADO, TITANIO NATURAL, LAVANDA, etc)
3. Match ancorado em \`\\b\` (word boundary) pra não pegar \"BLACK\" dentro de \"BLACKBIRD\"
4. Prioriza cores compostas mais longas (TITANIO PRETO antes de PRETO)

## Impacto

- SKUs gerados em POSTs \`/api/vendas\` agora capturam cor mesmo sem campo explícito
- Backfill de vendas antigas vai regenerar SKUs corretos se rodar \`?force=1\`
- Nicolas consegue vincular o item do estoque normalmente após F5

🤖 Generated with [Claude Code](https://claude.com/claude-code)