### PR TITLE
fix(sku): trocar bloqueio por alerta + botão 'Registrar mesmo assim'

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -37,8 +37,11 @@ function formatSkuDivergenciaMsg(json: {
   const diffs = (json.diferencas || [])
     .map((d) => `• ${d.campo}: ${d.esperado} → ${d.selecionado}`)
     .join("\n");
+  // Temporario: texto de ALERTA em vez de "bloqueada" — andre pediu pra liberar
+  // registro via botao "Registrar mesmo assim" ate ajustes finos do sistema SKU
+  // (acessorios cadastrados com categoria errada disparam falso-positivo).
   return [
-    "🚫 PRODUTO ERRADO — venda bloqueada",
+    "⚠️ ALERTA — produto não bate 100% com o pedido",
     "",
     `Cliente pediu:    ${json.produto_venda || "?"}`,
     `Você selecionou:  ${json.produto_estoque || "?"}`,
@@ -46,12 +49,17 @@ function formatSkuDivergenciaMsg(json: {
     "Diverge em:",
     diffs || `• SKU diferente (${json.esperado} ≠ ${json.selecionado})`,
     "",
-    "Corrija a seleção antes de registrar.",
+    "Revise a seleção. Se realmente é o produto certo, clique em “Registrar mesmo assim”.",
   ].join("\n");
 }
 
 export default function VendasPage() {
   const { password, user, darkMode } = useAdmin();
+  // SKU override: quando backend retorna 409 SKU_DIVERGENTE, em vez de bloquear
+  // a venda exibe alerta com botao "Registrar mesmo assim". Se usuario clicar,
+  // seta a ref e chama handleSubmit de novo com flag _sku_override=true.
+  const skuOverrideRef = useRef(false);
+  const [skuAlertaAtivo, setSkuAlertaAtivo] = useState(false);
   const vendedoresList = useVendedores(password);
   const dm = darkMode;
   const [vendas, setVendas] = useState<Venda[]>([]);
@@ -1717,6 +1725,7 @@ export default function VendasPage() {
           for (let i = 0; i < nPatch; i++) {
             const patchBody: Record<string, unknown> = { id: editandoGrupoIds[i], ...groupPayloads[i] };
             if (precisaCriarGrupo) patchBody.grupo_id = grupoIdOriginal;
+            if (skuOverrideRef.current) patchBody._sku_override = true;
             const res = await fetch("/api/vendas", {
               method: "PATCH",
               headers: { "Content-Type": "application/json", "x-admin-password": password },
@@ -1730,6 +1739,7 @@ export default function VendasPage() {
                   ? formatSkuDivergenciaMsg(json)
                   : "Erro ao atualizar: " + (json.error || "erro desconhecido"),
               );
+              if (json.codigo === "SKU_DIVERGENTE") setSkuAlertaAtivo(true);
               break;
             }
           }
@@ -1737,7 +1747,8 @@ export default function VendasPage() {
           // 2. POST novos produtos (se allProducts.length > editandoGrupoIds.length)
           if (allOk && allProducts.length > editandoGrupoIds.length) {
             for (let i = editandoGrupoIds.length; i < allProducts.length; i++) {
-              const payload = { ...groupPayloads[i], grupo_id: grupoIdOriginal };
+              const payload: Record<string, unknown> = { ...groupPayloads[i], grupo_id: grupoIdOriginal };
+              if (skuOverrideRef.current) payload._sku_override = true;
               const res = await fetch("/api/vendas", {
                 method: "POST",
                 headers: { "Content-Type": "application/json", "x-admin-password": password },
@@ -1751,6 +1762,7 @@ export default function VendasPage() {
                     ? formatSkuDivergenciaMsg(json)
                     : "Erro ao criar novo item: " + (json.error || "erro desconhecido"),
                 );
+                if (json.codigo === "SKU_DIVERGENTE") setSkuAlertaAtivo(true);
                 break;
               }
             }
@@ -1801,6 +1813,8 @@ export default function VendasPage() {
             setCatSel(""); setEstoqueId(""); setProdutoManual(false); setShowSegundaTroca(false);
             localStorage.removeItem("tigrao_venda_draft");
             setMsg(msgFinal);
+            setSkuAlertaAtivo(false);
+            skuOverrideRef.current = false;
             fetchVendas();
             fetchEstoque();
           }
@@ -1808,10 +1822,12 @@ export default function VendasPage() {
           // Edição simples (1 produto)
           const prod = allProducts[0];
           const payload = buildPayload(prod);
+          const body: Record<string, unknown> = { id: editandoVendaId, ...payload };
+          if (skuOverrideRef.current) body._sku_override = true;
           const res = await fetch("/api/vendas", {
             method: "PATCH",
             headers: { "Content-Type": "application/json", "x-admin-password": password },
-            body: JSON.stringify({ id: editandoVendaId, ...payload }),
+            body: JSON.stringify(body),
           });
           const json = await res.json();
           if (json.ok || json.data) {
@@ -1843,6 +1859,9 @@ export default function VendasPage() {
             setCatSel(""); setEstoqueId(""); setProdutoManual(false); setShowSegundaTroca(false);
             localStorage.removeItem("tigrao_venda_draft");
             setMsg("Venda atualizada com sucesso!");
+            // Sucesso — resetar estado do alerta/override
+            setSkuAlertaAtivo(false);
+            skuOverrideRef.current = false;
             fetchVendas();
             fetchEstoque();
           } else {
@@ -1853,6 +1872,13 @@ export default function VendasPage() {
                 ? formatSkuDivergenciaMsg(json)
                 : "Erro ao atualizar: " + (json.error || "erro desconhecido"),
             );
+            if (json.codigo === "SKU_DIVERGENTE") {
+              setSkuAlertaAtivo(true);
+            } else {
+              // Erro diferente → limpa flag pra proximo save nao carregar override
+              setSkuAlertaAtivo(false);
+              skuOverrideRef.current = false;
+            }
           }
         }
       } catch {
@@ -1877,10 +1903,13 @@ export default function VendasPage() {
       const prod = allProducts[i];
 
       try {
+        const bodyFinal = skuOverrideRef.current
+          ? { ...payload, _sku_override: true }
+          : payload;
         const res = await fetch("/api/vendas", {
           method: "POST",
           headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
-          body: JSON.stringify(payload),
+          body: JSON.stringify(bodyFinal),
         });
         const json = await res.json();
         if (json.ok) {
@@ -1890,9 +1919,10 @@ export default function VendasPage() {
             errors.push(`⚠️ Crédito lojista: ${json.creditoDebitError}`);
           }
         } else if (json.codigo === "SKU_DIVERGENTE") {
-          // Erro critico: produto nao bate com o pedido. Mensagem detalhada
-          // em vez de concatenar no erros[] generico.
+          // Alerta: produto nao bate com o pedido. Admin pode confirmar via
+          // botao "Registrar mesmo assim" que refaz o submit com _sku_override.
           errors.push(`${prod.produto}: ${formatSkuDivergenciaMsg(json)}`);
+          setSkuAlertaAtivo(true);
         } else {
           errors.push(`${prod.produto}: ${json.error}`);
         }
@@ -1905,6 +1935,9 @@ export default function VendasPage() {
     }
 
     if (successCount > 0) {
+      // Sucesso — resetar estado do alerta/override pra nao carregar no proximo save
+      setSkuAlertaAtivo(false);
+      skuOverrideRef.current = false;
       setDuplicadoInfo(null);
       setLastClienteData(null);
       setProdutosCarrinho([]);
@@ -2550,7 +2583,46 @@ export default function VendasPage() {
             </div>
           )}
 
-          {msg && <div className={`px-4 py-3 rounded-xl text-sm whitespace-pre-line ${msg.includes("Erro") || msg.includes("🚫") || msg.includes("bloqueada") ? "bg-red-50 text-red-700 border border-red-200" : "bg-green-50 text-green-700"}`}>{msg}</div>}
+          {msg && (
+            <div className={`px-4 py-3 rounded-xl text-sm whitespace-pre-line ${
+              skuAlertaAtivo
+                ? "bg-amber-50 text-amber-800 border border-amber-300"
+                : msg.includes("Erro") || msg.includes("🚫") || msg.includes("bloqueada")
+                  ? "bg-red-50 text-red-700 border border-red-200"
+                  : "bg-green-50 text-green-700"
+            }`}>
+              <div>{msg}</div>
+              {skuAlertaAtivo && (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    onClick={() => {
+                      // Override: proxima submissao envia _sku_override=true e pula validacao.
+                      // Limpa msg + alerta e re-chama handleSubmit pra retentar o save.
+                      skuOverrideRef.current = true;
+                      setSkuAlertaAtivo(false);
+                      setMsg("");
+                      handleSubmit();
+                    }}
+                    disabled={saving}
+                    className="px-4 py-2 rounded-lg text-sm font-semibold bg-amber-600 text-white hover:bg-amber-700 disabled:opacity-50 transition-colors"
+                  >
+                    ⚠️ Registrar mesmo assim
+                  </button>
+                  <button
+                    onClick={() => {
+                      // Usuario quer corrigir a selecao — so limpa o alerta
+                      setSkuAlertaAtivo(false);
+                      skuOverrideRef.current = false;
+                      setMsg("");
+                    }}
+                    className="px-4 py-2 rounded-lg text-sm font-medium border border-amber-400 text-amber-800 bg-white hover:bg-amber-50 transition-colors"
+                  >
+                    Corrigir seleção
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Row 1: Data + Brinde */}
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">


### PR DESCRIPTION
## Problema

Nicolas tentou registrar venda de Magic Trackpad e iPad Air M3 mas o bloqueio disparou falso-positivo — produtos legítimos travados por causa de classificação de SKU incompleta em acessórios ou formulários preenchidos pelo cliente.

Exemplos das screenshots:
- **Magic Trackpad**: diverge em categoria (MAGIC → ACC), modelo e cor — acessório cadastrado errado
- **iPad Air M3**: o formulário veio como iPhone 16 (dados do cliente bagunçados), totalmente diferente

Em ambos, o admin sabe que tá fazendo o certo mas o sistema trava.

## Solução (temporária até ajuste fino)

**Muda bloqueio → alerta com override.** O flag `_sku_override` já existia no backend — agora o frontend usa de verdade:

### Antes
\`\`\`
🚫 PRODUTO ERRADO — venda bloqueada
...
Corrija a seleção antes de registrar.
\`\`\`
Botão Salvar trava. Impossível prosseguir.

### Depois
\`\`\`
⚠️ ALERTA — produto não bate 100% com o pedido
...
Revise a seleção. Se realmente é o produto certo, clique em "Registrar mesmo assim".

[⚠️ Registrar mesmo assim]   [Corrigir seleção]
\`\`\`

Admin vê o alerta, confere os detalhes e decide:
- **"Registrar mesmo assim"** → refaz o submit com `_sku_override: true` → backend grava normal
- **"Corrigir seleção"** → só limpa o alerta, admin troca o produto

## Cobertura

Os 3 fluxos de save no `/admin/vendas` foram atualizados:
- PATCH edição simples (1 produto)
- PATCH + POST no multi-produto (edição de grupo)
- POST loop (criar venda nova)

Banner fica laranja em vez de vermelho quando o alerta tá ativo (cor de "atenção" em vez de "erro").

## Depois

A proteção continua existindo — admin precisa confirmar ativamente em cada divergência. Quando a classificação de acessórios for ajustada (categoria ACESSORIOS em vez de IPADS, etc), o alerta vai aparecer bem menos. Se quiser voltar pro modo bloqueio, é só trocar 2 linhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)