### PR TITLE
fix(sku): alerta agregado multi-produto + reconhecer tela (13) no MacBook/iPad

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -23,7 +23,7 @@ const VENDAS_PASSWORD = "tigrao$vendas";
 // Formata a resposta de erro do backend quando SKU do estoque selecionado
 // nao bate com o SKU esperado pela venda (cliente pediu produto diferente).
 // Retorna string multilinha pronta pra setMsg.
-function formatSkuDivergenciaMsg(json: {
+interface SkuDivergencia {
   codigo?: string;
   error?: string;
   produto_venda?: string;
@@ -31,7 +31,9 @@ function formatSkuDivergenciaMsg(json: {
   diferencas?: Array<{ campo: string; esperado: string; selecionado: string }>;
   esperado?: string;
   selecionado?: string;
-}): string {
+}
+
+function formatSkuDivergenciaMsg(json: SkuDivergencia): string {
   if (json?.codigo !== "SKU_DIVERGENTE") {
     return json?.error || "erro desconhecido";
   }
@@ -52,6 +54,32 @@ function formatSkuDivergenciaMsg(json: {
     "",
     "Revise a seleção. Se realmente é o produto certo, clique em “Registrar mesmo assim”.",
   ].join("\n");
+}
+
+// Formata N divergencias de uma vez quando o carrinho tem multiplos produtos e
+// mais de um diverge. Evita que o admin precise salvar 3x pra ver 3 alertas —
+// lista tudo junto pra ele revisar de uma vez so.
+function formatSkuDivergenciasMultiplas(erros: SkuDivergencia[]): string {
+  if (erros.length === 0) return "";
+  if (erros.length === 1) return formatSkuDivergenciaMsg(erros[0]);
+
+  const linhas = [
+    `⚠️ ALERTA — ${erros.length} produtos não batem 100%`,
+    "",
+  ];
+  erros.forEach((e, idx) => {
+    const diffs = (e.diferencas || [])
+      .map((d) => `   • ${d.campo}: ${d.esperado} → ${d.selecionado}`)
+      .join("\n");
+    linhas.push(
+      `${idx + 1}) ${e.produto_venda || "?"}`,
+      `   → Você vinculou: ${e.produto_estoque || "?"}`,
+      diffs || `   • SKU diferente`,
+      "",
+    );
+  });
+  linhas.push("Revise cada um. Se estiver tudo certo, clique em “Registrar mesmo assim”.");
+  return linhas.join("\n");
 }
 
 export default function VendasPage() {
@@ -1746,6 +1774,11 @@ export default function VendasPage() {
             || (precisaCriarGrupo ? crypto.randomUUID() : editandoGrupoIds[0]);
 
           let allOk = true;
+          // Acumula divergencias de SKU (nao quebra o loop) — assim o admin
+          // ve TODAS as linhas problematicas de uma vez em vez de salvar
+          // varias vezes descobrindo 1 por vez.
+          const skuDivergencias: SkuDivergencia[] = [];
+          let primeiroErroNaoSku = "";
 
           // 1. PATCH nos produtos que casam com vendas existentes.
           // Se estamos criando grupo novo (venda unica virando multi), propaga grupo_id
@@ -1762,18 +1795,22 @@ export default function VendasPage() {
             });
             const json = await res.json();
             if (!json.ok && !json.data) {
-              allOk = false;
-              setMsg(
-                json.codigo === "SKU_DIVERGENTE"
-                  ? formatSkuDivergenciaMsg(json)
-                  : "Erro ao atualizar: " + (json.error || "erro desconhecido"),
-              );
-              if (json.codigo === "SKU_DIVERGENTE") setSkuAlertaAtivo(true);
-              break;
+              if (json.codigo === "SKU_DIVERGENTE") {
+                // Coleta e continua — vai reportar tudo no final.
+                skuDivergencias.push(json);
+                allOk = false;
+              } else if (!primeiroErroNaoSku) {
+                // Outros erros (nao SKU): guarda o primeiro e quebra o loop.
+                primeiroErroNaoSku = "Erro ao atualizar: " + (json.error || "erro desconhecido");
+                allOk = false;
+                break;
+              }
             }
           }
 
           // 2. POST novos produtos (se allProducts.length > editandoGrupoIds.length)
+          // So roda se fase 1 passou 100% — divergencias de SKU em PATCH
+          // existentes impedem avancar pra criar itens novos sem admin revisar.
           if (allOk && allProducts.length > editandoGrupoIds.length) {
             for (let i = editandoGrupoIds.length; i < allProducts.length; i++) {
               const payload: Record<string, unknown> = { ...groupPayloads[i], grupo_id: grupoIdOriginal };
@@ -1785,16 +1822,24 @@ export default function VendasPage() {
               });
               const json = await res.json();
               if (!json.ok && !json.data) {
-                allOk = false;
-                setMsg(
-                  json.codigo === "SKU_DIVERGENTE"
-                    ? formatSkuDivergenciaMsg(json)
-                    : "Erro ao criar novo item: " + (json.error || "erro desconhecido"),
-                );
-                if (json.codigo === "SKU_DIVERGENTE") setSkuAlertaAtivo(true);
-                break;
+                if (json.codigo === "SKU_DIVERGENTE") {
+                  skuDivergencias.push(json);
+                  allOk = false;
+                } else if (!primeiroErroNaoSku) {
+                  primeiroErroNaoSku = "Erro ao criar novo item: " + (json.error || "erro desconhecido");
+                  allOk = false;
+                  break;
+                }
               }
             }
+          }
+
+          // Se teve divergencia de SKU em qualquer fase, mostra alerta agregado
+          if (skuDivergencias.length > 0) {
+            setMsg(formatSkuDivergenciasMultiplas(skuDivergencias));
+            setSkuAlertaAtivo(true);
+          } else if (primeiroErroNaoSku) {
+            setMsg(primeiroErroNaoSku);
           }
 
           // 3. DELETE vendas removidas (se allProducts.length < editandoGrupoIds.length)
@@ -1926,6 +1971,9 @@ export default function VendasPage() {
     let successCount = 0;
     const errors: string[] = [];
     const savedVendaIds: string[] = [];
+    // Acumula divergencias de SKU pra mostrar tudo de uma vez no final
+    // (multi-produto com varios erros SKU = 1 alerta consolidado).
+    const skuDivergenciasPost: SkuDivergencia[] = [];
 
     for (let i = 0; i < payloads.length; i++) {
       const payload = payloads[i];
@@ -1948,10 +1996,9 @@ export default function VendasPage() {
             errors.push(`⚠️ Crédito lojista: ${json.creditoDebitError}`);
           }
         } else if (json.codigo === "SKU_DIVERGENTE") {
-          // Alerta: produto nao bate com o pedido. Admin pode confirmar via
-          // botao "Registrar mesmo assim" que refaz o submit com _sku_override.
-          errors.push(`${prod.produto}: ${formatSkuDivergenciaMsg(json)}`);
-          setSkuAlertaAtivo(true);
+          // Alerta: coleta e continua o loop pra reportar TODOS os SKUs
+          // divergentes de uma vez (evita admin salvar varias vezes).
+          skuDivergenciasPost.push(json);
         } else {
           errors.push(`${prod.produto}: ${json.error}`);
         }
@@ -1961,6 +2008,11 @@ export default function VendasPage() {
         setOfflineCount(getQueueCount());
         errors.push(`${prod.produto}: salva offline (erro de rede)`);
       }
+    }
+
+    // Se teve divergencias SKU, ativa o alerta agregado (setMsg vem depois)
+    if (skuDivergenciasPost.length > 0) {
+      setSkuAlertaAtivo(true);
     }
 
     if (successCount > 0) {
@@ -2000,12 +2052,16 @@ export default function VendasPage() {
       localStorage.removeItem("tigrao_venda_draft");
       const statusTxt = vendaProgramada ? "programada" : "registrada";
       const plural = successCount > 1 ? "s" : "";
-      setMsg(`${successCount} venda${plural} ${statusTxt}${plural}!${errors.length > 0 ? ` (${errors.length} erro${errors.length > 1 ? "s" : ""})` : ""}`);
+      const totalFalhas = errors.length + skuDivergenciasPost.length;
+      setMsg(`${successCount} venda${plural} ${statusTxt}${plural}!${totalFalhas > 0 ? ` (${totalFalhas} erro${totalFalhas > 1 ? "s" : ""})` : ""}`);
       fetchVendas();
       fetchEstoque();
       // NF é adicionada depois nas vendas pendentes, não no momento do registro
 
       // Entrega NÃO é criada automaticamente — equipe cria manualmente na agenda
+    } else if (skuDivergenciasPost.length > 0) {
+      // Nenhuma venda registrada + todas bateram SKU_DIVERGENTE → alerta consolidado
+      setMsg(formatSkuDivergenciasMultiplas(skuDivergenciasPost));
     } else {
       setMsg("Erro: " + errors.join("; "));
     }

--- a/lib/sku-validator.ts
+++ b/lib/sku-validator.ts
@@ -65,8 +65,21 @@ export function compararSkus(
     };
   }
 
-  // Caso 3: divergem — bloqueia com diff detalhado
+  // Caso 3: divergem — analisa componentes pra decidir se e divergencia real
+  // ou so informacao parcial (SKU legado sem cor vs estoque com cor, etc).
   const diferencas = identificarDiferencas(esperado, selecionado);
+
+  // Se identificarDiferencas tolerou todas as diferencas (componentes
+  // ausentes em um lado), retorna ok=true — SKUs sao compativeis.
+  if (diferencas.length === 0) {
+    return {
+      ok: true,
+      podeValidar: true,
+      skuEsperado: esperado,
+      skuSelecionado: selecionado,
+    };
+  }
+
   const camposMsg = diferencas.map((d) => d.campo).join(", ");
   return {
     ok: false,
@@ -106,33 +119,27 @@ function identificarDiferencas(esperado: string, selecionado: string): Array<{ c
   // Specs: comparar por tipo conhecido (GB/TB = storage, mm = tamanho, MM = memoria, etc)
   const specE = extrairComponentes(pE.specs);
   const specS = extrairComponentes(pS.specs);
-  if (specE.storage !== specS.storage && (specE.storage || specS.storage)) {
-    diffs.push({
-      campo: "storage",
-      esperado: specE.storage || "—",
-      selecionado: specS.storage || "—",
-    });
+
+  // Regra de tolerancia: se um lado tem o componente e o outro nao (null),
+  // considera "SKU parcial" compativel. Ex: venda antiga gravada sem cor
+  // deve bater com estoque que tem cor (desde que modelo/storage batam).
+  // So marca divergencia quando AMBOS os lados tem valor e sao diferentes.
+  const difere = (a: string | null, b: string | null): boolean => !!(a && b && a !== b);
+
+  if (difere(specE.storage, specS.storage)) {
+    diffs.push({ campo: "storage", esperado: specE.storage!, selecionado: specS.storage! });
   }
-  if (specE.cor !== specS.cor && (specE.cor || specS.cor)) {
-    diffs.push({
-      campo: "cor",
-      esperado: specE.cor || "—",
-      selecionado: specS.cor || "—",
-    });
+  if (difere(specE.cor, specS.cor)) {
+    diffs.push({ campo: "cor", esperado: specE.cor!, selecionado: specS.cor! });
   }
-  if (specE.tamanhoWatch !== specS.tamanhoWatch && (specE.tamanhoWatch || specS.tamanhoWatch)) {
-    diffs.push({
-      campo: "tamanho",
-      esperado: specE.tamanhoWatch || "—",
-      selecionado: specS.tamanhoWatch || "—",
-    });
+  if (difere(specE.tamanhoWatch, specS.tamanhoWatch)) {
+    diffs.push({ campo: "tamanho", esperado: specE.tamanhoWatch!, selecionado: specS.tamanhoWatch! });
   }
-  if (specE.chip !== specS.chip && (specE.chip || specS.chip)) {
-    diffs.push({
-      campo: "chip",
-      esperado: specE.chip || "—",
-      selecionado: specS.chip || "—",
-    });
+  if (difere(specE.chip, specS.chip)) {
+    diffs.push({ campo: "chip", esperado: specE.chip!, selecionado: specS.chip! });
+  }
+  if (difere(specE.tela, specS.tela)) {
+    diffs.push({ campo: "tela", esperado: specE.tela!, selecionado: specS.tela! });
   }
 
   // Seminovo vs novo
@@ -144,11 +151,9 @@ function identificarDiferencas(esperado: string, selecionado: string): Array<{ c
     });
   }
 
-  // Fallback: se nao conseguiu identificar por componente conhecido mas SKUs
-  // diferem, pelo menos avisa que "outros campos" divergem.
-  if (diffs.length === 0) {
-    diffs.push({ campo: "specs", esperado: pE.specs.join("-"), selecionado: pS.specs.join("-") });
-  }
+  // Nao usa fallback "specs diferentes" quando nao acha heuristica — aqui
+  // os SKUs podem divergir string-wise mas serem compativeis (ex: um tem cor,
+  // outro nao). Preferimos tolerar do que bloquear venda legitima.
 
   return diffs;
 }
@@ -160,24 +165,29 @@ function extrairComponentes(specs: string[]): {
   cor: string | null;
   tamanhoWatch: string | null;
   chip: string | null;
+  tela: string | null;
 } {
   let storage: string | null = null;
   let tamanhoWatch: string | null = null;
   let chip: string | null = null;
+  let tela: string | null = null;
   const naoClassificados: string[] = [];
 
   for (const s of specs) {
     if (/^\d+(GB|TB)$/.test(s)) { storage = s; continue; }
     if (/^\d+MM$/.test(s)) { tamanhoWatch = s; continue; }
     if (/^M\d+(-PRO|-MAX|-ULTRA|-PROMAX)?$/.test(s)) { chip = s; continue; }
-    if (s === "GPS" || s === "GPSCEL" || s === "WIFI" || s === "CELL" || s === "SEMINOVO") continue;
+    // Tela de MacBook/iPad: numero sozinho entre 10-17 (ex: 11, 13, 14, 15, 16).
+    // Sem isso, "13" (tela do MacBook Air) era tratado como cor.
+    if (/^\d+$/.test(s) && Number(s) >= 10 && Number(s) <= 17) { tela = s; continue; }
+    if (s === "GPS" || s === "GPSCEL" || s === "WIFI" || s === "CELL" || s === "SEMINOVO" || s === "ANC") continue;
     naoClassificados.push(s);
   }
 
   // Cor = o que sobrou, normalmente 1 ou 2 segmentos no final (ex TITANIO-PRETO).
   const cor = naoClassificados.length > 0 ? naoClassificados.join("-") : null;
 
-  return { storage, cor, tamanhoWatch, chip };
+  return { storage, cor, tamanhoWatch, chip, tela };
 }
 
 // ─── Nome canonico pra exibicao humana ────────────────────────────


### PR DESCRIPTION
## Sobe em cima do #762 (já mergeado). Duas coisas:

### 1. Alerta agregado no multi-produto
**Antes:** carrinho com 3 produtos divergentes mostrava 1 alerta, admin salvava, aparecia o próximo, salvava, etc.

**Depois:** coleta TODAS as divergências e mostra num único alerta:

\`\`\`
⚠️ ALERTA — 2 produtos não batem 100%

1) iPad Air M3 11" 128GB Cinza
   → Você vinculou: iPhone 16 128GB White
   • categoria, modelo, chip, condição

2) AirPods Pro
   → Você vinculou: AirPods Max
   • modelo

Revise cada um. Se estiver tudo certo, clique em "Registrar mesmo assim".
\`\`\`

Aplica tanto em edição de grupo (PATCH loop) quanto em criar venda nova multi-produto (POST loop).

### 2. Fix da tela do MacBook/iPad confundida com cor
Caso reportado pelo André: MacBook Air M5 13" mostrava `cor: 13 → 13-PRATA` porque a função \`extrairComponentes\` do validator tratava o número "13" (tela) como parte da cor.

**Fix:**
- Regex nova reconhece número sozinho entre 10-17 como **tela** (MacBook 13/14/15/16, iPad 11/13)
- Helper \`difere(a, b)\` só marca divergência quando AMBOS os lados têm valor diferente. Se um lado é null (venda antiga sem cor, por ex), **tolera**
- Removido fallback "specs diferentes" que gerava falso positivo

### Resultado
SKU com "MACBOOK-AIR-M5-13-16GB-512GB" (sem cor) vs "MACBOOK-AIR-M5-13-16GB-512GB-PRATA" (com cor) agora são considerados **compatíveis**. O "13" não é mais interpretado como cor.

Venda do Nicolas passa sem precisar apertar "Registrar mesmo assim".

🤖 Generated with [Claude Code](https://claude.com/claude-code)