### PR TITLE
fix(display): Magic Keyboard e outros acessórios não caem mais no branch IPAD

### DIFF
--- a/lib/produto-display.ts
+++ b/lib/produto-display.ts
@@ -226,7 +226,11 @@ export function getModeloBase(produto: string, categoria: string, observacao?: s
   const p = (produto || "").toUpperCase().trim();
   let baseCat = getBaseCat(categoria || "");
   if (!baseCat || !["IPHONES","IPADS","MACBOOK","MAC_MINI","APPLE_WATCH","AIRPODS","ACESSORIOS"].includes(baseCat)) {
-    if (/\bIPHONE\b/.test(p)) baseCat = "IPHONES";
+    // ACESSORIOS ANTES de IPAD/IPHONE/etc — senao "Magic Keyboard iPad Pro M4"
+    // cai em IPADS (porque tem "IPAD" no nome) e vira "iPad Pro M4" no display,
+    // escondendo que e um acessorio. Lista cobre os acessorios Apple comuns.
+    if (/\bMAGIC\s*(KEYBOARD|MOUSE|TRACKPAD)\b|\bAPPLE\s*PENCIL\b|\bCARREGADOR\b|\bCAPA\b|\bCASE\b|\bCABO\b|\bFONTE\b|\bPELICULA\b|\bP[EÉ]LICULA\b|\bADAPTADOR\b|\bHUB\b|\bPULSEIRA\b|\bSMART\s*FOLIO\b/.test(p)) baseCat = "ACESSORIOS";
+    else if (/\bIPHONE\b/.test(p)) baseCat = "IPHONES";
     else if (/\bIPAD\b/.test(p)) baseCat = "IPADS";
     else if (/\bMACBOOK\b/.test(p)) baseCat = "MACBOOK";
     else if (/\bMAC\s*MINI\b/.test(p)) baseCat = "MAC_MINI";


### PR DESCRIPTION
## Bug reportado pelo André

Venda do Antonio: Magic Keyboard para iPad Pro M4 aparecia na coluna PRODUTO como **\"iPad Pro M4\"** — escondendo que é um acessório.

## Causa

Em \`getModeloBase\`, quando a venda tem \`categoria = null\` (caso dessa venda), tenta inferir via texto:

\`\`\`ts
if (/\bIPHONE\b/.test(p)) baseCat = \"IPHONES\";
else if (/\bIPAD\b/.test(p)) baseCat = \"IPADS\";  // ← pega \"IPAD\" em \"MAGIC KEYBOARD IPAD PRO M4\"
...
\`\`\`

Como o nome \"Magic Keyboard iPad Pro M4\" contém \"IPAD\", baseCat virava IPADS. Aí entrava no branch de iPad que extrai só o modelo (\"iPad Pro M4\") perdendo o \"Magic Keyboard\".

## Fix

Detectar ACESSÓRIOS **antes** de iPad/iPhone/etc quando categoria vem vazia. Lista cobre:

- Magic Keyboard/Mouse/Trackpad
- Apple Pencil
- Carregador
- Capa / Case
- Cabo
- Fonte
- Película
- Adaptador
- Hub
- Pulseira
- Smart Folio

Quando bate, cai no branch ACESSORIOS que preserva o nome completo (\"MAGIC KEYBOARD IPAD PRO M4\") e só remove cor do final.

## Resultado

| Produto | Antes | Depois |
|---|---|---|
| MAGIC KEYBOARD IPAD PRO M4 | iPad Pro M4 | MAGIC KEYBOARD IPAD PRO M4 |
| APPLE PENCIL USB-C IPAD | iPad | APPLE PENCIL USB-C IPAD |
| CAPA IPHONE 17 PRO | iPhone 17 Pro | CAPA IPHONE 17 PRO |

🤖 Generated with [Claude Code](https://claude.com/claude-code)