### PR TITLE
fix(sku): corrigir falsos positivos e adicionar acoes em reconciliacao

### DIFF
--- a/app/admin/reconciliacao-sku/page.tsx
+++ b/app/admin/reconciliacao-sku/page.tsx
@@ -60,6 +60,21 @@ export default function ReconciliacaoSkuPage() {
   const [tipoFiltro, setTipoFiltro] = useState<TipoInc | "todos">("todos");
   const [skuInfo, setSkuInfo] = useState<string | null>(null);
   const [periodoDias, setPeriodoDias] = useState(30);
+  const [syncingSku, setSyncingSku] = useState(false);
+  const [syncMsg, setSyncMsg] = useState<string | null>(null);
+  // Set de ids (venda_id ou estoque_id) que o admin marcou como "ignorar".
+  // Persiste em localStorage — util pra casos legitimos como atacado em lote,
+  // brindes internos, ou vendas fora do sistema que nao queremos ver de novo.
+  const [ignorados, setIgnorados] = useState<Set<string>>(() => {
+    if (typeof window === "undefined") return new Set();
+    try {
+      const raw = localStorage.getItem("tigrao_reconciliacao_ignorados") || "[]";
+      return new Set(JSON.parse(raw) as string[]);
+    } catch {
+      return new Set();
+    }
+  });
+  const [mostrarIgnorados, setMostrarIgnorados] = useState(false);
 
   const fetchData = useCallback(() => {
     if (!password) return;
@@ -86,9 +101,78 @@ export default function ReconciliacaoSkuPage() {
     fetchData();
   }, [fetchData]);
 
-  const filtradas = (inconsistencias || []).filter((i) =>
-    tipoFiltro === "todos" ? true : i.tipo === tipoFiltro,
-  );
+  // Chave unica pra persistir decisao de ignorar: usa o ID mais especifico
+  // disponivel (venda_id > estoque_id) mais o tipo, pra evitar colisao entre
+  // tipos de alerta que compartilhem ids.
+  const keyIgnorar = (i: Inconsistencia): string =>
+    `${i.tipo}:${i.ids.venda_id || i.ids.estoque_id || "?"}`;
+
+  const toggleIgnorar = (inc: Inconsistencia) => {
+    const k = keyIgnorar(inc);
+    const novo = new Set(ignorados);
+    if (novo.has(k)) novo.delete(k);
+    else novo.add(k);
+    setIgnorados(novo);
+    try {
+      localStorage.setItem("tigrao_reconciliacao_ignorados", JSON.stringify([...novo]));
+    } catch {}
+  };
+
+  const limparIgnorados = () => {
+    if (!confirm("Remover todos os alertas ignorados? Eles voltarao a aparecer na proxima auditoria.")) return;
+    setIgnorados(new Set());
+    try {
+      localStorage.setItem("tigrao_reconciliacao_ignorados", "[]");
+    } catch {}
+  };
+
+  const filtradas = (inconsistencias || []).filter((i) => {
+    if (tipoFiltro !== "todos" && i.tipo !== tipoFiltro) return false;
+    const isIgnorado = ignorados.has(keyIgnorar(i));
+    if (mostrarIgnorados) return isIgnorado;
+    return !isIgnorado;
+  });
+  const numIgnorados = (inconsistencias || []).filter((i) => ignorados.has(keyIgnorar(i))).length;
+
+  // Corrige divergencias SKU em massa: copia estoque.sku → venda.sku quando
+  // diferem. Resolve o caso Daniel (SKUs cruzados entre produtos do grupo) e
+  // Glauco (Magic Mouse com SKU gerado via texto antes do backfill).
+  const syncSkuDivergentes = async () => {
+    if (!password) return;
+    const divergentes = (inconsistencias || []).filter(
+      (i) => i.tipo === "SKU_DIVERGENTE_PERSISTIDO" && i.ids.venda_id,
+    );
+    if (divergentes.length === 0) {
+      setSyncMsg("Nenhuma divergencia SKU pra corrigir");
+      return;
+    }
+    if (!confirm(`Sincronizar ${divergentes.length} vendas com SKU do estoque? Isso sobrescreve o SKU atual da venda com o SKU gravado no estoque vinculado.`)) {
+      return;
+    }
+    setSyncingSku(true);
+    setSyncMsg(null);
+    try {
+      const venda_ids = divergentes.map((i) => i.ids.venda_id!).filter(Boolean);
+      const res = await fetch("/api/admin/sku/reconciliacao", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-admin-password": password },
+        body: JSON.stringify({ action: "sync_from_estoque", venda_ids }),
+      });
+      const json = await res.json();
+      if (json.ok) {
+        setSyncMsg(
+          `✅ ${json.atualizadas} vendas atualizadas${json.falhas?.length ? ` (${json.falhas.length} falhas)` : ""}`,
+        );
+        fetchData();
+      } else {
+        setSyncMsg(`Erro: ${json.error || "desconhecido"}`);
+      }
+    } catch (err) {
+      setSyncMsg(`Erro de rede: ${err}`);
+    } finally {
+      setSyncingSku(false);
+    }
+  };
 
   const severidadeColor = (s: Severidade): string =>
     s === "alta" ? "bg-red-100 text-red-700 border-red-200"
@@ -105,7 +189,7 @@ export default function ReconciliacaoSkuPage() {
             Auditoria cruzando estoque × vendas × SKU — detecta sumiço, erro de registro e divergências.
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex gap-2 flex-wrap">
           <select
             value={periodoDias}
             onChange={(e) => setPeriodoDias(Number(e.target.value))}
@@ -122,41 +206,65 @@ export default function ReconciliacaoSkuPage() {
           >
             Atualizar
           </button>
+          {resumo && resumo.por_tipo.SKU_DIVERGENTE_PERSISTIDO > 0 && (
+            <button
+              onClick={syncSkuDivergentes}
+              disabled={syncingSku}
+              className="px-3 py-1.5 rounded-lg text-xs font-medium bg-[#E8740E] text-white hover:bg-[#D26509] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              title="Corrige automaticamente as vendas com SKU divergente — copia o SKU do estoque vinculado pra venda."
+            >
+              {syncingSku ? "Sincronizando…" : `🔧 Sincronizar ${resumo.por_tipo.SKU_DIVERGENTE_PERSISTIDO} SKUs`}
+            </button>
+          )}
         </div>
       </div>
-
-      {/* Resumo */}
-      {resumo && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          <KPICard
-            label="Total"
-            value={resumo.total}
-            sub={`${resumo.periodo.from} → ${resumo.periodo.until}`}
-            accent={resumo.total === 0 ? "green" : resumo.total > 10 ? "red" : "orange"}
-          />
-          <KPICard
-            label="Alta severidade"
-            value={resumo.por_severidade.alta}
-            sub="investigar urgente"
-            accent="red"
-          />
-          <KPICard
-            label="Divergências SKU"
-            value={resumo.por_tipo.SKU_DIVERGENTE_PERSISTIDO}
-            sub="produto errado"
-            accent="red"
-          />
-          <KPICard
-            label="Possíveis sumiços"
-            value={resumo.por_tipo.ESGOTADO_SEM_VENDA}
-            sub="esgotados sem venda"
-            accent="orange"
-          />
+      {syncMsg && (
+        <div className="bg-[#FFF5EB] border border-[#E8740E]/30 rounded-lg p-3 text-xs text-[#1D1D1F]">
+          {syncMsg}
         </div>
       )}
 
+      {/* Resumo — exclui os ignorados pra nao inflar os numeros com casos ja triados */}
+      {resumo && (() => {
+        const ativos = (inconsistencias || []).filter((i) => !ignorados.has(keyIgnorar(i)));
+        const ativosPorTipo = {
+          SKU_DIVERGENTE_PERSISTIDO: ativos.filter((i) => i.tipo === "SKU_DIVERGENTE_PERSISTIDO").length,
+          ESGOTADO_SEM_VENDA: ativos.filter((i) => i.tipo === "ESGOTADO_SEM_VENDA").length,
+          VENDA_SEM_ESTOQUE: ativos.filter((i) => i.tipo === "VENDA_SEM_ESTOQUE").length,
+        };
+        const ativosAlta = ativos.filter((i) => i.severidade === "alta").length;
+        return (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <KPICard
+              label="Total ativo"
+              value={ativos.length}
+              sub={`${resumo.periodo.from} → ${resumo.periodo.until}${numIgnorados > 0 ? ` · ${numIgnorados} ignorados` : ""}`}
+              accent={ativos.length === 0 ? "green" : ativos.length > 10 ? "red" : "orange"}
+            />
+            <KPICard
+              label="Alta severidade"
+              value={ativosAlta}
+              sub="investigar urgente"
+              accent="red"
+            />
+            <KPICard
+              label="Divergências SKU"
+              value={ativosPorTipo.SKU_DIVERGENTE_PERSISTIDO}
+              sub="produto errado"
+              accent="red"
+            />
+            <KPICard
+              label="Possíveis sumiços"
+              value={ativosPorTipo.ESGOTADO_SEM_VENDA}
+              sub="esgotados sem venda"
+              accent="orange"
+            />
+          </div>
+        );
+      })()}
+
       {/* Filtros por tipo */}
-      <div className="flex gap-2 flex-wrap">
+      <div className="flex gap-2 flex-wrap items-center">
         <button
           onClick={() => setTipoFiltro("todos")}
           className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
@@ -176,6 +284,28 @@ export default function ReconciliacaoSkuPage() {
             {TIPO_LABEL[tipo].icone} {TIPO_LABEL[tipo].titulo} ({resumo?.por_tipo[tipo] || 0})
           </button>
         ))}
+        {numIgnorados > 0 && (
+          <>
+            <span className="w-px h-5 bg-[#D2D2D7] mx-1" />
+            <button
+              onClick={() => setMostrarIgnorados(!mostrarIgnorados)}
+              className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                mostrarIgnorados ? "bg-[#86868B] text-white" : "bg-white border border-[#D2D2D7] text-[#86868B]"
+              }`}
+              title="Mostra/esconde os alertas que voce marcou como 'ignorar'"
+            >
+              {mostrarIgnorados ? "👁 Ver ativos" : `🙈 Ignorados (${numIgnorados})`}
+            </button>
+            {mostrarIgnorados && (
+              <button
+                onClick={limparIgnorados}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium bg-white border border-[#D2D2D7] text-[#86868B] hover:border-red-300 hover:text-red-600 transition-colors"
+              >
+                Limpar ignorados
+              </button>
+            )}
+          </>
+        )}
       </div>
 
       {/* Lista de inconsistências */}
@@ -248,6 +378,21 @@ export default function ReconciliacaoSkuPage() {
                         Ver estoque
                       </a>
                     )}
+                    <button
+                      onClick={() => toggleIgnorar(inc)}
+                      className={`text-xs px-2 py-1 rounded border text-center transition-colors ${
+                        mostrarIgnorados
+                          ? "border-[#E8740E]/30 text-[#E8740E] hover:bg-[#FFF5EB]"
+                          : "border-[#D2D2D7] text-[#86868B] hover:border-red-300 hover:text-red-600"
+                      }`}
+                      title={
+                        mostrarIgnorados
+                          ? "Voltar a mostrar este alerta"
+                          : "Ocultar este alerta — usar pra casos legitimos (atacado, brinde, venda fora do sistema)"
+                      }
+                    >
+                      {mostrarIgnorados ? "↩ Restaurar" : "🙈 Ignorar"}
+                    </button>
                   </div>
                 </div>
               </div>

--- a/app/api/admin/sku/reconciliacao/route.ts
+++ b/app/api/admin/sku/reconciliacao/route.ts
@@ -25,6 +25,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
+import { compararSkus } from "@/lib/sku-validator";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
@@ -78,22 +79,27 @@ export async function GET(req: NextRequest) {
       for (const v of vendasComEstoque) {
         const est = estoqueMap.get(v.estoque_id!);
         if (!est || !est.sku) continue; // se estoque nao tem SKU, pula
-        if (est.sku !== v.sku) {
-          resultados.push({
-            tipo: "SKU_DIVERGENTE_PERSISTIDO",
-            severidade: "alta",
-            descricao: "Venda vinculada a item de estoque com SKU diferente",
-            produto: v.produto || est.produto,
-            detalhes: {
-              venda_sku: v.sku,
-              estoque_sku: est.sku,
-              cliente: v.cliente || "?",
-              data: v.data || "?",
-              preco: Number(v.preco_vendido || 0),
-            },
-            ids: { venda_id: v.id, estoque_id: v.estoque_id! },
-          });
-        }
+        // Usa o mesmo comparador do bloqueio de criacao/edicao — tolera SKU
+        // parcial (ex: venda gravada sem cor vs estoque com cor). Se compararSkus
+        // considera OK, NAO e divergencia real — pula.
+        const comp = compararSkus(v.sku, est.sku);
+        if (comp.ok) continue;
+        resultados.push({
+          tipo: "SKU_DIVERGENTE_PERSISTIDO",
+          severidade: "alta",
+          descricao: comp.motivo
+            ? `Divergencia em: ${comp.motivo}`
+            : "Venda vinculada a item de estoque com SKU diferente",
+          produto: v.produto || est.produto,
+          detalhes: {
+            venda_sku: v.sku,
+            estoque_sku: est.sku,
+            cliente: v.cliente || "?",
+            data: v.data || "?",
+            preco: Number(v.preco_vendido || 0),
+          },
+          ids: { venda_id: v.id, estoque_id: v.estoque_id! },
+        });
       }
     }
 
@@ -187,6 +193,73 @@ export async function GET(req: NextRequest) {
     };
 
     return NextResponse.json({ ok: true, resumo, inconsistencias: resultados });
+  } catch (err) {
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}
+
+// ─── POST: sincronizar SKU das vendas a partir do estoque vinculado ──
+// Corrige o caso onde venda.sku foi gerado errado (texto livre) mas estoque.sku
+// esta correto. Copia estoque.sku pra venda.sku pra cada venda_id informado.
+//
+// Body: { action: "sync_from_estoque", venda_ids: string[] }
+// Resp: { ok, atualizadas: n, falhas: [{ venda_id, motivo }] }
+export async function POST(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const body = await req.json();
+    if (body.action !== "sync_from_estoque") {
+      return NextResponse.json({ error: "action invalida — use sync_from_estoque" }, { status: 400 });
+    }
+    const vendaIds = Array.isArray(body.venda_ids) ? body.venda_ids.filter((v: unknown) => typeof v === "string") : [];
+    if (vendaIds.length === 0) {
+      return NextResponse.json({ error: "venda_ids vazio" }, { status: 400 });
+    }
+
+    const { data: vendas } = await supabase
+      .from("vendas")
+      .select("id, sku, estoque_id")
+      .in("id", vendaIds)
+      .not("estoque_id", "is", null);
+    if (!vendas || vendas.length === 0) {
+      return NextResponse.json({ ok: true, atualizadas: 0, falhas: vendaIds.map((id: string) => ({ venda_id: id, motivo: "venda nao encontrada ou sem estoque_id" })) });
+    }
+
+    const estoqueIds = vendas.map((v) => v.estoque_id!).filter(Boolean) as string[];
+    const { data: estoques } = await supabase
+      .from("estoque")
+      .select("id, sku")
+      .in("id", estoqueIds);
+    const skuByEstoqueId = new Map<string, string>();
+    for (const e of estoques || []) {
+      if (e.sku) skuByEstoqueId.set(e.id, e.sku);
+    }
+
+    let atualizadas = 0;
+    const falhas: Array<{ venda_id: string; motivo: string }> = [];
+    for (const v of vendas) {
+      const estoqueSku = skuByEstoqueId.get(v.estoque_id!);
+      if (!estoqueSku) {
+        falhas.push({ venda_id: v.id, motivo: "estoque sem SKU" });
+        continue;
+      }
+      if (estoqueSku === v.sku) {
+        // Ja bate — nada a fazer
+        continue;
+      }
+      const { error: upErr } = await supabase
+        .from("vendas")
+        .update({ sku: estoqueSku })
+        .eq("id", v.id);
+      if (upErr) {
+        falhas.push({ venda_id: v.id, motivo: upErr.message });
+      } else {
+        atualizadas++;
+      }
+    }
+
+    return NextResponse.json({ ok: true, atualizadas, falhas });
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 500 });
   }

--- a/lib/sku.ts
+++ b/lib/sku.ts
@@ -444,6 +444,18 @@ export function isValidSku(sku: string): boolean {
 // Retorna a categoria canonica do estoque (IPHONES, IPADS, MACBOOK, ...) ou OUTROS.
 export function detectarCategoriaPorTexto(texto: string | null | undefined): string {
   const up = upper(texto);
+  // ACESSORIOS PRIMEIRO — senao "Magic Keyboard iPad Pro" cai em IPADS
+  // (porque tem "IPAD" no nome) e gera SKU como se fosse um iPad.
+  // Lista cobre os acessorios Apple comuns:
+  //   Magic Mouse/Keyboard/Trackpad, Apple Pencil, Smart Folio,
+  //   Carregadores (fonte/cabo), Capas, Peliculas, Adaptadores, HUB, Pulseiras
+  if (/\bMAGIC\s*(KEYBOARD|MOUSE|TRACKPAD)\b/.test(up)) return "ACESSORIOS";
+  if (/\bAPPLE\s*PENCIL\b/.test(up)) return "ACESSORIOS";
+  if (/\bSMART\s*FOLIO\b|\bSMART\s*COVER\b/.test(up)) return "ACESSORIOS";
+  if (/\bCARREGADOR\b|\bFONTE\s*(APPLE|USB)\b|\bCABO\s*(USB|LIGHTNING|TIPO)/.test(up)) return "ACESSORIOS";
+  if (/\bCAPA\b|\bCASE\b|\bP[EÉ]LICULA\b|\bPELICULA\b/.test(up)) return "ACESSORIOS";
+  if (/\bADAPTADOR\b|\bHUB\b|\bDOCK\b/.test(up)) return "ACESSORIOS";
+  if (/\bPULSEIRA\b(?!\s*ESPORTIVA.*WATCH)/.test(up)) return "ACESSORIOS";
   if (/IPHONE/.test(up)) return "IPHONES";
   if (/IPAD/.test(up)) return "IPADS";
   if (/MAC.*MINI/.test(up)) return "MAC_MINI";


### PR DESCRIPTION
## Bug reportado pelo André

Página `/admin/reconciliacao-sku` mostrava **5 divergências SKU** e **73 sumiços**, a maioria falsos positivos ou casos legítimos. Explicação do André:
> "porque voce que criou os SKU, e ta dizendo divergencias"

Fair — muitos não eram bug real. Fix dos 4 pontos:

---

### 🔧 Fix 1: Reconciliação tolera SKU parcial

**Problema:** API comparava `venda.sku !== estoque.sku` com igualdade estrita. Mas SKU parcial (sem cor) é comum em vendas antigas:

- venda: `MACBOOK-AIR-M5-13-16GB-512GB`
- estoque: `MACBOOK-AIR-M5-13-16GB-512GB-PRATA`
- **Falso positivo** — é match, só falta cor no lado da venda.

**Fix:** Usa `compararSkus` (mesmo comparador do bloqueio de criação). Se ele tolera (diferença só em cor quando um lado não tem), pula o alerta.

**Elimina alertas de:** Caio (MacBook sem cor), Thamyllis (iPhone 17 PRO MAX sem cor).

---

### 🔧 Fix 2: Acessórios Apple detectados como ACESSORIOS

**Problema:** `detectarCategoriaPorTexto` retornava "OUTROS" pra Magic Mouse, Apple Pencil, etc. Com cat="OUTROS", gerarSku caía no FALLBACK e gerava SKUs inconsistentes:

- venda.sku: `APPLE-MAGIC-MOUSE-BRANCO` (fallback)
- estoque.sku: `ACC-MAGIC-MOUSE-USB-C-BRANCO` (ACESSORIOS)

**Fix:** Regex detecta acessórios ANTES de iPad/iPhone/etc (importante — Magic Keyboard contém "IPAD" no texto mas tem que cair em ACESSORIOS).

**Cobre:** Magic Mouse/Keyboard/Trackpad, Apple Pencil, Smart Folio/Cover, Carregadores (fonte Apple, cabo USB/Lightning), Capas/Case/Película, Adaptadores/HUB/Dock, Pulseiras.

**Elimina alertas futuros de:** Glauco (Magic Mouse) e similares.

---

### 🔧 Fix 3: Botão "Sincronizar SKUs divergentes"

**Problema:** Para vendas JÁ existentes com SKU errado (caso Daniel — SKUs cruzados entre iPhone e iPad do mesmo grupo), não havia como corrigir sem editar manualmente.

**Fix:**
- Novo endpoint `POST /api/admin/sku/reconciliacao` com `action: sync_from_estoque` que copia `estoque.sku → venda.sku` pros `venda_ids` informados.
- Botão laranja no header: **🔧 Sincronizar N SKUs** — corrige todos de uma vez com confirmação.

**Resolve:**
- Daniel (SKUs cruzados — estoque tem SKUs corretos, venda.sku salvo errado)
- Glauco (Magic Mouse com SKU via fallback antes do backfill)
- Divergências futuras similares

---

### 🔧 Fix 4: "Ignorar" alertas legítimos (atacado, brinde, etc)

**Problema:** 73 sumiços incluíam muita coisa legítima: vendas atacado (1 venda, 4 unidades esgotadas), brindes, vendas fora do sistema.

**Fix:** Persistência via localStorage — admin marca alertas como ignorar quando são casos legítimos. UI:
- Botão **🙈 Ignorar** por linha
- Toggle no header **🙈 Ignorados (N)** pra ver os ocultos
- **Limpar ignorados** pra resetar
- KPIs recalculam excluindo os ignorados (mostram **Total ativo**)

Tudo client-side, sem migration.

---

## Test plan

- [ ] Preview Vercel compila
- [ ] Abrir `/admin/reconciliacao-sku`
  - [ ] Caio MacBook e Thamyllis iPhone somem da lista de divergentes
  - [ ] Botão "🔧 Sincronizar SKUs" aparece se ainda tiver divergentes
  - [ ] Clicar → confirma → Daniel e Glauco somem após sync
  - [ ] Botão **🙈 Ignorar** oculta linha + toggle header aparece
- [ ] Criar venda nova de Magic Mouse → SKU sai como `ACC-MAGIC-MOUSE-...`
- [ ] Criar venda de Apple Pencil → mesmo padrão

🤖 Generated with [Claude Code](https://claude.com/claude-code)