### PR TITLE
fix(sku): parseSku trata variantes iPhone (PRO, MAX) como parte do modelo

### DIFF
--- a/lib/sku.ts
+++ b/lib/sku.ts
@@ -398,6 +398,14 @@ function isSpecSegment(s: string): boolean {
   return false;
 }
 
+// Variantes que sao parte do nome do modelo (nao sao specs). Sempre ficam no
+// modelo quando aparecem depois da categoria+gen. Ex:
+//   IPHONE-17-PRO-MAX → modelo "IPHONE-17-PRO-MAX" (PRO e MAX sao variantes)
+//   IPAD-AIR, MACBOOK-PRO, WATCH-ULTRA, IPAD-MINI, etc.
+const VARIANTES_MODELO = new Set([
+  "PRO", "MAX", "PLUS", "AIR", "MINI", "ULTRA", "NEO",
+]);
+
 export function parseSku(sku: string): SkuComponents | null {
   if (!sku || !sku.trim()) return null;
   const partes = sku.toUpperCase().trim().split("-");
@@ -407,14 +415,20 @@ export function parseSku(sku: string): SkuComponents | null {
   const partesLimpas = seminovo ? partes.slice(0, -1) : partes;
   const categoria = partesLimpas[0];
 
-  // Modelo = do primeiro segmento ate ANTES da primeira "spec" conhecida.
-  // Cobre variantes com N segmentos: IPHONE-17-PRO-MAX, IPHONE-17-AIR,
-  // MACBOOK-AIR-M5, IPAD-PRO-M4, WATCH-ULTRA-2, AIRPODS-PRO-2, etc.
-  // Antes: slice(0, 2) fixo quebrava pra todos esses e mandava a variante
-  // pro bucket de specs/cor.
+  // Modelo = do primeiro segmento ate ANTES da primeira spec "real".
+  // Regras especiais pra evitar colisao de numeros 10-17 (tela vs geracao):
+  //   - IPHONE pos 1 ("17" em IPHONE-17) e a geracao, NAO tela. Continua.
+  //   - VARIANTES_MODELO (PRO, MAX, AIR, etc) sempre ficam no modelo.
+  // Outras categorias (IPAD, MACBOOK) tem tela apos o chip (M4), entao
+  // o fluxo padrao funciona — para no M\d+ e chip/tela/storage vao pra specs.
   let modeloFim = partesLimpas.length;
   for (let i = 1; i < partesLimpas.length; i++) {
-    if (isSpecSegment(partesLimpas[i])) {
+    const seg = partesLimpas[i];
+    // iPhone geracao: "17" em IPHONE-17 nao e tela, e gen.
+    if (categoria === "IPHONE" && i === 1 && /^\d+E?$/.test(seg)) continue;
+    // Variantes sempre ficam no modelo.
+    if (VARIANTES_MODELO.has(seg)) continue;
+    if (isSpecSegment(seg)) {
       modeloFim = i;
       break;
     }


### PR DESCRIPTION
## Bug descoberto na tela de Reconciliação SKU

Depois do PR #778 (tolerar SKU parcial) + PR #780 (backfill cor), ainda aparecia:

> **IPHONE 17 PRO MAX PRO MAX 512GB COSMIC ORANGE**
> Divergencia em: cor
> venda_sku: `IPHONE-17-PRO-MAX-512GB`
> estoque_sku: `IPHONE-17-PRO-MAX-512GB-LARANJA`

Esse caso **deveria** ter sido tolerado (venda sem cor vs estoque com cor). Mas não foi. Fui investigar e achei outro bug.

## Causa raiz

`parseSku` quebrava o modelo em `"IPHONE-17"` porque `"17"` casa com regex de tela (10-17), que foi pensada pra iPad/MacBook. Resultado:

```
parseSku("IPHONE-17-PRO-MAX-512GB-LARANJA")
  modelo: "IPHONE-17"             ← WRONG, deveria ser IPHONE-17-PRO-MAX
  specs:  ["PRO", "MAX", "512GB", "LARANJA"]
```

Aí `extrairComponentes` tratava `"PRO"` e `"MAX"` como cor (segmentos não classificados), e `compararSkus` via:

- cor esperada (venda): `"PRO-MAX"`
- cor selecionada (estoque): `"PRO-MAX-LARANJA"`
- `difere("PRO-MAX", "PRO-MAX-LARANJA") = true` → `"Divergencia em: cor"`

Também afetava o **display** — na teoria o iPhone 17 Pro Max Laranja apareceria como "iPhone 17 PRO MAX **Pro Max Laranja**" (duplicando!).

## Fix

`parseSku` agora tem 2 regras especiais no loop de boundary detection:

1. **IPHONE pos 1** — o primeiro dígito após "IPHONE" é geração, não tela.
2. **VARIANTES_MODELO** (PRO, MAX, PLUS, AIR, MINI, ULTRA, NEO) sempre ficam no modelo.

```ts
for (let i = 1; i < partesLimpas.length; i++) {
  const seg = partesLimpas[i];
  // iPhone geracao: "17" em IPHONE-17 nao e tela, e gen.
  if (categoria === "IPHONE" && i === 1 && /^\d+E?$/.test(seg)) continue;
  // Variantes sempre ficam no modelo.
  if (VARIANTES_MODELO.has(seg)) continue;
  if (isSpecSegment(seg)) {
    modeloFim = i;
    break;
  }
}
```

## Resultado

| SKU | Antes | Depois |
|-----|-------|--------|
| `IPHONE-17-PRO-MAX-512GB` | modelo=`IPHONE-17`, specs=[`PRO`,`MAX`,`512GB`] | modelo=`IPHONE-17-PRO-MAX`, specs=[`512GB`] |
| `IPHONE-17-PRO-MAX-512GB-LARANJA` | modelo=`IPHONE-17`, cor=`PRO-MAX-LARANJA` | modelo=`IPHONE-17-PRO-MAX`, cor=`LARANJA` |
| `IPHONE-16-128GB-BRANCO` | modelo=`IPHONE-16`, cor=`BRANCO` | idem (já funcionava) |
| `IPHONE-17-AIR-256GB` | modelo=`IPHONE-17`, cor=`AIR` | modelo=`IPHONE-17-AIR`, cor=null |
| `IPAD-AIR-M3-11-128GB-CINZA` | modelo=`IPAD-AIR` | idem |
| `MACBOOK-AIR-M5-13-16GB-512GB` | modelo=`MACBOOK-AIR` | idem |

Impacto:
- **Thamyllis** iPhone 17 PRO MAX COSMIC ORANGE deixa de aparecer como divergente
- **Display** dos iPhones 17 PRO MAX com cor sai limpo (não duplica PRO MAX)
- Outras categorias continuam iguais

## Test plan

- [ ] Preview compila
- [ ] `/admin/reconciliacao-sku` → Thamyllis (última divergência restante) some da lista
- [ ] Vendas de iPhone 17 PRO MAX na aba Em Andamento mostram só a cor, sem duplicar "Pro Max"

🤖 Generated with [Claude Code](https://claude.com/claude-code)