### PR TITLE
feat(reconciliacao): auto-classifica sumicos cruzando com vendas

### DIFF
--- a/app/admin/reconciliacao-sku/page.tsx
+++ b/app/admin/reconciliacao-sku/page.tsx
@@ -14,6 +14,16 @@ const fmt = (v: number | null | undefined) =>
 
 type Severidade = "alta" | "media" | "baixa";
 type TipoInc = "SKU_DIVERGENTE_PERSISTIDO" | "ESGOTADO_SEM_VENDA" | "VENDA_SEM_ESTOQUE";
+type TipoHipotese = "serial_match" | "atacado_proximo" | "venda_nao_vinculada" | "brinde_proximo" | "nenhuma";
+
+interface Hipotese {
+  tipo: TipoHipotese;
+  confianca: "alta" | "media" | "baixa";
+  descricao: string;
+  venda_id?: string;
+  cliente?: string;
+  data_venda?: string;
+}
 
 interface Inconsistencia {
   tipo: TipoInc;
@@ -22,6 +32,7 @@ interface Inconsistencia {
   produto: string;
   detalhes: Record<string, string | number | null>;
   ids: { venda_id?: string; estoque_id?: string };
+  hipotese?: Hipotese;
 }
 
 interface Resumo {
@@ -30,6 +41,40 @@ interface Resumo {
   por_severidade: Record<Severidade, number>;
   periodo: { from: string; until: string };
 }
+
+// Visualizacao das hipoteses — badge colorido + dica contextual.
+const HIPOTESE_LABEL: Record<TipoHipotese, { titulo: string; cor: string; bg: string; border: string }> = {
+  serial_match: {
+    titulo: "Venda encontrada (serial bate)",
+    cor: "text-green-800",
+    bg: "bg-green-50",
+    border: "border-green-300",
+  },
+  venda_nao_vinculada: {
+    titulo: "Venda do mesmo SKU + data",
+    cor: "text-blue-800",
+    bg: "bg-blue-50",
+    border: "border-blue-300",
+  },
+  atacado_proximo: {
+    titulo: "Atacado (lote)",
+    cor: "text-purple-800",
+    bg: "bg-purple-50",
+    border: "border-purple-300",
+  },
+  brinde_proximo: {
+    titulo: "Brinde",
+    cor: "text-pink-800",
+    bg: "bg-pink-50",
+    border: "border-pink-300",
+  },
+  nenhuma: {
+    titulo: "Sem pista — investigar",
+    cor: "text-red-800",
+    bg: "bg-red-50",
+    border: "border-red-300",
+  },
+};
 
 const TIPO_LABEL: Record<TipoInc, { titulo: string; icone: string; explicacao: string }> = {
   SKU_DIVERGENTE_PERSISTIDO: {
@@ -63,6 +108,7 @@ export default function ReconciliacaoSkuPage() {
   const [syncingSku, setSyncingSku] = useState(false);
   const [syncMsg, setSyncMsg] = useState<string | null>(null);
   const [backfillingCor, setBackfillingCor] = useState(false);
+  const [vinculandoAuto, setVinculandoAuto] = useState(false);
   // Set de ids (venda_id ou estoque_id) que o admin marcou como "ignorar".
   // Persiste em localStorage — util pra casos legitimos como atacado em lote,
   // brindes internos, ou vendas fora do sistema que nao queremos ver de novo.
@@ -133,6 +179,88 @@ export default function ReconciliacaoSkuPage() {
     try {
       localStorage.setItem("tigrao_reconciliacao_ignorados", JSON.stringify([...novo]));
     } catch {}
+  };
+
+  // Vincula venda-estoque baseado na hipotese. Usa quando a hipotese tem
+  // venda_id e o admin confirma. Seta venda.estoque_id = estoque_id, o que
+  // resolve o sumi\u00e7o (venda fica com baixa, estoque deixa de estar orfao).
+  const vincularVendaEstoque = async (inc: Inconsistencia) => {
+    if (!password || !inc.hipotese?.venda_id || !inc.ids.estoque_id) return;
+    const h = inc.hipotese;
+    const msg = `Vincular esta venda de ${h.cliente || "?"} (${h.data_venda || "?"}) ao item de estoque?\n\nIsso resolve o sumi\u00e7o — a venda passa a ter baixa no estoque.`;
+    if (!confirm(msg)) return;
+    setVinculandoAuto(true);
+    setSyncMsg(null);
+    try {
+      const res = await fetch("/api/admin/sku/reconciliacao", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-admin-password": password },
+        body: JSON.stringify({
+          action: "vincular_venda_estoque",
+          pares: [{ venda_id: h.venda_id, estoque_id: inc.ids.estoque_id }],
+        }),
+      });
+      const json = await res.json();
+      if (json.ok && json.vinculadas > 0) {
+        setSyncMsg(`\u2705 Vinculo feito — venda agora esta vinculada ao item do estoque.`);
+        fetchData();
+      } else {
+        const motivo = json.falhas?.[0]?.motivo || json.error || "desconhecido";
+        setSyncMsg(`Erro: ${motivo}`);
+      }
+    } catch (err) {
+      setSyncMsg(`Erro de rede: ${err}`);
+    } finally {
+      setVinculandoAuto(false);
+    }
+  };
+
+  // Vincula automaticamente TODOS os sumicos que tem hipotese de alta ou media
+  // confianca (serial_match / venda_nao_vinculada). Acao em massa — util pra
+  // resolver muitos sumicos de uma vez depois do auto-classify.
+  const vincularTodosAuto = async () => {
+    if (!password) return;
+    const alvos = (inconsistencias || []).filter(
+      (i) => i.tipo === "ESGOTADO_SEM_VENDA"
+        && !ignorados.has(keyIgnorar(i))
+        && i.hipotese?.venda_id
+        && (i.hipotese.tipo === "serial_match" || i.hipotese.tipo === "venda_nao_vinculada"),
+    );
+    if (alvos.length === 0) {
+      setSyncMsg("Nenhum sumi\u00e7o com hipotese de alta/media confianca pra vincular");
+      return;
+    }
+    const msg = `Vincular ${alvos.length} sumicos de uma vez?\n\n`
+      + `Cada um tem uma venda identificada por serial/IMEI ou SKU+data. `
+      + `Vincula todos — casos duvidosos (atacado, brinde, sem pista) ficam de fora.`;
+    if (!confirm(msg)) return;
+    setVinculandoAuto(true);
+    setSyncMsg(null);
+    try {
+      const pares = alvos.map((i) => ({
+        venda_id: i.hipotese!.venda_id!,
+        estoque_id: i.ids.estoque_id!,
+      }));
+      const res = await fetch("/api/admin/sku/reconciliacao", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-admin-password": password },
+        body: JSON.stringify({ action: "vincular_venda_estoque", pares }),
+      });
+      const json = await res.json();
+      if (json.ok) {
+        setSyncMsg(
+          `\u2705 ${json.vinculadas} vinculos feitos` +
+          (json.falhas?.length ? ` (${json.falhas.length} falhas)` : ""),
+        );
+        fetchData();
+      } else {
+        setSyncMsg(`Erro: ${json.error || "desconhecido"}`);
+      }
+    } catch (err) {
+      setSyncMsg(`Erro de rede: ${err}`);
+    } finally {
+      setVinculandoAuto(false);
+    }
   };
 
   // Ignora todas as inconsistencias com MESMO SKU do item clicado. Util pra
@@ -298,6 +426,25 @@ export default function ReconciliacaoSkuPage() {
           >
             {backfillingCor ? "Preenchendo…" : "🎨 Backfill cor das vendas"}
           </button>
+          {(() => {
+            const autoVinc = (inconsistencias || []).filter(
+              (i) => i.tipo === "ESGOTADO_SEM_VENDA"
+                && !ignorados.has(keyIgnorar(i))
+                && i.hipotese?.venda_id
+                && (i.hipotese.tipo === "serial_match" || i.hipotese.tipo === "venda_nao_vinculada"),
+            );
+            if (autoVinc.length === 0) return null;
+            return (
+              <button
+                onClick={vincularTodosAuto}
+                disabled={vinculandoAuto}
+                className="px-3 py-1.5 rounded-lg text-xs font-medium bg-green-600 text-white hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                title={`Vincula automaticamente ${autoVinc.length} sumi\u00e7os onde achei venda correspondente por serial/IMEI ou SKU+data. Nao toca em casos duvidosos.`}
+              >
+                {vinculandoAuto ? "Vinculando…" : `\u2705 Auto-vincular ${autoVinc.length} sumi\u00e7os`}
+              </button>
+            );
+          })()}
         </div>
       </div>
       {syncMsg && (
@@ -430,6 +577,23 @@ export default function ReconciliacaoSkuPage() {
                     <p className="text-sm font-medium text-[#1D1D1F] mt-1">{inc.produto}</p>
                     <p className="text-xs text-[#86868B] mt-0.5">{inc.descricao}</p>
 
+                    {/* Hipotese — auto-classificacao do sumi\u00e7o */}
+                    {inc.hipotese && (
+                      <div className={`mt-2 p-2 rounded-md border ${HIPOTESE_LABEL[inc.hipotese.tipo].bg} ${HIPOTESE_LABEL[inc.hipotese.tipo].border}`}>
+                        <div className="flex items-center gap-2 mb-1">
+                          <span className={`text-[10px] font-bold uppercase tracking-wide ${HIPOTESE_LABEL[inc.hipotese.tipo].cor}`}>
+                            Hip\u00f3tese: {HIPOTESE_LABEL[inc.hipotese.tipo].titulo}
+                          </span>
+                          <span className="text-[10px] text-[#86868B]">
+                            (conf. {inc.hipotese.confianca})
+                          </span>
+                        </div>
+                        <p className={`text-xs ${HIPOTESE_LABEL[inc.hipotese.tipo].cor}`}>
+                          {inc.hipotese.descricao}
+                        </p>
+                      </div>
+                    )}
+
                     {/* Detalhes */}
                     <div className="mt-2 flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] text-[#6E6E73]">
                       {Object.entries(inc.detalhes).map(([k, v]) => {
@@ -461,6 +625,23 @@ export default function ReconciliacaoSkuPage() {
                       >
                         Ver venda
                       </a>
+                    )}
+                    {/* Botao de vincular — so aparece pra sumicos com hipotese
+                         de alta/media confianca (serial_match ou venda_nao_vinculada)
+                         que teem venda_id identificada */}
+                    {inc.tipo === "ESGOTADO_SEM_VENDA"
+                      && inc.hipotese?.venda_id
+                      && inc.ids.estoque_id
+                      && (inc.hipotese.tipo === "serial_match" || inc.hipotese.tipo === "venda_nao_vinculada")
+                      && !mostrarIgnorados && (
+                      <button
+                        onClick={() => vincularVendaEstoque(inc)}
+                        disabled={vinculandoAuto}
+                        className="text-xs px-2 py-1 rounded border border-green-400 bg-green-50 text-green-700 hover:bg-green-100 transition-colors disabled:opacity-50"
+                        title={`Vincula a venda ao item — resolve o sumi\u00e7o de uma vez`}
+                      >
+                        \u2705 Vincular
+                      </button>
                     )}
                     {inc.ids.estoque_id && (
                       <a

--- a/app/api/admin/sku/reconciliacao/route.ts
+++ b/app/api/admin/sku/reconciliacao/route.ts
@@ -34,6 +34,24 @@ function auth(req: NextRequest) {
   return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
 }
 
+// Hipotese automatica — cruzamento heuristico pra classificar sumicos
+// segundo a causa mais provavel. Permite o admin agir rapido sem abrir cada
+// caso pra investigar manualmente.
+interface Hipotese {
+  // Tipo da hipotese:
+  //   serial_match    — achou venda com mesmo serial/imei (match certeiro)
+  //   atacado_proximo — achou venda atacado com mesmo SKU em data proxima
+  //   venda_nao_vinculada — venda com mesmo SKU, proxima, mas sem estoque_id
+  //   brinde_proximo  — venda brinde com mesmo SKU em data proxima
+  //   nenhuma         — nada encontrado, investigar
+  tipo: "serial_match" | "atacado_proximo" | "venda_nao_vinculada" | "brinde_proximo" | "nenhuma";
+  confianca: "alta" | "media" | "baixa";
+  descricao: string;
+  venda_id?: string;
+  cliente?: string;
+  data_venda?: string;
+}
+
 interface Inconsistencia {
   tipo: "SKU_DIVERGENTE_PERSISTIDO" | "ESGOTADO_SEM_VENDA" | "VENDA_SEM_ESTOQUE";
   severidade: "alta" | "media" | "baixa";
@@ -41,6 +59,7 @@ interface Inconsistencia {
   produto: string;
   detalhes: Record<string, string | number | null>;
   ids: { venda_id?: string; estoque_id?: string };
+  hipotese?: Hipotese;
 }
 
 function daysAgoIso(days: number): string {
@@ -121,11 +140,147 @@ export async function GET(req: NextRequest) {
         .in("estoque_id", esgotadoIds);
       const vinculados = new Set((vendasVinculadas || []).map((v) => v.estoque_id));
 
-      for (const e of esgotados) {
-        if (vinculados.has(e.id)) continue;
+      const sumicos = esgotados.filter((e) => !vinculados.has(e.id));
+
+      // Cruzamento heuristico: pra cada sumico, tenta achar uma venda que
+      // explique a saida. 3 estrategias em ordem de confianca decrescente:
+      //   1. Mesmo serial/imei (match certeiro)
+      //   2. Mesmo SKU + data proxima (±3 dias) + atacado/brinde (legitimo)
+      //   3. Mesmo SKU + data proxima + sem estoque_id (venda nao vinculada)
+      //
+      // Carrega todas as vendas candidatas em 1 query pra evitar N+1.
+      const skusEsgotados = [...new Set(sumicos.map((e) => e.sku).filter(Boolean) as string[])];
+      const seriaisEsgotados = [...new Set(sumicos.map((e) => e.serial_no).filter(Boolean) as string[])];
+      const imeisEsgotados = [...new Set(sumicos.map((e) => e.imei).filter(Boolean) as string[])];
+
+      // Data limite: 7 dias antes do primeiro sumico (margem de seguranca)
+      const dataMinimaVendas = (() => {
+        const min = sumicos.reduce((acc, e) => {
+          if (!e.updated_at) return acc;
+          return !acc || e.updated_at < acc ? e.updated_at : acc;
+        }, null as string | null);
+        if (!min) return fromDate;
+        const d = new Date(min);
+        d.setDate(d.getDate() - 7);
+        return d.toISOString().slice(0, 10);
+      })();
+
+      // 1 query pra todas as vendas potencialmente relacionadas
+      let vendasCandidatas: Array<{
+        id: string; produto: string | null; sku: string | null; cliente: string | null;
+        data: string | null; serial_no: string | null; imei: string | null;
+        estoque_id: string | null; tipo: string | null; is_brinde: boolean | null;
+      }> = [];
+      if (skusEsgotados.length > 0 || seriaisEsgotados.length > 0 || imeisEsgotados.length > 0) {
+        const filtros: string[] = [];
+        if (skusEsgotados.length > 0) filtros.push(`sku.in.(${skusEsgotados.map((s) => `"${s}"`).join(",")})`);
+        if (seriaisEsgotados.length > 0) filtros.push(`serial_no.in.(${seriaisEsgotados.map((s) => `"${s}"`).join(",")})`);
+        if (imeisEsgotados.length > 0) filtros.push(`imei.in.(${imeisEsgotados.map((i) => `"${i}"`).join(",")})`);
+
+        const { data: vendas } = await supabase
+          .from("vendas")
+          .select("id, produto, sku, cliente, data, serial_no, imei, estoque_id, tipo, is_brinde")
+          .or(filtros.join(","))
+          .gte("data", dataMinimaVendas)
+          .neq("status_pagamento", "CANCELADO");
+        vendasCandidatas = vendas || [];
+      }
+
+      // Helper: diferenca de dias entre duas datas ISO (YYYY-MM-DD ou com T)
+      const diffDias = (a: string | null, b: string | null): number => {
+        if (!a || !b) return 999;
+        const ta = new Date(a.slice(0, 10)).getTime();
+        const tb = new Date(b.slice(0, 10)).getTime();
+        return Math.abs((ta - tb) / 86400000);
+      };
+
+      for (const e of sumicos) {
+        // Analisa hipoteses por ordem de confianca
+        let hipotese: Hipotese | undefined;
+        const dataSumico = e.updated_at ? e.updated_at.slice(0, 10) : null;
+
+        // 1. Match de serial/imei (confianca alta — praticamente certeza)
+        const matchSerial = vendasCandidatas.find((v) => {
+          if (v.estoque_id) return false; // ja vinculada a outro estoque
+          if (e.serial_no && v.serial_no && v.serial_no.toUpperCase() === e.serial_no.toUpperCase()) return true;
+          if (e.imei && v.imei && v.imei === e.imei) return true;
+          return false;
+        });
+        if (matchSerial) {
+          hipotese = {
+            tipo: "serial_match",
+            confianca: "alta",
+            descricao: `Venda de ${matchSerial.cliente || "?"} (${matchSerial.data || "?"}) tem o mesmo ${matchSerial.serial_no ? "serial" : "IMEI"} mas nao esta vinculada ao estoque. Basta vincular.`,
+            venda_id: matchSerial.id,
+            cliente: matchSerial.cliente || undefined,
+            data_venda: matchSerial.data || undefined,
+          };
+        }
+
+        // 2. Venda atacado / brinde com mesmo SKU em data proxima (legitimo)
+        if (!hipotese && e.sku) {
+          const atacadoOuBrinde = vendasCandidatas.find((v) => {
+            if (v.sku !== e.sku) return false;
+            if (diffDias(v.data, dataSumico) > 5) return false;
+            return v.tipo === "ATACADO" || !!v.is_brinde;
+          });
+          if (atacadoOuBrinde) {
+            hipotese = {
+              tipo: atacadoOuBrinde.is_brinde ? "brinde_proximo" : "atacado_proximo",
+              confianca: "media",
+              descricao: atacadoOuBrinde.is_brinde
+                ? `Brinde de ${atacadoOuBrinde.cliente || "?"} em ${atacadoOuBrinde.data} — provavelmente este item. Ignora com seguranca.`
+                : `Venda atacado pra ${atacadoOuBrinde.cliente || "?"} em ${atacadoOuBrinde.data} com mesmo SKU — provavelmente este item faz parte do lote. Ignora com seguranca.`,
+              venda_id: atacadoOuBrinde.id,
+              cliente: atacadoOuBrinde.cliente || undefined,
+              data_venda: atacadoOuBrinde.data || undefined,
+            };
+          }
+        }
+
+        // 3. Venda normal com mesmo SKU em data proxima, sem estoque_id (nao vinculada)
+        if (!hipotese && e.sku) {
+          const candidatasNaoVinculadas = vendasCandidatas.filter((v) => {
+            if (v.sku !== e.sku) return false;
+            if (v.estoque_id) return false;
+            if (diffDias(v.data, dataSumico) > 5) return false;
+            return true;
+          });
+          // Pega a mais proxima na data
+          candidatasNaoVinculadas.sort((a, b) => diffDias(a.data, dataSumico) - diffDias(b.data, dataSumico));
+          const naoVinculada = candidatasNaoVinculadas[0];
+          if (naoVinculada) {
+            hipotese = {
+              tipo: "venda_nao_vinculada",
+              confianca: "media",
+              descricao: `Venda de ${naoVinculada.cliente || "?"} em ${naoVinculada.data} tem o mesmo SKU mas nao foi vinculada. Provavelmente este item — vincular resolve.`,
+              venda_id: naoVinculada.id,
+              cliente: naoVinculada.cliente || undefined,
+              data_venda: naoVinculada.data || undefined,
+            };
+          }
+        }
+
+        // 4. Nada achado — possivel problema real
+        if (!hipotese) {
+          hipotese = {
+            tipo: "nenhuma",
+            confianca: "baixa",
+            descricao: "Nao achei venda relacionada. Pode ser venda fora do sistema, brinde nao registrado, perda, roubo ou uso interno.",
+          };
+        }
+
+        // Severidade: se achou venda pra vincular, e media (acao simples).
+        // Se atacado/brinde, e baixa (legitimo). Se nao achou nada, alta.
+        const severidadeHipotese = hipotese.tipo === "serial_match" || hipotese.tipo === "venda_nao_vinculada"
+          ? "media"
+          : hipotese.tipo === "atacado_proximo" || hipotese.tipo === "brinde_proximo"
+          ? "baixa"
+          : "alta";
+
         resultados.push({
           tipo: "ESGOTADO_SEM_VENDA",
-          severidade: "alta",
+          severidade: severidadeHipotese,
           descricao: "Item marcado como ESGOTADO mas sem venda vinculada",
           produto: e.produto,
           detalhes: {
@@ -134,9 +289,10 @@ export async function GET(req: NextRequest) {
             serial: e.serial_no,
             imei: e.imei,
             custo: Number(e.custo_unitario || 0),
-            desde: e.updated_at ? e.updated_at.slice(0, 10) : "?",
+            desde: dataSumico || "?",
           },
-          ids: { estoque_id: e.id },
+          ids: { estoque_id: e.id, ...(hipotese.venda_id ? { venda_id: hipotese.venda_id } : {}) },
+          hipotese,
         });
       }
     }
@@ -198,69 +354,141 @@ export async function GET(req: NextRequest) {
   }
 }
 
-// ─── POST: sincronizar SKU das vendas a partir do estoque vinculado ──
-// Corrige o caso onde venda.sku foi gerado errado (texto livre) mas estoque.sku
-// esta correto. Copia estoque.sku pra venda.sku pra cada venda_id informado.
+// ─── POST: acoes de auto-correcao ───────────────────────────────────
+// Ha 2 actions suportadas:
 //
-// Body: { action: "sync_from_estoque", venda_ids: string[] }
-// Resp: { ok, atualizadas: n, falhas: [{ venda_id, motivo }] }
+//   action=sync_from_estoque
+//     Corrige venda.sku divergente copiando de estoque.sku
+//     Body: { venda_ids: string[] }
+//
+//   action=vincular_venda_estoque
+//     Vincula uma venda orfa a um item de estoque sumido (quando
+//     hipotese automatica tem alta confianca — serial_match ou sku+data)
+//     Body: { pares: [{ venda_id, estoque_id }, ...] }
+//     Seta venda.estoque_id = estoque_id pra cada par. Resolve sumicos
+//     que tem venda correspondente mas nunca foram vinculados.
 export async function POST(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   try {
     const body = await req.json();
-    if (body.action !== "sync_from_estoque") {
-      return NextResponse.json({ error: "action invalida — use sync_from_estoque" }, { status: 400 });
-    }
-    const vendaIds = Array.isArray(body.venda_ids) ? body.venda_ids.filter((v: unknown) => typeof v === "string") : [];
-    if (vendaIds.length === 0) {
-      return NextResponse.json({ error: "venda_ids vazio" }, { status: 400 });
-    }
 
-    const { data: vendas } = await supabase
-      .from("vendas")
-      .select("id, sku, estoque_id")
-      .in("id", vendaIds)
-      .not("estoque_id", "is", null);
-    if (!vendas || vendas.length === 0) {
-      return NextResponse.json({ ok: true, atualizadas: 0, falhas: vendaIds.map((id: string) => ({ venda_id: id, motivo: "venda nao encontrada ou sem estoque_id" })) });
+    if (body.action === "sync_from_estoque") {
+      return await syncFromEstoque(body);
     }
-
-    const estoqueIds = vendas.map((v) => v.estoque_id!).filter(Boolean) as string[];
-    const { data: estoques } = await supabase
-      .from("estoque")
-      .select("id, sku")
-      .in("id", estoqueIds);
-    const skuByEstoqueId = new Map<string, string>();
-    for (const e of estoques || []) {
-      if (e.sku) skuByEstoqueId.set(e.id, e.sku);
+    if (body.action === "vincular_venda_estoque") {
+      return await vincularVendaEstoque(body);
     }
-
-    let atualizadas = 0;
-    const falhas: Array<{ venda_id: string; motivo: string }> = [];
-    for (const v of vendas) {
-      const estoqueSku = skuByEstoqueId.get(v.estoque_id!);
-      if (!estoqueSku) {
-        falhas.push({ venda_id: v.id, motivo: "estoque sem SKU" });
-        continue;
-      }
-      if (estoqueSku === v.sku) {
-        // Ja bate — nada a fazer
-        continue;
-      }
-      const { error: upErr } = await supabase
-        .from("vendas")
-        .update({ sku: estoqueSku })
-        .eq("id", v.id);
-      if (upErr) {
-        falhas.push({ venda_id: v.id, motivo: upErr.message });
-      } else {
-        atualizadas++;
-      }
-    }
-
-    return NextResponse.json({ ok: true, atualizadas, falhas });
+    return NextResponse.json({ error: "action invalida — use sync_from_estoque ou vincular_venda_estoque" }, { status: 400 });
   } catch (err) {
     return NextResponse.json({ error: String(err) }, { status: 500 });
   }
+}
+
+async function syncFromEstoque(body: Record<string, unknown>) {
+  const vendaIds = Array.isArray(body.venda_ids) ? body.venda_ids.filter((v: unknown) => typeof v === "string") as string[] : [];
+  if (vendaIds.length === 0) {
+    return NextResponse.json({ error: "venda_ids vazio" }, { status: 400 });
+  }
+
+  const { data: vendas } = await supabase
+    .from("vendas")
+    .select("id, sku, estoque_id")
+    .in("id", vendaIds)
+    .not("estoque_id", "is", null);
+  if (!vendas || vendas.length === 0) {
+    return NextResponse.json({ ok: true, atualizadas: 0, falhas: vendaIds.map((id: string) => ({ venda_id: id, motivo: "venda nao encontrada ou sem estoque_id" })) });
+  }
+
+  const estoqueIds = vendas.map((v) => v.estoque_id!).filter(Boolean) as string[];
+  const { data: estoques } = await supabase
+    .from("estoque")
+    .select("id, sku")
+    .in("id", estoqueIds);
+  const skuByEstoqueId = new Map<string, string>();
+  for (const e of estoques || []) {
+    if (e.sku) skuByEstoqueId.set(e.id, e.sku);
+  }
+
+  let atualizadas = 0;
+  const falhas: Array<{ venda_id: string; motivo: string }> = [];
+  for (const v of vendas) {
+    const estoqueSku = skuByEstoqueId.get(v.estoque_id!);
+    if (!estoqueSku) {
+      falhas.push({ venda_id: v.id, motivo: "estoque sem SKU" });
+      continue;
+    }
+    if (estoqueSku === v.sku) continue;
+    const { error: upErr } = await supabase
+      .from("vendas")
+      .update({ sku: estoqueSku })
+      .eq("id", v.id);
+    if (upErr) {
+      falhas.push({ venda_id: v.id, motivo: upErr.message });
+    } else {
+      atualizadas++;
+    }
+  }
+
+  return NextResponse.json({ ok: true, atualizadas, falhas });
+}
+
+async function vincularVendaEstoque(body: Record<string, unknown>) {
+  const paresRaw = Array.isArray(body.pares) ? body.pares : [];
+  const pares = paresRaw
+    .filter((p): p is { venda_id: string; estoque_id: string } =>
+      !!p && typeof p === "object" &&
+      typeof (p as { venda_id?: unknown }).venda_id === "string" &&
+      typeof (p as { estoque_id?: unknown }).estoque_id === "string",
+    );
+  if (pares.length === 0) {
+    return NextResponse.json({ error: "pares vazio ou formato invalido" }, { status: 400 });
+  }
+
+  // Carrega vendas alvo — so aceita vincular vendas SEM estoque_id (evita
+  // sobrescrever vinculos existentes por engano).
+  const vendaIds = [...new Set(pares.map((p) => p.venda_id))];
+  const { data: vendas } = await supabase
+    .from("vendas")
+    .select("id, estoque_id, sku")
+    .in("id", vendaIds);
+  const vendasMap = new Map((vendas || []).map((v) => [v.id, v]));
+
+  // Carrega estoques alvo — copia SKU pra venda se venda nao tiver
+  const estoqueIds = [...new Set(pares.map((p) => p.estoque_id))];
+  const { data: estoques } = await supabase
+    .from("estoque")
+    .select("id, sku")
+    .in("id", estoqueIds);
+  const estoqueMap = new Map((estoques || []).map((e) => [e.id, e]));
+
+  let vinculadas = 0;
+  const falhas: Array<{ venda_id: string; motivo: string }> = [];
+  for (const par of pares) {
+    const v = vendasMap.get(par.venda_id);
+    if (!v) {
+      falhas.push({ venda_id: par.venda_id, motivo: "venda nao encontrada" });
+      continue;
+    }
+    if (v.estoque_id) {
+      falhas.push({ venda_id: par.venda_id, motivo: "venda ja tem estoque_id (nao sobrescrevo)" });
+      continue;
+    }
+    const est = estoqueMap.get(par.estoque_id);
+    const updates: Record<string, string | null> = { estoque_id: par.estoque_id };
+    // Copia SKU do estoque se venda nao tiver (consistencia com POST /api/vendas)
+    if (est?.sku && !v.sku) updates.sku = est.sku;
+
+    const { error: upErr } = await supabase
+      .from("vendas")
+      .update(updates)
+      .eq("id", par.venda_id);
+    if (upErr) {
+      falhas.push({ venda_id: par.venda_id, motivo: upErr.message });
+    } else {
+      vinculadas++;
+    }
+  }
+
+  return NextResponse.json({ ok: true, vinculadas, falhas });
 }


### PR DESCRIPTION
## Pedido do André

> "voce nao consegue fazer esse cruzamento pra identificar todos sumicos?"

Sim! Implementei classificação automática com badges coloridos + botão de auto-vincular.

## Como funciona

Pra cada sumiço, o backend tenta achar uma venda relacionada em 3 estratégias (por ordem de confiança):

### 1. 🟢 Serial/IMEI match (confiança ALTA)
Venda existe com mesmo serial_no ou imei mas sem estoque_id → **basta vincular**.

### 2. 🔵 Mesmo SKU + data próxima + sem estoque_id (MÉDIA)
Venda normal do mesmo SKU em ±5 dias, nunca foi vinculada → **provavelmente este item**.

### 3. 🟣🌸 Atacado / 🎁 Brinde próximo (MÉDIA)
Venda atacado ou brinde em ±5 dias com mesmo SKU → **caso legítimo, ignora**.

### 4. 🔴 Nada encontrado (BAIXA)
Nenhuma das estratégias funcionou → **investigar** (possível roubo, perda, venda fora do sistema).

## UI

Cada sumiço vira um card com:
- Badge colorido + título da hipótese
- Descrição contextual (ex: "Venda de João Silva em 2026-04-18 tem o mesmo serial — basta vincular")
- Nível de confiança

Ações:
- **✅ Vincular** (por linha, pra hipóteses alta/média) — resolve 1 sumiço
- **✅ Auto-vincular N sumiços** (header verde) — resolve TODOS os certeiros de uma vez

Casos duvidosos (atacado, brinde, sem pista) ficam de fora do auto-vincular pro admin decidir manualmente.

## Fluxo esperado

1. Merge → deploy
2. Admin abre `/admin/reconciliacao-sku`
3. Olha a cor dos badges:
   - **Verde/Azul**: clica **✅ Auto-vincular N** → resolve os certeiros
   - **Roxo/Rosa**: clica **🙈 Ignorar todos do mesmo SKU** → atacado/brinde em lote
   - **Vermelho**: investigar manualmente (venda fora do sistema / roubo)

Tempo de triagem: **horas → minutos**.

## Endpoints

### GET (modificado)
Cada inconsistência ESGOTADO_SEM_VENDA ganha campo `hipotese`:
```ts
hipotese: {
  tipo: "serial_match" | "venda_nao_vinculada" | "atacado_proximo" | "brinde_proximo" | "nenhuma";
  confianca: "alta" | "media" | "baixa";
  descricao: string;
  venda_id?: string;  // se alta/media, aponta pra venda candidata
  cliente?: string;
  data_venda?: string;
}
```

### POST action=vincular_venda_estoque (novo)
```
body: { pares: [{ venda_id, estoque_id }, ...] }
resp: { ok, vinculadas, falhas }
```
Seta `venda.estoque_id = estoque_id` pra cada par (só se venda ainda não tiver vínculo — não sobrescreve).

## Performance

Queries em batch com OR filters (sku IN, serial_no IN, imei IN) — evita N+1. Pra 73 sumiços e 500 vendas no período: 1 query extra.

## Test plan

- [ ] Preview compila
- [ ] `/admin/reconciliacao-sku` → cada sumiço tem badge de hipótese
- [ ] Sumiços com serial match mostram "✅ Vincular"
- [ ] Botão "✅ Auto-vincular N sumiços" aparece quando há N candidatos
- [ ] Clicar vincula e remove o sumiço da lista
- [ ] Atacados/brindes mostram badge roxo/rosa (sem botão Vincular)
- [ ] "Sem pista" fica vermelho

🤖 Generated with [Claude Code](https://claude.com/claude-code)