### PR TITLE
feat(reconciliacao): auto-classify completo — lote presumido + vendas sem baixa

### DIFF
--- a/app/admin/reconciliacao-sku/page.tsx
+++ b/app/admin/reconciliacao-sku/page.tsx
@@ -14,13 +14,18 @@ const fmt = (v: number | null | undefined) =>
 
 type Severidade = "alta" | "media" | "baixa";
 type TipoInc = "SKU_DIVERGENTE_PERSISTIDO" | "ESGOTADO_SEM_VENDA" | "VENDA_SEM_ESTOQUE";
-type TipoHipotese = "serial_match" | "atacado_proximo" | "venda_nao_vinculada" | "brinde_proximo" | "nenhuma";
+type TipoHipotese =
+  | "serial_match" | "atacado_proximo" | "venda_nao_vinculada"
+  | "brinde_proximo" | "lote_presumido"
+  | "estoque_disponivel" | "estoque_esgotado"
+  | "nenhuma";
 
 interface Hipotese {
   tipo: TipoHipotese;
   confianca: "alta" | "media" | "baixa";
   descricao: string;
   venda_id?: string;
+  estoque_id?: string;
   cliente?: string;
   data_venda?: string;
 }
@@ -45,7 +50,7 @@ interface Resumo {
 // Visualizacao das hipoteses — badge colorido + dica contextual.
 const HIPOTESE_LABEL: Record<TipoHipotese, { titulo: string; cor: string; bg: string; border: string }> = {
   serial_match: {
-    titulo: "Venda encontrada (serial bate)",
+    titulo: "Serial/IMEI bate — basta vincular",
     cor: "text-green-800",
     bg: "bg-green-50",
     border: "border-green-300",
@@ -56,8 +61,26 @@ const HIPOTESE_LABEL: Record<TipoHipotese, { titulo: string; cor: string; bg: st
     bg: "bg-blue-50",
     border: "border-blue-300",
   },
+  estoque_disponivel: {
+    titulo: "Item disponivel no estoque",
+    cor: "text-blue-800",
+    bg: "bg-blue-50",
+    border: "border-blue-300",
+  },
+  estoque_esgotado: {
+    titulo: "Item ja ESGOTADO — possivel dupla contagem",
+    cor: "text-orange-800",
+    bg: "bg-orange-50",
+    border: "border-orange-300",
+  },
   atacado_proximo: {
-    titulo: "Atacado (lote)",
+    titulo: "Atacado (venda achada)",
+    cor: "text-purple-800",
+    bg: "bg-purple-50",
+    border: "border-purple-300",
+  },
+  lote_presumido: {
+    titulo: "Lote atacado presumido",
     cor: "text-purple-800",
     bg: "bg-purple-50",
     border: "border-purple-300",
@@ -181,14 +204,29 @@ export default function ReconciliacaoSkuPage() {
     } catch {}
   };
 
-  // Vincula venda-estoque baseado na hipotese. Usa quando a hipotese tem
-  // venda_id e o admin confirma. Seta venda.estoque_id = estoque_id, o que
-  // resolve o sumi\u00e7o (venda fica com baixa, estoque deixa de estar orfao).
+  // Helpers pra extrair venda_id/estoque_id de uma inconsistencia com hipotese.
+  // Funciona pros 2 casos:
+  //   ESGOTADO_SEM_VENDA: ids.estoque_id fixo + hipotese.venda_id sugerido
+  //   VENDA_SEM_ESTOQUE: ids.venda_id fixo + hipotese.estoque_id sugerido
+  const getParVincular = (inc: Inconsistencia): { venda_id: string; estoque_id: string } | null => {
+    if (!inc.hipotese) return null;
+    const venda_id = inc.ids.venda_id || inc.hipotese.venda_id;
+    const estoque_id = inc.ids.estoque_id || inc.hipotese.estoque_id;
+    if (!venda_id || !estoque_id) return null;
+    return { venda_id, estoque_id };
+  };
+
+  // Vincula venda-estoque baseado na hipotese. Seta venda.estoque_id=estoque_id
+  // o que resolve tanto o sumi\u00e7o (ESGOTADO sem venda) quanto a venda sem baixa.
   const vincularVendaEstoque = async (inc: Inconsistencia) => {
-    if (!password || !inc.hipotese?.venda_id || !inc.ids.estoque_id) return;
-    const h = inc.hipotese;
-    const msg = `Vincular esta venda de ${h.cliente || "?"} (${h.data_venda || "?"}) ao item de estoque?\n\nIsso resolve o sumi\u00e7o — a venda passa a ter baixa no estoque.`;
-    if (!confirm(msg)) return;
+    if (!password) return;
+    const par = getParVincular(inc);
+    if (!par) return;
+    const h = inc.hipotese!;
+    const contexto = inc.tipo === "ESGOTADO_SEM_VENDA"
+      ? `Vincular venda de ${h.cliente || "?"} (${h.data_venda || "?"}) ao item de estoque?\n\nResolve o sumi\u00e7o — a venda passa a ter baixa.`
+      : `Vincular esta venda ao item do estoque (${HIPOTESE_LABEL[h.tipo].titulo})?\n\nResolve a venda sem baixa — estoque vai marcar o item como esgotado.`;
+    if (!confirm(contexto)) return;
     setVinculandoAuto(true);
     setSyncMsg(null);
     try {
@@ -197,7 +235,7 @@ export default function ReconciliacaoSkuPage() {
         headers: { "Content-Type": "application/json", "x-admin-password": password },
         body: JSON.stringify({
           action: "vincular_venda_estoque",
-          pares: [{ venda_id: h.venda_id, estoque_id: inc.ids.estoque_id }],
+          pares: [par],
         }),
       });
       const json = await res.json();
@@ -215,32 +253,36 @@ export default function ReconciliacaoSkuPage() {
     }
   };
 
-  // Vincula automaticamente TODOS os sumicos que tem hipotese de alta ou media
-  // confianca (serial_match / venda_nao_vinculada). Acao em massa — util pra
-  // resolver muitos sumicos de uma vez depois do auto-classify.
+  // Tipos de hipotese que representam "alta/media certeza de vinculo" — usado
+  // pros botoes de auto-vincular (evita vincular casos duvidosos).
+  const hipotesesVinculaveis = new Set<TipoHipotese>([
+    "serial_match",
+    "venda_nao_vinculada",
+    "estoque_disponivel",
+  ]);
+
+  // Vincula automaticamente TODOS os alertas (sumicos + vendas sem baixa)
+  // com hipotese vinculavel. Acao em massa — um clique resolve varios casos.
   const vincularTodosAuto = async () => {
     if (!password) return;
     const alvos = (inconsistencias || []).filter(
-      (i) => i.tipo === "ESGOTADO_SEM_VENDA"
-        && !ignorados.has(keyIgnorar(i))
-        && i.hipotese?.venda_id
-        && (i.hipotese.tipo === "serial_match" || i.hipotese.tipo === "venda_nao_vinculada"),
+      (i) => !ignorados.has(keyIgnorar(i))
+        && i.hipotese
+        && hipotesesVinculaveis.has(i.hipotese.tipo)
+        && getParVincular(i),
     );
     if (alvos.length === 0) {
-      setSyncMsg("Nenhum sumi\u00e7o com hipotese de alta/media confianca pra vincular");
+      setSyncMsg("Nenhum alerta com hipotese vinculavel");
       return;
     }
-    const msg = `Vincular ${alvos.length} sumicos de uma vez?\n\n`
-      + `Cada um tem uma venda identificada por serial/IMEI ou SKU+data. `
-      + `Vincula todos — casos duvidosos (atacado, brinde, sem pista) ficam de fora.`;
+    const msg = `Vincular ${alvos.length} alertas de uma vez?\n\n`
+      + `Cada um tem contraparte identificada (serial/IMEI match ou SKU disponivel no estoque). `
+      + `Vincula todos — casos duvidosos (atacado, brinde, dupla contagem, sem pista) ficam de fora.`;
     if (!confirm(msg)) return;
     setVinculandoAuto(true);
     setSyncMsg(null);
     try {
-      const pares = alvos.map((i) => ({
-        venda_id: i.hipotese!.venda_id!,
-        estoque_id: i.ids.estoque_id!,
-      }));
+      const pares = alvos.map((i) => getParVincular(i)!).filter(Boolean);
       const res = await fetch("/api/admin/sku/reconciliacao", {
         method: "POST",
         headers: { "Content-Type": "application/json", "x-admin-password": password },
@@ -428,10 +470,10 @@ export default function ReconciliacaoSkuPage() {
           </button>
           {(() => {
             const autoVinc = (inconsistencias || []).filter(
-              (i) => i.tipo === "ESGOTADO_SEM_VENDA"
-                && !ignorados.has(keyIgnorar(i))
-                && i.hipotese?.venda_id
-                && (i.hipotese.tipo === "serial_match" || i.hipotese.tipo === "venda_nao_vinculada"),
+              (i) => !ignorados.has(keyIgnorar(i))
+                && i.hipotese
+                && hipotesesVinculaveis.has(i.hipotese.tipo)
+                && getParVincular(i),
             );
             if (autoVinc.length === 0) return null;
             return (
@@ -439,9 +481,9 @@ export default function ReconciliacaoSkuPage() {
                 onClick={vincularTodosAuto}
                 disabled={vinculandoAuto}
                 className="px-3 py-1.5 rounded-lg text-xs font-medium bg-green-600 text-white hover:bg-green-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                title={`Vincula automaticamente ${autoVinc.length} sumi\u00e7os onde achei venda correspondente por serial/IMEI ou SKU+data. Nao toca em casos duvidosos.`}
+                title={`Vincula automaticamente ${autoVinc.length} alertas (sumi\u00e7os + vendas sem baixa) onde achei contraparte por serial/IMEI ou SKU. Nao toca em casos duvidosos.`}
               >
-                {vinculandoAuto ? "Vinculando…" : `\u2705 Auto-vincular ${autoVinc.length} sumi\u00e7os`}
+                {vinculandoAuto ? "Vinculando…" : `\u2705 Auto-vincular ${autoVinc.length} alertas`}
               </button>
             );
           })()}
@@ -626,19 +668,20 @@ export default function ReconciliacaoSkuPage() {
                         Ver venda
                       </a>
                     )}
-                    {/* Botao de vincular — so aparece pra sumicos com hipotese
-                         de alta/media confianca (serial_match ou venda_nao_vinculada)
-                         que teem venda_id identificada */}
-                    {inc.tipo === "ESGOTADO_SEM_VENDA"
-                      && inc.hipotese?.venda_id
-                      && inc.ids.estoque_id
-                      && (inc.hipotese.tipo === "serial_match" || inc.hipotese.tipo === "venda_nao_vinculada")
+                    {/* Botao de vincular — aparece em sumi\u00e7os E vendas sem baixa
+                         quando a hipotese indica contraparte vinculavel (serial match
+                         ou SKU disponivel no estoque). Um clique resolve ambos os casos. */}
+                    {inc.hipotese
+                      && hipotesesVinculaveis.has(inc.hipotese.tipo)
+                      && getParVincular(inc)
                       && !mostrarIgnorados && (
                       <button
                         onClick={() => vincularVendaEstoque(inc)}
                         disabled={vinculandoAuto}
                         className="text-xs px-2 py-1 rounded border border-green-400 bg-green-50 text-green-700 hover:bg-green-100 transition-colors disabled:opacity-50"
-                        title={`Vincula a venda ao item — resolve o sumi\u00e7o de uma vez`}
+                        title={inc.tipo === "ESGOTADO_SEM_VENDA"
+                          ? "Vincula a venda ao item — resolve o sumi\u00e7o"
+                          : "Vincula esta venda ao item do estoque — resolve a venda sem baixa"}
                       >
                         \u2705 Vincular
                       </button>

--- a/app/api/admin/sku/reconciliacao/route.ts
+++ b/app/api/admin/sku/reconciliacao/route.ts
@@ -34,20 +34,27 @@ function auth(req: NextRequest) {
   return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
 }
 
-// Hipotese automatica — cruzamento heuristico pra classificar sumicos
-// segundo a causa mais provavel. Permite o admin agir rapido sem abrir cada
-// caso pra investigar manualmente.
+// Hipotese automatica — cruzamento heuristico pra classificar sumicos e
+// vendas sem baixa segundo a causa mais provavel. Permite o admin agir rapido
+// sem abrir cada caso pra investigar manualmente.
 interface Hipotese {
   // Tipo da hipotese:
-  //   serial_match    — achou venda com mesmo serial/imei (match certeiro)
-  //   atacado_proximo — achou venda atacado com mesmo SKU em data proxima
-  //   venda_nao_vinculada — venda com mesmo SKU, proxima, mas sem estoque_id
-  //   brinde_proximo  — venda brinde com mesmo SKU em data proxima
-  //   nenhuma         — nada encontrado, investigar
-  tipo: "serial_match" | "atacado_proximo" | "venda_nao_vinculada" | "brinde_proximo" | "nenhuma";
+  //   serial_match           — achou contraparte com mesmo serial/imei (match certeiro)
+  //   atacado_proximo        — achou venda atacado com mesmo SKU em data proxima
+  //   venda_nao_vinculada    — venda com mesmo SKU, proxima, mas sem estoque_id
+  //   brinde_proximo         — venda brinde com mesmo SKU em data proxima
+  //   lote_presumido         — 3+ sumicos iguais (mesmo SKU, data proxima) = atacado provavel
+  //   estoque_disponivel     — (VENDA_SEM_ESTOQUE) item com mesmo SKU existe EM ESTOQUE
+  //   estoque_esgotado       — (VENDA_SEM_ESTOQUE) item com mesmo SKU existe ESGOTADO
+  //   nenhuma                — nada encontrado, investigar
+  tipo: "serial_match" | "atacado_proximo" | "venda_nao_vinculada"
+    | "brinde_proximo" | "lote_presumido"
+    | "estoque_disponivel" | "estoque_esgotado"
+    | "nenhuma";
   confianca: "alta" | "media" | "baixa";
   descricao: string;
   venda_id?: string;
+  estoque_id?: string;    // usado em VENDA_SEM_ESTOQUE pra sugerir vinculo reverso
   cliente?: string;
   data_venda?: string;
 }
@@ -141,6 +148,30 @@ export async function GET(req: NextRequest) {
       const vinculados = new Set((vendasVinculadas || []).map((v) => v.estoque_id));
 
       const sumicos = esgotados.filter((e) => !vinculados.has(e.id));
+
+      // Heuristica "lote presumido": 3+ sumicos do mesmo SKU em ate 7 dias entre
+      // si = provavel atacado em lote. Muito provavelmente e uma venda que o
+      // admin registrou uma vez mas o estoque tem varias unidades marcadas
+      // ESGOTADO (ou 1 venda pro lojista com multiplas unidades).
+      const sumicosPorSku = new Map<string, typeof sumicos>();
+      for (const s of sumicos) {
+        if (!s.sku) continue;
+        const lista = sumicosPorSku.get(s.sku) || [];
+        lista.push(s);
+        sumicosPorSku.set(s.sku, lista);
+      }
+      const lotePresumido = new Set<string>(); // ids de estoque que entram em lote
+      for (const [, lista] of sumicosPorSku) {
+        if (lista.length < 3) continue;
+        // Checa se estao em uma janela de 7 dias
+        const datas = lista.map((s) => s.updated_at?.slice(0, 10)).filter(Boolean).sort();
+        if (datas.length < 3) continue;
+        const primeiro = new Date(datas[0]!).getTime();
+        const ultimo = new Date(datas[datas.length - 1]!).getTime();
+        if ((ultimo - primeiro) / 86400000 <= 7) {
+          for (const s of lista) lotePresumido.add(s.id);
+        }
+      }
 
       // Cruzamento heuristico: pra cada sumico, tenta achar uma venda que
       // explique a saida. 3 estrategias em ordem de confianca decrescente:
@@ -261,7 +292,18 @@ export async function GET(req: NextRequest) {
           }
         }
 
-        // 4. Nada achado — possivel problema real
+        // 4. Lote presumido (3+ iguais em 7 dias, sem venda atacado explicita
+        // achada). Menos certeza que atacado_proximo, mas forte indicio.
+        if (!hipotese && lotePresumido.has(e.id)) {
+          const totalLote = sumicosPorSku.get(e.sku!)?.length || 0;
+          hipotese = {
+            tipo: "lote_presumido",
+            confianca: "media",
+            descricao: `${totalLote} unidades do mesmo SKU marcadas ESGOTADO em datas proximas — padrao classico de venda atacado em lote. Provavelmente pode ignorar.`,
+          };
+        }
+
+        // 5. Nada achado — possivel problema real
         if (!hipotese) {
           hipotese = {
             tipo: "nenhuma",
@@ -271,10 +313,10 @@ export async function GET(req: NextRequest) {
         }
 
         // Severidade: se achou venda pra vincular, e media (acao simples).
-        // Se atacado/brinde, e baixa (legitimo). Se nao achou nada, alta.
+        // Se atacado/brinde/lote, e baixa (legitimo). Se nao achou nada, alta.
         const severidadeHipotese = hipotese.tipo === "serial_match" || hipotese.tipo === "venda_nao_vinculada"
           ? "media"
-          : hipotese.tipo === "atacado_proximo" || hipotese.tipo === "brinde_proximo"
+          : hipotese.tipo === "atacado_proximo" || hipotese.tipo === "brinde_proximo" || hipotese.tipo === "lote_presumido"
           ? "baixa"
           : "alta";
 
@@ -310,13 +352,108 @@ export async function GET(req: NextRequest) {
       .neq("status_pagamento", "FORMULARIO_PREENCHIDO"); // formulario preenchido ainda nao foi processado
 
     if (vendasSemEstoque && vendasSemEstoque.length > 0) {
-      for (const v of vendasSemEstoque) {
-        // Se tem serial ou imei, provavelmente e aparelho rastreavel que deveria
-        // estar vinculado. Sem serial/imei (ex: AirPods unitarios), nao alerta.
-        if (!v.serial_no && !v.imei) continue;
+      const vendasAlvo = vendasSemEstoque.filter((v) => v.serial_no || v.imei);
+
+      // Cruzamento heuristico pra auto-classificar vendas sem baixa:
+      //   1. Serial/IMEI bate com algum item de estoque → basta vincular
+      //   2. SKU bate com item em estoque (EM ESTOQUE) → pode ser este item
+      //   3. SKU bate com item ESGOTADO → pode ser que ja foi dado baixa
+      //      em outra venda (nao vincular, alertar dupla contagem)
+      //
+      // Carrega estoque candidato em 1 query — filtra por SKU/serial/imei.
+      const skusVendas = [...new Set(vendasAlvo.map((v) => v.sku).filter(Boolean) as string[])];
+      const seriaisVendas = [...new Set(vendasAlvo.map((v) => v.serial_no).filter(Boolean) as string[])];
+      const imeisVendas = [...new Set(vendasAlvo.map((v) => v.imei).filter(Boolean) as string[])];
+
+      let estoqueCandidato: Array<{
+        id: string; produto: string; sku: string | null;
+        serial_no: string | null; imei: string | null; status: string | null;
+      }> = [];
+      if (skusVendas.length > 0 || seriaisVendas.length > 0 || imeisVendas.length > 0) {
+        const filtros: string[] = [];
+        if (skusVendas.length > 0) filtros.push(`sku.in.(${skusVendas.map((s) => `"${s}"`).join(",")})`);
+        if (seriaisVendas.length > 0) filtros.push(`serial_no.in.(${seriaisVendas.map((s) => `"${s}"`).join(",")})`);
+        if (imeisVendas.length > 0) filtros.push(`imei.in.(${imeisVendas.map((i) => `"${i}"`).join(",")})`);
+
+        const { data } = await supabase
+          .from("estoque")
+          .select("id, produto, sku, serial_no, imei, status")
+          .or(filtros.join(","));
+        estoqueCandidato = data || [];
+      }
+
+      for (const v of vendasAlvo) {
+        let hipotese: Hipotese | undefined;
+
+        // 1. Serial/IMEI match — confianca alta
+        const matchSerial = estoqueCandidato.find((e) => {
+          if (v.serial_no && e.serial_no && v.serial_no.toUpperCase() === e.serial_no.toUpperCase()) return true;
+          if (v.imei && e.imei && v.imei === e.imei) return true;
+          return false;
+        });
+        if (matchSerial) {
+          // Se item ta em estoque — vincula pra marcar saida
+          if (matchSerial.status === "EM ESTOQUE" || matchSerial.status === "PENDENTE") {
+            hipotese = {
+              tipo: "serial_match",
+              confianca: "alta",
+              descricao: `Item com mesmo ${v.serial_no ? "serial" : "IMEI"} existe no estoque (status: ${matchSerial.status}). Vincular da baixa automaticamente.`,
+              estoque_id: matchSerial.id,
+            };
+          } else if (matchSerial.status === "ESGOTADO") {
+            // Item ja esta esgotado — serial bate, provavelmente e a mesma unidade
+            // mas o vinculo ficou solto. Vincular corrige.
+            hipotese = {
+              tipo: "serial_match",
+              confianca: "alta",
+              descricao: `Item com mesmo ${v.serial_no ? "serial" : "IMEI"} existe no estoque (ja ESGOTADO). Vincular fecha o circuito.`,
+              estoque_id: matchSerial.id,
+            };
+          }
+        }
+
+        // 2. SKU match — confianca media
+        if (!hipotese && v.sku) {
+          // Prefere item EM ESTOQUE (disponivel); se nao achar, considera ESGOTADO
+          const emEstoque = estoqueCandidato.find((e) => e.sku === v.sku && e.status === "EM ESTOQUE");
+          const esgotado = estoqueCandidato.find((e) => e.sku === v.sku && e.status === "ESGOTADO");
+          if (emEstoque) {
+            hipotese = {
+              tipo: "estoque_disponivel",
+              confianca: "media",
+              descricao: `Ha item com mesmo SKU no estoque (disponivel). Pode ser este — verifica serial/IMEI antes de vincular.`,
+              estoque_id: emEstoque.id,
+            };
+          } else if (esgotado) {
+            hipotese = {
+              tipo: "estoque_esgotado",
+              confianca: "baixa",
+              descricao: `Ha item com mesmo SKU ja ESGOTADO. Pode ser dupla contagem (outra venda ja deu baixa) — investigar antes de vincular.`,
+              estoque_id: esgotado.id,
+            };
+          }
+        }
+
+        // 3. Nada encontrado
+        if (!hipotese) {
+          hipotese = {
+            tipo: "nenhuma",
+            confianca: "baixa",
+            descricao: "Nao achei item correspondente no estoque. Item pode ter sido importado direto, nao cadastrado, ou deletado.",
+          };
+        }
+
+        const severidadeV = hipotese.tipo === "serial_match"
+          ? "media"
+          : hipotese.tipo === "estoque_disponivel"
+          ? "media"
+          : hipotese.tipo === "estoque_esgotado"
+          ? "alta" // dupla contagem = perigoso
+          : "media";
+
         resultados.push({
           tipo: "VENDA_SEM_ESTOQUE",
-          severidade: "media",
+          severidade: severidadeV,
           descricao: "Venda registrada sem vincular item do estoque",
           produto: v.produto,
           detalhes: {
@@ -327,7 +464,8 @@ export async function GET(req: NextRequest) {
             imei: v.imei,
             preco: Number(v.preco_vendido || 0),
           },
-          ids: { venda_id: v.id },
+          ids: { venda_id: v.id, ...(hipotese.estoque_id ? { estoque_id: hipotese.estoque_id } : {}) },
+          hipotese,
         });
       }
     }


### PR DESCRIPTION
## Pedido do André

> "investigue e corrija todos esses"

Pros 47 alertas restantes:
- **8 SKU divergentes** → 1 clique em **🔧 Sincronizar 8 SKUs** já existente resolve
- **10 sumiços** — 9 estavam "sem pista" mesmo sendo claramente atacado em lote
- **29 vendas sem baixa** — nenhuma classificação automática

Este PR implementa 3 melhorias.

### 🟣 Detecta "lote presumido" nos sumiços

Quando há **3+ itens com mesmo SKU esgotados em ≤7 dias**, marca como `lote_presumido` — padrão clássico de atacado em lote onde 1 venda representa N unidades mas só 1 foi vinculada.

**Resolve os 7 IPHONE-17-PRO-MAX-256GB-PRATA** da sua lista. Antes: "Sem pista — investigar" (vermelho). Agora: "Lote atacado presumido" (roxo, ignorar com segurança).

### 🔵 Auto-classify pras vendas sem baixa

Antes só existia pros sumiços. Agora as 29 vendas sem baixa também cruzam com estoque:

| Tipo | O que é | Ação |
|------|---------|------|
| 🟢 **Serial bate** | Item no estoque com mesmo serial/IMEI | **Vincular** (1 click) |
| 🔵 **Item disponível** | Item EM ESTOQUE com mesmo SKU | Vincular (confere serial antes) |
| 🟠 **Item já esgotado** | Mesmo SKU já ESGOTADO em outra venda | ⚠️ **Dupla contagem!** Investigar |
| 🔴 **Sem pista** | Nada no estoque | Item não cadastrado / deletado |

### ✅ Botão "Auto-vincular N alertas" unificado

Agora conta **sumiços + vendas sem baixa** juntas. Um clique resolve todas as vinculáveis. Botão **Vincular** por linha também funciona nos 2 tipos.

## Fluxo esperado pós-merge

1. **Merge + deploy**
2. Abrir `/admin/reconciliacao-sku` → **Atualizar**
3. Clicar **🔧 Sincronizar 8 SKUs** → resolve todos os 8 divergentes (fontes Apple + seminovos)
4. Clicar **✅ Auto-vincular N alertas** → resolve os com serial/SKU match (sumiços verdes/azuis + vendas sem baixa verdes/azuis)
5. Nos restantes:
   - **Roxo** (lote presumido / atacado) → **🙈 Ignorar todos do mesmo SKU** (`🙈×N` por linha) ou **🙈 Ignorar todos**
   - **Laranja** (dupla contagem) → ⚠️ investigar manualmente antes de qualquer ação
   - **Vermelho** → investigar histórico

Deve zerar a lista ou deixar só 2-3 casos reais que precisam de atenção humana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)