### PR TITLE
fix(vendas): extractCor nao confunde '512GB' com cor

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -17,7 +17,7 @@ import { useVendedores } from "@/lib/vendedores";
 import BarcodeScanner from "@/components/BarcodeScanner";
 import ProdutoSpecFields, { createEmptyProdutoRow, type ProdutoRowState } from "@/components/admin/ProdutoSpecFields";
 import { SkuFilterBanner, useSkuFilter } from "@/components/admin/SkuFilterBanner";
-import { gerarSkuSafe, detectarCategoriaPorTexto } from "@/lib/sku";
+import { gerarSkuSafe, detectarCategoriaPorTexto, parseSku } from "@/lib/sku";
 
 const fmt = (v: number) => `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
 
@@ -3331,11 +3331,42 @@ export default function VendasPage() {
                     <div className={`p-4 rounded-xl text-center text-sm ${dm ? "bg-[#2C2C2E] text-[#636366]" : "bg-[#F5F5F7] text-[#86868B]"}`}>{serialBusca.trim() ? "Nenhum produto com esse serial" : "Nenhum produto disponivel nesta categoria"}</div>
                   );
 
-                  // Extrair cor do nome do produto
+                  // Extrair cor do nome do produto.
+                  // Pega o que vem APOS o ULTIMO storage (GB/TB) — em produtos
+                  // com RAM+SSD (MacBook: "8GB 512GB Azul"), o ultimo e o SSD
+                  // que fica imediatamente antes da cor.
+                  // Bug fixado: regex antiga /\d+GB\s+/ exigia espaco depois, entao
+                  // em "MacBook Neo 13 8GB 512GB" (sem cor no nome), split pegava
+                  // so "8GB " como separador e retornava "512GB" como cor.
                   const extractCor = (nome: string) => {
-                    const after = nome.split(/\d+GB\s+/)[1];
+                    const matches = [...nome.matchAll(/\d+(GB|TB)\b/gi)];
+                    if (matches.length === 0) return null;
+                    const last = matches[matches.length - 1];
+                    const after = nome.slice(last.index! + last[0].length).trim();
                     if (!after) return null;
-                    return after.split(/\s+(LL|BE|BR|BZ|CH|ZD|ZP|HN|J|N|VC|AA|E|LZ|QL)\s*/i)[0]?.trim() || null;
+                    const candidato = after
+                      .split(/\s+(LL|BE|BR|BZ|CH|ZD|ZP|HN|J|N|VC|AA|E|LZ|QL)\s*/i)[0]
+                      ?.trim() || null;
+                    // Rejeita se o "candidato" ainda parece storage — nome do
+                    // produto nao tem cor cadastrada. Admin deve usar p.cor.
+                    if (candidato && /^\d+(GB|TB)$/i.test(candidato)) return null;
+                    return candidato;
+                  };
+
+                  // Fallback final quando nem p.cor nem nome do produto tem cor:
+                  // extrai dos segmentos nao-classificaveis do SKU canonico.
+                  // Ex: MACBOOK-NEO-13-8GB-512GB-AZUL → cor "AZUL" (Pt: "Azul")
+                  const extractCorSku = (sku: string | null | undefined) => {
+                    if (!sku) return null;
+                    const parsed = parseSku(sku);
+                    if (!parsed) return null;
+                    const isSpec = (s: string) =>
+                      /^\d+(GB|TB|MM)$/.test(s) ||
+                      /^M\d+/.test(s) ||
+                      (/^\d+$/.test(s) && Number(s) >= 10 && Number(s) <= 17) ||
+                      ["GPS", "GPSCEL", "WIFI", "CELL", "SEMINOVO", "ANC"].includes(s);
+                    const corSegs = parsed.specs.filter((s) => !isSpec(s));
+                    return corSegs.length > 0 ? corSegs.join("-") : null;
                   };
 
                   // Extrair modelo base (sem cor) pra agrupar cores num card só.
@@ -3352,7 +3383,11 @@ export default function VendasPage() {
                     const itens = grupos[key];
                     for (const p of itens) {
                       const base = extractModeloBase(stripOrigemVendas(p.produto), p.categoria || "", p.observacao);
-                      const cor = p.cor || extractCor(p.produto) || "—";
+                      // Cor: ordem de confiabilidade — p.cor > nome > SKU > "—"
+                      const cor = p.cor
+                        || extractCor(p.produto)
+                        || extractCorSku(p.sku)
+                        || "—";
                       if (!porModelo[base]) porModelo[base] = {};
                       if (!porModelo[base][cor]) porModelo[base][cor] = [];
                       porModelo[base][cor].push(p);


### PR DESCRIPTION
## Bug reportado pelo André

> "o sistema está colocando 512GB como se fosse cor. o certo seria Azul no lugar de 512GB"

No seletor de unidades de estoque da Nova Venda, o MacBook Neo 13" 8GB 512GB mostrava **"512GB"** no lugar de **"Azul"**. E quando o admin escolhia o produto, aparecia "Nenhuma unidade desse produto em estoque ainda" mesmo tendo unidades.

## Causa raiz

A função `extractCor` usava regex `/\d+GB\s+/` que exige espaço **depois** do GB. No nome `"MacBook Neo 13 8GB 512GB"` (sem cor registrada no nome):

- `"8GB "` casa (tem espaço depois)
- `"512GB"` no fim da string **não casa** (sem espaço)

Split retorna `["MacBook Neo 13", "512GB"]`. Aí `after = "512GB"`, passa pela lógica de origem fiscal (não casa nenhuma LL/BR/JPA/etc) e retorna **"512GB" como cor**.

## Fix em 2 camadas

### 1. Pega o ÚLTIMO storage, não só com espaço

Usa `matchAll(/\d+(GB|TB)\b/gi)` pra achar todos os storages. Pega o último match (que em MacBook com RAM+SSD é o SSD, imediatamente antes da cor).

### 2. Rejeita candidato que ainda é storage

Se o "candidato" de cor ainda casa `/^\d+(GB|TB)$/`, descarta. O nome do produto realmente não tem cor.

### 3. Fallback pro SKU

Quando `p.cor=null` e `extractCor` também não acha, usa `parseSku(p.sku)` pra pegar segmentos não-classificáveis. Ex:

```
SKU: MACBOOK-NEO-13-8GB-512GB-AZUL
→ parseSku → specs: ["13", "8GB", "512GB", "AZUL"]
→ filtra classificáveis (tela=13, storage=8GB+512GB)
→ sobra "AZUL"
→ corParaPT → "Azul"
```

## Ordem final de confiabilidade

```
p.cor (DB) > extractCor (nome) > extractCorSku (SKU) > "—"
```

## Test plan

- [ ] Preview compila
- [ ] Nova venda → digitar "macbook neo 13" → abrir grupo "8GB 512GB"
  - [ ] Mostra "Azul" e "Prata" (não mais "512GB")
  - [ ] Clicar na cor mostra os seriais
  - [ ] Selecionar → mostra "MACBOOK NEO 13" | 8GB | 512GB AZUL" sem erro "nenhuma unidade"

🤖 Generated with [Claude Code](https://claude.com/claude-code)