### PR TITLE
fix(vendas): seletor de unidade tolera chip/variante extra no estoque

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -3629,6 +3629,44 @@ export default function VendasPage() {
                         if (alvo.startsWith(skuEstoqueFinal + "-")) return true;
                       }
                     }
+                    // Match D (componentes essenciais): quando SKUs diferem em
+                    // chip/variante mas batem em modelo base + storage + cor,
+                    // considera compativel. Cobre caso reportado:
+                    //   venda: MACBOOK-NEO-13-8GB-512GB-PRATA (formulario simples)
+                    //   estoque: MACBOOK-NEO-A18-PRO-13-8GB-512GB-PRATA (completo)
+                    // Match C nao cobre pq "A18-PRO" ta no meio, nao no fim.
+                    if (skuEstoqueFinal) {
+                      const parsedEst = parseSku(skuEstoqueFinal);
+                      if (parsedEst) {
+                        const isSpecForCor = (s: string) =>
+                          /^\d+(GB|TB|MM)$/.test(s) ||
+                          /^M\d+/.test(s) ||
+                          (/^\d+$/.test(s) && Number(s) >= 10 && Number(s) <= 17) ||
+                          ["GPS", "GPSCEL", "WIFI", "CELL", "SEMINOVO", "ANC"].includes(s);
+                        const getStorage = (specs: string[]) => specs.find(s => /^\d+(GB|TB)$/.test(s)) || null;
+                        const getCor = (specs: string[]) => specs.filter(s => !isSpecForCor(s)).join("-") || null;
+                        const estStorage = getStorage(parsedEst.specs);
+                        const estCor = getCor(parsedEst.specs);
+                        for (const alvo of skusAlvo) {
+                          const parsedAlv = parseSku(alvo);
+                          if (!parsedAlv) continue;
+                          // Categoria tem que bater
+                          if (parsedAlv.categoria !== parsedEst.categoria) continue;
+                          // Modelo base compativel: um e subset do outro (ex:
+                          // MACBOOK-NEO ⊂ MACBOOK-NEO-A18-PRO)
+                          const modeloCompat = parsedAlv.modelo === parsedEst.modelo
+                            || parsedEst.modelo.startsWith(parsedAlv.modelo + "-")
+                            || parsedAlv.modelo.startsWith(parsedEst.modelo + "-");
+                          if (!modeloCompat) continue;
+                          // Storage bate (ou um dos lados nao tem)
+                          const alvStorage = getStorage(parsedAlv.specs);
+                          const alvCor = getCor(parsedAlv.specs);
+                          const storageOk = !alvStorage || !estStorage || alvStorage === estStorage;
+                          const corOk = !alvCor || !estCor || alvCor === estCor;
+                          if (storageOk && corOk) return true;
+                        }
+                      }
+                    }
                     return false;
                   });
 


### PR DESCRIPTION
## Bug reportado pelo André

Venda do Marcelo Cardoso (MacBook Neo 13" 8GB 512GB **Prata**) mostrava **"Nenhuma unidade desse produto em estoque"** mesmo tendo **2 unidades** do MacBook Neo **A18 PRO** 13" 8GB 512GB Prata disponíveis (seriais `FDQ3XVT3GK` e `F6WY9MXKPY`).

## Causa raiz

- Venda: `MACBOOK-NEO-13-8GB-512GB-PRATA` (formulário sem chip)
- Estoque: `MACBOOK-NEO-A18-PRO-13-8GB-512GB-PRATA` (completo)

O Match C (prefix) não cobre esse caso porque `A18-PRO` está no **meio** do SKU, não no fim. Nenhuma das duas strings é prefix da outra.

## Fix — Match D (componentes essenciais)

Quando Match A/B/C falham, parseia os SKUs e considera compatível quando:

1. **Categoria bate** (`MACBOOK === MACBOOK`)
2. **Modelo base é subset** — um começa com o outro + `-` (ex: `MACBOOK-NEO ⊂ MACBOOK-NEO-A18-PRO`). Admin não especificou chip, aceita qualquer variante de chip do mesmo modelo.
3. **Storage bate** (ou um lado não tem)
4. **Cor bate** (ou um lado não tem)

## Ordem de matches agora

| Match | Descrição | Exemplo |
|-------|-----------|---------|
| A | SKU persistido === SKU venda | `IPHONE-17-256GB-PRETO === IPHONE-17-256GB-PRETO` |
| B | SKU inferido === SKU venda | similar, regenerando do texto |
| C | Prefix direto | `IPHONE-17-256GB` ⊂ `IPHONE-17-256GB-PRETO` |
| **D (novo)** | **Componentes essenciais** | `MACBOOK-NEO-13-...-PRATA` ≈ `MACBOOK-NEO-A18-PRO-13-...-PRATA` |

D é o mais permissivo. Ainda bloqueia divergência real (modelo/storage/cor diferente) — só tolera quando o detalhe extra é "modelo mais específico".

## Resultado esperado

Pós-merge, a venda do Marcelo mostra os 2 MacBook Neo A18 PRO como opções, admin clica no serial que sair.

## Test plan

- [ ] Preview compila
- [ ] Venda Marcelo Cardoso → seletor mostra `MacBook Neo A18 PRO 13" 8GB 512GB Prata` (2 un.)
- [ ] Clicar no serial vincula sem erro
- [ ] Ainda bloqueia casos reais — ex: venda `IPHONE-17-256GB-PRETO` não mostra estoque de `IPHONE-17-256GB-BRANCO`

🤖 Generated with [Claude Code](https://claude.com/claude-code)