### PR TITLE
fix(vendas): Match D compara SSD (maior storage) em vez do primeiro GB

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -3643,7 +3643,18 @@ export default function VendasPage() {
                           /^M\d+/.test(s) ||
                           (/^\d+$/.test(s) && Number(s) >= 10 && Number(s) <= 17) ||
                           ["GPS", "GPSCEL", "WIFI", "CELL", "SEMINOVO", "ANC"].includes(s);
-                        const getStorage = (specs: string[]) => specs.find(s => /^\d+(GB|TB)$/.test(s)) || null;
+                        // Pega o MAIOR storage (SSD em MacBook — diferencial
+                        // comercial). Pegar o primeiro pegaria RAM (8GB) que
+                        // bate em TODOS os MacBooks e daria match falso-positivo.
+                        const getStorage = (specs: string[]) => {
+                          const storages = specs.filter(s => /^\d+(GB|TB)$/.test(s));
+                          if (storages.length === 0) return null;
+                          return storages.sort((a, b) => {
+                            const valA = a.endsWith("TB") ? parseInt(a) * 1024 : parseInt(a);
+                            const valB = b.endsWith("TB") ? parseInt(b) * 1024 : parseInt(b);
+                            return valB - valA;
+                          })[0];
+                        };
                         const getCor = (specs: string[]) => specs.filter(s => !isSpecForCor(s)).join("-") || null;
                         const estStorage = getStorage(parsedEst.specs);
                         const estCor = getCor(parsedEst.specs);
@@ -3658,7 +3669,7 @@ export default function VendasPage() {
                             || parsedEst.modelo.startsWith(parsedAlv.modelo + "-")
                             || parsedAlv.modelo.startsWith(parsedEst.modelo + "-");
                           if (!modeloCompat) continue;
-                          // Storage bate (ou um dos lados nao tem)
+                          // Storage (SSD) bate (ou um dos lados nao tem)
                           const alvStorage = getStorage(parsedAlv.specs);
                           const alvCor = getCor(parsedAlv.specs);
                           const storageOk = !alvStorage || !estStorage || alvStorage === estStorage;


### PR DESCRIPTION
## Bug reportado pelo André

> "só temos 2 silver e 2 Azul do modelo macbook Neo A18 PRO, nao sei porque está aparecendo 5 serial"

Depois do PR #788 (Match D), o seletor do MacBook Neo 13" 8GB 512GB **Prata** mostrava **5 seriais** em vez de 2. E provavelmente também mostraria os Azuis (4 total) — mas apareceram 5, ou seja até unidades de 256GB foram incluídas.

## Causa

`getStorage` pegava o **primeiro** match de `/^\d+(GB|TB)$/` nas specs. Mas em MacBook, o primeiro é a **RAM (8GB)**, não o SSD (512GB).

```
Venda specs:  [13, 8GB, 512GB, PRATA]
  getStorage (bug) → "8GB"   ← pega RAM
Estoque 256GB: [13, 8GB, 256GB, PRATA]
  getStorage (bug) → "8GB"   ← mesma RAM
→ match falso-positivo (admin queria 512GB)
```

Como **todos** os MacBook Neo têm 8GB de RAM, o storage "batia" em tudo e Match D incluía unidades de 256GB, 512GB, 1TB — tudo.

## Fix

`getStorage` agora pega o **MAIOR** storage (filtra + sort decrescente). Em MacBook isso sempre é o SSD — o diferencial comercial real.

```
Venda 512GB → getStorage → "512GB"
Estoque 256GB → "256GB" → diff → não match ✓
Estoque 512GB → "512GB" → match ✓
Estoque 1TB → "1024GB" (1024) → diff → não match ✓
```

Funciona também para iPhone (só 1 storage) — sort de 1 elemento é no-op.

## Resultado esperado

Venda Marcelo Cardoso mostra só os 2 MacBook Neo A18 PRO 512GB **Prata** (FDQ3XVT3GK, F6WY9MXKPY) — não os Azuis, não os 256GB.

## Test plan

- [ ] Preview compila
- [ ] Venda Marcelo → seletor mostra 2 unidades (não 5)
- [ ] Unidades são: FDQ3XVT3GK e F6WY9MXKPY (os 2 Prata 512GB)
- [ ] Não mostra Azul nem 256GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)