### PR TITLE
fix(vendas): toggle Programar venda visivel em edicao pra mover/remover agendamento

### DIFF
--- a/app/admin/vendas/page.tsx
+++ b/app/admin/vendas/page.tsx
@@ -5059,8 +5059,9 @@ export default function VendasPage() {
             );
           })()}
 
-          {/* Toggle Programar Venda */}
-          {!editandoVendaId && (
+          {/* Toggle Programar Venda — visivel tambem em edicao pra
+              admin remover/mudar agendamento de venda ja finalizada */}
+          {(
             <div className={`p-3 rounded-xl border space-y-3 ${vendaProgramada ? (dm ? "border-purple-500 bg-purple-900/20" : "border-purple-400 bg-purple-50") : dm ? "border-[#3A3A3C] bg-[#1C1C1E]" : "border-[#D2D2D7] bg-[#F5F5F7]"}`}>
               <label className="flex items-center gap-2 cursor-pointer">
                 <input


### PR DESCRIPTION
## Resumo

- Toggle **📅 Programar venda** em [app/admin/vendas/page.tsx:5063](app/admin/vendas/page.tsx#L5063) estava escondido quando `editandoVendaId` (so aparecia em venda nova).
- Resultado: venda PROGRAMADA/FINALIZADA com `data_programada` futura nao tinha como ter o agendamento removido nem a data trocada — o listing prioriza `data_programada` sobre `data` ([app/admin/vendas/page.tsx:5737](app/admin/vendas/page.tsx#L5737)) entao a venda ficava presa no dia futuro.
- **Caso real:** cliente agendou retirada pra 25/04 mas pagou antes (24/04). Venda aparecia como AMANHA em vez de hoje, sem como mover.

## Fix

Removido o gate `!editandoVendaId &&` no wrapper do toggle. Em modo edicao o admin agora pode:
- **Desmarcar** "Programar venda" → `data_programada=null`, status preserva FINALIZADO via `statusPagamentoOriginal` (ja existente em [app/admin/vendas/page.tsx:1310](app/admin/vendas/page.tsx#L1310)), venda volta pra lista do dia de `v.data`
- **Mudar a data programada** sem desmarcar

`buildPayload` ja trata o caso correto: `data_programada: vendaProgramada && dataProgramada ? dataProgramada : null` ([app/admin/vendas/page.tsx:1312](app/admin/vendas/page.tsx#L1312)).

## Test plan

- [ ] Editar uma venda PROGRAMADA → bloco roxo "Programar venda" aparece ja preenchido com data e radio "Aguardando/Sinal/Ja pago" preservados
- [ ] Editar venda FINALIZADA com data_programada futura → desmarcar toggle → salvar → venda some da lista do dia futuro e aparece no dia de `v.data`
- [ ] Editar mesma venda → so trocar a "Data programada" pra outro dia → salvar → venda muda de grupo de data
- [ ] Editar venda **sem** agendamento → toggle aparece desmarcado, marcar/preencher data → vira PROGRAMADA
- [ ] Editar venda comum (nao programada) e salvar sem mexer no toggle → status_pagamento e data_programada inalterados

🤖 Generated with [Claude Code](https://claude.com/claude-code)