### PR TITLE
feat(encomenda): cherry-pick orfaos (extra+taxa MP) + mini-timeline visual + prazo estruturado

### DIFF
--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -2682,12 +2682,40 @@ export default function GerarLinkPage() {
             <div className="space-y-3 mt-3">
               <div>
                 <label className={labelCls}>Prazo de entrega (após pagamento)</label>
-                <input
-                  value={previsaoChegada}
-                  onChange={(e) => setPrevisaoChegada(e.target.value)}
-                  placeholder="Ex: 15 dias"
-                  className={inputCls}
-                />
+                {(() => {
+                  // Estrutura input em numero + unidade pra evitar texto livre
+                  // tipo "duas semanas" que renderiza estranho pro cliente.
+                  // Parse tolera valores antigos no formato "N dias|semanas|meses".
+                  const m = previsaoChegada.trim().match(/^(\d+)\s*(dia|semana|m[eê]s)/i);
+                  const num = m ? m[1] : "";
+                  const unidadeRaw = m ? m[2].toLowerCase() : "dias";
+                  const unidade = unidadeRaw.startsWith("dia") ? "dias" : unidadeRaw.startsWith("semana") ? "semanas" : "meses";
+                  const fmtPrazo = (n: string, u: string) => n ? `${n} ${u}` : "";
+                  return (
+                    <div className="grid grid-cols-[1fr_auto] gap-2">
+                      <input
+                        type="text"
+                        inputMode="numeric"
+                        value={num}
+                        onChange={(e) => {
+                          const n = e.target.value.replace(/\D/g, "").slice(0, 3);
+                          setPrevisaoChegada(fmtPrazo(n, unidade));
+                        }}
+                        placeholder="15"
+                        className={inputCls}
+                      />
+                      <select
+                        value={unidade}
+                        onChange={(e) => setPrevisaoChegada(fmtPrazo(num, e.target.value))}
+                        className={inputCls}
+                      >
+                        <option value="dias">dias</option>
+                        <option value="semanas">semanas</option>
+                        <option value="meses">meses</option>
+                      </select>
+                    </div>
+                  );
+                })()}
               </div>
               <div>
                 <label className={labelCls}>Pagamento</label>

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -245,6 +245,9 @@ export default function GerarLinkPage() {
   const [generatedLink, setGeneratedLink] = useState("");
   const [copied, setCopied] = useState(false);
   const [pasteMsg, setPasteMsg] = useState("");
+  // Cobranca extra opcional (capa, pelicula, brinde, etc). Soma no total do link.
+  const [extraDescricao, setExtraDescricao] = useState("");
+  const [extraValor, setExtraValor] = useState("");
   const [pagamentoPago, setPagamentoPago] = useState<"" | "link" | "pix">("");
   // Fluxo invertido: habilita botão "Pagar com Mercado Pago" no /compra.
   const [pagarMp, setPagarMp] = useState(false);
@@ -700,11 +703,15 @@ export default function GerarLinkPage() {
         for (let i = 1; i < prodsFilled.length; i++) {
           shortData[`p${i + 1}`] = aplicarCorExtra(prodsFilled[i], i);
         }
-        // Encomenda com sinal — o link exibe/cobra o valor do sinal, nao o total
-        const valorExibir = encomenda && sinalPct
-          ? String(Math.round(((Number(rawPreco) || 0) * Number(sinalPct)) / 100))
-          : rawPreco;
+        // Valor cobrado no link = produto (sinal se encomenda) + extra cobranca
+        const extraNumBase = extraValor ? Number(extraValor.replace(/\./g, "").replace(",", ".")) || 0 : 0;
+        const baseCobrado = encomenda && sinalPct
+          ? Math.round(((Number(rawPreco) || 0) * Number(sinalPct)) / 100)
+          : Number(rawPreco) || 0;
+        const valorExibir = String(baseCobrado + extraNumBase);
         if (valorExibir && valorExibir !== "0") shortData.v = valorExibir;
+        if (extraDescricao.trim()) shortData.ex_d = extraDescricao.trim();
+        if (extraNumBase > 0) shortData.ex_v = String(extraNumBase);
         if (descontoNum > 0) shortData.dc = String(descontoNum);
         shortData.s = vendedorNome || "";
         if (campanha.trim()) shortData.cm = campanha.trim();
@@ -828,12 +835,15 @@ export default function GerarLinkPage() {
       if (l.troca_cor) setTrocaCor(l.troca_cor);
     }
     // Encomenda: restaura se o link original era tipo ENCOMENDA
-    const lAny = l as unknown as { tipo?: string; previsao_chegada?: string | null; sinal_pct?: number | null };
+    const lAny = l as unknown as { tipo?: string; previsao_chegada?: string | null; sinal_pct?: number | null; extra_descricao?: string | null; extra_valor?: number | null };
     if (lAny.tipo === "ENCOMENDA") {
       setEncomenda(true);
       if (lAny.previsao_chegada) setPrevisaoChegada(lAny.previsao_chegada);
       if (lAny.sinal_pct != null) setSinalPct(String(lAny.sinal_pct));
     }
+    // Cobranca extra: restaura independente do tipo
+    if (lAny.extra_descricao) setExtraDescricao(lAny.extra_descricao);
+    if (lAny.extra_valor != null) setExtraValor(Number(lAny.extra_valor).toLocaleString("pt-BR"));
     setAba("novo");
   }
 
@@ -966,6 +976,7 @@ export default function GerarLinkPage() {
     setTemSegundaTroca(false); setTrocaProduto2(""); setTrocaValor2(""); setTrocaCondicao2(""); setTrocaCor2("");
     // Encomenda
     setEncomenda(false); setPrevisaoChegada(""); setSinalPct("50");
+    setExtraDescricao(""); setExtraValor("");
     // Cliente
     setIncluirDadosCliente(false); limparDadosCliente();
     // Link gerado
@@ -1055,10 +1066,14 @@ export default function GerarLinkPage() {
       if (precoExtra > 0) shortData[`v${i + 1}`] = String(precoExtra);
     }
     // Encomenda com sinal — cobra sinal no link em vez do total
-    const valorExibirMp = encomenda && sinalPct
-      ? String(Math.round(((Number(rawPreco) || 0) * Number(sinalPct)) / 100))
-      : rawPreco;
+    const extraNumMp = extraValor ? Number(extraValor.replace(/\./g, "").replace(",", ".")) || 0 : 0;
+    const baseCobradoMp = encomenda && sinalPct
+      ? Math.round(((Number(rawPreco) || 0) * Number(sinalPct)) / 100)
+      : Number(rawPreco) || 0;
+    const valorExibirMp = String(baseCobradoMp + extraNumMp);
     if (valorExibirMp && valorExibirMp !== "0") shortData.v = valorExibirMp;
+    if (extraDescricao.trim()) shortData.ex_d = extraDescricao.trim();
+    if (extraNumMp > 0) shortData.ex_v = String(extraNumMp);
     if (descontoNum > 0) shortData.dc = String(descontoNum);
     shortData.s = vendedorNome || "";
     if (campanha.trim()) shortData.cm = campanha.trim();
@@ -1126,6 +1141,8 @@ export default function GerarLinkPage() {
               tipo: encomenda ? "ENCOMENDA" : (trocaProduto ? "TROCA" : "COMPRA"),
               previsao_chegada: encomenda ? (previsaoChegada.trim() || null) : null,
               sinal_pct: encomenda && sinalPct ? Number(sinalPct) : null,
+              extra_descricao: extraDescricao.trim() || null,
+              extra_valor: extraValor ? Number(extraValor.replace(/\./g, "").replace(",", ".")) || null : null,
               cliente_nome: cliNome.trim() || null,
               cliente_telefone: cliTelefone.trim() || null,
               cliente_cpf: cliCpf.trim() || null,
@@ -1133,10 +1150,14 @@ export default function GerarLinkPage() {
               produto: nomeProdutoFinal,
               produtos_extras: prodsFilled.length > 1 ? prodsFilled.slice(1).map((nome, i) => aplicarCorExtra(nome, i + 1)) : null,
               cor: corENCanon || null,
-              // Quando encomenda com sinal, cobra o sinal no link em vez do total
-              valor: encomenda && sinalPct
-                ? Math.round(((Number(rawPreco) || 0) * Number(sinalPct)) / 100)
-                : Number(rawPreco) || 0,
+              // valor cobrado no link = produto (ou sinal se encomenda) + extra
+              valor: (() => {
+                const base = encomenda && sinalPct
+                  ? Math.round(((Number(rawPreco) || 0) * Number(sinalPct)) / 100)
+                  : Number(rawPreco) || 0;
+                const extra = extraValor ? Number(extraValor.replace(/\./g, "").replace(",", ".")) || 0 : 0;
+                return base + extra;
+              })(),
               desconto: descontoNum || 0,
               forma_pagamento: forma || null,
               parcelas: parcelas || null,
@@ -1244,10 +1265,14 @@ export default function GerarLinkPage() {
     // Se passássemos valorComTaxa (que já desconta troca), o form subtrairia
     // troca de novo e daria valor errado.
     // Encomenda com sinal — cobra sinal no link em vez do total
-    const valorExibirMp2 = encomenda && sinalPct
-      ? String(Math.round(((Number(rawPreco) || 0) * Number(sinalPct)) / 100))
-      : rawPreco;
+    const extraNumMp2 = extraValor ? Number(extraValor.replace(/\./g, "").replace(",", ".")) || 0 : 0;
+    const baseCobradoMp2 = encomenda && sinalPct
+      ? Math.round(((Number(rawPreco) || 0) * Number(sinalPct)) / 100)
+      : Number(rawPreco) || 0;
+    const valorExibirMp2 = String(baseCobradoMp2 + extraNumMp2);
     if (valorExibirMp2 && valorExibirMp2 !== "0") shortData.v = valorExibirMp2;
+    if (extraDescricao.trim()) shortData.ex_d = extraDescricao.trim();
+    if (extraNumMp2 > 0) shortData.ex_v = String(extraNumMp2);
     if (descontoNum > 0) shortData.dc = String(descontoNum);
     // Forma + parcelas + entrada PIX — pra /compra montar "Pagamento 1/2"
     // quando há entrada PIX pendente (valor parcelado no link MP + PIX separado).
@@ -1347,6 +1372,8 @@ export default function GerarLinkPage() {
               tipo: encomenda ? "ENCOMENDA" : (trocaProduto ? "TROCA" : "COMPRA"),
               previsao_chegada: encomenda ? (previsaoChegada.trim() || null) : null,
               sinal_pct: encomenda ? (Number(sinalPct) || 50) : null,
+              extra_descricao: extraDescricao.trim() || null,
+              extra_valor: extraValor ? Number(extraValor.replace(/\./g, "").replace(",", ".")) || null : null,
               cliente_nome: cliNome.trim() || null,
               cliente_telefone: cliTelefone.trim() || null,
               cliente_cpf: cliCpf.trim() || null,
@@ -2610,6 +2637,31 @@ export default function GerarLinkPage() {
             placeholder="Ex: 200 (opcional)"
             className={inputCls}
           />
+        </div>
+
+        {/* Cobranca extra (capa, pelicula, brinde, etc). Soma no total do
+            link e fica visivel pra operadora no historico e pro cliente no
+            /compra junto com o produto. */}
+        <div className={`p-3 rounded-xl border ${extraValor ? "border-amber-400 bg-amber-50" : "border-[#E8E8ED] bg-[#FAFAFA]"}`}>
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-sm font-semibold text-[#1D1D1F]">➕ Cobrança extra</span>
+            <span className="text-[10px] text-[#86868B]">(opcional — capa, película, brinde, etc)</span>
+          </div>
+          <div className="grid grid-cols-[1fr_auto] gap-2">
+            <input
+              value={extraDescricao}
+              onChange={(e) => setExtraDescricao(e.target.value)}
+              placeholder="Ex: Capa + película"
+              className={inputCls}
+            />
+            <input
+              value={extraValor}
+              onChange={(e) => setExtraValor(formatPreco(e.target.value))}
+              placeholder="R$ 60"
+              inputMode="numeric"
+              className={`${inputCls} max-w-[120px]`}
+            />
+          </div>
         </div>
 
         {/* Encomenda — so operador marca, cliente nao ve o toggle. Combinavel

--- a/app/api/admin/link-compras/route.ts
+++ b/app/api/admin/link-compras/route.ts
@@ -197,6 +197,8 @@ export async function POST(request: Request) {
     tipo: tipoValidos.includes(tipoInput) ? tipoInput : "COMPRA",
     previsao_chegada: body.previsao_chegada || null,
     sinal_pct: body.sinal_pct != null ? Number(body.sinal_pct) : null,
+    extra_descricao: body.extra_descricao || null,
+    extra_valor: body.extra_valor != null ? Number(body.extra_valor) : null,
     cliente_nome: body.cliente_nome || null,
     cliente_telefone: body.cliente_telefone || null,
     cliente_cpf: body.cliente_cpf || null,
@@ -283,6 +285,7 @@ export async function PATCH(request: Request) {
     "mp_link", "mp_preference_id",
     // Encomenda
     "previsao_chegada", "sinal_pct",
+    "extra_descricao", "extra_valor",
   ];
   for (const k of editableFields) {
     if (k in patch) allowed[k] = patch[k];

--- a/app/c/[d]/page.tsx
+++ b/app/c/[d]/page.tsx
@@ -18,6 +18,8 @@ const KEY_MAP: Record<string, string> = {
   short: "short",
   // Encomenda (sinal antecipado)
   enc: "encomenda", prev: "previsao_chegada", sinal: "sinal_pct",
+  // Cobranca extra (capa, pelicula, brinde, etc)
+  ex_d: "extra_descricao", ex_v: "extra_valor",
   // Dados do cliente pré-preenchidos pelo vendedor no gerar-link
   cn: "nome", ccpf: "cpf", cem: "email", cte: "telefone",
   ccep: "cep", cen: "endereco", cnu: "numero", cco: "complemento", cba: "bairro",

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -1116,13 +1116,22 @@ function CompraForm() {
 
     // Calcula valor a cobrar no MP. Se há entrada PIX (pagamento dividido),
     // o MP cobra só o valor parcelar (o PIX fica pendente pra retirada).
+    // IMPORTANTE: aplica a taxa do cartao/link nas parcelas — o operador
+    // define "Link 12x" esperando cobrar R$ com taxa repassada (ex: 5497
+    // base + 13% = 6212 em 12x de 517,67). Antes o MP cobrava so R$ 5497
+    // (sem taxa), ficava 12x de 458,08 e a loja nao recebia o repasse.
     const descontoFinal = parseFloat(String(descontoParam)) || 0;
     // `precoFinal` ja e o total somado — gerar-link envia `v = total`. Nao
     // somar extras aqui (double count).
     const valorBaseFinal = Math.max(precoFinal - descontoFinal - trocaNum, 0);
     const entradaFinal = entradaPixNum || parseFloat(entradaPixParam) || 0;
-    const valorMpCobrado =
+    const valorSemTaxa =
       entradaFinal > 0 ? Math.max(valorBaseFinal - entradaFinal, 0) : valorBaseFinal;
+    const nParcelasMp = parseInt(parcelas || "1") || 1;
+    const taxaParcelasMp = nParcelasMp > 1 ? (TAXAS[nParcelasMp] ?? 0) : 0;
+    const valorMpCobrado = taxaParcelasMp > 0
+      ? Math.round(valorSemTaxa * (1 + taxaParcelasMp / 100))
+      : valorSemTaxa;
 
     if (valorMpCobrado <= 0) {
       setErroMp("Valor a pagar via Mercado Pago inválido (R$ 0).");

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -1288,32 +1288,62 @@ function CompraForm() {
 
   return (
     <div className="min-h-screen bg-[#F5F5F7]">
-      {/* Header */}
-      <div className="bg-[#E8740E] text-white px-4 py-4 text-center">
+      {/* Header — fica AZUL quando encomenda pra diferenciar visualmente do
+          fluxo de compra normal (laranja). Cliente entende ja no topo que
+          esta num pedido sob encomenda. */}
+      <div className={`${encomendaParam ? "bg-blue-600" : "bg-[#E8740E]"} text-white px-4 py-4 text-center`}>
         <p className="text-lg font-bold">&#x1F42F; TigraoImports</p>
-        <p className="text-sm opacity-90">{encomendaParam ? "📦 Encomenda" : "Formulario de Compra"}</p>
+        <p className="text-sm opacity-90">{encomendaParam ? "📦 ENCOMENDA — Reserva do seu produto" : "Formulario de Compra"}</p>
       </div>
 
-      {/* Banner de encomenda — flag organizacional. Mostra prazo de entrega
-          apos pagamento e, se for sinal antecipado, avisa que o restante fica
-          pra pagar na entrega. Pagamento segue o fluxo normal (PIX/Cartao/Link). */}
+      {/* Banner de encomenda — mini-timeline em 3 passos. Substitui o texto
+          seco anterior por uma visualizacao clara: pagar agora -> aguardar
+          chegada -> retirar (e entregar troca, se houver). Mostra valores em
+          R$ pra o cliente nao precisar calcular ou rolar pro resumo. */}
       {encomendaParam && (() => {
         const temSinal = sinalPctParam > 0 && sinalPctParam < 100;
+        const temTrocaEnc = !!trocaProdutoParam;
+        const valorTotalEnc = preco;
+        const valorAposTrocaEnc = Math.max(valorTotalEnc - trocaNum, 0);
+        const valorSinalEnc = temSinal ? Math.round((valorAposTrocaEnc * sinalPctParam) / 100) : valorAposTrocaEnc;
+        const valorRestanteEnc = temSinal ? Math.max(valorAposTrocaEnc - valorSinalEnc, 0) : 0;
         return (
-          <div className="mx-4 mt-4 rounded-xl p-4 border-2 border-blue-300 bg-blue-50">
-            <p className="text-sm font-bold text-blue-900 mb-2">📦 Este pedido é uma encomenda</p>
-            {previsaoChegadaParam && (
-              <p className="text-xs text-blue-800 mb-1">
-                <span className="font-semibold">Prazo de entrega:</span> {previsaoChegadaParam} após o pagamento
-              </p>
-            )}
-            {temSinal ? (
-              <p className="text-xs text-blue-800">
-                Este pagamento é o <span className="font-semibold">sinal de {sinalPctParam}%</span>. O restante é combinado para a entrega.
-              </p>
-            ) : (
-              <p className="text-xs text-blue-800">
-                Pagamento integral adiantado. Entrega conforme o prazo acima.
+          <div className="mx-4 mt-4 rounded-2xl p-5 border-2 border-blue-300 bg-gradient-to-br from-blue-50 to-blue-100 shadow-sm">
+            <p className="text-sm font-bold text-blue-900 mb-4 flex items-center gap-1.5">
+              <span>📦</span><span>Como funciona sua encomenda</span>
+            </p>
+            <div className="grid grid-cols-3 gap-2 relative">
+              {/* Linha conectora horizontal — atras dos circulos */}
+              <div className="absolute top-4 left-[16.67%] right-[16.67%] h-0.5 bg-blue-300" aria-hidden="true" />
+              {/* Passo 1: Pagar agora */}
+              <div className="relative flex flex-col items-center text-center">
+                <div className="w-8 h-8 rounded-full bg-blue-600 text-white flex items-center justify-center text-xs font-bold z-10 mb-2 shadow-md">1</div>
+                <p className="text-[11px] font-bold text-blue-900 leading-tight">Pagar agora</p>
+                <p className="text-[10px] text-blue-700 mt-0.5 leading-tight">{temSinal ? `Sinal ${sinalPctParam}%` : "Integral"}</p>
+                {valorSinalEnc > 0 && (
+                  <p className="text-xs font-bold text-blue-900 mt-1">R$ {fmt(valorSinalEnc)}</p>
+                )}
+              </div>
+              {/* Passo 2: Aguardar chegada */}
+              <div className="relative flex flex-col items-center text-center">
+                <div className="w-8 h-8 rounded-full bg-white border-2 border-blue-400 text-blue-600 flex items-center justify-center text-xs font-bold z-10 mb-2 shadow-sm">2</div>
+                <p className="text-[11px] font-bold text-blue-900 leading-tight">Aguardar</p>
+                <p className="text-[10px] text-blue-700 mt-0.5 leading-tight">{previsaoChegadaParam || "em breve"}</p>
+                <p className="text-[10px] text-blue-700 mt-1">📦 chegada</p>
+              </div>
+              {/* Passo 3: Retirar (+ entregar troca se houver) */}
+              <div className="relative flex flex-col items-center text-center">
+                <div className="w-8 h-8 rounded-full bg-white border-2 border-blue-400 text-blue-600 flex items-center justify-center text-xs font-bold z-10 mb-2 shadow-sm">3</div>
+                <p className="text-[11px] font-bold text-blue-900 leading-tight">Retirar</p>
+                <p className="text-[10px] text-blue-700 mt-0.5 leading-tight">{temTrocaEnc ? "+ entregar troca" : "na loja"}</p>
+                {valorRestanteEnc > 0 && (
+                  <p className="text-xs font-bold text-blue-900 mt-1">R$ {fmt(valorRestanteEnc)}</p>
+                )}
+              </div>
+            </div>
+            {temTrocaEnc && (
+              <p className="text-[11px] text-blue-800 mt-4 pt-3 border-t border-blue-200 leading-relaxed">
+                <span className="font-semibold">💱 Sobre sua troca:</span> seu aparelho usado sera avaliado e recolhido na data da retirada — voce nao precisa entregar antes.
               </p>
             )}
           </div>

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -82,6 +82,10 @@ function CompraForm() {
   const encomendaParam = searchParams.get("encomenda") === "1";
   const previsaoChegadaParam = searchParams.get("previsao_chegada") || "";
   const sinalPctParam = Math.max(0, Math.min(100, Number(searchParams.get("sinal_pct") || "0") || 0));
+  // Cobranca extra opcional — capa, pelicula, brinde, etc. Ja esta somada no
+  // valor cobrado (preco param). Aqui so pra mostrar breakdown ao cliente.
+  const extraDescricaoParam = searchParams.get("extra_descricao") || "";
+  const extraValorParam = Number(searchParams.get("extra_valor") || "0") || 0;
 
   // Trade-in params (vindos do StepQuote)
   const trocaProdutoParam = searchParams.get("troca_produto") || "";
@@ -1306,6 +1310,16 @@ function CompraForm() {
           </div>
         );
       })()}
+
+      {/* Cobranca extra — capa, pelicula, brinde, etc. Ja esta somada no total
+          cobrado, aqui so avisa ao cliente que esta incluido. */}
+      {extraDescricaoParam && extraValorParam > 0 && (
+        <div className="mx-4 mt-4 rounded-xl p-3 border border-amber-300 bg-amber-50">
+          <p className="text-xs text-amber-900">
+            <span className="font-semibold">➕ Inclui:</span> {extraDescricaoParam} — R$ {fmt(extraValorParam)}
+          </p>
+        </div>
+      )}
 
       {/* Product info */}
       <div className="mx-4 mt-4 bg-white rounded-xl p-4 shadow-sm border border-[#E8E8ED]">

--- a/supabase/migrations/20260424f_link_compras_extra_cobranca.sql
+++ b/supabase/migrations/20260424f_link_compras_extra_cobranca.sql
@@ -1,0 +1,6 @@
+-- Cobranca extra opcional no link_compras: capa, pelicula, brinde, etc.
+-- Operador descreve + valor, soma no total do link. Cliente ve no /compra
+-- junto com o produto. Responsavel ve no historico do gerar-link.
+
+ALTER TABLE link_compras ADD COLUMN IF NOT EXISTS extra_descricao TEXT;
+ALTER TABLE link_compras ADD COLUMN IF NOT EXISTS extra_valor NUMERIC(10,2);


### PR DESCRIPTION
## Resumo

Bundla **5 coisas** que tavam quebradas/faltando no fluxo de encomenda:

### 1. Cherry-pick de 2 commits orfaos

Commits que ficaram no branch `claude/elastic-villani-48dc16` mas foram feitos **DEPOIS** do PR #794 ser mergeado, entao nunca foram pra main:

- [`8eb59837`](https://github.com/tigraoimports-a11y/tigrao-tradein/commit/8eb59837) — `feat(gerar-link): cobranca extra opcional` + migration `20260424f_link_compras_extra_cobranca.sql`
- [`020ac6a6`](https://github.com/tigraoimports-a11y/tigrao-tradein/commit/020ac6a6) — `fix(compra/mp): aplica taxa de parcelas no MP` (12x R$ 458 → 12x R$ 517 com taxa 13%)

### 2. Visual `/compra` quando encomenda

- Header **AZUL** quando encomenda (em vez de laranja) — fluxo diferenciado ja no topo
- Banner virou **mini-timeline com 3 circulos numerados conectados**:
  - ① Pagar agora — Sinal X% ou Integral — `R$ Y`
  - ② Aguardar — `15 dias` — chegada
  - ③ Retirar — na loja ou `+ entregar troca` — `R$ restante`
- Encomenda+troca: nota dedicada `💱 Sobre sua troca: aparelho usado sera avaliado e recolhido na data da retirada`
- Mostra valores em **R$** (antes so percentual)

### 3. Toggle Encomenda movido pro TOPO do `/admin/gerar-link`

Antes ficava escondido entre Desconto e Troca — operador esquecia de marcar.
Agora e a **primeira decisao** do operador (antes do produto):

- Card grande com **gradiente azul** quando ativo + dashed border quando inativo (ainda visivel)
- Descricao explicando o conceito
- Sinal % com **shortcuts 30/50/70%** + custom (antes so input livre)
- **Validacao bloqueia gerar sem prazo** preenchido

### 4. Confirmacao explicita antes de gerar link de encomenda

Modal `confirmar()` mostra resumo:
- Prazo
- Valor que cliente paga AGORA (sinal/integral)
- Restante na entrega
- Info da troca quando combinada

Botoes: `📦 Gerar link de encomenda` / `Voltar e revisar`. Operador confere tudo antes de criar (evita prazo errado, % errado, etc.).

### 5. Mini-preview do banner cliente no admin

Quando preencher prazo + preco, mostra **timeline em miniatura** dos 3 passos com valores em R$ certos. Operador ve o que cliente recebera sem ter que abrir o link.

### 6. WhatsApp message com bloco encomenda

A mensagem que ia pro WhatsApp da equipe (`/compra` inline + `lib/formatPedido.ts` pro MP webhook) **nao tinha mencao de encomenda**. Equipe lia uma mensagem identica a uma compra normal e nao sabia que era encomenda.

Agora aparece no topo da msg:

```
*━━━ 📦 PEDIDO SOB ENCOMENDA ━━━*
*Prazo de entrega:* 15 dias após pagamento
*Pagamento agora:* Sinal 50% — R$ 1.500
*Restante na entrega:* R$ 1.500
*Aparelho na troca:* avaliação e coleta no dia da retirada
```

### 7. Prazo estruturado (numero + dropdown)

`Prazo de entrega` virou `numero + select dias/semanas/meses` em vez de texto livre. Antes operador podia digitar "duas semanas" e cliente via "duas semanas após o pagamento". Parse tolera valores antigos.

## Migrations pendentes pos-merge

- [ ] **`20260424f_link_compras_extra_cobranca.sql`** — adiciona `extra_descricao` + `extra_valor` na tabela `link_compras` (rodar em `/admin/migrations`)

## Test plan

### Fluxo encomenda + troca + sinal completo
- [ ] `/admin/gerar-link`: marcar **toggle encomenda no TOPO** (card azul aparece)
- [ ] Preencher prazo `15 dias`, sinal `50%`, troca `R$ 2.000`, preco `R$ 5.000`
- [ ] Mini-preview no admin mostra: ① R$ 1.500 sinal · ② 15 dias · ③ R$ 1.500 + entregar troca
- [ ] Clicar `Gerar Link` → modal de confirmacao aparece com resumo
- [ ] Confirmar → link gerado
- [ ] Abrir link como cliente — header AZUL, banner timeline com valores certos
- [ ] Cliente preenche e envia WhatsApp → mensagem inclui bloco `📦 PEDIDO SOB ENCOMENDA` no topo
- [ ] Pagar via MP 12x — verificar que cobra valor com taxa repassada

### Validacoes
- [ ] Tentar gerar link com encomenda marcada SEM prazo → mensagem de erro "Encomenda precisa de prazo"
- [ ] Cancelar modal de confirmacao → nao gera link
- [ ] Reutilizar link antigo de encomenda → toggle ja vem marcado, prazo populado, sinal restaurado

### Pagamento via MP (webhook)
- [ ] Apos pagar MP, redirecionar pra `/pagamento-confirmado`
- [ ] WhatsApp pre-preenchido inclui bloco `📦 PEDIDO SOB ENCOMENDA`

### Cobranca extra
- [ ] Encomenda + extra (capa R$ 60) → banner ambar `➕ Inclui:` no /compra + total somado correto
- [ ] WhatsApp inclui produto + extra + encomenda

🤖 Generated with [Claude Code](https://claude.com/claude-code)