### PR TITLE
feat(encomenda): regras de local + data 24h + fluxo pagamento

### DIFF
--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -2414,7 +2414,13 @@ export default function GerarLinkPage() {
             <input
               type="checkbox"
               checked={encomenda}
-              onChange={(e) => { setEncomenda(e.target.checked); if (!e.target.checked) { setPrevisaoChegada(""); setSinalPct(""); } }}
+              onChange={(e) => {
+                const checked = e.target.checked;
+                setEncomenda(checked);
+                if (!checked) { setPrevisaoChegada(""); setSinalPct(""); }
+                // Encomenda nao aceita shopping/correios — limpa se ja selecionado
+                else if (localEntrega === "shopping" || localEntrega === "correios") setLocalEntrega("");
+              }}
               className="w-5 h-5 mt-0.5 rounded accent-blue-600"
             />
             <div className="flex-1">
@@ -3107,6 +3113,38 @@ export default function GerarLinkPage() {
           )}
         </div>
 
+        {/* Bloco fluxo de pagamento — explica em texto claro o que cliente vai
+            pagar agora e quando, especialmente em encomenda com sinal. So
+            renderiza quando ha forma + preco preenchidos. */}
+        {forma && precoBase > 0 && (() => {
+          const trocaTotalFx = (Number(rawTrocaVal) || 0) + (Number(rawTrocaVal2) || 0);
+          const baseAposTroca = Math.max(precoBase - trocaTotalFx - descontoNum, 0);
+          const pctFx = Number(sinalPct) || 0;
+          const temSinalFx = encomenda && pctFx > 0 && pctFx < 100;
+          const valorAgora = temSinalFx ? Math.round((baseAposTroca * pctFx) / 100) : baseAposTroca;
+          const valorRestante = temSinalFx ? Math.max(baseAposTroca - valorAgora, 0) : 0;
+          const formaLabel = forma === "Pix" ? "PIX" : forma === "Link de Pagamento" ? `Link MP${parcelas ? ` ${parcelas}x` : ""}` : forma === "Cartao Credito" ? `Cartão${parcelas ? ` ${parcelas}x` : ""}` : forma === "Cartao Debito" ? "Débito" : forma === "Especie" ? "Espécie" : forma;
+          return (
+            <div className={`rounded-xl border p-3 text-xs leading-relaxed ${encomenda ? "border-blue-300 bg-blue-50 text-blue-900" : "border-[#D2D2D7] bg-[#F9F9FB] text-[#1D1D1F]"}`}>
+              <p className="font-bold mb-1.5">{encomenda ? "📦 Fluxo de pagamento (encomenda)" : "💳 Fluxo de pagamento"}</p>
+              <ol className="space-y-1 list-none">
+                <li>
+                  <span className="font-semibold">1.</span> Cliente paga <strong>R$ {valorAgora.toLocaleString("pt-BR")}</strong> agora via <strong>{formaLabel}</strong>{temSinalFx ? ` (sinal ${pctFx}%)` : ""}
+                </li>
+                {encomenda && previsaoChegada && (
+                  <li><span className="font-semibold">2.</span> Aguarda <strong>{previsaoChegada}</strong> para chegada do produto</li>
+                )}
+                {valorRestante > 0 && (
+                  <li><span className="font-semibold">{encomenda && previsaoChegada ? "3" : "2"}.</span> Paga restante <strong>R$ {valorRestante.toLocaleString("pt-BR")}</strong> na entrega</li>
+                )}
+                {trocaTotalFx > 0 && (
+                  <li><span className="font-semibold">{encomenda ? "4" : "2"}.</span> 💱 Aparelho da troca (R$ {trocaTotalFx.toLocaleString("pt-BR")}) recolhido na retirada</li>
+                )}
+              </ol>
+            </div>
+          );
+        })()}
+
         {showEntradaPix && (
           <div>
             <label className={labelCls}>Entrada no Pix (R$)</label>
@@ -3123,14 +3161,33 @@ export default function GerarLinkPage() {
 
         <div>
           <label className={labelCls}>Local de Entrega</label>
-          <select value={localEntrega} onChange={(e) => { setLocalEntrega(e.target.value); if (e.target.value !== "shopping" && e.target.value !== "outro") setShoppingNome(""); }} className={inputCls}>
+          <select
+            value={localEntrega}
+            onChange={(e) => {
+              const v = e.target.value;
+              // Encomenda nao aceita shopping/correios — se selecionou um, derruba
+              if (encomenda && (v === "shopping" || v === "correios")) return;
+              setLocalEntrega(v);
+              if (v !== "shopping" && v !== "outro") setShoppingNome("");
+            }}
+            className={inputCls}
+          >
             <option value="">-- Opcional --</option>
-            <option value="loja">Retirada em Loja</option>
-            <option value="shopping">Entrega em Shopping</option>
-            <option value="residencia">Entrega em Residencia</option>
-            <option value="correios">📦 Envio Correios</option>
-            <option value="outro">Outro local</option>
+            <option value="loja">Retirada no Escritório</option>
+            <option value="residencia">Entrega em Residência</option>
+            <option value="outro">Outro local combinado</option>
+            {!encomenda && (
+              <>
+                <option value="shopping">Entrega em Shopping</option>
+                <option value="correios">📦 Envio Correios</option>
+              </>
+            )}
           </select>
+          {encomenda && (
+            <p className="text-[11px] text-blue-700 mt-1">
+              📦 Encomenda: só aceita Residência, Escritório ou Outro local. {(localEntrega === "residencia" || localEntrega === "outro") && <span className="font-semibold">Pagamento será antecipado.</span>}
+            </p>
+          )}
         </div>
 
         {(localEntrega === "shopping" || localEntrega === "outro") && (
@@ -3164,12 +3221,38 @@ export default function GerarLinkPage() {
           </div>
           <div>
             <label className={labelCls}>Data</label>
-            <input
-              type="date"
-              value={dataEntrega}
-              onChange={(e) => setDataEntrega(e.target.value)}
-              className={inputCls}
-            />
+            {(() => {
+              // Encomenda: orcamento dura 24h, entao agendamento so pode ser
+              // hoje ou amanha. Fora disso, sem restricao (usa min/max do form
+              // padrao do browser, que aceita qualquer data).
+              const hoje = new Date();
+              const amanha = new Date(hoje); amanha.setDate(amanha.getDate() + 1);
+              const isoFmt = (d: Date) => d.toLocaleDateString("en-CA", { timeZone: "America/Sao_Paulo" });
+              const minDate = encomenda ? isoFmt(hoje) : undefined;
+              const maxDate = encomenda ? isoFmt(amanha) : undefined;
+              return (
+                <input
+                  type="date"
+                  value={dataEntrega}
+                  min={minDate}
+                  max={maxDate}
+                  onChange={(e) => {
+                    let v = e.target.value;
+                    if (encomenda && v && (v < minDate! || v > maxDate!)) {
+                      // Clamp pra dentro da janela encomenda
+                      v = v < minDate! ? minDate! : maxDate!;
+                    }
+                    setDataEntrega(v);
+                  }}
+                  className={inputCls}
+                />
+              );
+            })()}
+            {encomenda && (
+              <p className="text-[11px] text-blue-700 mt-1">
+                ⏱ Encomenda: agendamento até amanhã (orçamento expira em 24h)
+              </p>
+            )}
           </div>
         </div>
 

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -422,7 +422,9 @@ function CompraForm() {
       : "Loja"
   );
   const [tipoEntrega, setTipoEntrega] = useState<"Shopping" | "Residencia" | "Outro">(
-    localParam === "shopping" ? "Shopping"
+    // Encomenda nao aceita Shopping — derruba pra Residencia se o link veio com shopping
+    encomendaParam && localParam === "shopping" ? "Residencia"
+      : localParam === "shopping" ? "Shopping"
       : localParam === "outro" ? "Outro"
       : "Residencia"
   );
@@ -637,7 +639,9 @@ function CompraForm() {
   const [erroMp, setErroMp] = useState("");
 
   // Janela de agendamento (hoje a D+2 de calendário, pulando domingos).
-  const agendamentoBounds = useMemo(() => getAgendamentoBounds(), []);
+  // Encomenda: orcamento dura 24h — janela de agendamento encolhe pra
+  // hoje + amanha (em vez de hoje + 2 dias).
+  const agendamentoBounds = useMemo(() => getAgendamentoBounds(new Date(), { encomenda: encomendaParam }), [encomendaParam]);
 
   // Installment calculations
   const descontoNum = parseFloat(String(descontoParam)) || 0;
@@ -837,7 +841,15 @@ function CompraForm() {
 
     const isTradeInFlow = isFromTradeIn || trocaProduto;
     const enderecoFull = `${endereco}, ${numero}${complemento ? ` - ${complemento}` : ""}`;
-    const pagEntrega = pagamentoPagoParam ? "" : local === "Correios" ? "! PAGAMENTO ANTECIPADO" : local === "Entrega" && tipoEntrega === "Residencia" ? "! PAGAMENTO ANTECIPADO" : local === "Entrega" ? "PAGAR NA ENTREGA" : "";
+    // Encomenda: sempre antecipado (cliente paga sinal ou integral pelo link
+    // antes do produto chegar — recolhimento da troca/diferenca fica pra
+    // retirada). Sem encomenda: residencia/correios = antecipado, resto = na entrega.
+    const pagEntrega = pagamentoPagoParam ? ""
+      : encomendaParam ? "! PAGAMENTO ANTECIPADO"
+      : local === "Correios" ? "! PAGAMENTO ANTECIPADO"
+      : local === "Entrega" && tipoEntrega === "Residencia" ? "! PAGAMENTO ANTECIPADO"
+      : local === "Entrega" ? "PAGAR NA ENTREGA"
+      : "";
 
     // Bloco encomenda — vai logo no topo da mensagem pra equipe ver na
     // primeira linha que e pedido sob encomenda. Inclui prazo, valor pago
@@ -2237,14 +2249,20 @@ function CompraForm() {
                   iso = `${y}-${m}-${day}`;
                 }
                 if (iso !== raw) {
-                  alert("Agendamento disponivel apenas para hoje, amanha ou depois de amanha (sem domingo).");
+                  alert(encomendaParam
+                    ? "Encomenda: agendamento so pode ser hoje ou amanha (orcamento expira em 24h)."
+                    : "Agendamento disponivel apenas para hoje, amanha ou depois de amanha (sem domingo).");
                 }
                 setDataEntrega(iso);
               }}
               min={agendamentoBounds.min}
               max={agendamentoBounds.max}
               className={inputCls} />
-            <p className="text-[11px] text-[#86868B] mt-1">Agendamento disponivel para hoje, amanha ou depois de amanha. Domingo indisponivel.</p>
+            <p className={`text-[11px] mt-1 ${encomendaParam ? "text-blue-700 font-medium" : "text-[#86868B]"}`}>
+              {encomendaParam
+                ? "📦 Encomenda: agendamento até amanhã (orçamento válido por 24h)."
+                : "Agendamento disponivel para hoje, amanha ou depois de amanha. Domingo indisponivel."}
+            </p>
           </div>)}
 
           {/* Horário — dinâmico conforme tipo + dia da semana (não mostra pra Correios) */}
@@ -2269,17 +2287,24 @@ function CompraForm() {
           {local === "Entrega" && (
             <div className="space-y-3">
               <label className="block text-sm font-medium text-[#1D1D1F] mb-2">Local de entrega *</label>
-              {/* "Outro" só aparece com localParam=outro (exceção liberada pelo operador). */}
-              <div className={`grid gap-3 ${localOutroHabilitado ? "grid-cols-3" : "grid-cols-2"}`}>
+              {/* "Outro" só aparece com localParam=outro (exceção liberada pelo operador).
+                  Encomenda nao aceita Shopping — operador combina entrega em residencia
+                  ou outro local quando o produto chegar. */}
+              <div className={`grid gap-3 ${(() => {
+                const c = 1 + (encomendaParam ? 0 : 1) + (localOutroHabilitado || encomendaParam ? 1 : 0);
+                return c === 1 ? "grid-cols-1" : c === 2 ? "grid-cols-2" : "grid-cols-3";
+              })()}`}>
                 <label className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 cursor-pointer transition-colors ${tipoEntrega === "Residencia" ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
                   <input type="radio" name="tipoEntrega" value="Residencia" checked={tipoEntrega === "Residencia"} onChange={() => { setTipoEntrega("Residencia"); setShopping(""); }} className="sr-only" />
                   &#x1F3E0; <span className="font-medium text-sm">Residência</span>
                 </label>
-                <label className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 cursor-pointer transition-colors ${tipoEntrega === "Shopping" ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
-                  <input type="radio" name="tipoEntrega" value="Shopping" checked={tipoEntrega === "Shopping"} onChange={() => setTipoEntrega("Shopping")} className="sr-only" />
-                  &#x1F3EC; <span className="font-medium text-sm">Shopping</span>
-                </label>
-                {localOutroHabilitado && (
+                {!encomendaParam && (
+                  <label className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 cursor-pointer transition-colors ${tipoEntrega === "Shopping" ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
+                    <input type="radio" name="tipoEntrega" value="Shopping" checked={tipoEntrega === "Shopping"} onChange={() => setTipoEntrega("Shopping")} className="sr-only" />
+                    &#x1F3EC; <span className="font-medium text-sm">Shopping</span>
+                  </label>
+                )}
+                {(localOutroHabilitado || encomendaParam) && (
                   <label className={`flex items-center justify-center gap-2 px-4 py-3 rounded-lg border-2 cursor-pointer transition-colors ${tipoEntrega === "Outro" ? "border-[#E8740E] bg-[#FFF5EB] text-[#E8740E]" : "border-[#D2D2D7] bg-[#F5F5F7] text-[#6E6E73]"}`}>
                     <input type="radio" name="tipoEntrega" value="Outro" checked={tipoEntrega === "Outro"} onChange={() => setTipoEntrega("Outro")} className="sr-only" />
                     &#x1F4CD; <span className="font-medium text-sm">Outro local</span>
@@ -2287,8 +2312,8 @@ function CompraForm() {
                 )}
               </div>
               {!pagamentoPagoParam && (
-                <div className={`p-3 rounded-lg text-sm font-semibold text-center ${tipoEntrega === "Residencia" ? "bg-yellow-50 border border-yellow-200 text-yellow-700" : "bg-green-50 border border-green-200 text-green-700"}`}>
-                  {tipoEntrega === "Residencia" ? "⚠️ PAGAMENTO ANTECIPADO" : "✅ PAGAR NA ENTREGA"}
+                <div className={`p-3 rounded-lg text-sm font-semibold text-center ${(encomendaParam || tipoEntrega === "Residencia") ? "bg-yellow-50 border border-yellow-200 text-yellow-700" : "bg-green-50 border border-green-200 text-green-700"}`}>
+                  {(encomendaParam || tipoEntrega === "Residencia") ? "⚠️ PAGAMENTO ANTECIPADO" : "✅ PAGAR NA ENTREGA"}
                 </div>
               )}
               {tipoEntrega === "Shopping" && (

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -27,15 +27,29 @@ function fmtLocalDate(d: Date): string {
 /**
  * Janela de agendamento do Link de Compra: mínimo = hoje (ou amanhã se >=18h),
  * máximo = min + 2 dias. Domingos são pulados em ambos os extremos.
+ *
+ * `opts.encomenda`: encomenda tem orçamento valido por 24h, entao max = min + 1
+ * dia. Se cair em domingo, NAO empurra pra segunda (encolhe pra so o min em vez
+ * de estourar a janela de 24h pra 72h).
  */
-export function getAgendamentoBounds(now: Date = new Date()): { min: string; max: string } {
+export function getAgendamentoBounds(
+  now: Date = new Date(),
+  opts: { encomenda?: boolean } = {}
+): { min: string; max: string } {
   const base = new Date(now);
   base.setDate(base.getDate() + (base.getHours() >= 18 ? 1 : 0));
   while (base.getDay() === 0) base.setDate(base.getDate() + 1);
 
   const max = new Date(base);
-  max.setDate(max.getDate() + 2);
-  if (max.getDay() === 0) max.setDate(max.getDate() + 1);
+  max.setDate(max.getDate() + (opts.encomenda ? 1 : 2));
+  if (max.getDay() === 0) {
+    if (opts.encomenda) {
+      // Encomenda: nao estoura janela de 24h — encolhe pro proprio min
+      max.setDate(max.getDate() - 1);
+    } else {
+      max.setDate(max.getDate() + 1);
+    }
+  }
 
   return { min: fmtLocalDate(base), max: fmtLocalDate(max) };
 }


### PR DESCRIPTION
## Por que esse PR existe

Continuacao do [#798](https://github.com/tigraoimports-a11y/tigrao-tradein/pull/798) (mergeado mas pegou so o 1o commit) — adapta o resto do form pras regras de negocio da encomenda.

## Mudancas

### 1. Local de entrega restringido em encomenda (admin + cliente)
- So aceita **Residência**, **Escritório** (loja), **Outro local combinado**
- Hide Shopping e Correios
- Auto-limpa se operador tinha Shopping/Correios selecionado antes de marcar encomenda

### 2. Data limitada a 24h em encomenda
- Agendamento so hoje ou amanha (`getAgendamentoBounds(now, { encomenda: true })`)
- Domingo NAO empurra pra segunda — encolhe pro min em vez de estourar 24h pra 72h
- Aviso azul: "📦 Encomenda: agendamento até amanhã (orçamento expira em 24h)"

### 3. Pagamento antecipado forcado em encomenda
- Encomenda + qualquer local (residencia/escritorio/outro) → **⚠️ PAGAMENTO ANTECIPADO**
- Antes so residencia/correios eram antecipado; encomenda+outro caia em "PAGAR NA ENTREGA" por engano
- WhatsApp message inclui `! PAGAMENTO ANTECIPADO`

### 4. Bloco fluxo de pagamento no admin
Card abaixo da Forma de Pagamento numera o que cliente vai pagar e quando:

```
📦 Fluxo de pagamento (encomenda)
1. Cliente paga R$ 1.500 agora via Link MP 12x (sinal 50%)
2. Aguarda 15 dias para chegada do produto
3. Paga restante R$ 1.500 na entrega
4. 💱 Aparelho da troca (R$ 2.000) recolhido na retirada
```

Compra normal (sem encomenda) tambem tem versao simplificada do bloco.

## Test plan

- [ ] `/admin/gerar-link` + toggle encomenda: select Local Entrega so mostra Residencia/Escritorio/Outro
- [ ] Date input com min=hoje, max=amanha
- [ ] Forma de Pagamento → bloco azul aparece com fluxo numerado
- [ ] `/compra?encomenda=1`: tipoEntrega so mostra Residencia + Outro (sem Shopping)
- [ ] Local Entrega + Outro → "⚠️ PAGAMENTO ANTECIPADO"
- [ ] Date input cliente: min/max corretos com aviso azul
- [ ] WhatsApp message inclui `! PAGAMENTO ANTECIPADO` em encomenda+qualquer local

🤖 Generated with [Claude Code](https://claude.com/claude-code)