### PR TITLE
feat(tradein/admin): bundle COMPLETO (15 itens \u2014 resumo + admin + bugs + Watch + modal + help)

### DIFF
--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -271,13 +271,14 @@ export default function ConfiguracoesPage() {
           )}
         </div>
 
-        {/* WhatsApp Seminovos — por categoria */}
+        {/* WhatsApp Troca — Outros Modelos (antes "Seminovos") */}
         <div className="bg-white rounded-xl p-5 shadow-sm border border-[#E8E8ED] space-y-4">
           <div>
-            <p className="font-bold text-[#1D1D1F]">📱 WhatsApp Troca — Seminovos</p>
+            <p className="font-bold text-[#1D1D1F]">📱 WhatsApp Troca — Outros Modelos</p>
             <p className="text-xs text-[#86868B] mt-1">
-              Número que recebe formulários de troca para cada categoria de seminovo.
-              Deixe <b>vazio</b> pra cair no <b>WhatsApp Principal</b> (fallback).
+              Roteamento por categoria pra trocas que vao pra um numero diferente do <b>WhatsApp Principal</b>.
+              Hoje recebe formularios de seminovos por categoria (iPhone Seminovo, iPad Seminovo, etc).
+              Deixe <b>vazio</b> pra cair no Principal (fallback).
             </p>
           </div>
 

--- a/app/admin/precos/page.tsx
+++ b/app/admin/precos/page.tsx
@@ -6,6 +6,7 @@ import { useTabParam } from "@/lib/useTabParam";
 import { getCategoriasPrecos, addCategoriaPrecos, removeCategoriaPrecos, EMOJI_OPTIONS, DEFAULT_CATEGORIAS_SEMINOVOS } from "@/lib/categorias";
 import type { Categoria } from "@/lib/categorias";
 import { corParaPT } from "@/lib/cor-pt";
+import { useConfirmModal } from "@/components/admin/ConfirmModal";
 
 const UsadosContent = lazy(() => import("@/app/admin/usados/page").then(m => ({ default: m.UsadosContent })));
 
@@ -49,6 +50,7 @@ function applyOrder(rows: PrecoProduto[], catKey: string): PrecoProduto[] {
 
 function PrecosContent() {
   const { password, user } = useAdmin();
+  const { confirm: confirmModal, modal: confirmModalUI } = useConfirmModal();
   const [loading, setLoading] = useState(false);
   const [data, setData] = useState<PrecoProduto[] | null>(null);
   const [editing, setEditing] = useState<Record<string, string>>({});
@@ -178,8 +180,14 @@ function PrecosContent() {
     setShowNewCat(false);
   }
 
-  function handleRemoveCategoria(key: string) {
-    if (!confirm(`Remover categoria "${categorias.find((c) => c.key === key)?.label}"?`)) return;
+  async function handleRemoveCategoria(key: string) {
+    const label = categorias.find((c) => c.key === key)?.label;
+    const ok = await confirmModal({
+      title: `Remover categoria "${label}"?`,
+      confirmLabel: "Remover",
+      variant: "danger",
+    });
+    if (!ok) return;
     const updated = removeCategoriaPrecos(key);
     setCategorias(updated);
     if (tab === key) setTab("IPHONE");
@@ -269,7 +277,12 @@ function PrecosContent() {
   }
 
   async function handleDelete(row: PrecoProduto) {
-    if (!confirm(`Remover ${row.modelo} ${row.armazenamento}?`)) return;
+    const ok = await confirmModal({
+      title: `Remover ${row.modelo} ${row.armazenamento}?`,
+      confirmLabel: "Remover",
+      variant: "danger",
+    });
+    if (!ok) return;
     await fetch("/api/admin/precos", {
       method: "DELETE",
       headers: { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
@@ -462,6 +475,7 @@ function PrecosContent() {
 
   return (
     <div className="max-w-4xl mx-auto space-y-4">
+      {confirmModalUI}
       <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
           <h2 className="text-lg font-bold text-[#1D1D1F]">Painel de Precos</h2>

--- a/app/admin/precos/page.tsx
+++ b/app/admin/precos/page.tsx
@@ -66,6 +66,9 @@ function PrecosContent() {
   // Headers editáveis (renomear colunas)
   const [editingHeader, setEditingHeader] = useState<{ catKey: string; colIdx: number } | null>(null);
 
+  // Renomear titulo do grupo (modelo) — atualiza todas as linhas em batch via PATCH.
+  const [editingGroup, setEditingGroup] = useState<{ original: string; current: string } | null>(null);
+
   // Categorias dinâmicas (somente para lacrados — seminovos tem lista fixa)
   const [categorias, setCategorias] = useState<Categoria[]>(() => getCategoriasPrecos());
   const [showNewCat, setShowNewCat] = useState(false);
@@ -94,6 +97,29 @@ function PrecosContent() {
     if (!tabKeys.includes(tab) && tabKeys.length > 0) setTab(tabKeys[0]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewTipo]);
+  // Renomear o titulo do grupo (campo `modelo` em batch — todas variantes do
+  // modelo recebem o novo nome). PATCH no /api/admin/precos.
+  async function handleRenameGroup() {
+    if (!editingGroup) return;
+    const newName = editingGroup.current.trim();
+    if (!newName || newName === editingGroup.original) { setEditingGroup(null); return; }
+    setSaving("rename-group");
+    const headers = { "Content-Type": "application/json", "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") };
+    const res = await fetch("/api/admin/precos", {
+      method: "PATCH", headers,
+      body: JSON.stringify({ action: "rename_modelo", oldModelo: editingGroup.original, newModelo: newName, categoria: tab }),
+    });
+    if (!res.ok) {
+      const j = await res.json().catch(() => ({}));
+      alert(`Erro ao renomear: ${j.error || "falha"}`);
+      setSaving(null);
+      return;
+    }
+    await fetchData(password);
+    setEditingGroup(null);
+    setSaving(null);
+  }
+
   const [showAdd, setShowAdd] = useState(false);
   const [newProd, setNewProd] = useState({ modelo: "", preco_pix: "", tipo: "TRADEIN" });
   // Campos de especificação dinâmicos (label + valor) — combinados com " | " no armazenamento
@@ -809,10 +835,55 @@ function PrecosContent() {
           // Gerar headers das colunas de spec (usa labels salvos pelo usuário)
           const defaultLabels = getLabelsForCategory(tab);
 
+          // No MacBook o groupLabel e derivado da tela ("MacBooks 14\"") — nao
+          // representa um `modelo` cadastrado. Pra outras categorias o
+          // groupLabel === r.modelo, entao da pra renomear em batch.
+          const canRenameGroup = !isMac;
+          const isEditingThis = editingGroup?.original === groupLabel;
+
           return (
           <div key={groupLabel} className="bg-white border border-[#D2D2D7] rounded-2xl overflow-hidden shadow-sm">
-            <div className="px-5 py-3 bg-[#F5F5F7] border-b border-[#D2D2D7]">
-              <h2 className="font-semibold text-[#1D1D1F]">{groupLabel}</h2>
+            <div className="px-5 py-3 bg-[#F5F5F7] border-b border-[#D2D2D7] flex items-center gap-2">
+              {isEditingThis ? (
+                <>
+                  <input
+                    autoFocus
+                    value={editingGroup!.current}
+                    onChange={(e) => setEditingGroup({ ...editingGroup!, current: e.target.value })}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleRenameGroup();
+                      if (e.key === "Escape") setEditingGroup(null);
+                    }}
+                    className="flex-1 px-2 py-1 rounded border border-[#E8740E] text-sm font-semibold focus:outline-none"
+                  />
+                  <button
+                    onClick={handleRenameGroup}
+                    disabled={saving === "rename-group"}
+                    className="px-3 py-1 rounded text-xs font-semibold bg-[#E8740E] text-white hover:bg-[#F5A623] disabled:opacity-50"
+                  >
+                    {saving === "rename-group" ? "..." : "Salvar"}
+                  </button>
+                  <button
+                    onClick={() => setEditingGroup(null)}
+                    className="px-3 py-1 rounded text-xs text-[#86868B] hover:text-[#1D1D1F] border border-[#D2D2D7]"
+                  >
+                    Cancelar
+                  </button>
+                </>
+              ) : (
+                <>
+                  <h2 className="font-semibold text-[#1D1D1F]">{groupLabel}</h2>
+                  {canRenameGroup && (
+                    <button
+                      onClick={() => setEditingGroup({ original: groupLabel, current: groupLabel })}
+                      title="Renomear grupo (atualiza todas as variantes)"
+                      className="text-[11px] text-[#86868B] hover:text-[#E8740E] transition-colors"
+                    >
+                      ✏️ Renomear
+                    </button>
+                  )}
+                </>
+              )}
             </div>
             <table className="w-full text-sm">
               <thead>

--- a/app/admin/usados/page.tsx
+++ b/app/admin/usados/page.tsx
@@ -4,6 +4,7 @@ import { hojeBR } from "@/lib/date-utils";
 import { useEffect, useState, useCallback } from "react";
 import { useAutoRefetch } from "@/lib/useAutoRefetch";
 import { useAdmin } from "@/components/admin/AdminShell";
+import { useConfirmModal } from "@/components/admin/ConfirmModal";
 
 interface ValorUsado {
   id: string;
@@ -215,6 +216,7 @@ interface GarantiaRow {
 
 export function UsadosContent() {
   const { password, user } = useAdmin();
+  const { confirm: confirmModal, prompt: promptModal, modal: confirmModalUI } = useConfirmModal();
   const [valores, setValores] = useState<ValorUsado[]>([]);
   const [descontos, setDescontos] = useState<DescontoCondicao[]>([]);
   const [excluidos, setExcluidos] = useState<string[]>([]);
@@ -505,7 +507,13 @@ export function UsadosContent() {
   // Remove uma variante especifica (1 linha no banco). Usado pelo botao "×" em
   // cada celula de conectividade.
   const handleDeleteVariant = async (v: ValorUsado) => {
-    if (!confirm(`Remover "${v.modelo} — ${v.armazenamento}" do banco?\n\nSo apaga essa variante especifica; as outras conectividades do mesmo armaz/tela continuam intactas.`)) return;
+    const ok = await confirmModal({
+      title: `Remover "${v.modelo} — ${v.armazenamento}"?`,
+      description: "So apaga essa variante especifica; as outras conectividades do mesmo armaz/tela continuam intactas.",
+      confirmLabel: "Remover",
+      variant: "danger",
+    });
+    if (!ok) return;
     const k = `del-${v.id}`;
     setSaving(k);
     const res = await apiPost({ action: "delete_valor", id: v.id });
@@ -573,7 +581,13 @@ export function UsadosContent() {
   };
 
   const handleRemoveDesconto = async (d: DescontoCondicao) => {
-    if (!confirm(`Remover "${d.detalhe}" de "${d.condicao}"?`)) return;
+    const ok = await confirmModal({
+      title: `Remover "${d.detalhe}"?`,
+      description: `Desconto de "${d.condicao}" sera apagado.`,
+      confirmLabel: "Remover",
+      variant: "danger",
+    });
+    if (!ok) return;
     // Delete via upsert with special value to mark for deletion
     // Actually, we need a delete action in the API. For now, set discount to 0 to effectively disable it.
     // Or better: we can add a delete action
@@ -907,6 +921,7 @@ export function UsadosContent() {
 
   return (
     <div className="space-y-6">
+      {confirmModalUI}
       <div className="flex items-center justify-between flex-wrap gap-3">
         <h2 className="text-lg font-bold text-[#1D1D1F]">Avaliacao de Usados</h2>
         <div className="flex gap-2">
@@ -1175,11 +1190,15 @@ export function UsadosContent() {
                     )}
                     <button
                       onClick={async () => {
-                        const novo = prompt(`Renomear "${modelo}" para:`, modelo);
-                        if (novo === null) return; // cancelou
+                        const novo = await promptModal({
+                          title: `Renomear "${modelo}"`,
+                          description: "Atualiza TODAS as variantes (armazenamento), descontos ligados ao modelo, registros de excluidos e de garantia.",
+                          defaultValue: modelo,
+                          confirmLabel: "Renomear",
+                        });
+                        if (!novo) return;
                         const trimmed = novo.trim();
                         if (!trimmed || trimmed === modelo) return;
-                        if (!confirm(`Renomear "${modelo}" para "${trimmed}"?\n\nIsso atualiza TODAS as variantes (armazenamento), descontos ligados ao modelo, registros de excluidos e de garantia.`)) return;
                         const res = await apiPost({ action: "rename_modelo", modelo_antigo: modelo, modelo_novo: trimmed });
                         const json = await res.json().catch(() => ({}));
                         if (!res.ok) {
@@ -1198,7 +1217,13 @@ export function UsadosContent() {
                     </button>
                     <button
                       onClick={async () => {
-                        if (!confirm(`Excluir "${modelo}" do simulador?\n\nCliente nao vera mais esse modelo na lista de troca. Pra reativar, va na aba "Excluidos" e remova da lista.`)) return;
+                        const ok = await confirmModal({
+                          title: `Excluir "${modelo}" do simulador?`,
+                          description: "Cliente nao vera mais esse modelo na lista de troca. Pra reativar, va na aba 'Excluidos' e remova da lista.",
+                          confirmLabel: "Excluir",
+                          variant: "danger",
+                        });
+                        if (!ok) return;
                         await apiPost({ action: "add_excluido", modelo });
                         setExcluidos((prev) => prev.includes(modelo) ? prev : [...prev, modelo]);
                       }}
@@ -1209,7 +1234,13 @@ export function UsadosContent() {
                     </button>
                     <button
                       onClick={async () => {
-                        if (!confirm(`APAGAR "${modelo}" DE VEZ?\n\nIsso remove todos os armazenamentos, garantias, descontos por modelo e a entrada em "Excluidos" desse modelo. Nao da pra desfazer — so re-cadastrando.\n\nUse quando o modelo foi cadastrado errado ou saiu de catalogo.`)) return;
+                        const ok = await confirmModal({
+                          title: `APAGAR "${modelo}" DE VEZ?`,
+                          description: "Isso remove todos os armazenamentos, garantias, descontos por modelo e a entrada em 'Excluidos' desse modelo. Nao da pra desfazer — so re-cadastrando.\n\nUse quando o modelo foi cadastrado errado ou saiu de catalogo.",
+                          confirmLabel: "Apagar de vez",
+                          variant: "danger",
+                        });
+                        if (!ok) return;
                         const res = await apiPost({ action: "delete_modelo_full", modelo });
                         if (!res.ok) { const j = await res.json().catch(() => ({})); alert(`Erro: ${j.error || "falha ao apagar"}`); return; }
                         setValores((prev) => prev.filter((v) => v.modelo !== modelo));

--- a/app/admin/usados/page.tsx
+++ b/app/admin/usados/page.tsx
@@ -779,6 +779,27 @@ export function UsadosContent() {
     }
   }
 
+  // Ordena os nomes de modelo dentro do grupo. Pra MacBook, prioriza tela
+  // (14"→15"→16") e depois o chip (M1 antes de M1 Pro antes de M1 Max antes de
+  // M2). Pra outras categorias, alfabetico estavel.
+  const modelSortKey = (name: string): [number, number, number, string] => {
+    const screenMatch = name.match(/(\d+(?:\.\d+)?)\s*"/);
+    const screen = screenMatch ? parseFloat(screenMatch[1]) : 0;
+    const chipMatch = name.match(/\bM(\d+)(?:\s+(Pro|Max))?\b/i);
+    const chipNum = chipMatch ? parseInt(chipMatch[1]) : 0;
+    const variant = (chipMatch?.[2] || "").toLowerCase();
+    const variantOrd = variant === "" ? 0 : variant === "pro" ? 1 : variant === "max" ? 2 : 3;
+    return [screen, chipNum, variantOrd, name];
+  };
+  const sortedModelos = Object.keys(grouped).sort((a, b) => {
+    const ka = modelSortKey(a);
+    const kb = modelSortKey(b);
+    for (let i = 0; i < 3; i++) {
+      if (ka[i] !== kb[i]) return Number(ka[i]) - Number(kb[i]);
+    }
+    return String(ka[3]).localeCompare(String(kb[3]));
+  });
+
   // Map de modelos conhecidos (case-insensitive): valores base + modelos extraídos dos descontos
   const modelosMap = new Map<string, string>(); // lowercase → nome canônico
   valores.forEach(v => { if (v.modelo) modelosMap.set(v.modelo.toLowerCase(), v.modelo); });
@@ -1119,7 +1140,8 @@ export function UsadosContent() {
               </button>
             </div>
           ) : (
-            Object.entries(grouped).map(([modelo, rows]) => {
+            sortedModelos.map((modelo) => {
+              const rows = grouped[modelo];
               const conectividadesDoModelo = conectividadesByModel[modelo] || [];
               return (
               <div key={modelo} className="bg-white border border-[#D2D2D7] rounded-2xl overflow-hidden shadow-sm">
@@ -1504,7 +1526,17 @@ export function UsadosContent() {
                                 <button onClick={() => handleSaveValor(v)} disabled={isSaving} className="px-3 py-1.5 rounded-lg text-xs font-semibold bg-[#E8740E] text-white hover:bg-[#F5A623] disabled:opacity-50">{isSaving ? "..." : "Salvar"}</button>
                               </div>
                             ) : (
-                              <button onClick={() => setEditing({ ...editing, [key]: String(v.valor_base) })} className="px-3 py-1.5 rounded-lg text-xs text-[#86868B] hover:text-[#E8740E] border border-[#D2D2D7] hover:border-[#E8740E] transition-colors">Editar</button>
+                              <div className="flex gap-2 justify-end items-center">
+                                <button onClick={() => setEditing({ ...editing, [key]: String(v.valor_base) })} className="px-3 py-1.5 rounded-lg text-xs text-[#86868B] hover:text-[#E8740E] border border-[#D2D2D7] hover:border-[#E8740E] transition-colors">Editar</button>
+                                <button
+                                  onClick={() => handleDeleteVariant(v)}
+                                  disabled={saving === `del-${v.id}`}
+                                  title="Remover essa variante (combo invalido tipo 24GB+256GB)"
+                                  className="text-red-300 hover:text-red-600 text-base leading-none"
+                                >
+                                  ✕
+                                </button>
+                              </div>
                             )}
                           </td>
                         </tr>

--- a/app/api/admin/precos/route.ts
+++ b/app/api/admin/precos/route.ts
@@ -250,6 +250,45 @@ export async function PUT(req: NextRequest) {
   return NextResponse.json({ ok: true, imported: rows.length });
 }
 
+// PATCH — operacoes em lote. Hoje suporta `rename_modelo`: troca o `modelo`
+// de TODAS as linhas dentro de uma categoria pra agrupa-las sob um novo
+// titulo no painel de precos. Usado pelo botao "Renomear grupo" — sem isso,
+// admin teria que editar cada variante individual.
+export async function PATCH(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const role = getRole(req);
+  const permissoes = getPermissoes(req);
+  if (!hasPermission(role, "precos.write", permissoes)) return NextResponse.json({ error: "Sem permissao" }, { status: 403 });
+  const usuario = getUsuario(req);
+
+  const body = await req.json();
+  const { action, oldModelo, newModelo, categoria } = body;
+
+  if (action !== "rename_modelo") {
+    return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+  }
+  if (!oldModelo || !newModelo) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+  if (oldModelo === newModelo) {
+    return NextResponse.json({ ok: true, updated: 0 });
+  }
+
+  const { supabase } = await import("@/lib/supabase");
+
+  // Filtra por categoria quando enviada — evita renomear grupo de outra
+  // categoria com mesmo nome (defensivo, geralmente nao acontece).
+  let q = supabase.from("precos").update({ modelo: newModelo, updated_at: new Date().toISOString() }).eq("modelo", oldModelo);
+  if (categoria) q = q.eq("categoria", categoria);
+  const { data, error } = await q.select("id");
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  const updated = (data ?? []).length;
+  await logActivity(usuario, "Renomeou grupo de precos", `${oldModelo} -> ${newModelo} (${updated} variantes)`, "precos");
+
+  return NextResponse.json({ ok: true, updated });
+}
+
 // DELETE — remover um produto
 export async function DELETE(req: NextRequest) {
   if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/components/StepManualHandoff.tsx
+++ b/components/StepManualHandoff.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { getAnyConditionLines, type AnyConditionData, type DeviceType } from "@/lib/calculations";
+import { getAnyConditionEntries, type AnyConditionData, type DeviceType } from "@/lib/calculations";
 import type { TradeInQuestion } from "@/lib/types";
 import { getHoneypotValue } from "@/lib/honeypot-client";
 
@@ -24,6 +24,11 @@ interface StepManualHandoffProps {
   deviceType2?: DeviceType;
   extraAnswers2?: Record<string, unknown>;
   extraQuestions2?: TradeInQuestion[];
+  // Configuracao completa de perguntas (admin) — usada pra ordenar a mistura de
+  // condicoes hardcoded + perguntas dinamicas no resumo, respeitando o `ordem`
+  // que o operador definiu. Sem isso, condLines aparecem antes e o admin nao
+  // consegue intercalar (ex: bateria entre garantia e arranhoes).
+  questionsConfig?: TradeInQuestion[];
   // Produto novo escolhido
   newModel: string;
   newStorage: string;
@@ -38,6 +43,24 @@ interface StepManualHandoffProps {
   vendedor?: string | null;
   onReset: () => void;
   onGoToStep?: (step: number) => void;
+}
+
+// Ordem fallback dos slugs hardcoded (espelha StepUsedDeviceMulti). Usado
+// quando o admin nao definiu ordem pra um slug — ex: hardcoded sem entrada no qc.
+const HARDCODED_DEFAULT_ORDEM: Record<string, number> = {
+  hasDamage: 1, battery: 2, hasWearMarks: 3, wearMarks: 4,
+  screenScratch: 4.1, sideScratch: 4.2, peeling: 4.3,
+  bodyScratch: 4.4, keyboardCondition: 4.5,
+  partsReplaced: 5, hasCharger: 5.5, hasWarranty: 6, warrantyMonth: 7,
+  hasApplePencil: 7.5, hasOriginalBox: 8,
+};
+
+const SLUG_SUFFIXES = ["_iphone", "_ipad", "_macbook", "_watch"];
+function normalizeSlug(slug: string): string {
+  for (const suf of SLUG_SUFFIXES) {
+    if (slug.endsWith(suf)) return slug.slice(0, -suf.length);
+  }
+  return slug;
 }
 
 /** Resolve a opcao escolhida pelo cliente. Aceita boolean (yes/no) ou string. */
@@ -61,32 +84,67 @@ function formatExtraAnswer(q: TradeInQuestion, value: unknown): string {
   return opt?.label || String(value);
 }
 
-/** Linha pro resumo do produto. `fullSentence: true` indica que `value` ja e a
- *  frase completa (ex: "Possui o carregador completo original da Apple") e o
- *  render deve esconder o `label:` prefix. */
-type ExtraLine = { label: string; value: string; fullSentence?: boolean };
+/** Linha unificada do resumo. `bold` (opcional) e o prefixo a destacar (titulo
+ *  da pergunta) — quando ausente, a linha inteira renderiza como texto comum
+ *  (condicoes hardcoded e respostas com summaryLabel). */
+type SummaryLine = { slug: string; ordem: number; bold?: string; text: string };
 
-// Converte respostas dinamicas em pares { label, value } pra renderizar/exibir.
-// Pra perguntas com `summaryLabel` na opcao escolhida, retorna a frase completa
-// como `fullSentence` — o resumo mostra so a frase, sem o titulo da pergunta.
-function formatExtraLines(questions: TradeInQuestion[] | undefined, answers: Record<string, unknown> | undefined): ExtraLine[] {
-  if (!questions || !answers) return [];
-  return questions
-    .map((q): ExtraLine | null => {
-      const raw = answers[q.slug];
+/** Constroi um lookup slug → ordem a partir do qc do admin (com slugs
+ *  normalizados). Ordem do admin sempre vence o HARDCODED_DEFAULT_ORDEM. */
+function buildOrdemBySlug(questionsConfig: TradeInQuestion[] | undefined): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const q of questionsConfig ?? []) {
+    if (q.ativo === false) continue;
+    if (typeof q.ordem === "number") map.set(normalizeSlug(q.slug), q.ordem);
+  }
+  return map;
+}
+
+/** Mistura entries hardcoded + perguntas dinamicas em uma lista ordenada pelo
+ *  ordem do admin. Se admin moveu uma yesno dynamic pra ordem 2.5, ela aparece
+ *  entre `hasDamage` (1) e `wearMarks` (4) no resumo. */
+function buildOrderedLines(
+  deviceType: DeviceType,
+  condition: AnyConditionData,
+  extraQuestions: TradeInQuestion[] | undefined,
+  extraAnswers: Record<string, unknown> | undefined,
+  questionsConfig: TradeInQuestion[] | undefined,
+): SummaryLine[] {
+  const ordemBySlug = buildOrdemBySlug(questionsConfig);
+  const ordemFor = (slug: string): number => {
+    const fromAdmin = ordemBySlug.get(slug);
+    if (fromAdmin !== undefined) return fromAdmin;
+    return HARDCODED_DEFAULT_ORDEM[slug] ?? 999;
+  };
+
+  // Hardcoded: cada entry vira linha de texto simples (sem bold prefix).
+  const condLines: SummaryLine[] = getAnyConditionEntries(deviceType, condition).map((e) => ({
+    slug: e.slug,
+    ordem: ordemFor(e.slug),
+    text: e.text,
+  }));
+
+  // Dinamicas: cada pergunta respondida vira KV (com bold) ou frase completa
+  // (sem bold) quando a opcao tem summaryLabel cadastrado.
+  const extraLines: SummaryLine[] = (extraQuestions ?? [])
+    .map((q): SummaryLine | null => {
+      const raw = extraAnswers?.[q.slug];
       if (raw === undefined || raw === null || raw === "") return null;
-      // Multiselect / Array — sem suporte a summaryLabel por enquanto, cai no kv padrao
+      const slugN = normalizeSlug(q.slug);
+      const ordem = typeof q.ordem === "number" ? q.ordem : ordemFor(slugN);
       if (!Array.isArray(raw)) {
         const opt = findSelectedOption(q, raw);
         if (opt?.summaryLabel) {
-          return { label: q.titulo || q.slug, value: opt.summaryLabel, fullSentence: true };
+          return { slug: slugN, ordem, text: opt.summaryLabel };
         }
       }
       const value = formatExtraAnswer(q, raw);
       if (value === "—") return null;
-      return { label: q.titulo || q.slug, value };
+      return { slug: slugN, ordem, bold: q.titulo || q.slug, text: value };
     })
-    .filter((l): l is ExtraLine => l !== null);
+    .filter((l): l is SummaryLine => l !== null);
+
+  return [...condLines, ...extraLines].sort((a, b) => a.ordem - b.ordem);
 }
 
 /**
@@ -100,6 +158,7 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
     extraAnswers, extraQuestions,
     usedModel2, usedStorage2, usedColor2, condition2, deviceType2,
     extraAnswers2, extraQuestions2,
+    questionsConfig,
     newModel, newStorage, newPrice,
     clienteNome, clienteWhatsApp, clienteInstagram, clienteOrigem,
     whatsappNumero, vendedor, onReset, onGoToStep,
@@ -110,9 +169,18 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
   const hasSecond = !!(usedModel2 && usedStorage2);
   const fmt = (v: number) => `R$ ${Math.round(v).toLocaleString("pt-BR")}`;
 
-  // Linhas das perguntas dinamicas pra resumo UI + mensagem WhatsApp
-  const extraLines1 = formatExtraLines(extraQuestions, extraAnswers);
-  const extraLines2 = formatExtraLines(extraQuestions2, extraAnswers2);
+  // Lista unificada (condicoes hardcoded + perguntas dinamicas) ordenada pela
+  // posicao definida no admin. Usado tanto no resumo UI quanto na mensagem
+  // WhatsApp e no lead, pra que a ordem visivel pro cliente bata com o que
+  // chega pro operador.
+  const orderedLines1 = buildOrderedLines(deviceType, condition, extraQuestions, extraAnswers, questionsConfig);
+  const orderedLines2 = (hasSecond && condition2 && deviceType2)
+    ? buildOrderedLines(deviceType2, condition2, extraQuestions2, extraAnswers2, questionsConfig)
+    : [];
+
+  function lineToText(l: SummaryLine): string {
+    return l.bold ? `${l.bold}: ${l.text}` : l.text;
+  }
 
   function buildWhatsAppMsg(): string {
     const lines: string[] = [];
@@ -133,19 +201,13 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
     if (hasSecond) lines.push("", `*Aparelho 1:*`);
     lines.push(`Modelo: ${usedModel} ${usedStorage}`);
     if (usedColor) lines.push(`Cor: ${usedColor}`);
-    const condLines = getAnyConditionLines(deviceType, condition);
-    if (condLines.length > 0) lines.push(`Condição: ${condLines.join(", ")}`);
-    // Perguntas dinamicas (cadastradas via /admin/simulacoes). Pra opcoes com
-    // summaryLabel cadastrado, mostra so a frase completa (sem prefixo "label:").
-    for (const l of extraLines1) lines.push(l.fullSentence ? l.value : `${l.label}: ${l.value}`);
+    for (const l of orderedLines1) lines.push(lineToText(l));
 
     if (hasSecond && condition2 && deviceType2) {
       lines.push("", `*Aparelho 2:*`);
       lines.push(`Modelo: ${usedModel2} ${usedStorage2 || ""}`);
       if (usedColor2) lines.push(`Cor: ${usedColor2}`);
-      const condLines2 = getAnyConditionLines(deviceType2, condition2);
-      if (condLines2.length > 0) lines.push(`Condição: ${condLines2.join(", ")}`);
-      for (const l of extraLines2) lines.push(l.fullSentence ? l.value : `${l.label}: ${l.value}`);
+      for (const l of orderedLines2) lines.push(lineToText(l));
     }
 
     lines.push("");
@@ -157,13 +219,9 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
     setEnviando(true);
     // Salva lead com status AVALIACAO_MANUAL pra equipe ter historico
     try {
-      const condLines = getAnyConditionLines(deviceType, condition);
-      const condLines2 = hasSecond && condition2 && deviceType2 ? getAnyConditionLines(deviceType2, condition2) : [];
-      // Respostas dinamicas viram linhas "Label: Valor" (ou frase completa
-      // quando summaryLabel cadastrado) e entram em condicaoLinhas pra chegar
-      // no admin junto com as condicoes hardcoded.
-      const extraLinesStr1 = extraLines1.map((l) => l.fullSentence ? l.value : `${l.label}: ${l.value}`);
-      const extraLinesStr2 = extraLines2.map((l) => l.fullSentence ? l.value : `${l.label}: ${l.value}`);
+      // condicaoLinhas chega no admin com a mesma ordem que o cliente viu.
+      const condicaoLinhas = orderedLines1.map(lineToText);
+      const condicaoLinhas2 = orderedLines2.map(lineToText);
       await fetch("/api/leads", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -182,7 +240,7 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
           diferenca: 0,
           status: "AVALIACAO_MANUAL",
           formaPagamento: "WhatsApp Avaliacao Manual",
-          condicaoLinhas: [...condLines, ...extraLinesStr1],
+          condicaoLinhas,
           whatsappDestino: whatsappNumero,
           vendedor: vendedor || null,
           ...(hasSecond ? {
@@ -190,7 +248,7 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
             storageUsado2: usedStorage2,
             corUsado2: usedColor2 || "",
             avaliacaoUsado2: 0,
-            condicaoLinhas2: [...condLines2, ...extraLinesStr2],
+            condicaoLinhas2: condicaoLinhas2,
           } : {}),
           website: getHoneypotValue(),
         }),
@@ -236,44 +294,30 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
             {usedModel} {usedStorage}
             {usedColor ? ` · ${usedColor}` : ""}
           </p>
-          {(() => {
-            const condLines1 = getAnyConditionLines(deviceType, condition);
-            const hasLines = condLines1.length > 0 || extraLines1.length > 0;
-            return hasLines ? (
-              <div className="mt-2 space-y-0.5">
-                {condLines1.map((l, i) => (
-                  <p key={`c-${i}`} className="text-[12px]" style={{ color: "var(--ti-muted)" }}>{l}</p>
-                ))}
-                {extraLines1.map((l, i) => (
-                  <p key={`e-${i}`} className="text-[12px]" style={{ color: "var(--ti-muted)" }}>
-                    {l.fullSentence ? l.value : (<><span className="font-medium">{l.label}:</span> {l.value}</>)}
-                  </p>
-                ))}
-              </div>
-            ) : null;
-          })()}
+          {orderedLines1.length > 0 && (
+            <div className="mt-2 space-y-0.5">
+              {orderedLines1.map((l, i) => (
+                <p key={`l1-${i}`} className="text-[12px]" style={{ color: "var(--ti-muted)" }}>
+                  {l.bold ? (<><span className="font-medium">{l.bold}:</span> {l.text}</>) : l.text}
+                </p>
+              ))}
+            </div>
+          )}
           {hasSecond && (
             <>
               <p className="text-[14px] mt-3" style={{ color: "var(--ti-text)" }}>
                 {usedModel2} {usedStorage2}
                 {usedColor2 ? ` · ${usedColor2}` : ""}
               </p>
-              {(() => {
-                const condLines2 = condition2 && deviceType2 ? getAnyConditionLines(deviceType2, condition2) : [];
-                const hasLines = condLines2.length > 0 || extraLines2.length > 0;
-                return hasLines ? (
-                  <div className="mt-2 space-y-0.5">
-                    {condLines2.map((l, i) => (
-                      <p key={`c2-${i}`} className="text-[12px]" style={{ color: "var(--ti-muted)" }}>{l}</p>
-                    ))}
-                    {extraLines2.map((l, i) => (
-                      <p key={`e2-${i}`} className="text-[12px]" style={{ color: "var(--ti-muted)" }}>
-                        {l.fullSentence ? l.value : (<><span className="font-medium">{l.label}:</span> {l.value}</>)}
-                      </p>
-                    ))}
-                  </div>
-                ) : null;
-              })()}
+              {orderedLines2.length > 0 && (
+                <div className="mt-2 space-y-0.5">
+                  {orderedLines2.map((l, i) => (
+                    <p key={`l2-${i}`} className="text-[12px]" style={{ color: "var(--ti-muted)" }}>
+                      {l.bold ? (<><span className="font-medium">{l.bold}:</span> {l.text}</>) : l.text}
+                    </p>
+                  ))}
+                </div>
+              )}
             </>
           )}
         </div>

--- a/components/StepManualHandoff.tsx
+++ b/components/StepManualHandoff.tsx
@@ -40,7 +40,16 @@ interface StepManualHandoffProps {
   onGoToStep?: (step: number) => void;
 }
 
-// Formata uma resposta dinamica em string human-readable.
+/** Resolve a opcao escolhida pelo cliente. Aceita boolean (yes/no) ou string. */
+function findSelectedOption(q: TradeInQuestion, value: unknown) {
+  if (typeof value === "boolean") {
+    const target = value ? "yes" : "no";
+    return q.opcoes.find((o) => o.value === target || o.value === (value ? "sim" : "nao"));
+  }
+  return q.opcoes.find((o) => o.value === value);
+}
+
+// Formata uma resposta dinamica em string human-readable (so o valor, sem o titulo).
 function formatExtraAnswer(q: TradeInQuestion, value: unknown): string {
   if (value === undefined || value === null || value === "") return "—";
   if (Array.isArray(value)) {
@@ -52,12 +61,32 @@ function formatExtraAnswer(q: TradeInQuestion, value: unknown): string {
   return opt?.label || String(value);
 }
 
+/** Linha pro resumo do produto. `fullSentence: true` indica que `value` ja e a
+ *  frase completa (ex: "Possui o carregador completo original da Apple") e o
+ *  render deve esconder o `label:` prefix. */
+type ExtraLine = { label: string; value: string; fullSentence?: boolean };
+
 // Converte respostas dinamicas em pares { label, value } pra renderizar/exibir.
-function formatExtraLines(questions: TradeInQuestion[] | undefined, answers: Record<string, unknown> | undefined): { label: string; value: string }[] {
+// Pra perguntas com `summaryLabel` na opcao escolhida, retorna a frase completa
+// como `fullSentence` — o resumo mostra so a frase, sem o titulo da pergunta.
+function formatExtraLines(questions: TradeInQuestion[] | undefined, answers: Record<string, unknown> | undefined): ExtraLine[] {
   if (!questions || !answers) return [];
   return questions
-    .map((q) => ({ label: q.titulo || q.slug, value: formatExtraAnswer(q, answers[q.slug]) }))
-    .filter((l) => l.value !== "—");
+    .map((q): ExtraLine | null => {
+      const raw = answers[q.slug];
+      if (raw === undefined || raw === null || raw === "") return null;
+      // Multiselect / Array — sem suporte a summaryLabel por enquanto, cai no kv padrao
+      if (!Array.isArray(raw)) {
+        const opt = findSelectedOption(q, raw);
+        if (opt?.summaryLabel) {
+          return { label: q.titulo || q.slug, value: opt.summaryLabel, fullSentence: true };
+        }
+      }
+      const value = formatExtraAnswer(q, raw);
+      if (value === "—") return null;
+      return { label: q.titulo || q.slug, value };
+    })
+    .filter((l): l is ExtraLine => l !== null);
 }
 
 /**
@@ -106,8 +135,9 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
     if (usedColor) lines.push(`Cor: ${usedColor}`);
     const condLines = getAnyConditionLines(deviceType, condition);
     if (condLines.length > 0) lines.push(`Condição: ${condLines.join(", ")}`);
-    // Perguntas dinamicas (cadastradas via /admin/simulacoes)
-    for (const l of extraLines1) lines.push(`${l.label}: ${l.value}`);
+    // Perguntas dinamicas (cadastradas via /admin/simulacoes). Pra opcoes com
+    // summaryLabel cadastrado, mostra so a frase completa (sem prefixo "label:").
+    for (const l of extraLines1) lines.push(l.fullSentence ? l.value : `${l.label}: ${l.value}`);
 
     if (hasSecond && condition2 && deviceType2) {
       lines.push("", `*Aparelho 2:*`);
@@ -115,7 +145,7 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
       if (usedColor2) lines.push(`Cor: ${usedColor2}`);
       const condLines2 = getAnyConditionLines(deviceType2, condition2);
       if (condLines2.length > 0) lines.push(`Condição: ${condLines2.join(", ")}`);
-      for (const l of extraLines2) lines.push(`${l.label}: ${l.value}`);
+      for (const l of extraLines2) lines.push(l.fullSentence ? l.value : `${l.label}: ${l.value}`);
     }
 
     lines.push("");
@@ -129,10 +159,11 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
     try {
       const condLines = getAnyConditionLines(deviceType, condition);
       const condLines2 = hasSecond && condition2 && deviceType2 ? getAnyConditionLines(deviceType2, condition2) : [];
-      // Respostas dinamicas viram linhas "Label: Valor" e entram em condicaoLinhas
-      // pra chegar no admin junto com as condicoes hardcoded.
-      const extraLinesStr1 = extraLines1.map((l) => `${l.label}: ${l.value}`);
-      const extraLinesStr2 = extraLines2.map((l) => `${l.label}: ${l.value}`);
+      // Respostas dinamicas viram linhas "Label: Valor" (ou frase completa
+      // quando summaryLabel cadastrado) e entram em condicaoLinhas pra chegar
+      // no admin junto com as condicoes hardcoded.
+      const extraLinesStr1 = extraLines1.map((l) => l.fullSentence ? l.value : `${l.label}: ${l.value}`);
+      const extraLinesStr2 = extraLines2.map((l) => l.fullSentence ? l.value : `${l.label}: ${l.value}`);
       await fetch("/api/leads", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -215,7 +246,7 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
                 ))}
                 {extraLines1.map((l, i) => (
                   <p key={`e-${i}`} className="text-[12px]" style={{ color: "var(--ti-muted)" }}>
-                    <span className="font-medium">{l.label}:</span> {l.value}
+                    {l.fullSentence ? l.value : (<><span className="font-medium">{l.label}:</span> {l.value}</>)}
                   </p>
                 ))}
               </div>
@@ -237,7 +268,7 @@ export default function StepManualHandoff(p: StepManualHandoffProps) {
                     ))}
                     {extraLines2.map((l, i) => (
                       <p key={`e2-${i}`} className="text-[12px]" style={{ color: "var(--ti-muted)" }}>
-                        <span className="font-medium">{l.label}:</span> {l.value}
+                        {l.fullSentence ? l.value : (<><span className="font-medium">{l.label}:</span> {l.value}</>)}
                       </p>
                     ))}
                   </div>

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -43,6 +43,26 @@ const HARDCODED_DEFAULT_ORDEM: Record<string, number> = {
   partsReplaced: 5, hasWarranty: 6, warrantyMonth: 7, hasOriginalBox: 8,
 };
 
+// Material da caixa do Apple Watch por geracao Series. Hardcoded porque nao
+// vem do catalogo hoje — admin nao tem dimensao separada pra isso. Usado pra
+// (1) filtrar cores disponiveis conforme caixa e (2) forcar GPS+Cel em Titanio.
+// Series 9: Aluminio (cores standard) + Aco Inoxidavel (Grafite/Prateado/Dourado).
+// Series 10/11: Aluminio + Titanio (Natural/Dourado/Ardosia, sempre GPS+Cel).
+const WATCH_SERIES_CASES: Record<string, { material: string; cores: string[]; forceGPSCel?: boolean }[]> = {
+  "9": [
+    { material: "Alumínio", cores: ["Meia-noite", "Estelar", "Prateado", "Vermelho", "Rosa"] },
+    { material: "Aço Inoxidável", cores: ["Grafite", "Prateado", "Dourado"] },
+  ],
+  "10": [
+    { material: "Alumínio", cores: ["Ouro Rosa", "Prateado", "Preto Brilhante", "Cinza-espacial"] },
+    { material: "Titânio", cores: ["Titânio Natural", "Dourado", "Ardósia"], forceGPSCel: true },
+  ],
+  "11": [
+    { material: "Alumínio", cores: ["Ouro Rosa", "Prateado", "Preto Brilhante", "Cinza-espacial"] },
+    { material: "Titânio", cores: ["Titânio Natural", "Dourado", "Ardósia"], forceGPSCel: true },
+  ],
+};
+
 // Markdown seguro pra helpText: escape HTML primeiro, depois aplica formatacao.
 // Suporta:
 //  - **negrito**
@@ -213,6 +233,10 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   const [line, setLine] = useState("");
   const [model, setModel] = useState("");
   const [storage, setStorage] = useState("");
+  // Apple Watch Series: material da caixa (Aluminio/Aco Inoxidavel/Titanio).
+  // Afeta cores disponiveis + forca conectividade pra Titanio (sempre GPS+Cel).
+  // So aplica pra Watch Series — SE tem so Aluminio e Ultra tem so Titanio.
+  const [watchCase, setWatchCase] = useState<string | null>(null);
   const [hasDamage, setHasDamage] = useState<boolean | null>(null);
   const [battery, setBattery] = useState<number | null>(null);
   // Quando o cliente clica o botao "Normal" (em vez de digitar), guardamos o
@@ -248,8 +272,9 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   }, [deviceType]);
   useEffect(() => { fetchCores(); }, [fetchCores]);
 
-  // Cores pro modelo selecionado (traduzidas pra PT, dedup)
-  const coresModelo = useMemo(() => {
+  // Cores brutas pro modelo selecionado (traduzidas pra PT, dedup). A
+  // filtragem por caixa do Watch Series vem depois, em `coresModelo`.
+  const coresModeloRaw = useMemo(() => {
     if (!model) return [];
     // Tenta match exato primeiro
     let cores = coresDisponiveis[model];
@@ -348,6 +373,27 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
     return keys.sort((a, b) => extractNum(a) - extractNum(b));
   }, [chipGroups]);
   const modelsForChip = useMemo(() => chipGroups && subLine ? (chipGroups[subLine] || []) : [], [chipGroups, subLine]);
+
+  // Opcoes de caixa pro Apple Watch Series, determinadas pela geracao (subLine).
+  // Watch Series 9 → [Aluminio, Aco Inox]; Series 10/11 → [Aluminio, Titanio].
+  // SE e Ultra nao tem escolha — ignora.
+  const watchCaseOptions = useMemo(() => {
+    if (deviceType !== "watch" || line !== "Series") return [];
+    return WATCH_SERIES_CASES[subLine] || [];
+  }, [deviceType, line, subLine]);
+  const requiresWatchCase = watchCaseOptions.length > 0;
+
+  // Cores filtradas pela caixa quando aplicavel (Watch Series). Se a lista
+  // filtrada ficar vazia (ex: cor nao cadastrada no catalogo mas prevista no
+  // hardcoded), cai na lista bruta pra nao travar o cliente.
+  const coresModelo = useMemo(() => {
+    if (!requiresWatchCase || !watchCase) return coresModeloRaw;
+    const opt = watchCaseOptions.find((o) => o.material === watchCase);
+    if (!opt || opt.cores.length === 0) return coresModeloRaw;
+    const allowed = new Set(opt.cores.map((c) => c.toLowerCase()));
+    const filtered = coresModeloRaw.filter((c) => allowed.has(c.toLowerCase()));
+    return filtered.length > 0 ? filtered : coresModeloRaw;
+  }, [coresModeloRaw, requiresWatchCase, watchCase, watchCaseOptions]);
 
   // Se o chip selecionado tem só 1 modelo, auto-selecionar
   const needsScreenSize = modelsForChip.length > 1;
@@ -552,9 +598,9 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   const canProceed = model && storageCompleto && cor && baseValue !== null && !isExcluded && damageOk && partsOk && allCond && !batteryRejected && warrantyFilled && boxOk && dynamicOk;
 
   const tq = (q: string) => onTrackQuestion?.(1, q);
-  function handleLineChange(l: string) { setLine(l); setSubLine(""); setModel(""); setStorage(""); setHasDamage(null); tq("line"); }
-  function handleSubLineChange(sl: string) { setSubLine(sl); setModel(""); setStorage(""); setHasDamage(null); tq("chip"); }
-  function handleModelChange(m: string) { setModel(m); setStorage(""); setHasDamage(null); tq("model"); }
+  function handleLineChange(l: string) { setLine(l); setSubLine(""); setModel(""); setStorage(""); setWatchCase(null); setHasDamage(null); tq("line"); }
+  function handleSubLineChange(sl: string) { setSubLine(sl); setModel(""); setStorage(""); setWatchCase(null); setHasDamage(null); tq("chip"); }
+  function handleModelChange(m: string) { setModel(m); setStorage(""); setWatchCase(null); setHasDamage(null); tq("model"); }
 
   // Auto-select model when chip has only 1 model
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -573,6 +619,31 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
       setStorage(storages[0]);
     }
   }, [model, storages]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Titanio no Apple Watch Series 10/11 e sempre GPS+Cel. Quando o cliente
+  // seleciona Titanio, se o storage atual tem conectividade "GPS" puro, busca
+  // a variante equivalente com "GPS+Cel" (mesmo tamanho) e troca. Se nao
+  // existir, mantem o atual e deixa pro operador avaliar manualmente.
+  useEffect(() => {
+    if (!watchCase) return;
+    const opt = watchCaseOptions.find((o) => o.material === watchCase);
+    if (!opt?.forceGPSCel || !storage) return;
+    const parts = parseStorageSpec(storage);
+    const conect = (parts.conectividade || parts.tela || "").toLowerCase();
+    if (conect.includes("cel") || conect.includes("+")) return; // ja e GPS+Cel
+    // Procura variante compativel com mesmo tamanho (parts[0]) mas conectividade GPS+Cel
+    const alt = storages.find((s) => {
+      const p = parseStorageSpec(s);
+      return p.armazenamento === parts.armazenamento && /cel|\+/i.test(p.conectividade || p.tela);
+    });
+    if (alt && alt !== storage) setStorage(alt);
+  }, [watchCase, storage, storages, watchCaseOptions]);
+
+  // Limpa cor escolhida se mudou de caixa — cores disponiveis mudam.
+  useEffect(() => {
+    setCor("");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [watchCase]);
 
   const deviceLabel = DEVICE_LABELS[deviceType];
 
@@ -801,8 +872,27 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
         )
       )}
 
+      {/* Material da caixa — Watch Series 9/10/11. Series 9 tem Aluminio/Aco,
+          Series 10/11 tem Aluminio/Titanio. Titanio forca GPS+Cel via useEffect. */}
+      {model && storageCompleto && requiresWatchCase && (
+        <Section title="Material da caixa">
+          <div className={`grid gap-2 ${watchCaseOptions.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
+            {watchCaseOptions.map((opt) => (
+              <Btn key={opt.material} sel={watchCase === opt.material}
+                onClick={() => { setWatchCase(opt.material); tq("watchCase"); }}
+                className="w-full text-center">{opt.material}</Btn>
+            ))}
+          </div>
+          {watchCase && watchCaseOptions.find(o => o.material === watchCase)?.forceGPSCel && (
+            <p className="mt-2 text-center text-[11px]" style={{ color: "var(--ti-muted)" }}>
+              Titânio sempre vem com GPS + Celular — ajustado automaticamente.
+            </p>
+          )}
+        </Section>
+      )}
+
       {/* Cor do aparelho */}
-      {model && storageCompleto && coresModelo.length > 0 && (
+      {model && storageCompleto && (!requiresWatchCase || watchCase) && coresModelo.length > 0 && (
         <Section title="Qual a cor do seu aparelho?">
           <div className={`grid gap-2 ${coresModelo.length <= 4 ? "grid-cols-2" : "grid-cols-3"}`}>
             {coresModelo.map(c => (
@@ -819,7 +909,7 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
       )}
 
       {/* Cor manual — quando não tem cores do catálogo */}
-      {model && storageCompleto && coresModelo.length === 0 && (
+      {model && storageCompleto && (!requiresWatchCase || watchCase) && coresModelo.length === 0 && (
         <Section title="Qual a cor do seu aparelho?">
           <input
             type="text"
@@ -1239,10 +1329,19 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
       })}
 
       {canProceed && (
-        <button onClick={() => onNext({
-          usedModel: model, usedStorage: storage, usedColor: cor, condition: cond, tradeInValue, deviceType: calcDeviceType,
-          extraAnswers: dynamicQuestions.length > 0 ? extraAnswers : undefined,
-        })}
+        <button onClick={() => {
+          // Injetar watchCase como "pseudo-answer" quando aplicavel — TradeInCalculatorMulti
+          // reconhece o slug especial `__watchCase__` e monta uma pergunta sintetica
+          // pro resumo mostrar "Caixa: Aluminio" junto com as outras respostas.
+          const finalExtraAnswers = watchCase
+            ? { ...(extraAnswers || {}), __watchCase__: watchCase }
+            : extraAnswers;
+          const hasExtras = dynamicQuestions.length > 0 || !!watchCase;
+          onNext({
+            usedModel: model, usedStorage: storage, usedColor: cor, condition: cond, tradeInValue, deviceType: calcDeviceType,
+            extraAnswers: hasExtras ? finalExtraAnswers : undefined,
+          });
+        }}
           className="w-full py-4 rounded-2xl text-[17px] font-semibold text-white transition-all duration-200 active:scale-[0.98] shadow-lg"
           style={{ backgroundColor: "#22c55e", order: 999 }}>
           Ver minha avaliacao {"\u2192"}

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -43,15 +43,27 @@ const HARDCODED_DEFAULT_ORDEM: Record<string, number> = {
   partsReplaced: 5, hasWarranty: 6, warrantyMonth: 7, hasOriginalBox: 8,
 };
 
-// Markdown seguro pra helpText: escape HTML primeiro, depois aplica **bold**.
-// So permite negrito; nenhuma outra tag vira HTML.
+// Markdown seguro pra helpText: escape HTML primeiro, depois aplica formatacao.
+// Suporta:
+//  - **negrito**
+//  - *italico* (ou _italico_)
+//  - ## Titulo grande / ### subtitulo (so no inicio de linha)
+// Qualquer outra tag fica escapada — sem injecao de HTML arbitrario.
 function renderSafeMarkdown(raw: string): string {
-  const escaped = raw
+  let s = raw
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;");
-  return escaped.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  // Negrito **texto** — primeiro porque ** englobaria * solto se invertido
+  s = s.replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>");
+  // Italico *texto* ou _texto_ (nao casa com * sozinho — exige conteudo entre)
+  s = s.replace(/(?<![*])\*(?!\*)([^*\n]+?)\*(?!\*)/g, "<em>$1</em>");
+  s = s.replace(/(?<![_])_(?!_)([^_\n]+?)_(?!_)/g, "<em>$1</em>");
+  // Headers tamanho de fonte (so no inicio da linha)
+  s = s.replace(/^### (.+)$/gm, '<span style="font-size:1.05em;font-weight:600">$1</span>');
+  s = s.replace(/^## (.+)$/gm, '<span style="font-size:1.15em;font-weight:700">$1</span>');
+  return s;
 }
 
 // Formata uma resposta dinamica pra exibir no resumo/WhatsApp.

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -125,9 +125,12 @@ function extractLines(models: string[], deviceType: MultiDeviceType): string[] {
       // Apenas 3 linhas top-level: SE / Series / Ultra. Modelos que nao casam
       // com nenhum padrao sao ignorados (nao criamos linha "Apple Watch"
       // generica — antes virava despejo de todos os modelos).
+      // IMPORTANTE: `\b` depois de "SE" — sem isso, /SE/i case-insensitive
+      // batia em "Apple Watch SEries 9" (Se- prefixo de Series), classificando
+      // todos os Series como SE e fazendo a linha Series sumir do cliente.
       models.forEach((m) => {
-        if (/Apple Watch SE/i.test(m)) { s.add("SE"); return; }
-        if (/Apple Watch Ultra/i.test(m)) { s.add("Ultra"); return; }
+        if (/Apple Watch SE\b/i.test(m)) { s.add("SE"); return; }
+        if (/Apple Watch Ultra\b/i.test(m)) { s.add("Ultra"); return; }
         if (/Apple Watch (?:Series )?\d+/i.test(m)) { s.add("Series"); return; }
       });
       const order = ["SE", "Series", "Ultra"];
@@ -151,9 +154,11 @@ function getModelsInLine(allModels: string[], line: string, deviceType: MultiDev
       if (line === "Pro") return allModels.filter((m) => m.includes("Pro"));
       return allModels;
     case "watch":
-      if (line === "SE") return allModels.filter((m) => /Apple Watch SE/i.test(m));
-      if (line === "Ultra") return allModels.filter((m) => /Apple Watch Ultra/i.test(m));
-      if (line === "Series") return allModels.filter((m) => /Apple Watch (?:Series )?\d+/i.test(m) && !/Apple Watch SE/i.test(m) && !/Apple Watch Ultra/i.test(m));
+      // `\b` depois de SE/Ultra evita match "Series" (Se-prefix) e
+      // mantenedor consistencia com extractLines.
+      if (line === "SE") return allModels.filter((m) => /Apple Watch SE\b/i.test(m));
+      if (line === "Ultra") return allModels.filter((m) => /Apple Watch Ultra\b/i.test(m));
+      if (line === "Series") return allModels.filter((m) => /Apple Watch (?:Series )?\d+/i.test(m) && !/Apple Watch SE\b/i.test(m) && !/Apple Watch Ultra\b/i.test(m));
       return [];
     default:
       return [];
@@ -198,6 +203,10 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   const [storage, setStorage] = useState("");
   const [hasDamage, setHasDamage] = useState<boolean | null>(null);
   const [battery, setBattery] = useState<number | null>(null);
+  // Quando o cliente clica o botao "Normal" (em vez de digitar), guardamos o
+  // rotulo aqui pra que o resumo mostre "Bateria: Normal" no lugar do numero.
+  // Limpa quando o cliente digita um valor novo.
+  const [batteryLabel, setBatteryLabel] = useState<string | null>(null);
   const [screenScratch, setScreenScratch] = useState<"none"|"one"|"multiple"|null>(null);
   const [sideScratch, setSideScratch] = useState<"none"|"one"|"multiple"|null>(null);
   const [peeling, setPeeling] = useState<"none"|"light"|"heavy"|null>(null);
@@ -230,10 +239,22 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   // Cores pro modelo selecionado (traduzidas pra PT, dedup)
   const coresModelo = useMemo(() => {
     if (!model) return [];
-    // Tenta match exato primeiro, depois substring
+    // Tenta match exato primeiro
     let cores = coresDisponiveis[model];
     if (!cores) {
-      const entry = Object.entries(coresDisponiveis).find(([k]) => model.toUpperCase().includes(k.toUpperCase()) || k.toUpperCase().includes(model.toUpperCase()));
+      // Fallback: match por TOKENS (substring quebra com "iPad 11º (A16)" vs
+      // "iPad A16" — o "º (" entre os tokens nao aparece nos dois). Tokeniza
+      // ambos os lados, exige todos os tokens do MENOR lado presentes no maior,
+      // com minimo de 2 tokens pra nao colar match generico tipo so "iPad".
+      const tokens = (s: string) =>
+        s.toLowerCase().replace(/[º°ª()]/g, " ").split(/\s+/).filter(Boolean);
+      const modelT = tokens(model);
+      const entry = Object.entries(coresDisponiveis).find(([k]) => {
+        const keyT = tokens(k);
+        const shorter = modelT.length <= keyT.length ? modelT : keyT;
+        const longer = modelT.length <= keyT.length ? keyT : modelT;
+        return shorter.length >= 2 && shorter.every((t) => longer.includes(t));
+      });
       cores = entry?.[1] ?? [];
     }
     if (!cores || cores.length === 0) return [];
@@ -356,7 +377,8 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
 
   const cond: ConditionData = {
     screenScratch: screenScratch ?? "none", sideScratch: sideScratch ?? "none", peeling: peeling ?? "none",
-    battery: battery ?? 100, hasDamage: hasDamage === true, partsReplaced: partsReplaced ?? "no",
+    battery: battery ?? 100, batteryLabel: batteryLabel || undefined,
+    hasDamage: hasDamage === true, partsReplaced: partsReplaced ?? "no",
     partsReplacedDetail: partsReplaced === "apple" ? partsReplacedDetail : "",
     hasWarranty: hasWarranty === true, warrantyMonth: hasWarranty ? warrantyMonth : null,
     warrantyYear: hasWarranty ? warrantyYear : null, hasOriginalBox: hasOriginalBox === true,
@@ -825,10 +847,12 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
           <Section title={getQTitle(qc, "battery", deviceType === "macbook" ? "Ciclos de bateria" : "Saude da bateria")} order={getOrdem("battery")}>
             <div className="rounded-2xl p-4 space-y-3" style={{ backgroundColor: "var(--ti-card-bg)", border: "1px solid var(--ti-card-border)" }}>
               <div className="relative">
-                <input type="tel" inputMode="numeric" pattern="[0-9]*" value={battery ?? ""}
-                  placeholder={deviceType === "macbook" ? "Ex: 150" : "Ex: 87"}
+                <input type="tel" inputMode="numeric" pattern="[0-9]*"
+                  value={batteryLabel ? "" : (battery ?? "")}
+                  placeholder={batteryLabel ?? (deviceType === "macbook" ? "Ex: 150" : "Ex: 87")}
                   onChange={(e) => {
                     const r = e.target.value.replace(/\D/g, "");
+                    setBatteryLabel(null); // digitou — descarta rotulo "Normal"
                     if (r === "") { setBattery(null); return; }
                     // MacBook: campo armazena ciclos (0..9999). Demais: saude em % (1..100).
                     const cap = deviceType === "macbook" ? 9999 : 100;
@@ -838,7 +862,7 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                   className={`w-full px-4 py-3 ${deviceType === "macbook" ? "pr-4" : "pr-10"} rounded-xl text-[20px] font-bold text-center focus:outline-none transition-colors`}
                   style={{ backgroundColor: "var(--ti-input-bg)", border: "1px solid var(--ti-card-border)", color: "var(--ti-text)" }}
                 />
-                {deviceType !== "macbook" && (
+                {deviceType !== "macbook" && !batteryLabel && (
                   <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[16px] font-bold" style={{ color: "var(--ti-muted)" }}>%</span>
                 )}
               </div>
@@ -849,16 +873,38 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                     // iPad as vezes so mostra "Normal" em vez de numero — cliente
                     // clica pra liberar assumindo aparelho saudavel (100%).
                     setBattery(100);
+                    setBatteryLabel("Normal");
                     tq("battery");
                   }}
                   className="w-full py-2 rounded-xl text-[13px] font-medium transition-colors"
                   style={{
-                    backgroundColor: battery === 100 ? "var(--ti-success-light)" : "var(--ti-input-bg)",
-                    color: battery === 100 ? "var(--ti-success)" : "var(--ti-muted)",
-                    border: `1px solid ${battery === 100 ? "var(--ti-success)" : "var(--ti-card-border)"}`,
+                    backgroundColor: batteryLabel ? "var(--ti-success-light)" : "var(--ti-input-bg)",
+                    color: batteryLabel ? "var(--ti-success)" : "var(--ti-muted)",
+                    border: `1px solid ${batteryLabel ? "var(--ti-success)" : "var(--ti-card-border)"}`,
                   }}
                 >
                   Aparece só &quot;Normal&quot; no meu iPad
+                </button>
+              )}
+              {deviceType === "macbook" && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    // MacBook tambem suporta "Normal" — quando o cliente nao
+                    // sabe os ciclos. Marcamos batteryCycles=0 (sem desconto)
+                    // e o resumo mostra "Bateria: Normal".
+                    setBattery(0);
+                    setBatteryLabel("Normal");
+                    tq("battery");
+                  }}
+                  className="w-full py-2 rounded-xl text-[13px] font-medium transition-colors"
+                  style={{
+                    backgroundColor: batteryLabel ? "var(--ti-success-light)" : "var(--ti-input-bg)",
+                    color: batteryLabel ? "var(--ti-success)" : "var(--ti-muted)",
+                    border: `1px solid ${batteryLabel ? "var(--ti-success)" : "var(--ti-card-border)"}`,
+                  }}
+                >
+                  Não sei os ciclos — bateria normal
                 </button>
               )}
               {deviceType === "iphone" && (

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -18,6 +18,10 @@ interface StepUsedDeviceMultiProps {
   modelDiscounts?: Record<string, ModelDiscounts>;
   questionsConfig?: TradeInQuestion[] | null;
   deviceType: MultiDeviceType;
+  /** Labels editaveis cadastrados via /admin/simulacoes. Hoje usado pros help
+   *  texts do campo bateria (1 por device_type). Se vazio, cai nos valores
+   *  hardcoded pra nao quebrar clientes sem admin configurado. */
+  labels?: Record<string, string>;
   onNext: (data: { usedModel: string; usedStorage: string; usedColor: string; condition: AnyConditionData; tradeInValue: number; deviceType: DeviceType; extraAnswers?: Record<string, unknown> }) => void;
   onTrackQuestion?: (step: number, question: string) => void;
 }
@@ -213,7 +217,7 @@ function toCalcDeviceType(dt: MultiDeviceType): DeviceType {
   return dt;
 }
 
-export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelDiscounts, questionsConfig, deviceType, onNext, onTrackQuestion }: StepUsedDeviceMultiProps) {
+export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelDiscounts, questionsConfig, deviceType, labels, onNext, onTrackQuestion }: StepUsedDeviceMultiProps) {
   // Normaliza slugs: alguns cadastros no admin foram criados com sufixo de
   // device_type (ex: `hasDamage_ipad`, `battery_macbook`). O codigo usa os
   // slugs puros (`hasDamage`, `battery`), entao strip do sufixo `_${deviceType}`
@@ -1009,51 +1013,34 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                   Não sei os ciclos — bateria normal
                 </button>
               )}
-              {deviceType === "iphone" && (
-                <details className="rounded-xl p-3" style={{ backgroundColor: "var(--ti-input-bg)", border: "1px solid var(--ti-card-border)" }}>
-                  <summary className="text-[12px] font-semibold cursor-pointer" style={{ color: "var(--ti-accent)" }}>Como descobrir a saude da bateria?</summary>
-                  <div className="text-[11px] space-y-1 mt-2" style={{ color: "var(--ti-muted)" }}>
-                    <p>1. Abra <strong style={{ color: "var(--ti-text)" }}>Ajustes</strong> no seu iPhone</p>
-                    <p>2. Toque em <strong style={{ color: "var(--ti-text)" }}>Bateria</strong></p>
-                    <p>3. Toque em <strong style={{ color: "var(--ti-text)" }}>Saude e Carregamento da Bateria</strong></p>
-                    <p>4. Veja o valor em <strong style={{ color: "var(--ti-text)" }}>Capacidade Maxima</strong></p>
-                  </div>
-                </details>
-              )}
-              {deviceType === "ipad" && (
-                <details className="rounded-xl p-3" style={{ backgroundColor: "var(--ti-input-bg)", border: "1px solid var(--ti-card-border)" }}>
-                  <summary className="text-[12px] font-semibold cursor-pointer" style={{ color: "var(--ti-accent)" }}>Como descobrir a saude da bateria?</summary>
-                  <div className="text-[11px] space-y-1 mt-2" style={{ color: "var(--ti-muted)" }}>
-                    <p>1. Abra <strong style={{ color: "var(--ti-text)" }}>Ajustes</strong> no seu iPad</p>
-                    <p>2. Toque em <strong style={{ color: "var(--ti-text)" }}>Bateria</strong></p>
-                    <p>3. Toque em <strong style={{ color: "var(--ti-text)" }}>Saude da Bateria</strong></p>
-                    <p>4. Veja o valor em <strong style={{ color: "var(--ti-text)" }}>Capacidade Maxima</strong></p>
-                  </div>
-                </details>
-              )}
-              {deviceType === "macbook" && (
-                <details className="rounded-xl p-3" style={{ backgroundColor: "var(--ti-input-bg)", border: "1px solid var(--ti-card-border)" }}>
-                  <summary className="text-[12px] font-semibold cursor-pointer" style={{ color: "var(--ti-accent)" }}>Como descobrir os ciclos de bateria?</summary>
-                  <div className="text-[11px] space-y-1 mt-2" style={{ color: "var(--ti-muted)" }}>
-                    <p>1. Clique no menu <strong style={{ color: "var(--ti-text)" }}>Apple</strong> {">"} <strong style={{ color: "var(--ti-text)" }}>Sobre Este Mac</strong></p>
-                    <p>2. Clique em <strong style={{ color: "var(--ti-text)" }}>Mais Informacoes</strong></p>
-                    <p>3. Role ate o final e clique em <strong style={{ color: "var(--ti-text)" }}>Relatorio do Sistema</strong></p>
-                    <p>4. Na barra lateral, clique em <strong style={{ color: "var(--ti-text)" }}>Energia</strong></p>
-                    <p>5. Veja <strong style={{ color: "var(--ti-text)" }}>Contagem de Ciclos</strong></p>
-                  </div>
-                </details>
-              )}
-              {deviceType === "watch" && (
-                <details className="rounded-xl p-3" style={{ backgroundColor: "var(--ti-input-bg)", border: "1px solid var(--ti-card-border)" }}>
-                  <summary className="text-[12px] font-semibold cursor-pointer" style={{ color: "var(--ti-accent)" }}>Como descobrir a saude da bateria?</summary>
-                  <div className="text-[11px] space-y-1 mt-2" style={{ color: "var(--ti-muted)" }}>
-                    <p>1. No Apple Watch, abra <strong style={{ color: "var(--ti-text)" }}>Ajustes</strong></p>
-                    <p>2. Toque em <strong style={{ color: "var(--ti-text)" }}>Bateria</strong></p>
-                    <p>3. Toque em <strong style={{ color: "var(--ti-text)" }}>Saude da Bateria</strong></p>
-                    <p>4. Veja o valor em <strong style={{ color: "var(--ti-text)" }}>Capacidade Maxima</strong></p>
-                  </div>
-                </details>
-              )}
+              {/* Ajuda "Como descobrir a saude/ciclos da bateria?" — texto padrao
+                  por device_type, sobrescrivel via labels.help_battery_{device}
+                  em /admin/simulacoes. Suporta markdown (negrito, italico, ## titulo). */}
+              {(() => {
+                const defaults: Record<string, string> = {
+                  iphone: "## Como descobrir a saúde da bateria?\n\n1. Abra **Ajustes** no seu iPhone\n2. Toque em **Bateria**\n3. Toque em **Saúde e Carregamento da Bateria**\n4. Veja o valor em **Capacidade Máxima**",
+                  ipad: "## Como descobrir a saúde da bateria?\n\n1. Abra **Ajustes** no seu iPad\n2. Toque em **Bateria**\n3. Toque em **Saúde da Bateria**\n4. Veja o valor em **Capacidade Máxima**",
+                  macbook: "## Como descobrir os ciclos de bateria?\n\n1. Clique no menu **Apple** > **Sobre Este Mac**\n2. Clique em **Mais Informações**\n3. Role até o final e clique em **Relatório do Sistema**\n4. Na barra lateral, clique em **Energia**\n5. Veja **Contagem de Ciclos**",
+                  watch: "## Como descobrir a saúde da bateria?\n\n1. No Apple Watch, abra **Ajustes**\n2. Toque em **Bateria**\n3. Toque em **Saúde da Bateria**\n4. Veja o valor em **Capacidade Máxima**",
+                };
+                const key = `help_battery_${deviceType}`;
+                const raw = labels?.[key]?.trim() || defaults[deviceType] || "";
+                if (!raw) return null;
+                // Extrai primeiro `## Titulo` como summary; resto vai no body.
+                const headerMatch = raw.match(/^## (.+)$/m);
+                const title = headerMatch ? headerMatch[1] : "Como descobrir a saúde da bateria?";
+                const body = headerMatch ? raw.replace(/^## .+$/m, "").trim() : raw;
+                return (
+                  <details className="rounded-xl p-3" style={{ backgroundColor: "var(--ti-input-bg)", border: "1px solid var(--ti-card-border)" }}>
+                    <summary className="text-[12px] font-semibold cursor-pointer" style={{ color: "var(--ti-accent)" }}>{title}</summary>
+                    <div
+                      className="text-[11px] mt-2 whitespace-pre-wrap leading-relaxed"
+                      style={{ color: "var(--ti-muted)" }}
+                      dangerouslySetInnerHTML={{ __html: renderSafeMarkdown(body) }}
+                    />
+                  </details>
+                );
+              })()}
               {batteryRejected && batteryRejectMessage && (
                 <div className="rounded-2xl p-4 text-center" style={{ backgroundColor: "var(--ti-error-light)", border: "1px solid var(--ti-error)" }}>
                   <p className="text-[15px] font-semibold" style={{ color: "var(--ti-error)" }}>{batteryRejectMessage}</p>

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -277,6 +277,22 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
     const dynamicQs = (questionsConfig ?? []).filter(
       (q) => q.ativo !== false && !["battery","hasDamage","hasOriginalBox","hasWarranty","hasWearMarks","partsReplaced","peeling","screenScratch","sideScratch","warrantyMonth","wearMarks"].includes(q.slug)
     );
+    // Caixa do Apple Watch (hardcoded no StepUsedDeviceMulti) vem em
+    // extraAnswers.__watchCase__. Aqui injetamos pergunta sintetica pra que o
+    // resumo renderize "Caixa: Aluminio" junto das outras respostas.
+    if (data.extraAnswers?.__watchCase__) {
+      dynamicQs.push({
+        id: "synthetic-watch-case",
+        slug: "__watchCase__",
+        titulo: "Caixa",
+        tipo: "selection" as const,
+        opcoes: [],
+        ordem: 0.5, // aparece logo depois do hasDamage no resumo
+        ativo: true,
+        config: {},
+        device_type: "watch",
+      });
+    }
     if (step === 1) {
       setDeviceType(data.deviceType); setUsedModel(data.usedModel); setUsedStorage(data.usedStorage);
       setUsedColor(data.usedColor || "");

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -619,6 +619,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
               condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined}
               extraAnswers={extraAnswers} extraQuestions={extraQuestions}
               extraAnswers2={hasSecondDevice ? extraAnswers2 : undefined} extraQuestions2={hasSecondDevice ? extraQuestions2 : undefined}
+              questionsConfig={questionsConfig ?? undefined}
               newModel={newModel} newStorage={newStorage} newPrice={newPrice}
               clienteNome={clienteNome} clienteWhatsApp={clienteWhatsApp} clienteInstagram={clienteInstagram} clienteOrigem={clienteOrigem}
               whatsappNumero={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappPrincipal}

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -564,6 +564,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
               modelDiscounts={usedData.modelDiscounts}
               questionsConfig={questionsConfig}
               deviceType={selectedDeviceType}
+              labels={tradeinConfig?.labels}
               onNext={handleStep1Complete}
               onTrackQuestion={trackQuestion}
             />
@@ -611,6 +612,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
                 modelDiscounts={usedData.modelDiscounts}
                 questionsConfig={questionsConfig}
                 deviceType={selectedDeviceType}
+                labels={tradeinConfig?.labels}
                 onNext={handleStep1Complete}
                 onTrackQuestion={trackQuestion}
               />

--- a/components/admin/ConfirmModal.tsx
+++ b/components/admin/ConfirmModal.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+
+/** Modal simples pra substituir window.confirm/prompt/alert com UI consistente
+ *  e que nao bloqueia o thread. Uso:
+ *
+ *    const { confirm, alert, prompt, modal } = useConfirmModal();
+ *    if (await confirm({ title: "Excluir?", description: "Nao da pra desfazer." })) { ... }
+ *    const nome = await prompt({ title: "Novo nome", placeholder: "Ex: iPad A16" });
+ *    await alert({ title: "Erro", description: "falha ao salvar" });
+ *
+ *  E renderizar `{modal}` dentro do JSX do componente. */
+
+export type ConfirmOpts = {
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** "danger" → botao vermelho pra operacoes destrutivas. */
+  variant?: "default" | "danger";
+};
+
+export type PromptOpts = {
+  title: string;
+  description?: string;
+  placeholder?: string;
+  defaultValue?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+};
+
+export type AlertOpts = {
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  variant?: "default" | "danger";
+};
+
+type ModalState =
+  | { kind: "confirm"; opts: ConfirmOpts; resolve: (v: boolean) => void }
+  | { kind: "prompt"; opts: PromptOpts; resolve: (v: string | null) => void }
+  | { kind: "alert"; opts: AlertOpts; resolve: () => void }
+  | null;
+
+export function useConfirmModal() {
+  const [state, setState] = useState<ModalState>(null);
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const confirm = useCallback((opts: ConfirmOpts) => {
+    return new Promise<boolean>((resolve) => setState({ kind: "confirm", opts, resolve }));
+  }, []);
+
+  const prompt = useCallback((opts: PromptOpts) => {
+    return new Promise<string | null>((resolve) => {
+      setInputValue(opts.defaultValue ?? "");
+      setState({ kind: "prompt", opts, resolve });
+    });
+  }, []);
+
+  const alert = useCallback((opts: AlertOpts) => {
+    return new Promise<void>((resolve) => setState({ kind: "alert", opts, resolve }));
+  }, []);
+
+  useEffect(() => {
+    if (state?.kind === "prompt") {
+      // Foca o input no proximo tick pra esperar o portal renderizar.
+      setTimeout(() => inputRef.current?.select(), 0);
+    }
+  }, [state]);
+
+  const close = useCallback(() => setState(null), []);
+
+  const handleConfirm = () => {
+    if (!state) return;
+    if (state.kind === "confirm") state.resolve(true);
+    else if (state.kind === "prompt") state.resolve(inputValue.trim() || null);
+    else state.resolve();
+    close();
+  };
+
+  const handleCancel = () => {
+    if (!state) return;
+    if (state.kind === "confirm") state.resolve(false);
+    else if (state.kind === "prompt") state.resolve(null);
+    else state.resolve();
+    close();
+  };
+
+  const modal = state ? (
+    <div
+      className="fixed inset-0 z-[999] flex items-center justify-center p-4"
+      style={{ backgroundColor: "rgba(0,0,0,0.4)" }}
+      onClick={handleCancel}
+    >
+      <div
+        className="bg-white rounded-2xl shadow-xl max-w-md w-full p-5 space-y-3"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 className="font-bold text-[16px] text-[#1D1D1F]">{state.opts.title}</h3>
+        {state.opts.description && (
+          <p className="text-[13px] text-[#6E6E73] whitespace-pre-wrap">{state.opts.description}</p>
+        )}
+        {state.kind === "prompt" && (
+          <input
+            ref={inputRef}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleConfirm();
+              if (e.key === "Escape") handleCancel();
+            }}
+            placeholder={state.opts.placeholder || ""}
+            className="w-full px-3 py-2 border border-[#D2D2D7] rounded-lg text-sm focus:outline-none focus:border-[#E8740E]"
+          />
+        )}
+        <div className="flex justify-end gap-2 pt-1">
+          {state.kind !== "alert" && (
+            <button
+              onClick={handleCancel}
+              className="px-4 py-2 rounded-lg text-sm text-[#6E6E73] border border-[#D2D2D7] hover:bg-[#F5F5F7] transition-colors"
+            >
+              {state.kind === "prompt" ? (state.opts.cancelLabel || "Cancelar") : ((state.opts as ConfirmOpts).cancelLabel || "Cancelar")}
+            </button>
+          )}
+          <button
+            onClick={handleConfirm}
+            className={`px-4 py-2 rounded-lg text-sm font-semibold text-white transition-colors ${
+              (state.kind === "confirm" || state.kind === "alert") && state.opts.variant === "danger"
+                ? "bg-red-600 hover:bg-red-700"
+                : "bg-[#E8740E] hover:bg-[#F5A623]"
+            }`}
+          >
+            {state.kind === "confirm"
+              ? ((state.opts as ConfirmOpts).confirmLabel || "Confirmar")
+              : state.kind === "prompt"
+              ? ((state.opts as PromptOpts).confirmLabel || "OK")
+              : ((state.opts as AlertOpts).confirmLabel || "OK")}
+          </button>
+        </div>
+      </div>
+    </div>
+  ) : null;
+
+  return { confirm, prompt, alert, modal };
+}

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -491,7 +491,10 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
                         className="mt-1 w-full px-3 py-2 rounded border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
                       />
                       <p className="mt-1 text-[11px] text-[#86868B]">
-                        Aparece como painel expansivel abaixo do input. Use <code>**texto**</code> pra deixar em <strong>negrito</strong>. Quebras de linha sao preservadas.
+                        Aparece como painel expansivel abaixo do input. Formatacao suportada:{" "}
+                        <code>**negrito**</code> · <code>*italico*</code> ou <code>_italico_</code> ·{" "}
+                        <code>## Titulo grande</code> · <code>### Subtitulo</code> (no inicio da linha).
+                        Quebras de linha sao preservadas.
                       </p>
                     </div>
 

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -1,6 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import { TradeInQuestion, TradeInQuestionOption, SeminovoOption, SeminovoCategoria, getSeminovoVariantes, consolidateSeminovos } from "@/lib/types";
+import { useConfirmModal } from "@/components/admin/ConfirmModal";
 
 interface Props {
   password: string;
@@ -36,6 +37,7 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
   const [saving, setSaving] = useState<string | null>(null);
   const [msg, setMsg] = useState("");
   const [deviceTab, setDeviceTab] = useState("iphone");
+  const { confirm: confirmModal, prompt: promptModal, modal } = useConfirmModal();
 
   function getHeaders() {
     return { "x-admin-password": password, "Content-Type": "application/json" };
@@ -169,6 +171,7 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
 
   return (
     <div className="space-y-4">
+      {modal}
       {/* Device type tabs */}
       <div className="flex gap-2 flex-wrap items-center">
         {DEVICE_TABS.map(t => (
@@ -237,9 +240,18 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
         </div>
         <button
           onClick={async () => {
-            const titulo = prompt("Titulo da nova pergunta:");
+            const titulo = await promptModal({
+              title: "Nova pergunta",
+              description: "Informe o titulo da pergunta que o cliente vai ver.",
+              placeholder: "Ex: Possui o carregador original?",
+            });
             if (!titulo) return;
-            const tipo = prompt("Tipo (yesno, selection, numeric, multiselect, conditional_date):", "yesno");
+            const tipo = await promptModal({
+              title: "Tipo da pergunta",
+              description: "yesno | selection | numeric | multiselect | conditional_date",
+              placeholder: "yesno",
+              defaultValue: "yesno",
+            });
             if (!tipo) return;
             const slug = titulo.toLowerCase().replace(/[^a-z0-9]/g, "_").replace(/_+/g, "_").replace(/^_|_$/g, "").slice(0, 30);
             const ordem = questions.length + 1;
@@ -326,7 +338,13 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
               <div onClick={(e) => e.stopPropagation()}>
                 <button
                   onClick={async () => {
-                    if (!confirm(`Excluir pergunta "${q.titulo}"?`)) return;
+                    const ok = await confirmModal({
+                      title: "Excluir pergunta",
+                      description: `"${q.titulo}" vai sumir do formulario. Nao afeta respostas ja coletadas.`,
+                      confirmLabel: "Excluir",
+                      variant: "danger",
+                    });
+                    if (!ok) return;
                     const isUUID = /^[0-9a-f]{8}-/i.test(q.id);
                     if (isUUID) {
                       try {
@@ -580,10 +598,19 @@ const DEFAULT_SEMINOVOS: SeminovoOption[] = [
 
 const DEFAULT_ORIGENS = ["Anúncio", "Story", "Direct", "WhatsApp", "Indicação", "Já sou cliente"];
 
-const LABEL_GROUPS: { title: string; keys: { key: string; label: string }[] }[] = [
+const LABEL_GROUPS: { title: string; keys: { key: string; label: string; multiline?: boolean }[] }[] = [
   {
     title: "Etapa 1 — Aparelho Usado",
     keys: [{ key: "step1_titulo", label: "Título da etapa" }],
+  },
+  {
+    title: "Help texts da bateria (por categoria)",
+    keys: [
+      { key: "help_battery_iphone", label: "iPhone — passo a passo", multiline: true },
+      { key: "help_battery_ipad", label: "iPad — passo a passo", multiline: true },
+      { key: "help_battery_macbook", label: "MacBook — passo a passo (ciclos)", multiline: true },
+      { key: "help_battery_watch", label: "Apple Watch — passo a passo", multiline: true },
+    ],
   },
   {
     title: "Etapa 2 — Aparelho Novo",
@@ -802,14 +829,24 @@ function TradeInConfigAdmin({ password, deviceTab: _deviceTab }: { password: str
                 {group.title}
               </div>
               <div className="space-y-2">
-                {group.keys.map(({ key, label }) => (
+                {group.keys.map(({ key, label, multiline }) => (
                   <div key={key}>
                     <label className="text-[11px] text-[#86868B] mb-0.5 block">{label}</label>
-                    <input
-                      value={labels[key] || ""}
-                      onChange={(e) => setLabels({ ...labels, [key]: e.target.value })}
-                      className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
-                    />
+                    {multiline ? (
+                      <textarea
+                        value={labels[key] || ""}
+                        onChange={(e) => setLabels({ ...labels, [key]: e.target.value })}
+                        rows={6}
+                        placeholder="Markdown suportado: **negrito** · *italico* · ## Titulo"
+                        className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E] font-mono"
+                      />
+                    ) : (
+                      <input
+                        value={labels[key] || ""}
+                        onChange={(e) => setLabels({ ...labels, [key]: e.target.value })}
+                        className="w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                      />
+                    )}
                   </div>
                 ))}
               </div>

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -365,37 +365,52 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
                     <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">Opções de resposta</label>
                     <div className="mt-2 space-y-2">
                       {q.opcoes.map((opt, oi) => (
-                        <div key={oi} className="flex items-center gap-2 bg-[#F5F5F7] rounded-lg px-3 py-2">
-                          <input
-                            value={opt.label}
-                            onChange={(e) => updateOption(q.id, oi, { label: e.target.value })}
-                            className="flex-1 px-2 py-1 rounded border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
-                            placeholder="Label"
-                          />
-                          <div className="flex items-center gap-1">
-                            <span className="text-xs text-[#86868B]">R$</span>
+                        <div key={oi} className="bg-[#F5F5F7] rounded-lg px-3 py-2 space-y-2">
+                          <div className="flex items-center gap-2">
                             <input
-                              type="number"
-                              value={opt.discount}
-                              onChange={(e) => updateOption(q.id, oi, { discount: Number(e.target.value) })}
-                              className="w-20 px-2 py-1 rounded border border-[#D2D2D7] text-sm text-center focus:outline-none focus:border-[#E8740E]"
+                              value={opt.label}
+                              onChange={(e) => updateOption(q.id, oi, { label: e.target.value })}
+                              className="flex-1 px-2 py-1 rounded border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                              placeholder="Label do botao"
+                            />
+                            <div className="flex items-center gap-1">
+                              <span className="text-xs text-[#86868B]">R$</span>
+                              <input
+                                type="number"
+                                value={opt.discount}
+                                onChange={(e) => updateOption(q.id, oi, { discount: Number(e.target.value) })}
+                                className="w-20 px-2 py-1 rounded border border-[#D2D2D7] text-sm text-center focus:outline-none focus:border-[#E8740E]"
+                              />
+                            </div>
+                            {opt.reject && (
+                              <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-red-100 text-red-700">Rejeita</span>
+                            )}
+                            <label className="flex items-center gap-1 text-[10px] text-[#86868B]">
+                              <input
+                                type="checkbox"
+                                checked={!!opt.reject}
+                                onChange={(e) => updateOption(q.id, oi, { reject: e.target.checked })}
+                                className="w-3 h-3 accent-red-500"
+                              />
+                              Rejeitar
+                            </label>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <span className="text-[10px] font-semibold text-[#86868B] uppercase tracking-wider whitespace-nowrap">No resumo:</span>
+                            <input
+                              value={opt.summaryLabel || ""}
+                              onChange={(e) => updateOption(q.id, oi, { summaryLabel: e.target.value })}
+                              className="flex-1 px-2 py-1 rounded border border-[#D2D2D7] text-xs focus:outline-none focus:border-[#E8740E]"
+                              placeholder="Frase completa (ex: Possui o carregador completo original da Apple)"
                             />
                           </div>
-                          {opt.reject && (
-                            <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-red-100 text-red-700">Rejeita</span>
-                          )}
-                          <label className="flex items-center gap-1 text-[10px] text-[#86868B]">
-                            <input
-                              type="checkbox"
-                              checked={!!opt.reject}
-                              onChange={(e) => updateOption(q.id, oi, { reject: e.target.checked })}
-                              className="w-3 h-3 accent-red-500"
-                            />
-                            Rejeitar
-                          </label>
                         </div>
                       ))}
                     </div>
+                    <p className="mt-2 text-[11px] text-[#86868B]">
+                      <strong>Label do botão</strong>: aparece no formulário (ex: &quot;Sim&quot; / &quot;Nao&quot;).{" "}
+                      <strong>No resumo</strong> (opcional): frase completa pro StepManualHandoff e WhatsApp. Se vazio, mostra &quot;titulo: label&quot;.
+                    </p>
                   </div>
                 )}
 

--- a/lib/calculations.ts
+++ b/lib/calculations.ts
@@ -256,34 +256,42 @@ export function calculateQuote(
   return { tradeInValue, newPrice, difference, pix: difference, installments };
 }
 
+/** Linha do resumo com o slug da pergunta hardcoded que a gerou. Permite que
+ *  o StepManualHandoff intercale com perguntas dinamicas via ordem do admin. */
+export interface ConditionEntry {
+  slug: string;
+  text: string;
+}
+
 /**
- * Gera linhas de condicao para exibicao e WhatsApp
+ * Gera entries (slug + texto) das condicoes hardcoded de iPhone.
+ * Usar `getConditionLines` quando so o texto importa.
  */
-export function getConditionLines(condition: ConditionData, deviceType?: DeviceType): string[] {
+export function getConditionEntries(condition: ConditionData, deviceType?: DeviceType): ConditionEntry[] {
   const monthNames = ["Janeiro", "Fevereiro", "Marco", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"];
-  const lines: string[] = [];
+  const entries: ConditionEntry[] = [];
 
   // Trincado/defeito: hasDamage=true e rejeitado (nao chega aqui), entao so
   // confirma "Sem trincado/defeito" pro aparelho aceito.
-  lines.push(condition.hasDamage ? "Com trincado/defeito" : "Sem trincado/defeito");
+  entries.push({ slug: "hasDamage", text: condition.hasDamage ? "Com trincado/defeito" : "Sem trincado/defeito" });
 
   if (condition.warrantyMonth !== null) {
     const yearSuffix = condition.warrantyYear ? ` de ${condition.warrantyYear}` : "";
-    lines.push(`Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}`);
+    entries.push({ slug: "warrantyMonth", text: `Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}` });
   }
 
   // MacBook: campo battery armazena CICLOS (0..9999), demais dispositivos
   // armazenam saude de bateria em %. Label muda conforme o deviceType.
   if (deviceType === "macbook") {
-    lines.push(`Ciclos de bateria: ${condition.battery}`);
+    entries.push({ slug: "battery", text: `Ciclos de bateria: ${condition.battery}` });
   } else {
-    lines.push(`Saude bateria ${condition.battery}%`);
+    entries.push({ slug: "battery", text: `Saude bateria ${condition.battery}%` });
   }
 
   // New wear marks system
   if (condition.hasWearMarks !== undefined) {
     if (!condition.hasWearMarks || !condition.wearMarks || condition.wearMarks.length === 0) {
-      lines.push("Sem marcas de uso");
+      entries.push({ slug: "wearMarks", text: "Sem marcas de uso" });
     } else {
       const wearLabels: Record<string, string> = {
         screen_scratches: "Arranhoes na tela",
@@ -292,30 +300,38 @@ export function getConditionLines(condition: ConditionData, deviceType?: DeviceT
         heavy_peeling: "Descascado forte",
       };
       condition.wearMarks.forEach((m) => {
-        lines.push(wearLabels[m] || m);
+        entries.push({ slug: "wearMarks", text: wearLabels[m] || m });
       });
     }
   } else {
     // Legacy
-    if (condition.screenScratch === "none") lines.push("Sem arranhoes na tela");
-    else if (condition.screenScratch === "one") lines.push("1 arranhao na tela");
-    else lines.push("2 ou mais arranhoes na tela");
+    if (condition.screenScratch === "none") entries.push({ slug: "screenScratch", text: "Sem arranhoes na tela" });
+    else if (condition.screenScratch === "one") entries.push({ slug: "screenScratch", text: "1 arranhao na tela" });
+    else entries.push({ slug: "screenScratch", text: "2 ou mais arranhoes na tela" });
 
-    if (condition.sideScratch === "none") lines.push("Sem arranhoes laterais");
-    else if (condition.sideScratch === "one") lines.push("1 arranhao lateral");
-    else lines.push("2 ou mais arranhoes laterais");
+    if (condition.sideScratch === "none") entries.push({ slug: "sideScratch", text: "Sem arranhoes laterais" });
+    else if (condition.sideScratch === "one") entries.push({ slug: "sideScratch", text: "1 arranhao lateral" });
+    else entries.push({ slug: "sideScratch", text: "2 ou mais arranhoes laterais" });
 
-    if (condition.peeling === "none") lines.push("Sem marcas de uso");
-    else if (condition.peeling === "light") lines.push("Marcas de uso leves");
-    else lines.push("Marcas de uso fortes");
+    if (condition.peeling === "none") entries.push({ slug: "peeling", text: "Sem marcas de uso" });
+    else if (condition.peeling === "light") entries.push({ slug: "peeling", text: "Marcas de uso leves" });
+    else entries.push({ slug: "peeling", text: "Marcas de uso fortes" });
   }
 
-  if (condition.partsReplaced === "apple") lines.push(`Peca trocada na Apple (autorizada)${condition.partsReplacedDetail ? `: ${condition.partsReplacedDetail}` : ""}`);
-  else if (condition.partsReplaced === "no") lines.push("Sem pecas trocadas");
+  if (condition.partsReplaced === "apple") entries.push({ slug: "partsReplaced", text: `Peca trocada na Apple (autorizada)${condition.partsReplacedDetail ? `: ${condition.partsReplacedDetail}` : ""}` });
+  else if (condition.partsReplaced === "no") entries.push({ slug: "partsReplaced", text: "Sem pecas trocadas" });
 
-  lines.push(condition.hasOriginalBox ? "Tem a caixa original" : "Sem caixa original");
+  entries.push({ slug: "hasOriginalBox", text: condition.hasOriginalBox ? "Tem a caixa original" : "Sem caixa original" });
 
-  return lines;
+  return entries;
+}
+
+/**
+ * Gera linhas de condicao para exibicao e WhatsApp.
+ * Wrapper sobre `getConditionEntries` quando so o texto importa.
+ */
+export function getConditionLines(condition: ConditionData, deviceType?: DeviceType): string[] {
+  return getConditionEntries(condition, deviceType).map((e) => e.text);
 }
 
 /**
@@ -372,33 +388,37 @@ export function calculateIPadTradeInValue(
   return Math.max(value, 0);
 }
 
-export function getIPadConditionLines(condition: IPadConditionData): string[] {
+export function getIPadConditionEntries(condition: IPadConditionData): ConditionEntry[] {
   const monthNames = ["Janeiro", "Fevereiro", "Marco", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"];
-  const lines: string[] = [];
+  const entries: ConditionEntry[] = [];
 
   if (condition.warrantyMonth !== null) {
     const yearSuffix = condition.warrantyYear ? ` de ${condition.warrantyYear}` : "";
-    lines.push(`Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}`);
+    entries.push({ slug: "warrantyMonth", text: `Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}` });
   }
 
-  lines.push(`Saude bateria ${condition.battery}%`);
+  entries.push({ slug: "battery", text: `Saude bateria ${condition.battery}%` });
 
-  if (condition.screenScratch === "none") lines.push("Sem arranhoes na tela");
-  else if (condition.screenScratch === "one") lines.push("1 arranhao na tela");
-  else lines.push("2 ou mais arranhoes na tela");
+  if (condition.screenScratch === "none") entries.push({ slug: "screenScratch", text: "Sem arranhoes na tela" });
+  else if (condition.screenScratch === "one") entries.push({ slug: "screenScratch", text: "1 arranhao na tela" });
+  else entries.push({ slug: "screenScratch", text: "2 ou mais arranhoes na tela" });
 
-  if (condition.sideScratch === "none") lines.push("Sem arranhoes laterais");
-  else if (condition.sideScratch === "one") lines.push("1 arranhao lateral");
-  else lines.push("2 ou mais arranhoes laterais");
+  if (condition.sideScratch === "none") entries.push({ slug: "sideScratch", text: "Sem arranhoes laterais" });
+  else if (condition.sideScratch === "one") entries.push({ slug: "sideScratch", text: "1 arranhao lateral" });
+  else entries.push({ slug: "sideScratch", text: "2 ou mais arranhoes laterais" });
 
-  if (condition.peeling === "none") lines.push("Sem marcas de uso");
-  else if (condition.peeling === "light") lines.push("Marcas de uso leves");
-  else lines.push("Marcas de uso fortes");
+  if (condition.peeling === "none") entries.push({ slug: "peeling", text: "Sem marcas de uso" });
+  else if (condition.peeling === "light") entries.push({ slug: "peeling", text: "Marcas de uso leves" });
+  else entries.push({ slug: "peeling", text: "Marcas de uso fortes" });
 
-  lines.push(condition.hasApplePencil ? "Apple Pencil inclusa" : "Sem Apple Pencil");
-  lines.push(condition.hasOriginalBox ? "Tem a caixa original" : "Sem caixa original");
+  entries.push({ slug: "hasApplePencil", text: condition.hasApplePencil ? "Apple Pencil inclusa" : "Sem Apple Pencil" });
+  entries.push({ slug: "hasOriginalBox", text: condition.hasOriginalBox ? "Tem a caixa original" : "Sem caixa original" });
 
-  return lines;
+  return entries;
+}
+
+export function getIPadConditionLines(condition: IPadConditionData): string[] {
+  return getIPadConditionEntries(condition).map((e) => e.text);
 }
 
 // ──────────────────────────────────────────
@@ -447,32 +467,36 @@ export function calculateMacBookTradeInValue(
   return Math.max(value, 0);
 }
 
-export function getMacBookConditionLines(condition: MacBookConditionData): string[] {
+export function getMacBookConditionEntries(condition: MacBookConditionData): ConditionEntry[] {
   const monthNames = ["Janeiro", "Fevereiro", "Marco", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"];
-  const lines: string[] = [];
+  const entries: ConditionEntry[] = [];
 
   if (condition.warrantyMonth !== null) {
     const yearSuffix = condition.warrantyYear ? ` de ${condition.warrantyYear}` : "";
-    lines.push(`Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}`);
+    entries.push({ slug: "warrantyMonth", text: `Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}` });
   }
 
-  lines.push(`Ciclos de bateria: ${condition.batteryCycles}`);
+  entries.push({ slug: "battery", text: `Ciclos de bateria: ${condition.batteryCycles}` });
 
-  if (condition.screenScratch === "none") lines.push("Sem arranhoes na tela");
-  else if (condition.screenScratch === "one") lines.push("1 arranhao na tela");
-  else lines.push("2 ou mais arranhoes na tela");
+  if (condition.screenScratch === "none") entries.push({ slug: "screenScratch", text: "Sem arranhoes na tela" });
+  else if (condition.screenScratch === "one") entries.push({ slug: "screenScratch", text: "1 arranhao na tela" });
+  else entries.push({ slug: "screenScratch", text: "2 ou mais arranhoes na tela" });
 
-  if (condition.bodyScratch === "none") lines.push("Sem arranhoes no corpo");
-  else if (condition.bodyScratch === "light") lines.push("Arranhoes leves no corpo");
-  else lines.push("Arranhoes fortes no corpo");
+  if (condition.bodyScratch === "none") entries.push({ slug: "bodyScratch", text: "Sem arranhoes no corpo" });
+  else if (condition.bodyScratch === "light") entries.push({ slug: "bodyScratch", text: "Arranhoes leves no corpo" });
+  else entries.push({ slug: "bodyScratch", text: "Arranhoes fortes no corpo" });
 
-  if (condition.keyboardCondition === "perfect") lines.push("Teclado perfeito");
-  else lines.push("Teclado com teclas grudando");
+  if (condition.keyboardCondition === "perfect") entries.push({ slug: "keyboardCondition", text: "Teclado perfeito" });
+  else entries.push({ slug: "keyboardCondition", text: "Teclado com teclas grudando" });
 
-  lines.push(condition.hasCharger ? "Carregador incluso" : "Sem carregador");
-  lines.push(condition.hasOriginalBox ? "Tem a caixa original" : "Sem caixa original");
+  entries.push({ slug: "hasCharger", text: condition.hasCharger ? "Carregador incluso" : "Sem carregador" });
+  entries.push({ slug: "hasOriginalBox", text: condition.hasOriginalBox ? "Tem a caixa original" : "Sem caixa original" });
 
-  return lines;
+  return entries;
+}
+
+export function getMacBookConditionLines(condition: MacBookConditionData): string[] {
+  return getMacBookConditionEntries(condition).map((e) => e.text);
 }
 
 /**
@@ -495,21 +519,31 @@ export function calculateAnyTradeInValue(
 }
 
 /**
- * Helper unificado: gera linhas de condicao para qualquer tipo de dispositivo
+ * Helper unificado: gera entries (slug + texto) das condicoes hardcoded.
+ * Use no StepManualHandoff pra ordenar com perguntas dinamicas via admin.
+ */
+export function getAnyConditionEntries(
+  deviceType: DeviceType,
+  condition: AnyConditionData
+): ConditionEntry[] {
+  if (deviceType === "ipad" && isIPadCondition(condition)) {
+    return getIPadConditionEntries(condition);
+  }
+  if (deviceType === "macbook" && isMacBookCondition(condition)) {
+    return getMacBookConditionEntries(condition);
+  }
+  return getConditionEntries(condition as ConditionData, deviceType);
+}
+
+/**
+ * Helper unificado: gera linhas de condicao para qualquer tipo de dispositivo.
+ * Wrapper sobre `getAnyConditionEntries` quando so o texto importa.
  */
 export function getAnyConditionLines(
   deviceType: DeviceType,
   condition: AnyConditionData
 ): string[] {
-  if (deviceType === "ipad" && isIPadCondition(condition)) {
-    return getIPadConditionLines(condition);
-  }
-  if (deviceType === "macbook" && isMacBookCondition(condition)) {
-    return getMacBookConditionLines(condition);
-  }
-  // Fallback: trata como ConditionData genérica mas respeita deviceType pro
-  // label da bateria (MacBook = "Ciclos de bateria: X", outros = "Saude bateria X%").
-  return getConditionLines(condition as ConditionData, deviceType);
+  return getAnyConditionEntries(deviceType, condition).map((e) => e.text);
 }
 
 // ──────────────────────────────────────────

--- a/lib/calculations.ts
+++ b/lib/calculations.ts
@@ -7,6 +7,10 @@ export interface ConditionData {
   sideScratch: "none" | "one" | "multiple";
   peeling: "none" | "light" | "heavy";
   battery: number;
+  /** Quando o cliente clica "Normal" (botao quick-value) em vez de digitar um
+   *  numero, guardamos o rotulo aqui pra que o resumo mostre "Bateria: Normal"
+   *  em vez de "Saude bateria 100%". Limpa quando o cliente digita um valor. */
+  batteryLabel?: string | null;
   hasDamage: boolean;
   partsReplaced: "no" | "apple" | "thirdParty";
   partsReplacedDetail?: string;
@@ -29,6 +33,9 @@ export interface MacBookConditionData {
   screenScratch: "none" | "one" | "multiple";
   bodyScratch: "none" | "light" | "heavy";
   batteryCycles: number; // contagem de ciclos
+  /** Igual ao `batteryLabel` de ConditionData — quando o cliente clica
+   *  "Normal" em vez de digitar ciclos, guardamos o rotulo aqui. */
+  batteryLabel?: string | null;
   keyboardCondition: "perfect" | "sticky";
   hasCharger: boolean;
   hasDamage: boolean;
@@ -282,7 +289,11 @@ export function getConditionEntries(condition: ConditionData, deviceType?: Devic
 
   // MacBook: campo battery armazena CICLOS (0..9999), demais dispositivos
   // armazenam saude de bateria em %. Label muda conforme o deviceType.
-  if (deviceType === "macbook") {
+  // Se o cliente clicou o quick-value (ex: "Normal"), mostra o rotulo em vez
+  // do numero — pra refletir o que ele de fato escolheu na UI.
+  if (condition.batteryLabel) {
+    entries.push({ slug: "battery", text: `Bateria: ${condition.batteryLabel}` });
+  } else if (deviceType === "macbook") {
     entries.push({ slug: "battery", text: `Ciclos de bateria: ${condition.battery}` });
   } else {
     entries.push({ slug: "battery", text: `Saude bateria ${condition.battery}%` });
@@ -397,7 +408,11 @@ export function getIPadConditionEntries(condition: IPadConditionData): Condition
     entries.push({ slug: "warrantyMonth", text: `Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}` });
   }
 
-  entries.push({ slug: "battery", text: `Saude bateria ${condition.battery}%` });
+  if (condition.batteryLabel) {
+    entries.push({ slug: "battery", text: `Bateria: ${condition.batteryLabel}` });
+  } else {
+    entries.push({ slug: "battery", text: `Saude bateria ${condition.battery}%` });
+  }
 
   if (condition.screenScratch === "none") entries.push({ slug: "screenScratch", text: "Sem arranhoes na tela" });
   else if (condition.screenScratch === "one") entries.push({ slug: "screenScratch", text: "1 arranhao na tela" });
@@ -476,7 +491,11 @@ export function getMacBookConditionEntries(condition: MacBookConditionData): Con
     entries.push({ slug: "warrantyMonth", text: `Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}` });
   }
 
-  entries.push({ slug: "battery", text: `Ciclos de bateria: ${condition.batteryCycles}` });
+  if (condition.batteryLabel) {
+    entries.push({ slug: "battery", text: `Bateria: ${condition.batteryLabel}` });
+  } else {
+    entries.push({ slug: "battery", text: `Ciclos de bateria: ${condition.batteryCycles}` });
+  }
 
   if (condition.screenScratch === "none") entries.push({ slug: "screenScratch", text: "Sem arranhoes na tela" });
   else if (condition.screenScratch === "one") entries.push({ slug: "screenScratch", text: "1 arranhao na tela" });

--- a/lib/calculations.ts
+++ b/lib/calculations.ts
@@ -268,7 +268,8 @@ export function getConditionLines(condition: ConditionData, deviceType?: DeviceT
   lines.push(condition.hasDamage ? "Com trincado/defeito" : "Sem trincado/defeito");
 
   if (condition.warrantyMonth !== null) {
-    lines.push(`Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}`);
+    const yearSuffix = condition.warrantyYear ? ` de ${condition.warrantyYear}` : "";
+    lines.push(`Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}`);
   }
 
   // MacBook: campo battery armazena CICLOS (0..9999), demais dispositivos
@@ -376,7 +377,8 @@ export function getIPadConditionLines(condition: IPadConditionData): string[] {
   const lines: string[] = [];
 
   if (condition.warrantyMonth !== null) {
-    lines.push(`Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}`);
+    const yearSuffix = condition.warrantyYear ? ` de ${condition.warrantyYear}` : "";
+    lines.push(`Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}`);
   }
 
   lines.push(`Saude bateria ${condition.battery}%`);
@@ -450,7 +452,8 @@ export function getMacBookConditionLines(condition: MacBookConditionData): strin
   const lines: string[] = [];
 
   if (condition.warrantyMonth !== null) {
-    lines.push(`Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}`);
+    const yearSuffix = condition.warrantyYear ? ` de ${condition.warrantyYear}` : "";
+    lines.push(`Garantia Apple ate ${monthNames[condition.warrantyMonth - 1]}${yearSuffix}`);
   }
 
   lines.push(`Ciclos de bateria: ${condition.batteryCycles}`);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -43,6 +43,10 @@ export interface TradeInQuestionOption {
   variant?: "default" | "success" | "error";
   reject?: boolean;
   rejectMessage?: string;
+  /** Frase completa exibida no resumo do produto (StepManualHandoff + WhatsApp).
+   *  Quando setado, o resumo mostra apenas essa frase em vez de "titulo: label".
+   *  Ex: opção "Sim" pode ter summaryLabel="Possui o carregador completo original da Apple". */
+  summaryLabel?: string;
 }
 
 /** Pergunta configurável do trade-in */


### PR DESCRIPTION
Bundle de **15 itens** (todos) da lista de pendencias trade-in num PR so a pedido.

## Resumo do produto (StepManualHandoff)
1. **Item 1 — Ordem dynamic + hardcoded por admin**: condicoes hardcoded e perguntas dinamicas agora compartilham um array unico ordenado pelo `ordem` do admin.
2. **Item 2 — Yesno frase completa (`summaryLabel`)**: opcoes ganham campo "No resumo" no admin pra mostrar frase pronta em vez de "Pergunta?: Sim".
3. **Item 3 — Garantia ate Mes de Ano**: inclui o ano (ex: "Janeiro de 2027").

## Numeric quick-value
5. **Item 5 — Bateria "Normal"**: MacBook ganha botao equivalente ao iPad. Resumo mostra "Bateria: Normal" quando clicado.

## Bugs cliente
9. **Item 9 — Apple Watch Series**: regex `/Apple Watch SE/i` batia em "SEries". Ancorado com `\b`.
11. **Item 11 — iPad A16 cores**: substring vs "iPad 11º (A16)" nao casava. Match por tokens.

## Admin /usados
6+7. **Ordens MacBook (tela 14"→16", M1<M1 Pro<M1 Max<M2)**.
8. **Delete variante (✕)** pra MacBook/iPhone.

## Editor + /precos + Configs
4. **Item 4 — HelpText markdown**: `*italico*` / `_italico_` e `## Titulo` / `### Subtitulo` alem do `**negrito**`.
15. **Item 15 — Renomear grupo em /admin/precos**: botao "✏️ Renomear" inline + PATCH batch (1 SQL UPDATE).
14. **Item 14 — Label WhatsApp "Outros Modelos"**.

## Apple Watch — Material da caixa
10. **Item 10 — Caixa por geracao**: nova pergunta entre modelo e cor pro Watch Series. Hardcoded:
    - Series 9: Aluminio + Aco Inoxidavel
    - Series 10/11: Aluminio + Titanio (forca GPS+Cel)
    - Cores filtradas pelo material; resumo mostra "Caixa: Aluminio" via pergunta sintetica

## Admin UX
13. **Item 13 — ConfirmModal customizado**: `components/admin/ConfirmModal.tsx` com hook `useConfirmModal()` expoe `.confirm()/.prompt()/.alert()` via Promises. Substitui `window.confirm/prompt/alert` em TradeInQuestionsAdmin, admin/usados, admin/precos (outras abas seguem nativas ate serem tocadas).
12. **Item 12 — Help texts da bateria editaveis**: os 4 blocos "Como descobrir a saude da bateria?" (iPhone/iPad/MacBook/Watch) agora lem de `tradeinConfig.labels.help_battery_{device}` com fallback hardcoded. Admin edita em /admin/simulacoes → "Textos do Formulario" → "Help texts da bateria". Markdown completo suportado.

## Backward compat
- Todos novos campos (`summaryLabel`, `batteryLabel`, `warrantyYear`) opcionais.
- `getAnyConditionLines` mantida como wrapper de `getAnyConditionEntries`.
- Watch Ultra/SE pulam a pergunta de caixa.
- Help texts sem label caem no hardcoded.
- Nenhuma migration de banco.

## Test plan
- [ ] Resumo ordenado: yesno entre bateria e marcas
- [ ] Yesno summaryLabel: frase no lugar de "Pergunta?: Sim"
- [ ] Garantia com " de YYYY"
- [ ] iPad/MacBook bateria Normal: botao funciona, resumo correto
- [ ] Watch Series aparece na tela de selecao
- [ ] iPad A16 cores aparecem no cliente
- [ ] Admin /usados MacBook: ordens e delete ✕
- [ ] HelpText admin renderiza markdown
- [ ] Renomear grupo /precos atualiza todas variantes
- [ ] Label WhatsApp "Outros Modelos"
- [ ] Watch Series caixa: Series 9 = Aluminio/Aco, 10/11 = Aluminio/Titanio; Titanio força GPS+Cel
- [ ] ConfirmModal aparece em vez de confirm() em admin/usados
- [ ] Help text de bateria cadastrado no admin aparece no cliente
- [ ] iPhone trade-in (/troca) nao regrediu

🤖 Generated with [Claude Code](https://claude.com/claude-code)