### PR TITLE
fix(tradein): correcoes pos-#802 (yesno auto + MacBook ordem + admin merge + quick-value)

### DIFF
--- a/components/StepManualHandoff.tsx
+++ b/components/StepManualHandoff.tsx
@@ -72,6 +72,30 @@ function findSelectedOption(q: TradeInQuestion, value: unknown) {
   return q.opcoes.find((o) => o.value === value);
 }
 
+/** Heuristica pra construir uma frase completa de yesno SEM precisar do admin
+ *  cadastrar `summaryLabel`. Strip do "?" no final do titulo + prefixo "Não"
+ *  (com lowercase do primeiro caractere) quando a resposta for negativa.
+ *  Ex: "Possui o carregador completo original?" + Sim → "Possui o carregador completo original".
+ *      "Possui o carregador completo original?" + Não → "Não possui o carregador completo original". */
+function buildYesnoSummary(q: TradeInQuestion, value: unknown): string | null {
+  if (q.tipo !== "yesno") return null;
+  const titulo = (q.titulo || "").trim().replace(/\?+\s*$/, "").trim();
+  if (!titulo) return null;
+  let isPositive: boolean;
+  if (typeof value === "boolean") {
+    isPositive = value;
+  } else if (typeof value === "string") {
+    const v = value.toLowerCase().trim();
+    if (v === "yes" || v === "sim" || v === "true" || v === "1") isPositive = true;
+    else if (v === "no" || v === "nao" || v === "não" || v === "false" || v === "0") isPositive = false;
+    else return null;
+  } else {
+    return null;
+  }
+  if (isPositive) return titulo;
+  return `Não ${titulo[0].toLowerCase()}${titulo.slice(1)}`;
+}
+
 // Formata uma resposta dinamica em string human-readable (so o valor, sem o titulo).
 function formatExtraAnswer(q: TradeInQuestion, value: unknown): string {
   if (value === undefined || value === null || value === "") return "—";
@@ -136,6 +160,14 @@ function buildOrderedLines(
         const opt = findSelectedOption(q, raw);
         if (opt?.summaryLabel) {
           return { slug: slugN, ordem, text: opt.summaryLabel };
+        }
+        // Fallback heuristico: yesno sem summaryLabel cadastrado vira frase
+        // completa baseada no titulo. Evita "Pergunta?: Sim" no resumo —
+        // mostra "Possui o carregador completo" / "Não possui o carregador
+        // completo" automaticamente.
+        const yesno = buildYesnoSummary(q, raw);
+        if (yesno) {
+          return { slug: slugN, ordem, text: yesno };
         }
       }
       const value = formatExtraAnswer(q, raw);

--- a/components/StepManualHandoff.tsx
+++ b/components/StepManualHandoff.tsx
@@ -169,6 +169,16 @@ function buildOrderedLines(
         if (yesno) {
           return { slug: slugN, ordem, text: yesno };
         }
+        // Numeric com quick-value cadastrado: quando o valor bate exatamente,
+        // mostra o rotulo (ex: "Saude bateria: Normal" em vez de "100").
+        if (q.tipo === "numeric" && typeof raw === "number") {
+          const cfg = (q.config || {}) as Record<string, unknown>;
+          const quickLabel = typeof cfg.quickLabel === "string" && cfg.quickLabel.trim() ? cfg.quickLabel : null;
+          const quickValue = typeof cfg.quickValue === "number" ? cfg.quickValue : null;
+          if (quickLabel !== null && quickValue !== null && raw === quickValue) {
+            return { slug: slugN, ordem, bold: q.titulo || q.slug, text: quickLabel };
+          }
+        }
       }
       const value = formatExtraAnswer(q, raw);
       if (value === "—") return null;

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -1020,27 +1020,10 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                   Aparece só &quot;Normal&quot; no meu iPad
                 </button>
               )}
-              {deviceType === "macbook" && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    // MacBook tambem suporta "Normal" — quando o cliente nao
-                    // sabe os ciclos. Marcamos batteryCycles=0 (sem desconto)
-                    // e o resumo mostra "Bateria: Normal".
-                    setBattery(0);
-                    setBatteryLabel("Normal");
-                    tq("battery");
-                  }}
-                  className="w-full py-2 rounded-xl text-[13px] font-medium transition-colors"
-                  style={{
-                    backgroundColor: batteryLabel ? "var(--ti-success-light)" : "var(--ti-input-bg)",
-                    color: batteryLabel ? "var(--ti-success)" : "var(--ti-muted)",
-                    border: `1px solid ${batteryLabel ? "var(--ti-success)" : "var(--ti-card-border)"}`,
-                  }}
-                >
-                  Não sei os ciclos — bateria normal
-                </button>
-              )}
+              {/* MacBook nao tem mais o botao "Normal" hardcoded aqui — admin
+                  cadastra uma pergunta numeric de "Saude de bateria %" via
+                  /admin/simulacoes e configura `quickLabel`/`quickValue` ali.
+                  O botao aparece automaticamente abaixo do input dinamico. */}
               {/* Ajuda "Como descobrir a saude/ciclos da bateria?" — texto padrao
                   por device_type, sobrescrivel via labels.help_battery_{device}
                   em /admin/simulacoes. Suporta markdown (negrito, italico, ## titulo). */}
@@ -1308,12 +1291,18 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
               const rb = typeof cfg.rejectBelow === "number" ? cfg.rejectBelow : undefined;
               const rm = typeof cfg.rejectMessage === "string" ? cfg.rejectMessage : "";
               const isRejected = typeof val === "number" && rb !== undefined && val < rb;
+              // Quick-value (botao tipo "Normal" pra saude de bateria) — admin
+              // configura quickLabel + quickValue. Cliente clica em vez de digitar;
+              // o resumo mostra o rotulo no lugar do numero quando o valor bate.
+              const quickLabel = typeof cfg.quickLabel === "string" && cfg.quickLabel.trim() ? cfg.quickLabel : null;
+              const quickValue = typeof cfg.quickValue === "number" ? cfg.quickValue : null;
+              const quickActive = quickLabel !== null && quickValue !== null && val === quickValue;
               return (
                 <div className="rounded-2xl p-4 space-y-3" style={{ backgroundColor: "var(--ti-card-bg)", border: "1px solid var(--ti-card-border)" }}>
                   <input
                     type="number"
                     inputMode="numeric"
-                    value={typeof val === "number" ? String(val) : (typeof val === "string" ? val : "")}
+                    value={quickActive ? "" : (typeof val === "number" ? String(val) : (typeof val === "string" ? val : ""))}
                     onChange={(e) => {
                       const raw = e.target.value.trim();
                       const num = raw === "" ? undefined : Number(raw);
@@ -1322,8 +1311,22 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                     }}
                     className="w-full px-4 py-3 rounded-xl text-[20px] font-bold text-center focus:outline-none transition-colors"
                     style={{ backgroundColor: "var(--ti-input-bg)", color: "var(--ti-text)", border: "1px solid var(--ti-card-border)" }}
-                    placeholder={ph}
+                    placeholder={quickActive && quickLabel ? quickLabel : ph}
                   />
+                  {quickLabel !== null && quickValue !== null && (
+                    <button
+                      type="button"
+                      onClick={() => { setVal(quickValue); tq(q.slug); }}
+                      className="w-full py-2 rounded-xl text-[13px] font-medium transition-colors"
+                      style={{
+                        backgroundColor: quickActive ? "var(--ti-success-light)" : "var(--ti-input-bg)",
+                        color: quickActive ? "var(--ti-success)" : "var(--ti-muted)",
+                        border: `1px solid ${quickActive ? "var(--ti-success)" : "var(--ti-card-border)"}`,
+                      }}
+                    >
+                      {quickLabel}
+                    </button>
+                  )}
                   {help && (
                     <details className="rounded-xl p-3" style={{ backgroundColor: "var(--ti-input-bg)", border: "1px solid var(--ti-card-border)" }}>
                       <summary className="text-[12px] font-semibold cursor-pointer" style={{ color: "var(--ti-accent)" }}>{helpTitle}</summary>

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -370,13 +370,41 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   const chipList = useMemo(() => {
     if (!chipGroups) return [];
     const keys = Object.keys(chipGroups);
-    const extractNum = (s: string) => {
-      const m = s.match(/(\d+)/);
-      return m ? Number(m[1]) : 999;
+    // Pra MacBook/iPad: ordena por chip M-num e variante (plain < Pro < Max).
+    // Sem isso, "M1" e "M1 Pro" empatavam no number sort e ficavam fora de
+    // ordem (M1 Pro antes de M1). Pra Apple Watch (chip e so a geracao tipo
+    // "9", "10"), sem variante — extractKey retorna [9,0] e funciona igual.
+    const extractKey = (s: string): [number, number] => {
+      const m = s.match(/M(\d+)(?:\s+(Pro|Max))?/i);
+      if (m) {
+        const num = Number(m[1]);
+        const variant = (m[2] || "").toLowerCase();
+        const ord = variant === "" ? 0 : variant === "pro" ? 1 : variant === "max" ? 2 : 3;
+        return [num, ord];
+      }
+      // Fallback: extrai primeiro numero (Watch geracao "9", "10", etc).
+      const n = s.match(/(\d+)/);
+      return [n ? Number(n[1]) : 999, 0];
     };
-    return keys.sort((a, b) => extractNum(a) - extractNum(b));
+    return keys.sort((a, b) => {
+      const ka = extractKey(a);
+      const kb = extractKey(b);
+      if (ka[0] !== kb[0]) return ka[0] - kb[0];
+      return ka[1] - kb[1];
+    });
   }, [chipGroups]);
-  const modelsForChip = useMemo(() => chipGroups && subLine ? (chipGroups[subLine] || []) : [], [chipGroups, subLine]);
+  const modelsForChip = useMemo(() => {
+    const list = chipGroups && subLine ? (chipGroups[subLine] || []) : [];
+    // Ordena por tamanho de tela (14" antes de 16"). Sem isso, modelos podem
+    // chegar do banco em qualquer ordem — antes "16\"" aparecia antes de "14\""
+    // pra MacBook Pro M2 Pro porque a string "16" e maior que "14" no sort
+    // alfabetico padrao do Object.keys.
+    const screenInches = (m: string): number => {
+      const match = m.match(/(\d+)[""]/);
+      return match ? Number(match[1]) : 999;
+    };
+    return [...list].sort((a, b) => screenInches(a) - screenInches(b));
+  }, [chipGroups, subLine]);
 
   // Opcoes de caixa pro Apple Watch Series, determinadas pela geracao (subLine).
   // Watch Series 9 → [Aluminio, Aco Inox]; Series 10/11 → [Aluminio, Titanio].

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -502,6 +502,37 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
                     </div>
 
                     <div>
+                      <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">Botao rapido (quick value)</label>
+                      <p className="mt-0.5 text-[11px] text-[#86868B]">Cliente clica em vez de digitar — util pra &quot;Normal&quot; (=100%) ou &quot;Não sei&quot; (=0). No resumo aparece o rotulo em vez do numero.</p>
+                      <div className="mt-2 flex items-center gap-2">
+                        <input
+                          type="text"
+                          value={typeof (q.config as Record<string, unknown>).quickLabel === "string" ? (q.config.quickLabel as string) : ""}
+                          onChange={(e) => updateConfig(q.id, "quickLabel", e.target.value)}
+                          placeholder="Rotulo (ex: Normal)"
+                          className="flex-1 px-2 py-1 rounded border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                        />
+                        <span className="text-xs text-[#86868B]">=</span>
+                        <input
+                          type="number"
+                          value={typeof (q.config as Record<string, unknown>).quickValue === "number" ? String((q.config.quickValue as number)) : ""}
+                          onChange={(e) => {
+                            const raw = e.target.value.trim();
+                            if (raw === "") {
+                              const next = { ...q.config } as Record<string, unknown>;
+                              delete next.quickValue;
+                              updateQuestion(q.id, { config: next });
+                            } else {
+                              updateConfig(q.id, "quickValue", Number(raw));
+                            }
+                          }}
+                          placeholder="Valor (ex: 100)"
+                          className="w-28 px-2 py-1 rounded border border-[#D2D2D7] text-sm text-center focus:outline-none focus:border-[#E8740E]"
+                        />
+                      </div>
+                    </div>
+
+                    <div>
                       <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">Titulo do painel de ajuda</label>
                       <input
                         type="text"

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -43,29 +43,42 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
     return { "x-admin-password": password, "Content-Type": "application/json" };
   }
 
+  // Strip do sufixo `_iphone`/`_ipad`/`_macbook`/`_watch` pra comparar slugs
+  // do banco com os hardcoded que vem sem sufixo. Evita "battery" hardcoded
+  // sumir da lista quando o admin tem so "battery_ipad" no banco.
+  function bareSlug(slug: string): string {
+    for (const suf of ["_iphone", "_ipad", "_macbook", "_watch"]) {
+      if (slug.endsWith(suf)) return slug.slice(0, -suf.length);
+    }
+    return slug;
+  }
+
   function fetchQuestions(dt: string) {
     setLoading(true);
     setExpandedId(null);
-    fetch(`/api/admin/tradein-perguntas?device_type=${dt}`, { headers: getHeaders() })
-      .then(r => r.json())
-      .then(json => {
-        if (json.data && json.data.length > 0) {
-          setQuestions(json.data);
-        } else {
-          // Fallback: buscar perguntas padrão (hardcoded) e gerar IDs fake
-          return fetch(`/api/tradein-perguntas?device_type=${dt}`)
-            .then(r => r.json())
-            .then(json2 => {
-              const qs = (json2.data || []).map((q: TradeInQuestion, i: number) => ({
-                ...q,
-                id: q.id || `fallback-${dt}-${i}`,
-              }));
-              setQuestions(qs);
-              if (qs.length > 0) {
-                setMsg("Perguntas padrao carregadas. Edite e salve pra gravar no banco.");
-                setTimeout(() => setMsg(""), 4000);
-              }
-            });
+    // Sempre busca DB + defaults e MERGE: assim hardcoded (battery, hasDamage,
+    // etc) sempre aparecem no editor mesmo quando o admin so tem cadastros
+    // dinamicos no banco. Antes, iPad com perguntas custom no DB nao mostrava
+    // o "battery" hardcoded — admin so via no fluxo cliente, sem editar.
+    Promise.all([
+      fetch(`/api/admin/tradein-perguntas?device_type=${dt}`, { headers: getHeaders() }).then(r => r.json()).catch(() => ({ data: [] })),
+      fetch(`/api/tradein-perguntas?device_type=${dt}`).then(r => r.json()).catch(() => ({ data: [] })),
+    ])
+      .then(([dbJson, defJson]) => {
+        const dbQs: TradeInQuestion[] = dbJson.data || [];
+        const defQs: TradeInQuestion[] = defJson.data || [];
+        // Slugs ja presentes no DB (normalizados pra detectar sufixados).
+        const dbBareSlugs = new Set(dbQs.map(q => bareSlug(q.slug)));
+        // Adiciona defaults que nao existem no DB com IDs fake — admin pode
+        // editar e salvar pra promover pro banco.
+        const missingDefaults = defQs
+          .filter(q => !dbBareSlugs.has(bareSlug(q.slug)))
+          .map((q, i) => ({ ...q, id: q.id || `fallback-${dt}-${i}` }));
+        const merged = [...dbQs, ...missingDefaults].sort((a, b) => (a.ordem ?? 999) - (b.ordem ?? 999));
+        setQuestions(merged);
+        if (dbQs.length === 0 && missingDefaults.length > 0) {
+          setMsg("Perguntas padrao carregadas. Edite e salve pra gravar no banco.");
+          setTimeout(() => setMsg(""), 4000);
         }
       })
       .catch(err => setMsg("Erro: " + String(err)))


### PR DESCRIPTION
Continuacao do PR #802 ja mergeado. 2 commits cherry-picked do branch original com fixes de review apontados pelo Nicolas.

## Mudancas

### 1. Heuristica yesno no resumo do produto
Yesno sem `summaryLabel` cadastrado virava "Pergunta?: Sim" no resumo. Agora ha um fallback heuristico (`buildYesnoSummary`): pega o titulo, tira "?" e prefixa "Não " com lowercase quando a resposta e negativa.
- Ex: "Possui o carregador completo original?" + Sim → "Possui o carregador completo original"
- Ex: "Possui o carregador completo original?" + Nao → "Não possui o carregador completo original"

`summaryLabel` cadastrado pelo admin continua tendo prioridade — heuristica e so o fallback.

### 2. MacBook fluxo cliente fora de ordem
- **Modelos M-chip**: "M1 Pro" aparecia antes de "M1" (string sort empatava pelo numero). Agora ordena por [num, variantOrd] — plain (0) < Pro (1) < Max (2). Funciona pra M1 < M1 Pro < M1 Max < M2 < M2 Pro etc.
- **Tamanho de tela**: "16\"" aparecia antes de "14\"" porque modelos vinham em ordem alfabetica do banco. Agora `modelsForChip` ordena por inches.

### 3. Admin /simulacoes nao mostrava `battery` do iPad/MacBook
`fetchQuestions` usava fallback so se DB estivesse VAZIO. Agora SEMPRE busca DB + defaults e faz merge — qualquer hardcoded que nao esta no DB aparece no editor com ID fake (admin edita e salva pra promover pro banco). Slug normalizado (strip de `_ipad`/`_macbook`/`_watch`) pra detectar duplicatas.

### 4. Quick-value (Normal) configuravel pra perguntas numericas
Movendo a logica do botao "Normal" do MacBook hardcoded pra config dinamica:
- Removido botao "Não sei os ciclos — bateria normal" do MacBook hardcoded (estava duplicado com a pergunta dinamica de saude que o admin cadastrou).
- Admin: novos campos "Botao rapido (quick value)" no editor numeric (rotulo + valor) — vivem em `q.config.quickLabel` / `q.config.quickValue`.
- Cliente: input numeric dynamic agora renderiza um botao abaixo quando config tem `quickLabel`/`quickValue`. Clicar seta o valor; placeholder do input mostra o rotulo enquanto o quick esta ativo.
- Resumo: quando `answer === quickValue`, mostra "Titulo: rotulo" (ex: "Saude da bateria: Normal" em vez de "...: 100").

Botao "Normal" do iPad continua hardcoded — admin pode mover pra dynamic quando quiser via /admin/simulacoes editando a pergunta `battery` do iPad.

## Backward compat
- Heuristica yesno so roda quando `summaryLabel` nao cadastrado.
- Quick-value e opcional — sem cadastro, comportamento igual ao de antes.
- Merge de hardcoded so adiciona — nao remove cadastros existentes.
- Nenhuma migration de banco.

## Test plan
- [ ] **Yesno auto**: cadastrar yesno sem summaryLabel, responder, ver no resumo "Pergunta titulo" / "Não pergunta titulo" sem o "?"
- [ ] **MacBook chips**: linha Pro mostra M1 < M1 Pro < M2 < M2 Pro < M3
- [ ] **MacBook tela**: 14" antes de 16"
- [ ] **Admin iPad bateria**: ao abrir /admin/simulacoes aba iPad, ver "battery" listada (com fake ID se nao tiver no DB)
- [ ] **Quick-value MacBook**: cadastrar pergunta numeric "Saude de bateria %" pro MacBook com quickLabel="Normal" e quickValue=100. Cliente clica o botao → valor=100. Resumo mostra "Saude da bateria: Normal".
- [ ] iPhone trade-in (/troca) inteiro nao regrediu

🤖 Generated with [Claude Code](https://claude.com/claude-code)