### PR TITLE
fix(tradein): Watch + admin/usados ordens 4 categorias + summaryLabel por pergunta + help text inline

### DIFF
--- a/app/admin/usados/page.tsx
+++ b/app/admin/usados/page.tsx
@@ -793,31 +793,78 @@ export function UsadosContent() {
     }
   }
 
-  // Ordena os nomes de modelo dentro do grupo. Pra MacBook agrupa por linha
-  // (Air antes de Pro), depois geracao do chip (M1 < M1 Pro < M1 Max < M2 ...),
-  // e por fim tela (13" < 14" < 15" < 16"). Pra outras categorias, cai pra
-  // alfabetico estavel — todos com chipNum 0 dao o mesmo peso.
+  // Ordena os nomes de modelo dentro do grupo. Cada categoria usa uma chave
+  // diferente:
+  //   iPhone:  [num, varianteOrd, name]   (15 Pro Max, 16e, etc — variantes em IPHONE_VARIANTES)
+  //   iPad:    [linha, hasMChip?, gen, name]  (entrada → Air → Pro → mini, gens numericas antes do M-chip)
+  //   MacBook: [linha, chip, variantOrd, tela, name]  (Air → Pro, M1<M1 Pro<M1 Max<M2, 13<14<15<16)
+  //   Watch:   [linha, gen, name]  (SE → Series → Ultra, depois numero da geracao)
+  //   default: alfabetico
   //
-  // Chave: [linha, chipNum, variantOrd, screen, name].
-  const modelSortKey = (name: string): [number, number, number, number, string] => {
-    let lineOrd = 0;
-    if (/MacBook Pro/i.test(name)) lineOrd = 1;
-    else if (/MacBook Air/i.test(name)) lineOrd = 0;
-    const screenMatch = name.match(/(\d+(?:\.\d+)?)\s*"/);
-    const screen = screenMatch ? parseFloat(screenMatch[1]) : 0;
-    const chipMatch = name.match(/\bM(\d+)(?:\s+(Pro|Max))?\b/i);
-    const chipNum = chipMatch ? parseInt(chipMatch[1]) : 0;
-    const variant = (chipMatch?.[2] || "").toLowerCase();
-    const variantOrd = variant === "" ? 0 : variant === "pro" ? 1 : variant === "max" ? 2 : 3;
-    return [lineOrd, chipNum, variantOrd, screen, name];
+  // Sem isso, listagem ficava ordenada alfabeticamente — confuso pra achar
+  // modelos especificos quando misturava linhas (ex: Air e Pro intercalados).
+  const modelSortKey = (name: string): (number | string)[] => {
+    if (catFilter === "iphone") {
+      const m = name.match(/iPhone\s+(\d+)(e)?\s*(Plus|Air|Pro\s+Max|Pro)?/i);
+      if (!m) return [999, 99, name];
+      const num = parseInt(m[1]);
+      let v = "";
+      if (m[2]) v = "E";
+      else if (m[3]) v = m[3].toUpperCase().replace(/\s+/g, " ");
+      const variantOrder = ["", "E", "PLUS", "AIR", "PRO", "PRO MAX"];
+      const vOrd = variantOrder.indexOf(v);
+      return [num, vOrd < 0 ? 99 : vOrd, name];
+    }
+    if (catFilter === "ipad") {
+      // Linha: Entrada (sem Air/Pro/mini) < Air < Pro < mini (mesma ordem do
+      // selector LINHAS_BY_CAT).
+      let line = 0;
+      if (/iPad\s+Air/i.test(name)) line = 1;
+      else if (/iPad\s+Pro/i.test(name)) line = 2;
+      else if (/iPad\s+(?:m|M)ini/i.test(name)) line = 3;
+      const hasMChip = /\bM\d+/.test(name) ? 1 : 0;
+      // Gen: numero da geracao ("9", "10", "11") ou numero do chip ("M2"→2)
+      let gen = 0;
+      const mChip = name.match(/\bM(\d+)/);
+      const numGen = name.match(/(\d+)\s*[ºo°ª]/);
+      if (mChip) gen = parseInt(mChip[1]);
+      else if (numGen) gen = parseInt(numGen[1]);
+      return [line, hasMChip, gen, name];
+    }
+    if (catFilter === "macbook") {
+      let line = 0;
+      if (/MacBook\s+Pro/i.test(name)) line = 1;
+      else if (/MacBook\s+Air/i.test(name)) line = 0;
+      const screenMatch = name.match(/(\d+(?:\.\d+)?)\s*"/);
+      const screen = screenMatch ? parseFloat(screenMatch[1]) : 0;
+      const chipMatch = name.match(/\bM(\d+)(?:\s+(Pro|Max))?\b/i);
+      const chipNum = chipMatch ? parseInt(chipMatch[1]) : 0;
+      const variant = (chipMatch?.[2] || "").toLowerCase();
+      const variantOrd = variant === "" ? 0 : variant === "pro" ? 1 : variant === "max" ? 2 : 3;
+      return [line, chipNum, variantOrd, screen, name];
+    }
+    if (catFilter === "watch") {
+      let line = 0;
+      if (/Apple\s+Watch\s+SE/i.test(name)) line = 0;
+      else if (/Apple\s+Watch\s+Ultra/i.test(name)) line = 2;
+      else if (/Apple\s+Watch\s+(?:Series\s+)?\d+/i.test(name)) line = 1;
+      // Gen: numero direto (SE 2/3, Series 8-11, Ultra 1-3).
+      const numMatch = name.match(/(\d+)/);
+      const gen = numMatch ? parseInt(numMatch[1]) : 0;
+      return [line, gen, name];
+    }
+    return [name];
   };
   const sortedModelos = Object.keys(grouped).sort((a, b) => {
     const ka = modelSortKey(a);
     const kb = modelSortKey(b);
-    for (let i = 0; i < 4; i++) {
-      if (ka[i] !== kb[i]) return Number(ka[i]) - Number(kb[i]);
+    const len = Math.min(ka.length, kb.length);
+    for (let i = 0; i < len - 1; i++) {
+      const va = ka[i] as number;
+      const vb = kb[i] as number;
+      if (va !== vb) return va - vb;
     }
-    return String(ka[4]).localeCompare(String(kb[4]));
+    return String(ka[ka.length - 1]).localeCompare(String(kb[kb.length - 1]));
   });
 
   // Map de modelos conhecidos (case-insensitive): valores base + modelos extraídos dos descontos

--- a/components/StepManualHandoff.tsx
+++ b/components/StepManualHandoff.tsx
@@ -72,15 +72,19 @@ function findSelectedOption(q: TradeInQuestion, value: unknown) {
   return q.opcoes.find((o) => o.value === value);
 }
 
-/** Heuristica pra construir uma frase completa de yesno SEM precisar do admin
- *  cadastrar `summaryLabel`. Strip do "?" no final do titulo + prefixo "Não"
- *  (com lowercase do primeiro caractere) quando a resposta for negativa.
- *  Ex: "Possui o carregador completo original?" + Sim → "Possui o carregador completo original".
- *      "Possui o carregador completo original?" + Não → "Não possui o carregador completo original". */
+/** Heuristica pra construir uma frase completa de yesno. Pega `q.config.summaryLabel`
+ *  se setado pelo admin (mais conciso pro resumo); senao usa o titulo da
+ *  pergunta sem o "?". Pra resposta negativa, prefixa "Não " com lowercase
+ *  do primeiro caractere.
+ *  Ex: config.summaryLabel="Possui o carregador completo original" + Sim →
+ *      "Possui o carregador completo original".
+ *  Ex: titulo="Possui o carregador?" + Não → "Não possui o carregador". */
 function buildYesnoSummary(q: TradeInQuestion, value: unknown): string | null {
   if (q.tipo !== "yesno") return null;
-  const titulo = (q.titulo || "").trim().replace(/\?+\s*$/, "").trim();
-  if (!titulo) return null;
+  const cfgLabel = (q.config as Record<string, unknown>)?.summaryLabel;
+  const source = (typeof cfgLabel === "string" && cfgLabel.trim()) ? cfgLabel : q.titulo || "";
+  const base = source.trim().replace(/\?+\s*$/, "").trim();
+  if (!base) return null;
   let isPositive: boolean;
   if (typeof value === "boolean") {
     isPositive = value;
@@ -92,8 +96,16 @@ function buildYesnoSummary(q: TradeInQuestion, value: unknown): string | null {
   } else {
     return null;
   }
-  if (isPositive) return titulo;
-  return `Não ${titulo[0].toLowerCase()}${titulo.slice(1)}`;
+  if (isPositive) return base;
+  return `Não ${base[0].toLowerCase()}${base.slice(1)}`;
+}
+
+/** Pega o titulo "bold" pro resumo (numeric e fallback kv): usa
+ *  `q.config.summaryLabel` quando setado, senao o titulo da pergunta. */
+function summaryBold(q: TradeInQuestion): string {
+  const cfgLabel = (q.config as Record<string, unknown>)?.summaryLabel;
+  if (typeof cfgLabel === "string" && cfgLabel.trim()) return cfgLabel.trim();
+  return q.titulo || q.slug;
 }
 
 // Formata uma resposta dinamica em string human-readable (so o valor, sem o titulo).
@@ -170,19 +182,19 @@ function buildOrderedLines(
           return { slug: slugN, ordem, text: yesno };
         }
         // Numeric com quick-value cadastrado: quando o valor bate exatamente,
-        // mostra o rotulo (ex: "Saude bateria: Normal" em vez de "100").
+        // mostra o rotulo (ex: "Saude da bateria: Normal" em vez de "100").
         if (q.tipo === "numeric" && typeof raw === "number") {
           const cfg = (q.config || {}) as Record<string, unknown>;
           const quickLabel = typeof cfg.quickLabel === "string" && cfg.quickLabel.trim() ? cfg.quickLabel : null;
           const quickValue = typeof cfg.quickValue === "number" ? cfg.quickValue : null;
           if (quickLabel !== null && quickValue !== null && raw === quickValue) {
-            return { slug: slugN, ordem, bold: q.titulo || q.slug, text: quickLabel };
+            return { slug: slugN, ordem, bold: summaryBold(q), text: quickLabel };
           }
         }
       }
       const value = formatExtraAnswer(q, raw);
       if (value === "—") return null;
-      return { slug: slugN, ordem, bold: q.titulo || q.slug, text: value };
+      return { slug: slugN, ordem, bold: summaryBold(q), text: value };
     })
     .filter((l): l is SummaryLine => l !== null);
 

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -52,18 +52,19 @@ const HARDCODED_DEFAULT_ORDEM: Record<string, number> = {
 // (1) filtrar cores disponiveis conforme caixa e (2) forcar GPS+Cel em Titanio.
 // Series 9: Aluminio (cores standard) + Aco Inoxidavel (Grafite/Prateado/Dourado).
 // Series 10/11: Aluminio + Titanio (Natural/Dourado/Ardosia, sempre GPS+Cel).
-const WATCH_SERIES_CASES: Record<string, { material: string; cores: string[]; forceGPSCel?: boolean }[]> = {
+const WATCH_SERIES_CASES: Record<string, { material: string; forceGPSCel?: boolean }[]> = {
   "9": [
-    { material: "Alumínio", cores: ["Meia-noite", "Estelar", "Prateado", "Vermelho", "Rosa"] },
-    { material: "Aço Inoxidável", cores: ["Grafite", "Prateado", "Dourado"] },
+    { material: "Alumínio" },
+    // Series 9 Aco Inox so vem GPS+Cel de fabrica.
+    { material: "Aço Inoxidável", forceGPSCel: true },
   ],
   "10": [
-    { material: "Alumínio", cores: ["Ouro Rosa", "Prateado", "Preto Brilhante", "Cinza-espacial"] },
-    { material: "Titânio", cores: ["Titânio Natural", "Dourado", "Ardósia"], forceGPSCel: true },
+    { material: "Alumínio" },
+    { material: "Titânio", forceGPSCel: true },
   ],
   "11": [
-    { material: "Alumínio", cores: ["Ouro Rosa", "Prateado", "Preto Brilhante", "Cinza-espacial"] },
-    { material: "Titânio", cores: ["Titânio Natural", "Dourado", "Ardósia"], forceGPSCel: true },
+    { material: "Alumínio" },
+    { material: "Titânio", forceGPSCel: true },
   ],
 };
 
@@ -415,17 +416,11 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   }, [deviceType, line, subLine]);
   const requiresWatchCase = watchCaseOptions.length > 0;
 
-  // Cores filtradas pela caixa quando aplicavel (Watch Series). Se a lista
-  // filtrada ficar vazia (ex: cor nao cadastrada no catalogo mas prevista no
-  // hardcoded), cai na lista bruta pra nao travar o cliente.
-  const coresModelo = useMemo(() => {
-    if (!requiresWatchCase || !watchCase) return coresModeloRaw;
-    const opt = watchCaseOptions.find((o) => o.material === watchCase);
-    if (!opt || opt.cores.length === 0) return coresModeloRaw;
-    const allowed = new Set(opt.cores.map((c) => c.toLowerCase()));
-    const filtered = coresModeloRaw.filter((c) => allowed.has(c.toLowerCase()));
-    return filtered.length > 0 ? filtered : coresModeloRaw;
-  }, [coresModeloRaw, requiresWatchCase, watchCase, watchCaseOptions]);
+  // Cores: usa direto o catalogo cadastrado em /admin/usados (sem filtro por
+  // material). O admin gerencia a lista de cores por modelo, e o material da
+  // caixa fica capturado via watchCase no resumo. Antes filtrava por uma lista
+  // hardcoded que escondia cores cadastradas — operador cobrou pra mostrar todas.
+  const coresModelo = coresModeloRaw;
 
   // Se o chip selecionado tem só 1 modelo, auto-selecionar
   const needsScreenSize = modelsForChip.length > 1;
@@ -833,10 +828,80 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
             );
           })()
         ) : storages.some(hasStructuredStorage) ? (
-          // Formato estruturado "armaz | tela | conect" (iPad/Watch com
-          // variantes). Renderiza em steps sequenciais ao inves de 1 botao
-          // por combinacao — cliente escolhe armaz → tela → conectividade.
-          (() => {
+          // Formato estruturado: pra iPad e "armaz | tela | conect" (3 partes);
+          // pra Watch e "tamanho | conect" (2 partes). Branch por deviceType.
+          deviceType === "watch" ? (() => {
+            // Watch: parts[0] e tamanho da caixa (38mm, 41mm, 45mm...) e
+            // parts[1] e conectividade (GPS, GPS+Cel). parseStorageSpec coloca
+            // parts[1] no campo .tela (legacy de iPad), entao tratamos como
+            // conectividade aqui.
+            const specs = storages.map(s => {
+              const p = parseStorageSpec(s);
+              return { raw: s, tamanho: p.armazenamento, conect: p.tela || p.conectividade };
+            });
+            const currentP = storage ? parseStorageSpec(storage) : { armazenamento: "", tela: "", conectividade: "" };
+            const currentTamanho = currentP.armazenamento;
+            const currentConect = currentP.tela || currentP.conectividade;
+            const tamanhoOpts = [...new Set(specs.map(s => s.tamanho).filter(Boolean))];
+            const afterTamanho = specs.filter(s => s.tamanho === currentTamanho);
+            const conectOptsAll = [...new Set(afterTamanho.map(s => s.conect).filter(Boolean))];
+            // Material com forceGPSCel filtra so as opcoes com "Cel" (GPS+Cel,
+            // GPS + Cel etc) — Series 9 Aco Inox e Series 10/11 Titanio sempre
+            // saem GPS+Cel de fabrica.
+            const caixaOpt = watchCase ? watchCaseOptions.find(o => o.material === watchCase) : null;
+            const conectOpts = caixaOpt?.forceGPSCel
+              ? conectOptsAll.filter(c => /cel|\+/i.test(c))
+              : conectOptsAll;
+            const pickStorage = (tamanho: string, conect: string) => {
+              const match = specs.find(s => s.tamanho === tamanho && (!conect || s.conect === conect));
+              if (match) { setStorage(match.raw); tq("storage"); }
+            };
+            return (
+              <>
+                {tamanhoOpts.length > 0 && (
+                  <Section title="Tamanho da caixa">
+                    <div className={`grid gap-2 ${tamanhoOpts.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
+                      {tamanhoOpts.map(t => (
+                        <Btn key={t} sel={currentTamanho === t}
+                          onClick={() => pickStorage(t, "")}
+                          className="w-full text-center">{t}</Btn>
+                      ))}
+                    </div>
+                  </Section>
+                )}
+                {/* Material da caixa entra ENTRE tamanho e conectividade (so
+                    Watch Series). Quando a caixa forca GPS+Cel, o passo de
+                    conectividade so mostra essa opcao. */}
+                {currentTamanho && requiresWatchCase && (
+                  <Section title="Material da caixa">
+                    <div className={`grid gap-2 ${watchCaseOptions.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
+                      {watchCaseOptions.map((opt) => (
+                        <Btn key={opt.material} sel={watchCase === opt.material}
+                          onClick={() => { setWatchCase(opt.material); tq("watchCase"); }}
+                          className="w-full text-center">{opt.material}</Btn>
+                      ))}
+                    </div>
+                    {watchCase && caixaOpt?.forceGPSCel && (
+                      <p className="mt-2 text-center text-[11px]" style={{ color: "var(--ti-muted)" }}>
+                        {watchCase} sempre vem com GPS + Celular de fábrica.
+                      </p>
+                    )}
+                  </Section>
+                )}
+                {currentTamanho && (!requiresWatchCase || watchCase) && conectOpts.length > 0 && (
+                  <Section title="Conectividade">
+                    <div className={`grid gap-2 ${conectOpts.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
+                      {conectOpts.map(c => (
+                        <Btn key={c} sel={currentConect === c}
+                          onClick={() => pickStorage(currentTamanho, c)}
+                          className="w-full text-center">{c}</Btn>
+                      ))}
+                    </div>
+                  </Section>
+                )}
+              </>
+            );
+          })() : (() => {
             const specs = storages.map(s => ({ raw: s, ...parseStorageSpec(s) }));
             const currentParts = storage ? parseStorageSpec(storage) : { armazenamento: "", tela: "", conectividade: "" };
 
@@ -904,24 +969,10 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
         )
       )}
 
-      {/* Material da caixa — Watch Series 9/10/11. Series 9 tem Aluminio/Aco,
-          Series 10/11 tem Aluminio/Titanio. Titanio forca GPS+Cel via useEffect. */}
-      {model && storageCompleto && requiresWatchCase && (
-        <Section title="Material da caixa">
-          <div className={`grid gap-2 ${watchCaseOptions.length <= 2 ? "grid-cols-2 max-w-[320px] mx-auto" : "grid-cols-3"}`}>
-            {watchCaseOptions.map((opt) => (
-              <Btn key={opt.material} sel={watchCase === opt.material}
-                onClick={() => { setWatchCase(opt.material); tq("watchCase"); }}
-                className="w-full text-center">{opt.material}</Btn>
-            ))}
-          </div>
-          {watchCase && watchCaseOptions.find(o => o.material === watchCase)?.forceGPSCel && (
-            <p className="mt-2 text-center text-[11px]" style={{ color: "var(--ti-muted)" }}>
-              Titânio sempre vem com GPS + Celular — ajustado automaticamente.
-            </p>
-          )}
-        </Section>
-      )}
+      {/* Material da caixa do Apple Watch e renderizado INLINE no fluxo de
+          tamanho/conectividade (entre os dois) — ver bloco "watch" da
+          structured storage acima. Aqui era a posicao antiga depois da cor;
+          movido pra antes pra que conectividade possa filtrar GPS+Cel. */}
 
       {/* Cor do aparelho */}
       {model && storageCompleto && (!requiresWatchCase || watchCase) && coresModelo.length > 0 && (

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -1075,9 +1075,12 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                   cadastra uma pergunta numeric de "Saude de bateria %" via
                   /admin/simulacoes e configura `quickLabel`/`quickValue` ali.
                   O botao aparece automaticamente abaixo do input dinamico. */}
-              {/* Ajuda "Como descobrir a saude/ciclos da bateria?" — texto padrao
-                  por device_type, sobrescrivel via labels.help_battery_{device}
-                  em /admin/simulacoes. Suporta markdown (negrito, italico, ## titulo). */}
+              {/* Ajuda "Como descobrir a saude/ciclos da bateria?". Prioridade:
+                  1) helpText/helpTitle cadastrado na propria pergunta `battery`
+                     em /admin/simulacoes (mais especifico — admin edita inline)
+                  2) labels.help_battery_{device} de "Textos do Formulario" (legacy)
+                  3) defaults hardcoded
+                  Suporta markdown (negrito, italico, ## titulo). */}
               {(() => {
                 const defaults: Record<string, string> = {
                   iphone: "## Como descobrir a saúde da bateria?\n\n1. Abra **Ajustes** no seu iPhone\n2. Toque em **Bateria**\n3. Toque em **Saúde e Carregamento da Bateria**\n4. Veja o valor em **Capacidade Máxima**",
@@ -1085,12 +1088,25 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
                   macbook: "## Como descobrir os ciclos de bateria?\n\n1. Clique no menu **Apple** > **Sobre Este Mac**\n2. Clique em **Mais Informações**\n3. Role até o final e clique em **Relatório do Sistema**\n4. Na barra lateral, clique em **Energia**\n5. Veja **Contagem de Ciclos**",
                   watch: "## Como descobrir a saúde da bateria?\n\n1. No Apple Watch, abra **Ajustes**\n2. Toque em **Bateria**\n3. Toque em **Saúde da Bateria**\n4. Veja o valor em **Capacidade Máxima**",
                 };
-                const key = `help_battery_${deviceType}`;
-                const raw = labels?.[key]?.trim() || defaults[deviceType] || "";
+                // 1. helpText/helpTitle direto da pergunta `battery` no qc — quando
+                // admin edita inline na pergunta, isso vence. Slug normalizado
+                // (cliente ja recebe `battery` puro depois do strip de sufixo).
+                const batteryQ = qc?.find((q) => q.slug === "battery" && q.ativo !== false);
+                const cfg = (batteryQ?.config || {}) as Record<string, unknown>;
+                const cfgHelp = typeof cfg.helpText === "string" && cfg.helpText.trim() ? cfg.helpText : "";
+                const cfgTitle = typeof cfg.helpTitle === "string" && cfg.helpTitle.trim() ? cfg.helpTitle : "";
+                let raw = cfgHelp;
+                let titleOverride = cfgTitle;
+                if (!raw) {
+                  // 2. labels.help_battery_{device} legacy
+                  const key = `help_battery_${deviceType}`;
+                  raw = (labels?.[key]?.trim() || defaults[deviceType] || "");
+                }
                 if (!raw) return null;
-                // Extrai primeiro `## Titulo` como summary; resto vai no body.
+                // Extrai primeiro `## Titulo` como summary; resto vai no body
+                // (so quando o admin nao mandou um helpTitle separado).
                 const headerMatch = raw.match(/^## (.+)$/m);
-                const title = headerMatch ? headerMatch[1] : "Como descobrir a saúde da bateria?";
+                const title = titleOverride || (headerMatch ? headerMatch[1] : "Como descobrir a saúde da bateria?");
                 const body = headerMatch ? raw.replace(/^## .+$/m, "").trim() : raw;
                 return (
                   <details className="rounded-xl p-3" style={{ backgroundColor: "var(--ti-input-bg)", border: "1px solid var(--ti-card-border)" }}>

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -399,6 +399,31 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
                   />
                 </div>
 
+                {/* Frase concisa pro resumo do produto (opcional). Yesno: usa
+                    como base + prefixa "Não " no negativo. Numeric: usa como
+                    titulo bold ("Saude da bateria: 87"). Quando vazio, cai no
+                    titulo da pergunta. Vive em config.summaryLabel. */}
+                {(q.tipo === "yesno" || q.tipo === "numeric") && (
+                  <div>
+                    <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">
+                      Frase no resumo {q.tipo === "yesno" ? "(opcional)" : "(opcional, vira o titulo bold)"}
+                    </label>
+                    <input
+                      value={typeof (q.config as Record<string, unknown>).summaryLabel === "string" ? (q.config.summaryLabel as string) : ""}
+                      onChange={(e) => updateConfig(q.id, "summaryLabel", e.target.value)}
+                      placeholder={q.tipo === "yesno"
+                        ? "Ex: Possui o carregador completo original (\"Não \" e prefixado quando negativo)"
+                        : "Ex: Saude de bateria"}
+                      className="mt-1 w-full px-3 py-2 rounded-lg border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                    />
+                    <p className="mt-1 text-[11px] text-[#86868B]">
+                      {q.tipo === "yesno"
+                        ? "Aparece no resumo do produto (operador). Yesno: \"Possui o carregador\" / \"Não possui o carregador\". Quando vazio, cai no titulo (sem o \"?\")."
+                        : "Aparece como prefixo bold no resumo (ex: \"Saude de bateria: 87%\"). Quando vazio, usa o titulo da pergunta."}
+                    </p>
+                  </div>
+                )}
+
                 {/* Options editor - for selection, yesno, and multiselect */}
                 {(q.tipo === "selection" || q.tipo === "yesno" || q.tipo === "multiselect") && (
                   <div>


### PR DESCRIPTION
3 fixes que ficaram de fora do #805 (squash so pegou parte dos commits da branch).

## 1. Apple Watch — labels + Material da caixa antes da Conectividade
Reportado pelo Nicolas:
- "Armazenamento" mostrava 41mm/45mm — devia ser "Tamanho da caixa"
- "Tamanho da tela" mostrava GPS/GPS+Cel — devia ser "Conectividade"
- Material da caixa estava DEPOIS da conectividade — devia vir ANTES
- Series 9 Aço Inox so vem GPS+Cel de fabrica (igual Series 10/11 Titanio)
- Cores cadastradas no catalogo nao apareciam todas — filtro estava cortando

Mudancas:
- Branch separada do iPad/MacBook na renderizacao do storage estruturado
- Material da caixa entre Tamanho e Conectividade (so Series)
- forceGPSCel filtra opcoes de conectividade
- WATCH_SERIES_CASES.cores REMOVIDO — cores agora vem 100% do catalogo
- Aço Inox Series 9 ganhou forceGPSCel: true

## 2. Admin /usados — ordenacao por categoria
Reportado pelo Nicolas: "ipads e apple watchs fora de ordem tambem"

Cada catFilter agora tem chave propria de ordenacao:
- **iPhone**: [num, varianteOrd, name] — base < e < Plus < Air < Pro < Pro Max
- **iPad**: [linha, hasMChip, gen, name] — Entrada → Air → Pro → mini, gens numericas antes do M-chip
- **MacBook**: [linha, chip, variantOrd, tela, name] (ja estava)
- **Apple Watch**: [linha, gen, name] — SE → Series → Ultra, depois numero da geracao

## 3. Resumo: summaryLabel por pergunta + help text inline
Reportado pelo Nicolas:
- Resumo verboso: "Ainda possui o carregador completo original do MacBook" (titulo do cliente flow) — devia ficar "Possui o carregador completo original" no resumo
- "Saúde de bateria '%' do seu Mac atual? : Normal" — devia ficar "Saúde de Bateria: Normal"
- Help text de bateria nao atualizava ao editar `q.config.helpText`

Mudancas:
- Novo campo "Frase no resumo" a nivel de PERGUNTA (q.config.summaryLabel):
  - Yesno: usado positivo, prefixa "Não " no negativo automaticamente
  - Numeric: vira o titulo bold ("Saude de bateria: 87")
- Per-option summaryLabel continua tendo prioridade
- Help text de bateria agora prioriza q.config.helpText/helpTitle da pergunta
  `battery` (cadastrado inline) sobre `labels.help_battery_{device}` (legacy)

## Backward compat
- Todos os campos novos sao opcionais
- Sem mudanca de DB
- iPhone/iPad fluxo nao regrediu — Watch e branch separada

🤖 Generated with [Claude Code](https://claude.com/claude-code)