### PR TITLE
fix(tradein): cores Watch dedup + roteamento por categoria + unit no resumo

### DIFF
--- a/components/StepManualHandoff.tsx
+++ b/components/StepManualHandoff.tsx
@@ -116,6 +116,13 @@ function formatExtraAnswer(q: TradeInQuestion, value: unknown): string {
     return labels.length > 0 ? labels.join(", ") : "—";
   }
   if (typeof value === "boolean") return value ? "Sim" : "Nao";
+  // Numeric: anexa unidade cadastrada no q.config.unit (ex: "%", " ciclos").
+  // Saude da bateria => "84%". Ciclos => "150 ciclos". Sem unidade, so o numero.
+  if (q.tipo === "numeric" && typeof value === "number") {
+    const cfg = (q.config || {}) as Record<string, unknown>;
+    const unit = typeof cfg.unit === "string" ? cfg.unit : "";
+    return unit ? `${value}${unit}` : String(value);
+  }
   const opt = q.opcoes.find((o) => o.value === value);
   return opt?.label || String(value);
 }

--- a/components/StepUsedDeviceMulti.tsx
+++ b/components/StepUsedDeviceMulti.tsx
@@ -50,23 +50,41 @@ const HARDCODED_DEFAULT_ORDEM: Record<string, number> = {
 // Material da caixa do Apple Watch por geracao Series. Hardcoded porque nao
 // vem do catalogo hoje — admin nao tem dimensao separada pra isso. Usado pra
 // (1) filtrar cores disponiveis conforme caixa e (2) forcar GPS+Cel em Titanio.
-// Series 9: Aluminio (cores standard) + Aco Inoxidavel (Grafite/Prateado/Dourado).
-// Series 10/11: Aluminio + Titanio (Natural/Dourado/Ardosia, sempre GPS+Cel).
-const WATCH_SERIES_CASES: Record<string, { material: string; forceGPSCel?: boolean }[]> = {
+// Cores da Apple oficiais por geracao + material (BR). Aco Inox e Titanio
+// sempre vem GPS+Cel de fabrica.
+const WATCH_SERIES_CASES: Record<string, { material: string; cores: string[]; forceGPSCel?: boolean }[]> = {
   "9": [
-    { material: "Alumínio" },
-    // Series 9 Aco Inox so vem GPS+Cel de fabrica.
-    { material: "Aço Inoxidável", forceGPSCel: true },
+    { material: "Alumínio", cores: ["Estelar", "Meia-noite", "Prateado", "Vermelho", "Rosa"] },
+    { material: "Aço Inoxidável", cores: ["Grafite", "Prateado", "Dourado"], forceGPSCel: true },
   ],
   "10": [
-    { material: "Alumínio" },
-    { material: "Titânio", forceGPSCel: true },
+    { material: "Alumínio", cores: ["Ouro Rosa", "Prateado", "Preto Brilhante", "Cinza-espacial"] },
+    { material: "Titânio", cores: ["Titânio Natural", "Dourado", "Ardósia"], forceGPSCel: true },
   ],
   "11": [
-    { material: "Alumínio" },
-    { material: "Titânio", forceGPSCel: true },
+    { material: "Alumínio", cores: ["Ouro Rosa", "Prateado", "Preto Brilhante", "Cinza-espacial"] },
+    { material: "Titânio", cores: ["Titânio Natural", "Dourado", "Ardósia"], forceGPSCel: true },
   ],
 };
+
+// Aliases comuns no catalogo brasileiro vs nomenclatura Apple. "Prata" e
+// equivalente a "Prateado", "Preto" sozinho costuma ser "Preto Brilhante" do
+// Aluminio etc. Usado no filtro de cores por material pra nao deixar cor
+// cadastrada de fora so por causa de variacao no nome.
+const COR_ALIASES: Record<string, string[]> = {
+  prata: ["prateado"],
+  prateado: ["prata"],
+  preto: ["preto brilhante"],
+  "preto brilhante": ["preto"],
+  natural: ["titanio natural", "titânio natural"],
+  "titanio natural": ["natural", "titânio natural"],
+  "titânio natural": ["natural", "titanio natural"],
+};
+
+// Normaliza string pra comparacao de cor: lowercase, sem acento, trim.
+function normalizeCor(s: string): string {
+  return s.toLowerCase().normalize("NFD").replace(/[\u0300-\u036f]/g, "").trim();
+}
 
 // Markdown seguro pra helpText: escape HTML primeiro, depois aplica formatacao.
 // Suporta:
@@ -416,11 +434,53 @@ export default function StepUsedDeviceMulti({ usedValues, excludedModels, modelD
   }, [deviceType, line, subLine]);
   const requiresWatchCase = watchCaseOptions.length > 0;
 
-  // Cores: usa direto o catalogo cadastrado em /admin/usados (sem filtro por
-  // material). O admin gerencia a lista de cores por modelo, e o material da
-  // caixa fica capturado via watchCase no resumo. Antes filtrava por uma lista
-  // hardcoded que escondia cores cadastradas — operador cobrou pra mostrar todas.
-  const coresModelo = coresModeloRaw;
+  // Cores: filtra pelo material da caixa (Watch Series). O catalogo guarda
+  // cores por MODELO sem dimensao de material, entao usamos a lista hardcoded
+  // de WATCH_SERIES_CASES como allow-list — match e tolerante (case+acento
+  // insensitive + aliases comuns "Prata" <=> "Prateado", "Preto" <=> "Preto
+  // Brilhante"). Cores duplicadas no catalogo (ex: "Preto" e "Preto Brilhante"
+  // pra Aluminio) colapsam pelo alias, mostrando so o nome canonico Apple.
+  // Quando intersecao fica vazia (catalogo desalinhado), cai pra raw pra
+  // nao travar o cliente.
+  const coresModelo = useMemo(() => {
+    if (!requiresWatchCase || !watchCase) return coresModeloRaw;
+    const opt = watchCaseOptions.find((o) => o.material === watchCase);
+    if (!opt || opt.cores.length === 0) return coresModeloRaw;
+    const allowed = new Set(opt.cores.map(normalizeCor));
+    const matchAllowed = (cor: string): boolean => {
+      const n = normalizeCor(cor);
+      if (allowed.has(n)) return true;
+      const aliases = COR_ALIASES[n] || [];
+      return aliases.some((a) => allowed.has(normalizeCor(a)));
+    };
+    // Mostra cores na ordem do hardcoded (Apple oficial), nao na ordem alfabetica
+    // do catalogo. Cor cadastrada que nao bate no allow-list e descartada.
+    const filtered: string[] = [];
+    const seen = new Set<string>();
+    for (const canonica of opt.cores) {
+      const match = coresModeloRaw.find((cor) => {
+        const n = normalizeCor(cor);
+        if (seen.has(n)) return false;
+        if (n === normalizeCor(canonica)) return true;
+        const aliases = COR_ALIASES[n] || [];
+        return aliases.some((a) => normalizeCor(a) === normalizeCor(canonica));
+      });
+      if (match) {
+        filtered.push(match);
+        seen.add(normalizeCor(match));
+      }
+    }
+    // Inclui qualquer cor do catalogo que casa com allow-list mas nao foi pega
+    // no loop acima (ordem fora da Apple) — defensivo.
+    for (const cor of coresModeloRaw) {
+      const n = normalizeCor(cor);
+      if (!seen.has(n) && matchAllowed(cor)) {
+        filtered.push(cor);
+        seen.add(n);
+      }
+    }
+    return filtered.length > 0 ? filtered : coresModeloRaw;
+  }, [coresModeloRaw, requiresWatchCase, watchCase, watchCaseOptions]);
 
   // Se o chip selecionado tem só 1 modelo, auto-selecionar
   const needsScreenSize = modelsForChip.length > 1;

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -630,22 +630,31 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
               tradeinConfig={tradeinConfig} />
           )}
 
-          {step === 4 && avaliacaoManual && (
-            <StepManualHandoff
-              usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} condition={condition} deviceType={deviceType}
-              usedModel2={hasSecondDevice ? usedModel2 : undefined} usedStorage2={hasSecondDevice ? usedStorage2 : undefined} usedColor2={hasSecondDevice ? usedColor2 : undefined}
-              condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined}
-              extraAnswers={extraAnswers} extraQuestions={extraQuestions}
-              extraAnswers2={hasSecondDevice ? extraAnswers2 : undefined} extraQuestions2={hasSecondDevice ? extraQuestions2 : undefined}
-              questionsConfig={questionsConfig ?? undefined}
-              newModel={newModel} newStorage={newStorage} newPrice={newPrice}
-              clienteNome={clienteNome} clienteWhatsApp={clienteWhatsApp} clienteInstagram={clienteInstagram} clienteOrigem={clienteOrigem}
-              whatsappNumero={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappPrincipal}
-              vendedor={vendedor}
-              onReset={handleReset}
-              onGoToStep={handleGoToStep}
-            />
-          )}
+          {step === 4 && avaliacaoManual && (() => {
+            // Roteamento por categoria pra avaliacao manual: iPad/MacBook/Watch
+            // trade-in vai pro WhatsApp configurado em /admin/configuracoes
+            // (secao "WhatsApp Troca — Outros Modelos"). Antes ia tudo pro
+            // Principal (Bianca) ignorando a config — agora usa o numero da
+            // categoria, com fallback pro principal quando vazio.
+            const cat = (selectedDeviceType as keyof typeof whatsappSeminovoByCat) || "iphone";
+            const whatsappManualCat = whatsappSeminovoByCat[cat] || whatsappPrincipal;
+            return (
+              <StepManualHandoff
+                usedModel={usedModel} usedStorage={usedStorage} usedColor={usedColor} condition={condition} deviceType={deviceType}
+                usedModel2={hasSecondDevice ? usedModel2 : undefined} usedStorage2={hasSecondDevice ? usedStorage2 : undefined} usedColor2={hasSecondDevice ? usedColor2 : undefined}
+                condition2={hasSecondDevice ? condition2 : undefined} deviceType2={hasSecondDevice ? deviceType2 : undefined}
+                extraAnswers={extraAnswers} extraQuestions={extraQuestions}
+                extraAnswers2={hasSecondDevice ? extraAnswers2 : undefined} extraQuestions2={hasSecondDevice ? extraQuestions2 : undefined}
+                questionsConfig={questionsConfig ?? undefined}
+                newModel={newModel} newStorage={newStorage} newPrice={newPrice}
+                clienteNome={clienteNome} clienteWhatsApp={clienteWhatsApp} clienteInstagram={clienteInstagram} clienteOrigem={clienteOrigem}
+                whatsappNumero={(vendedor && VENDEDOR_WHATSAPP[vendedor]) || whatsappManualCat}
+                vendedor={vendedor}
+                onReset={handleReset}
+                onGoToStep={handleGoToStep}
+              />
+            );
+          })()}
           {step === 4 && !avaliacaoManual && (
             <StepQuote
               newModel={newModel} newStorage={newStorage} newPrice={newPrice}

--- a/components/admin/TradeInQuestionsAdmin.tsx
+++ b/components/admin/TradeInQuestionsAdmin.tsx
@@ -525,6 +525,20 @@ export default function TradeInQuestionsAdmin({ password }: Props) {
                     </div>
 
                     <div>
+                      <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">Unidade (sufixo no resumo)</label>
+                      <input
+                        type="text"
+                        value={typeof (q.config as Record<string, unknown>).unit === "string" ? (q.config.unit as string) : ""}
+                        onChange={(e) => updateConfig(q.id, "unit", e.target.value)}
+                        placeholder='Ex: "%" ou " ciclos" (com espaco no inicio)'
+                        className="mt-1 w-full px-3 py-2 rounded border border-[#D2D2D7] text-sm focus:outline-none focus:border-[#E8740E]"
+                      />
+                      <p className="mt-1 text-[11px] text-[#86868B]">
+                        Anexa ao numero no resumo: <code>84%</code> · <code>150 ciclos</code>. Vazio = so o numero.
+                      </p>
+                    </div>
+
+                    <div>
                       <label className="text-xs font-semibold text-[#86868B] uppercase tracking-wider">Placeholder do input</label>
                       <input
                         type="text"


### PR DESCRIPTION
3 fixes que ficaram de fora do squash do #807. Continuacao direta dos issues
reportados pelo Nicolas.

## 1. Apple Watch — cores filtradas pela caixa + dedup
Reportado: "as cores do apple watch tem que ficar divididas pelas caixas" e
"no Series 11/9 aparece Preto duas vezes".

- Restaurado `WATCH_SERIES_CASES.cores` com lista oficial Apple por geracao +
  material (Series 9 Al/Aço, Series 10/11 Al/Titanio).
- `coresModelo` filtra pelo allow-list do material escolhido.
- Match tolerante: case-insensitive + sem acento (NFD) + aliases
  (Prata<=>Prateado, Preto<=>Preto Brilhante, Natural<=>Titânio Natural).
- Quando catalogo tem ambos "Preto" e "Preto Brilhante" pra mesmo material,
  so o canonico Apple aparece (dedup via alias).
- Ordem segue lista hardcoded (Apple), nao alfabetica do catalogo.
- Defensivo: se intersecao fica vazia (catalogo desalinhado), cai pra raw
  pra nao travar o cliente.

## 2. Trade-in manual roteia pelo WhatsApp da categoria
Reportado: "ainda está indo para a Bianca" — config "Outros Modelos" em
/admin/configuracoes nao tava roteando trade-in manual.

`StepManualHandoff` (avaliacao manual) usava sempre `whatsappPrincipal` —
ignorava `whatsappSeminovoByCat`. Agora resolve pelo `selectedDeviceType`
(iPad/MacBook/Watch trade-in vai pro numero da categoria, com fallback pro
principal). Override por vendedor (?ref=) continua prioritario.

## 3. Unidade (sufixo) editavel + anexada no resumo numeric
Reportado: "Saúde de Bateria mostra '84' devia mostrar '84%'".

- Admin /simulacoes ganhou campo "Unidade (sufixo no resumo)" no editor de
  numeric — vive em `q.config.unit`.
- `formatExtraAnswer` em StepManualHandoff anexa unit ao valor: "84%",
  "150 ciclos". Sem unit cadastrada, so o numero.
- Quick-value (botao "Normal") nao anexa unit — fica "Saúde de Bateria: Normal".

## Backward compat
- Todas as mudancas sao puramente client-side ou aditivas.
- Sem migration de banco.
- iPhone/iPad fluxo nao regrediu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)