### PR TITLE
fix(tradein): labels admin + cores Watch + STATUS AVALIACAO_MANUAL (critico)

### DIFF
--- a/app/admin/configuracoes/page.tsx
+++ b/app/admin/configuracoes/page.tsx
@@ -276,17 +276,18 @@ export default function ConfiguracoesPage() {
           <div>
             <p className="font-bold text-[#1D1D1F]">📱 WhatsApp Troca — Outros Modelos</p>
             <p className="text-xs text-[#86868B] mt-1">
-              Roteamento por categoria pra trocas que vao pra um numero diferente do <b>WhatsApp Principal</b>.
-              Hoje recebe formularios de seminovos por categoria (iPhone Seminovo, iPad Seminovo, etc).
-              Deixe <b>vazio</b> pra cair no Principal (fallback).
+              Roteamento por categoria pra trocas que vao pra um numero diferente do <b>WhatsApp Principal</b>:
+              <br />• <b>iPhone Seminovo (compra)</b>: cliente quer comprar um iPhone seminovo
+              <br />• <b>iPad / MacBook / Apple Watch (trade-in)</b>: cliente trocando um destes (avaliacao manual)
+              <br />Deixe <b>vazio</b> pra cair no Principal (fallback).
             </p>
           </div>
 
           {([
-            { key: "iphone", label: "iPhone Seminovo", icon: "📱", value: formSemiIphone, set: setFormSemiIphone },
-            { key: "ipad", label: "iPad Seminovo", icon: "📱", value: formSemiIpad, set: setFormSemiIpad },
-            { key: "macbook", label: "MacBook Seminovo", icon: "💻", value: formSemiMacbook, set: setFormSemiMacbook },
-            { key: "watch", label: "Apple Watch Seminovo", icon: "⌚", value: formSemiWatch, set: setFormSemiWatch },
+            { key: "iphone", label: "iPhone Seminovo (compra)", icon: "📱", value: formSemiIphone, set: setFormSemiIphone },
+            { key: "ipad", label: "iPad (trade-in)", icon: "📱", value: formSemiIpad, set: setFormSemiIpad },
+            { key: "macbook", label: "MacBook (trade-in)", icon: "💻", value: formSemiMacbook, set: setFormSemiMacbook },
+            { key: "watch", label: "Apple Watch (trade-in)", icon: "⌚", value: formSemiWatch, set: setFormSemiWatch },
           ] as const).map((cat) => (
             <div key={cat.key} className="border-t border-[#F5F5F7] pt-3 first:border-t-0 first:pt-0 space-y-2">
               <div className="flex items-center justify-between">


### PR DESCRIPTION
Bundle de fixes que ficaram fora dos squashes anteriores. **Inclui um fix CRITICO** descoberto pelo Nicolas em 25/04: leads de trade-in manual (iPad/MacBook/Apple Watch) NAO estavam sendo salvos.

## 1. CRITICO — status AVALIACAO_MANUAL nao salvava
StepManualHandoff envia `status: "AVALIACAO_MANUAL"` mas o CHECK constraint
de `simulacoes.status` so aceitava ('GOSTEI', 'SAIR', 'AGUARDANDO_MP',
'INVALIDO'). INSERT falhava silenciosamente (try/catch engolia o erro), lead
sumia sem registro.

- **Migration** `20260425_simulacao_status_avaliacao_manual.sql` — adicionar
  'AVALIACAO_MANUAL' ao constraint. **Rodar em /admin/migrations apos deploy.**
- **/admin/simulacoes**: nova tab "Avaliação Manual" (azul, entre Saíram e
  Inválidos) + Item.status type atualizado.

## 2. Labels admin /configuracoes
- iPhone Seminovo → **iPhone Seminovo (compra)**
- iPad Seminovo → **iPad (trade-in)**
- MacBook Seminovo → **MacBook (trade-in)**
- Apple Watch Seminovo → **Apple Watch (trade-in)**

## 3. Cores Apple Watch — fixes acumulados
- Normalizacao tolera hifen/espaco
- Aliases EN/PT bidirecionais (Slate↔Ardósia, Silver↔Prata, etc)
- Dedup robusto via bucket de aliases (Preto + Preto Brilhante = uma cor)
- Aliases PT genericos (Preto/Dourado/Cinza cobrem multiplas cores Apple)
- Preferir nome canonico Apple ("Ardósia" em vez de "Cinza" do catalogo)
- Series 10 sem Cinza-espacial (3 cores oficiais Aluminio)

## Test plan
- [ ] **Rodar migration** em /admin/migrations
- [ ] Fazer simulacao trade-in Apple Watch, iPad, MacBook
- [ ] Verificar lead apareceu em /admin/simulacoes (tab "Avaliação Manual" ou Todos)
- [ ] iPhone trade-in com preco fixo continua salvando GOSTEI/SAIR
- [ ] Cores Watch corretas pelo material (Series 9/10/11 × Al/Aço/Ti)
- [ ] Labels /configuracoes mostram (compra) vs (trade-in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)