### PR TITLE
feat(reconciliacao): adicionar filtro 'Mes atual' no periodo

### DIFF
--- a/app/admin/reconciliacao-sku/page.tsx
+++ b/app/admin/reconciliacao-sku/page.tsx
@@ -127,7 +127,19 @@ export default function ReconciliacaoSkuPage() {
   const [loading, setLoading] = useState(true);
   const [tipoFiltro, setTipoFiltro] = useState<TipoInc | "todos">("todos");
   const [skuInfo, setSkuInfo] = useState<string | null>(null);
-  const [periodoDias, setPeriodoDias] = useState(30);
+  // Periodo: pode ser numero de dias ("7", "30", "90", "365") OU "mes_atual"
+  // (do dia 1 do mes ate hoje). String pra suportar ambos sem confundir tipos.
+  const [periodo, setPeriodo] = useState<string>("30");
+
+  // Calcula data inicial (YYYY-MM-DD) baseado na opcao selecionada.
+  const calcularFromDate = (opt: string): string => {
+    if (opt === "mes_atual") {
+      const hoje = new Date();
+      return new Date(hoje.getFullYear(), hoje.getMonth(), 1).toISOString().slice(0, 10);
+    }
+    const dias = Number(opt) || 30;
+    return new Date(Date.now() - dias * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  };
   const [syncingSku, setSyncingSku] = useState(false);
   const [syncMsg, setSyncMsg] = useState<string | null>(null);
   const [backfillingCor, setBackfillingCor] = useState(false);
@@ -149,7 +161,7 @@ export default function ReconciliacaoSkuPage() {
   const fetchData = useCallback(() => {
     if (!password) return;
     setLoading(true);
-    const fromDate = new Date(Date.now() - periodoDias * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const fromDate = calcularFromDate(periodo);
     fetch(`/api/admin/sku/reconciliacao?from=${fromDate}`, {
       headers: { "x-admin-password": password },
     })
@@ -164,7 +176,7 @@ export default function ReconciliacaoSkuPage() {
       })
       .catch(() => setInconsistencias([]))
       .finally(() => setLoading(false));
-  }, [password, periodoDias]);
+  }, [password, periodo]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -435,14 +447,15 @@ export default function ReconciliacaoSkuPage() {
         </div>
         <div className="flex gap-2 flex-wrap">
           <select
-            value={periodoDias}
-            onChange={(e) => setPeriodoDias(Number(e.target.value))}
+            value={periodo}
+            onChange={(e) => setPeriodo(e.target.value)}
             className="px-3 py-1.5 rounded-lg text-xs font-medium bg-white border border-[#D2D2D7]"
           >
-            <option value={7}>Últimos 7 dias</option>
-            <option value={30}>Últimos 30 dias</option>
-            <option value={90}>Últimos 90 dias</option>
-            <option value={365}>Último ano</option>
+            <option value="7">Últimos 7 dias</option>
+            <option value="30">Últimos 30 dias</option>
+            <option value="mes_atual">Mês atual</option>
+            <option value="90">Últimos 90 dias</option>
+            <option value="365">Último ano</option>
           </select>
           <button
             onClick={fetchData}


### PR DESCRIPTION
## Pedido do André

> "aqui deveria aparecer um filtro chamado 'mes atual'"

Útil pro fechamento mensal — ver tudo desde o dia 1 até hoje, sem ter que escolher "30 dias" (que pega do mês anterior também).

## Mudança

Filtro de período agora tem opção **"Mês atual"**:

- Últimos 7 dias
- Últimos 30 dias
- **Mês atual** ← novo
- Últimos 90 dias
- Último ano

## Implementação

- State refatorado de `periodoDias: number` → `periodo: string` (suporta tanto número de dias quanto chaves como `"mes_atual"`)
- Helper `calcularFromDate(opt)`:
  - `"mes_atual"` → primeiro dia do mês atual
  - `"7"`, `"30"`, `"90"`, `"365"` → N dias atrás
- `<option>` adicionada no select

🤖 Generated with [Claude Code](https://claude.com/claude-code)