### PR TITLE
feat(analytics): drop-off do formulario /compra (etapa 5 do funil)

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -29,10 +29,13 @@ interface AnalyticsData {
   whatsappCount: number;
   exitCount: number;
   cotarOutroCount: number;
+  compraViewCount?: number;
+  compraSubmitCount?: number;
   funnel: FunnelStep[];
   questionBreakdown: QuestionBreakdown[];
   daily: DailyData[];
   conversionRate: string;
+  conversionRateFinal?: string;
 }
 
 const STEP_LABELS: Record<number, string> = {
@@ -40,6 +43,7 @@ const STEP_LABELS: Record<number, string> = {
   2: "Aparelho Novo",
   3: "Seus Dados",
   4: "Cotacao",
+  5: "Formulario /compra",
 };
 
 const QUESTION_LABELS: Record<string, string> = {
@@ -134,7 +138,7 @@ export default function AnalyticsPage() {
       </div>
 
       {/* KPI Cards — top of funnel */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
         <KPICard label="Acessaram o site" value={data.visits} />
         <KPICard
           label="Iniciaram simulacao"
@@ -148,7 +152,6 @@ export default function AnalyticsPage() {
         <KPICard
           label="Fecharam pedido"
           value={data.whatsappCount}
-          accent
           sub={
             data.startedCount > 0
               ? `${((data.whatsappCount / data.startedCount) * 100).toFixed(0)}% de quem iniciou`
@@ -156,10 +159,20 @@ export default function AnalyticsPage() {
           }
         />
         <KPICard
-          label="Conversao geral"
-          value={`${data.conversionRate}%`}
+          label="Submeteram /compra"
+          value={data.compraSubmitCount ?? 0}
           accent
-          sub="fechou / acessou"
+          sub={
+            (data.compraViewCount ?? 0) > 0
+              ? `${((((data.compraSubmitCount ?? 0) / (data.compraViewCount ?? 1)) * 100)).toFixed(0)}% de quem entrou`
+              : "etapa 5 (formulario)"
+          }
+        />
+        <KPICard
+          label="Conversao final"
+          value={`${data.conversionRateFinal ?? data.conversionRate}%`}
+          accent
+          sub="submit /compra / acessos"
         />
       </div>
 
@@ -208,7 +221,8 @@ export default function AnalyticsPage() {
                 label: `Etapa ${f.step}: ${STEP_LABELS[f.step] || `Step ${f.step}`}`,
                 count: f.views,
               })),
-              { label: "Fecharam pedido (WhatsApp)", count: data.whatsappCount, isFinal: true },
+              { label: "Fecharam pedido (WhatsApp)", count: data.whatsappCount },
+              { label: "Submeteram /compra", count: data.compraSubmitCount ?? 0, isFinal: true },
             ];
             const max = Math.max(...fullFunnel.map((s) => s.count), 1);
             return fullFunnel.map((s, idx) => {

--- a/app/api/funnel/route.ts
+++ b/app/api/funnel/route.ts
@@ -97,6 +97,11 @@ export async function GET(req: NextRequest) {
     const whatsappSessions = new Set<string>();
     const exitSessions = new Set<string>();
     const cotarOutroSessions = new Set<string>();
+    // Etapa 5 do funil — formulario /compra (preenchimento de dados pessoais).
+    // Mede drop-off depois do orcamento aceito → quem chega no formulario e
+    // quem completa de fato.
+    const compraViewSessions = new Set<string>();
+    const compraSubmitSessions = new Set<string>();
 
     for (const row of rows) {
       sessions.add(row.session_id);
@@ -123,6 +128,8 @@ export async function GET(req: NextRequest) {
       if (row.event === "quote_whatsapp") whatsappSessions.add(row.session_id);
       if (row.event === "quote_exit") exitSessions.add(row.session_id);
       if (row.event === "quote_cotar_outro") cotarOutroSessions.add(row.session_id);
+      if (row.event === "compra_view") compraViewSessions.add(row.session_id);
+      if (row.event === "compra_submit") compraSubmitSessions.add(row.session_id);
     }
 
     // Visitas: prefer site_view, mas se ainda nao tem (deploy recente),
@@ -138,6 +145,18 @@ export async function GET(req: NextRequest) {
         completes,
         droppedHere: Math.max(views - completes, 0),
       };
+    });
+
+    // Etapa 5: formulario /compra. Diferente das etapas 1-4 (que sao
+    // sub-passos do simulador), esta e uma pagina nova com seu proprio
+    // pageview e submit. View = chegou no /compra, complete = submeteu.
+    const compraView = compraViewSessions.size;
+    const compraSubmit = compraSubmitSessions.size;
+    funnel.push({
+      step: 5,
+      views: compraView,
+      completes: compraSubmit,
+      droppedHere: Math.max(compraView - compraSubmit, 0),
     });
 
     const questionBreakdown = Object.entries(questionAnswers)
@@ -164,11 +183,17 @@ export async function GET(req: NextRequest) {
       whatsappCount: whatsappSessions.size,
       exitCount: exitSessions.size,
       cotarOutroCount: cotarOutroSessions.size,
+      compraViewCount: compraView,
+      compraSubmitCount: compraSubmit,
       funnel,
       questionBreakdown,
       daily,
       conversionRate: visits > 0
         ? ((whatsappSessions.size / visits) * 100).toFixed(1)
+        : "0",
+      // Conversao final ate submit do /compra (etapa 5)
+      conversionRateFinal: visits > 0
+        ? ((compraSubmit / visits) * 100).toFixed(1)
         : "0",
     });
   } catch (err) {

--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -6,6 +6,7 @@ import { WHATSAPP_FORMULARIO } from "@/lib/whatsapp-config";
 import { corParaPT } from "@/lib/cor-pt";
 import { getAgendamentoBounds } from "@/lib/date-utils";
 import { withUTMs } from "@/lib/utm-tracker";
+import { useTradeInAnalytics } from "@/lib/useTradeInAnalytics";
 
 function maskCPF(value: string) {
   const digits = value.replace(/\D/g, "").slice(0, 11);
@@ -67,6 +68,11 @@ interface ProdutoAPI {
 
 function CompraForm() {
   const searchParams = useSearchParams();
+  // Tracking de funil — etapa 5 (formulario de compra). Eventos:
+  //   compra_view    — cliente entrou na pagina
+  //   compra_submit  — cliente concluiu formulario com sucesso
+  // Permite ver drop-off do /troca → /compra → submit no /admin/analytics.
+  const { trackAction } = useTradeInAnalytics();
 
   // URL params
   const produtoParam = searchParams.get("produto") || searchParams.get("p") || "";
@@ -241,6 +247,13 @@ function CompraForm() {
   // teóricas (todas as cores Apple daquele modelo), complementa o estoque real
   // quando o modelo nao tem peças em estoque no momento.
   const [catalogoCores, setCatalogoCores] = useState<Record<string, string[]>>({});
+
+  // Tracking: dispara "compra_view" 1x quando cliente entra na pagina.
+  // Reutiliza session_id do /troca quando vier no mesmo navegador (analytics
+  // amarra as duas etapas como mesma jornada).
+  useEffect(() => {
+    trackAction("compra_view");
+  }, [trackAction]);
 
   // Fetch products + config
   useEffect(() => {
@@ -1087,6 +1100,9 @@ function CompraForm() {
       }
     }
 
+    // Tracking: cliente concluiu o formulario com sucesso (etapa 5 do funil)
+    trackAction("compra_submit");
+
     const url = `https://wa.me/${whatsappFinal}?text=${encodeURIComponent(lines.join("\n"))}`;
     window.open(url, "_blank");
   }
@@ -1291,6 +1307,9 @@ function CompraForm() {
           })),
         });
       } catch { /* não bloqueia redirect */ }
+
+      // Tracking: cliente concluiu o formulario com sucesso (etapa 5 do funil)
+      trackAction("compra_submit");
 
       // Redireciona pro Mercado Pago (troca a URL, não abre nova aba — assim
       // o cliente não perde o contexto do pedido).


### PR DESCRIPTION
## Pedido #20 do backlog

> "Drop-off de TODAS as etapas do funil"

Antes o funil ia até **"Fecharam pedido (WhatsApp)"** — etapa 4. Mas o cliente ainda precisa preencher `/compra` (dados pessoais, endereço, pagamento) pra venda virar realidade. Sem tracking ali, não sabíamos quantos desistiam no último passo.

## O que muda

### Tracking `/compra`
Reusa o hook `useTradeInAnalytics` (já em uso nas etapas 1-4). Dispara 2 eventos:
- `compra_view` — cliente entrou na página
- `compra_submit` — cliente concluiu (cobre tanto fluxo WhatsApp quanto Mercado Pago)

Reusa `session_id` do `/troca` quando vier do mesmo navegador — jornada amarrada.

### Dashboard `/admin/analytics`

**KPI cards** (agora 5, antes 4):

| Acessaram | Iniciaram | Fecharam (WhatsApp) | **Submeteram /compra** | **Conversão final** |

**Funil completo** ganha 1 barra final:
- Acessaram → Iniciaram → Etapa 1 → 2 → 3 → 4 → Fecharam → **Submeteram /compra** ⭐

**Drop-off por tela**: STEP_LABELS[5] = "Formulário /compra" → entra no card de "Onde as pessoas param".

## Por que importa

Dá pra ver **o gap crítico** entre "cliente fechou pedido no WhatsApp" e "cliente submeteu o formulário de fato". Se essa taxa cair muito → tem problema de UX no `/compra` (formulário longo? pagamento confuso? troca complicada?).

Conversão **geral** (até WhatsApp) vs **final** (até submit) mostra exatamente onde tá perdendo.

## Test plan

- [ ] Preview compila ✓
- [ ] Cliente entra em `/compra` → evento `compra_view` aparece no Supabase `tradein_analytics`
- [ ] Cliente submete formulário → evento `compra_submit`
- [ ] `/admin/analytics` mostra KPIs novos preenchidos
- [ ] Funil completo mostra a etapa 5 como barra final

🤖 Generated with [Claude Code](https://claude.com/claude-code)