### PR TITLE
feat(analytics): crescimento por regiao mes-a-mes (#22)

### DIFF
--- a/app/admin/analytics-vendas/page.tsx
+++ b/app/admin/analytics-vendas/page.tsx
@@ -61,9 +61,22 @@ interface OrigemCliente {
   pct: number;
 }
 
+interface RegiaoItem {
+  nome: string;
+  qtd: number;
+  receita?: number;
+  qtdAnterior?: number;
+  receitaAnterior?: number;
+  deltaQtd?: number;
+  deltaReceita?: number;
+}
+
 interface RegiaoData {
-  bairros: { nome: string; qtd: number }[];
-  cidades: { nome: string; qtd: number }[];
+  bairros: RegiaoItem[];
+  cidades: RegiaoItem[];
+  estados?: RegiaoItem[];
+  destaquesCrescimento?: RegiaoItem[];
+  destaquesQueda?: RegiaoItem[];
 }
 
 interface CoresPorModelo {
@@ -710,6 +723,90 @@ export default function AnalyticsVendasPage() {
               </div>
             </div>
           </Section>
+
+          {/* SECTION 8: Crescimento por Regiao (mes-a-mes) */}
+          {(data.regiao.destaquesCrescimento?.length || data.regiao.destaquesQueda?.length) ? (
+            <Section title="Crescimento por Regiao (vs mes anterior)">
+              <p className="text-xs text-[#86868B] mb-4">
+                Compara vendas do mes atual com o anterior. Onde voce esta crescendo, onde esta caindo.
+              </p>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
+                {/* MAIS CRESCERAM (verde) */}
+                <div>
+                  <h3 className="text-sm font-semibold text-green-700 mb-3">Bairros em alta</h3>
+                  <div className="space-y-2">
+                    {(data.regiao.destaquesCrescimento || []).map((r) => (
+                      <div key={r.nome} className="flex items-center justify-between p-3 rounded-lg bg-green-50 border border-green-200">
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-semibold text-[#1D1D1F] truncate">{r.nome}</p>
+                          <p className="text-[11px] text-[#86868B]">{r.qtdAnterior ?? 0} → {r.qtd} vendas</p>
+                        </div>
+                        <span className="text-sm font-bold text-green-700 ml-2 shrink-0">
+                          {r.qtdAnterior === 0 ? "novo" : `+${(r.deltaQtd ?? 0).toFixed(0)}%`}
+                        </span>
+                      </div>
+                    ))}
+                    {(!data.regiao.destaquesCrescimento || data.regiao.destaquesCrescimento.length === 0) && (
+                      <p className="text-xs text-[#86868B] italic">Sem dados suficientes ainda.</p>
+                    )}
+                  </div>
+                </div>
+
+                {/* MAIS CAIRAM (vermelho) */}
+                <div>
+                  <h3 className="text-sm font-semibold text-red-700 mb-3">Bairros em queda</h3>
+                  <div className="space-y-2">
+                    {(data.regiao.destaquesQueda || []).map((r) => (
+                      <div key={r.nome} className="flex items-center justify-between p-3 rounded-lg bg-red-50 border border-red-200">
+                        <div className="flex-1 min-w-0">
+                          <p className="text-sm font-semibold text-[#1D1D1F] truncate">{r.nome}</p>
+                          <p className="text-[11px] text-[#86868B]">{r.qtdAnterior ?? 0} → {r.qtd} vendas</p>
+                        </div>
+                        <span className="text-sm font-bold text-red-700 ml-2 shrink-0">
+                          {(r.deltaQtd ?? 0).toFixed(0)}%
+                        </span>
+                      </div>
+                    ))}
+                    {(!data.regiao.destaquesQueda || data.regiao.destaquesQueda.length === 0) && (
+                      <p className="text-xs text-[#86868B] italic">Nenhum bairro caiu vs mes anterior.</p>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              {/* Tabela completa: top 15 bairros com qtd atual + anterior + delta */}
+              <h3 className="text-sm font-semibold text-[#1D1D1F] mb-3">Comparativo completo (top 15 bairros)</h3>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="text-[11px] uppercase text-[#86868B] tracking-wide">
+                    <tr className="border-b border-[#E5E5EA]">
+                      <th className="text-left py-2">Bairro</th>
+                      <th className="text-right py-2">Anterior</th>
+                      <th className="text-right py-2">Atual</th>
+                      <th className="text-right py-2">Δ</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.regiao.bairros.map((r) => {
+                      const delta = r.deltaQtd ?? 0;
+                      const corDelta = delta > 0 ? "text-green-700" : delta < 0 ? "text-red-700" : "text-[#86868B]";
+                      const sinal = delta > 0 ? "+" : "";
+                      return (
+                        <tr key={r.nome} className="border-b border-[#F5F5F7] hover:bg-[#FAFAFB]">
+                          <td className="py-2 text-[#1D1D1F] font-medium">{r.nome}</td>
+                          <td className="py-2 text-right text-[#86868B]">{r.qtdAnterior ?? 0}</td>
+                          <td className="py-2 text-right text-[#1D1D1F] font-semibold">{r.qtd}</td>
+                          <td className={`py-2 text-right font-semibold ${corDelta}`}>
+                            {r.qtdAnterior === 0 && r.qtd > 0 ? "novo" : `${sinal}${delta.toFixed(0)}%`}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </Section>
+          ) : null}
         </>
       )}
     </div>

--- a/app/api/admin/analytics-vendas/route.ts
+++ b/app/api/admin/analytics-vendas/route.ts
@@ -226,41 +226,98 @@ export async function GET(req: NextRequest) {
       .sort((a, b) => b.qtd - a.qtd);
 
     // ---------------------------------------------------------------
-    // 6. VENDAS POR REGIAO
+    // 6. VENDAS POR REGIAO + CRESCIMENTO MES A MES
     // ---------------------------------------------------------------
-    const bairroMap: Record<string, { qtd: number; receita: number }> = {};
-    const cidadeMap: Record<string, { qtd: number; receita: number }> = {};
-    const estadoMap: Record<string, { qtd: number }> = {};
+    // Agrupa vendas em 2 mapas (atual + anterior) por bairro/cidade/UF, e
+    // calcula delta% pra cada região. Mostra onde o negócio esta crescendo
+    // ou caindo geograficamente.
+    type RegMap = Record<string, { qtd: number; receita: number }>;
+    const acumular = (vendas: typeof vendasMesAtual) => {
+      const bairros: RegMap = {};
+      const cidades: RegMap = {};
+      const estados: Record<string, { qtd: number }> = {};
+      for (const v of vendas) {
+        const bairro = v.bairro || "N/I";
+        const cidade = v.cidade || "N/I";
+        const uf = v.uf || "N/I";
+        const receita = Number(v.preco_vendido || 0);
+        if (!bairros[bairro]) bairros[bairro] = { qtd: 0, receita: 0 };
+        bairros[bairro].qtd++;
+        bairros[bairro].receita += receita;
+        if (!cidades[cidade]) cidades[cidade] = { qtd: 0, receita: 0 };
+        cidades[cidade].qtd++;
+        cidades[cidade].receita += receita;
+        if (!estados[uf]) estados[uf] = { qtd: 0 };
+        estados[uf].qtd++;
+      }
+      return { bairros, cidades, estados };
+    };
 
-    for (const v of vendasMesAtual) {
-      const bairro = v.bairro || "N/I";
-      const cidade = v.cidade || "N/I";
-      const uf = v.uf || "N/I";
+    const regAtual = acumular(vendasMesAtual);
+    const regAnterior = acumular(vendasMesAnterior);
 
-      if (!bairroMap[bairro]) bairroMap[bairro] = { qtd: 0, receita: 0 };
-      bairroMap[bairro].qtd++;
-      bairroMap[bairro].receita += Number(v.preco_vendido || 0);
+    // Helper: calcula delta% entre 2 valores. Cresce de 0 → N retorna 100*N
+    // (sentido "do zero pra qualquer coisa = crescimento alto"). Decresce de
+    // N → 0 retorna -100. Quando ambos sao 0, retorna 0.
+    const delta = (atual: number, anterior: number): number => {
+      if (anterior === 0 && atual === 0) return 0;
+      if (anterior === 0) return 100 * atual; // saiu do zero — destaca como ganho grande
+      return Math.round(((atual - anterior) / anterior) * 1000) / 10; // 1 casa decimal
+    };
 
-      if (!cidadeMap[cidade]) cidadeMap[cidade] = { qtd: 0, receita: 0 };
-      cidadeMap[cidade].qtd++;
-      cidadeMap[cidade].receita += Number(v.preco_vendido || 0);
+    // Une as chaves dos 2 meses (regiao pode ter sumido ou aparecido). Aceita
+    // qualquer Record de objeto pra reusar com bairros/cidades (com receita)
+    // e estados (so qtd).
+    const unirChaves = (a: Record<string, unknown>, b: Record<string, unknown>): string[] =>
+      [...new Set([...Object.keys(a), ...Object.keys(b)])];
 
-      if (!estadoMap[uf]) estadoMap[uf] = { qtd: 0 };
-      estadoMap[uf].qtd++;
-    }
+    const compararRegioes = (mapAtual: RegMap, mapAnterior: RegMap) =>
+      unirChaves(mapAtual, mapAnterior).map((nome) => {
+        const at = mapAtual[nome] || { qtd: 0, receita: 0 };
+        const an = mapAnterior[nome] || { qtd: 0, receita: 0 };
+        return {
+          nome,
+          qtd: at.qtd,
+          receita: at.receita,
+          qtdAnterior: an.qtd,
+          receitaAnterior: an.receita,
+          deltaQtd: delta(at.qtd, an.qtd),
+          deltaReceita: delta(at.receita, an.receita),
+        };
+      });
 
     const vendasPorRegiao = {
-      bairros: Object.entries(bairroMap)
-        .map(([nome, d]) => ({ nome, qtd: d.qtd, receita: d.receita }))
+      // Top 15 do mes atual por quantidade (mantem estrutura antiga mais 4 campos
+      // novos: qtdAnterior, receitaAnterior, deltaQtd, deltaReceita)
+      bairros: compararRegioes(regAtual.bairros, regAnterior.bairros)
         .sort((a, b) => b.qtd - a.qtd)
         .slice(0, 15),
-      cidades: Object.entries(cidadeMap)
-        .map(([nome, d]) => ({ nome, qtd: d.qtd, receita: d.receita }))
+      cidades: compararRegioes(regAtual.cidades, regAnterior.cidades)
         .sort((a, b) => b.qtd - a.qtd)
         .slice(0, 15),
-      estados: Object.entries(estadoMap)
-        .map(([nome, d]) => ({ nome, qtd: d.qtd }))
+      estados: unirChaves(regAtual.estados, regAnterior.estados)
+        .map((nome) => {
+          const at = regAtual.estados[nome] || { qtd: 0 };
+          const an = regAnterior.estados[nome] || { qtd: 0 };
+          return {
+            nome,
+            qtd: at.qtd,
+            qtdAnterior: an.qtd,
+            deltaQtd: delta(at.qtd, an.qtd),
+          };
+        })
         .sort((a, b) => b.qtd - a.qtd),
+      // Listas separadas pra "destaques" — top 5 que MAIS cresceram e MAIS cairam
+      // (ordem de delta, nao de qtd absoluta). So inclui regioes com pelo menos
+      // 1 venda no mes atual ou anterior.
+      destaquesCrescimento: compararRegioes(regAtual.bairros, regAnterior.bairros)
+        .filter((r) => r.qtd > 0 || r.qtdAnterior > 0)
+        .sort((a, b) => b.deltaQtd - a.deltaQtd)
+        .slice(0, 5),
+      destaquesQueda: compararRegioes(regAtual.bairros, regAnterior.bairros)
+        .filter((r) => r.qtdAnterior > 0) // so quem ja vendeu antes pode "cair"
+        .sort((a, b) => a.deltaQtd - b.deltaQtd)
+        .slice(0, 5),
     };
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
Pedido #22 do backlog: comparar vendas por regiao do mes atual com o anterior pra ver onde o negocio esta crescendo/caindo geograficamente.

─── Backend ─────────────────────────────────────────────────────── /api/admin/analytics-vendas

Antes: vendasPorRegiao agregava SO vendas do mes atual.
Agora: agrega vendas do mes atual + anterior, calcula delta%.

Resposta enriquecida em vendasPorRegiao:
  bairros[15]  — agora com qtdAnterior, receitaAnterior, deltaQtd, deltaReceita
  cidades[15]  — idem
  estados[]    — agora com qtdAnterior, deltaQtd
  destaquesCrescimento[5] — top 5 bairros que MAIS subiram em delta%
  destaquesQueda[5]       — top 5 bairros que MAIS cairam (so com vendas anteriores)

Helper delta(atual, anterior):
  - 0 → 0     = 0
  - 0 → N     = +100*N (saiu do zero, destaca como ganho grande)
  - N → 0     = -100
  - N → M     = ((M-N)/N)*100 (1 casa decimal)

─── Frontend ────────────────────────────────────────────────────── /admin/analytics-vendas

Nova Section 8: "Crescimento por Regiao (vs mes anterior)"

3 partes:
1. 2 colunas lado-a-lado:
   - 🟢 "Bairros em alta" (verde) — top 5 destaquesCrescimento
   - 🔴 "Bairros em queda" (vermelho) — top 5 destaquesQueda Cada item mostra "Anterior → Atual vendas" + delta% Bairros novos (anterior=0) marcados como "novo" em vez de %

2. Tabela completa: top 15 bairros do mes com colunas: Bairro | Anterior | Atual | Δ% Cores: verde (subiu), vermelho (caiu), cinza (igual)

So aparece quando ha dados em destaquesCrescimento OU destaquesQueda.