### PR TITLE
fix(analytics): tracking usa sendBeacon pra sobreviver navegacao

### DIFF
--- a/lib/useTradeInAnalytics.ts
+++ b/lib/useTradeInAnalytics.ts
@@ -14,12 +14,24 @@ function getSessionId(): string {
 
 // Endpoint /api/funnel (e nao /api/analytics) — adblockers bloqueiam URLs com
 // "analytics" e isso fazia 99% dos eventos sumirem em produ
+//
+// Usa navigator.sendBeacon como prioridade — survives navegacao (cliente
+// clica "Submeter" e o browser pula pro wa.me/MercadoPago, fetch normal e
+// CANCELADO; sendBeacon e garantido pelo browser ate completar).
+// Fallback: fetch com keepalive:true (mesma garantia em browsers modernos).
 function fire(payload: Record<string, unknown>) {
   try {
+    const body = JSON.stringify(payload);
+    if (typeof navigator !== "undefined" && typeof navigator.sendBeacon === "function") {
+      const blob = new Blob([body], { type: "application/json" });
+      const ok = navigator.sendBeacon("/api/funnel", blob);
+      if (ok) return;
+    }
     fetch("/api/funnel", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
+      body,
+      keepalive: true,
     }).catch(() => {
       /* silent — tracking should never break UX */
     });


### PR DESCRIPTION
## Bug reportado pelo André

> "essa semana várias pessoas submeteram/compraram e o sistema marca zerado"

## Causa

A função `fire()` usava `fetch()` simples, **sem keepalive**. Quando o cliente clica "Submeter" no `/compra`:

1. Dispara `trackAction("compra_submit")` → chamada fetch sai
2. Imediatamente `window.open(wa.me/...)` ou `window.location.href = MP`
3. Browser **cancela todas requests pendentes** ao navegar
4. O fetch nunca chega no servidor → evento perdido

Por isso `compra_submit` sempre zerado mesmo com vendas reais acontecendo.

## Fix

`fire()` agora usa `navigator.sendBeacon` como prioridade. `sendBeacon` é desenhado **especificamente** pra esse caso — browser garante que o request completa mesmo se a página for fechada/navegada.

Fallback: `fetch` com `keepalive: true` (mesma garantia em browsers modernos).

```ts
function fire(payload) {
  const body = JSON.stringify(payload);
  if (navigator.sendBeacon) {
    const blob = new Blob([body], { type: "application/json" });
    if (navigator.sendBeacon("/api/funnel", blob)) return;
  }
  fetch("/api/funnel", { method: "POST", body, keepalive: true }).catch(() => {});
}
```

## Cobertura

Mesma lógica protege **todos** os eventos do hook (não só `compra_submit`):
- `compra_view`, `compra_submit`
- `step_view`, `step_complete` (etapas 1-4)
- `quote_whatsapp`, `quote_exit`, `quote_cotar_outro`
- `site_view`, `question_answer`

Eventos disparados em fluxos rápidos também ficam garantidos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)