### PR TITLE
feat(admin): picker material da caixa Apple Watch Series em /gerar-link e /entregas

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -7,6 +7,7 @@ import { getTaxa, calcularLiquido } from "@/lib/taxas";
 import { INSTALLMENT_RATES } from "@/lib/calculations";
 import { formatProdutoDisplay, getModeloBase, limparNomeProduto } from "@/lib/produto-display";
 import { corParaPT } from "@/lib/cor-pt";
+import { WATCH_SERIES_CASES, detectWatchSeriesGen, detectWatchMaterial, filterCoresByCase, getAvailableMaterials } from "@/lib/watch-cores";
 import { useVendedores } from "@/lib/vendedores";
 
 interface EstoqueItem { id: string; produto: string; categoria: string; tipo: string; qnt: number; custo_unitario: number; cor: string | null; fornecedor: string | null; status: string; serial_no: string | null; imei: string | null; }
@@ -364,6 +365,9 @@ export default function EntregasPage() {
   const [carrinho, setCarrinho] = useState<CarrinhoItem[]>([]);
   const [addingProduct, setAddingProduct] = useState(false);
   const [tempCor, setTempCor] = useState("");
+  // Material da caixa do Apple Watch Series (Aluminio/Aco/Titanio). Filtra
+  // as cores quando o produto selecionado e Apple Watch Series 9/10/11.
+  const [tempWatchCase, setTempWatchCase] = useState("");
   const [desconto, setDesconto] = useState("");
   const [trocaAtiva, setTrocaAtiva] = useState(false);
   const [trocaValor, setTrocaValor] = useState("");
@@ -1664,31 +1668,73 @@ export default function EntregasPage() {
                         <div className={`max-h-[300px] overflow-y-auto rounded-xl border divide-y ${dm ? "border-[#3A3A3C] divide-[#3A3A3C]" : "border-[#D2D2D7] divide-[#E5E5EA]"}`}>
                           {produtosFiltradosPreco.length === 0 && <p className="text-xs text-center text-[#86868B] py-4">Nenhum produto</p>}
                           {produtosFiltradosPreco.map((m) => {
-                            const cores = coresParaProduto(m.nome);
+                            const coresRaw = coresParaProduto(m.nome);
+                            // Detecta Watch Series + material explicito no nome do
+                            // produto (ex: "Apple Watch Series 11 Titanio 42mm" → Titanio).
+                            // Quando material detectado no nome, bypassa o picker.
+                            const watchGen = detectWatchSeriesGen(m.nome);
+                            const matFromName = detectWatchMaterial(m.nome);
+                            // Materiais disponiveis: deriva do catalogo, ou forca o detectado
+                            // do nome. Quando so tem 1, picker nao aparece.
+                            const allCases = watchGen ? getAvailableMaterials(coresRaw, watchGen) : [];
+                            const caseOptions = (watchGen && matFromName)
+                              ? (allCases.find(o => o.material === matFromName)
+                                  ? [allCases.find(o => o.material === matFromName)!]
+                                  : (WATCH_SERIES_CASES[watchGen]?.filter(o => o.material === matFromName) || allCases))
+                              : allCases;
+                            const showCasePicker = !!watchGen && caseOptions.length > 1;
+                            // Material efetivo: tempWatchCase (operador escolheu) ou
+                            // detectado no nome ou auto-selecionado quando so 1.
+                            const effectiveMaterial = tempWatchCase || matFromName || (caseOptions.length === 1 ? caseOptions[0].material : "");
+                            const cores = (watchGen && effectiveMaterial)
+                              ? filterCoresByCase(coresRaw, watchGen, effectiveMaterial)
+                              : coresRaw;
+                            const isSelected = produtos[0] === m.nome;
                             return (
                               <div key={m.nome}>
                                 <button type="button" onClick={() => {
-                                  if (cores.length === 0) {
-                                    // No colors — add directly to carrinho
+                                  if (coresRaw.length === 0) {
                                     setCarrinho(prev => [...prev, { key: `${m.nome}-${Date.now()}`, nome: m.nome, cor: "", preco: m.preco, categoria: catSel }]);
-                                    setAddingProduct(false); setCatSel(""); setTempCor("");
+                                    setAddingProduct(false); setCatSel(""); setTempCor(""); setTempWatchCase("");
                                   } else {
-                                    // Has colors — select this product to show color chips
                                     setProdutos([m.nome]);
                                     setTempCor("");
+                                    setTempWatchCase("");
                                   }
-                                }} className={`w-full px-4 py-3 flex items-center justify-between text-left transition-all ${produtos[0] === m.nome ? (dm ? "bg-[#3A2410] border-l-4 border-[#E8740E]" : "bg-[#FFF5EB] border-l-4 border-[#E8740E]") : (dm ? "hover:bg-[#2C2C2E]" : "hover:bg-[#F9F9FB]")}`}>
-                                  <p className={`text-sm font-semibold ${produtos[0] === m.nome ? "text-[#E8740E]" : (dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]")}`}>{m.nome}</p>
-                                  <p className={`text-sm font-bold ${produtos[0] === m.nome ? "text-[#E8740E]" : (dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]")}`}>R$ {m.preco.toLocaleString("pt-BR")}</p>
+                                }} className={`w-full px-4 py-3 flex items-center justify-between text-left transition-all ${isSelected ? (dm ? "bg-[#3A2410] border-l-4 border-[#E8740E]" : "bg-[#FFF5EB] border-l-4 border-[#E8740E]") : (dm ? "hover:bg-[#2C2C2E]" : "hover:bg-[#F9F9FB]")}`}>
+                                  <p className={`text-sm font-semibold ${isSelected ? "text-[#E8740E]" : (dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]")}`}>{m.nome}</p>
+                                  <p className={`text-sm font-bold ${isSelected ? "text-[#E8740E]" : (dm ? "text-[#F5F5F7]" : "text-[#1D1D1F]")}`}>R$ {m.preco.toLocaleString("pt-BR")}</p>
                                 </button>
-                                {produtos[0] === m.nome && cores.length > 0 && (
+                                {/* Picker de material da caixa pra Watch Series — operador
+                                    escolhe Aluminio/Aco/Titanio antes da cor pra nao misturar. */}
+                                {isSelected && showCasePicker && (
+                                  <div className={`px-4 py-3 border-t ${dm ? "bg-[#2C2C2E] border-[#3A3A3C]" : "bg-[#FAFAFA] border-[#E5E5EA]"}`}>
+                                    <p className="text-xs font-medium mb-2 text-[#86868B]">Material da caixa:</p>
+                                    <div className="flex flex-wrap gap-2">
+                                      {caseOptions.map((opt) => (
+                                        <button key={opt.material} type="button" onClick={() => setTempWatchCase(tempWatchCase === opt.material ? "" : opt.material)}
+                                          className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${tempWatchCase === opt.material ? "bg-[#E8740E] text-white border-[#E8740E]" : (dm ? "bg-[#1C1C1E] text-[#F5F5F7] border-[#3A3A3C] hover:border-[#E8740E]" : "bg-white text-[#1D1D1F] border-[#D2D2D7] hover:border-[#E8740E]")}`}
+                                        >{opt.material}</button>
+                                      ))}
+                                    </div>
+                                    {tempWatchCase && caseOptions.find(o => o.material === tempWatchCase)?.forceGPSCel && (
+                                      <p className={`mt-2 text-[11px] ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
+                                        {tempWatchCase} sempre vem com GPS + Celular de fábrica.
+                                      </p>
+                                    )}
+                                  </div>
+                                )}
+                                {/* Cores aparecem quando: (1) nao precisa de picker
+                                    de material, OU (2) operador escolheu material, OU
+                                    (3) so tem 1 material disponivel (auto-selecionado). */}
+                                {isSelected && coresRaw.length > 0 && (!showCasePicker || effectiveMaterial) && (
                                   <div className={`px-4 py-3 border-t ${dm ? "bg-[#2C2C2E] border-[#3A3A3C]" : "bg-[#FAFAFA] border-[#E5E5EA]"}`}>
                                     <p className="text-xs font-medium mb-2 text-[#86868B]">Selecione a cor:</p>
                                     <div className="flex flex-wrap gap-2">
                                       {cores.map(cor => (
                                         <button key={cor} type="button" onClick={() => {
                                           setCarrinho(prev => [...prev, { key: `${m.nome}-${cor}-${Date.now()}`, nome: m.nome, cor, preco: m.preco, categoria: catSel }]);
-                                          setAddingProduct(false); setCatSel(""); setTempCor(""); setProdutos([""]);
+                                          setAddingProduct(false); setCatSel(""); setTempCor(""); setProdutos([""]); setTempWatchCase("");
                                         }}
                                           className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${dm ? "bg-[#1C1C1E] text-[#F5F5F7] border-[#3A3A3C] hover:border-[#E8740E] hover:bg-[#3A2410]" : "bg-white text-[#1D1D1F] border-[#D2D2D7] hover:border-[#E8740E] hover:bg-[#FFF5EB]"}`}
                                         >{cor}</button>

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -5,6 +5,7 @@ import { useAdmin } from "@/components/admin/AdminShell";
 import { WHATSAPP_DEFAULT } from "@/lib/whatsapp-config";
 import { useVendedores, getWhatsAppFromVendedores } from "@/lib/vendedores";
 import { corParaPT, corParaEN } from "@/lib/cor-pt";
+import { WATCH_SERIES_CASES, detectWatchSeriesGen, detectWatchMaterial, filterCoresByCase, getAvailableMaterials } from "@/lib/watch-cores";
 import { getModeloBase } from "@/lib/produto-display";
 import { buildWaFollowUpUrl } from "@/lib/whatsappFollowUp";
 import { getPublicBaseUrl } from "@/lib/public-url";
@@ -69,6 +70,9 @@ export default function GerarLinkPage() {
   }, [precosVenda, catSel]);
   const [corSel, setCorSel] = useState("");
   const [coresExtras, setCoresExtras] = useState<string[]>([]); // cor por índice extra (produto 2, 3, ...)
+  // Material da caixa do Apple Watch Series (Aluminio/Aco/Titanio). Filtra
+  // as cores disponiveis quando produtos[0] e Apple Watch Series 9/10/11.
+  const [watchCaseSel, setWatchCaseSel] = useState("");
 
   // Fetch estoque para obter cores reais disponíveis + seminovos
   const [estoqueItems, setEstoqueItems] = useState<{ produto: string; categoria: string; cor: string | null; qnt: number; tipo?: string; preco_sugerido?: number | null }[]>([]);
@@ -186,7 +190,57 @@ export default function GerarLinkPage() {
     return out.sort((a, b) => corParaPT(a).localeCompare(corParaPT(b)));
   }, [catalogoCores]);
 
-  const coresDisponiveis = useMemo(() => coresParaProduto(produtos[0] || ""), [produtos, coresParaProduto]);
+  // Detecta Apple Watch Series (9/10/11) no produto principal.
+  // SE/Ultra retornam null (so um material possivel — sem necessidade de filtro).
+  const watchSeriesGen = useMemo(() => detectWatchSeriesGen(produtos[0] || ""), [produtos]);
+
+  // Detecta material EXPLICITO no nome do produto (ex: "Apple Watch Series 11
+  // Titanio GPS+Cel 42mm"). Quando detectado, bypassa o picker e usa ja como
+  // material escolhido — operador cadastra preco do Titanio em /admin/precos
+  // com "Titanio" no nome e o sistema resolve automaticamente.
+  const watchMaterialFromName = useMemo(() => detectWatchMaterial(produtos[0] || ""), [produtos]);
+
+  // Materiais disponiveis sao DERIVADOS do catalogo cadastrado: so mostra
+  // Aluminio/Aço/Titanio se ha cores cadastradas pra esse material no admin.
+  // Quando o produto ja tem material explicito no nome, retorna apenas esse
+  // material (Titanio detectado → so Titanio).
+  const watchCaseOptions = useMemo(() => {
+    if (!watchSeriesGen) return [];
+    const raw = coresParaProduto(produtos[0] || "");
+    const all = getAvailableMaterials(raw, watchSeriesGen);
+    if (watchMaterialFromName) {
+      // Se a opcao detectada nao esta no catalogo (cores nao cadastradas
+      // ainda), retorna ela mesma assim com forceGPSCel inferido do hardcoded.
+      const found = all.find(o => o.material === watchMaterialFromName);
+      if (found) return [found];
+      const hardcoded = WATCH_SERIES_CASES[watchSeriesGen]?.find(o => o.material === watchMaterialFromName);
+      return hardcoded ? [{ ...hardcoded }] : all;
+    }
+    return all;
+  }, [watchSeriesGen, watchMaterialFromName, produtos, coresParaProduto]);
+
+  // Reset material quando o produto muda (ou nao e mais Watch Series).
+  // Auto-seleciona quando ha apenas 1 material disponivel (caso comum: Tigrao
+  // so tem Aluminio cadastrado, OU produto ja indica Titanio no nome).
+  useEffect(() => {
+    if (!watchSeriesGen) { setWatchCaseSel(""); return; }
+    if (watchCaseOptions.length === 1) {
+      if (watchCaseSel !== watchCaseOptions[0].material) setWatchCaseSel(watchCaseOptions[0].material);
+      return;
+    }
+    if (watchCaseSel && !watchCaseOptions.find(o => o.material === watchCaseSel)) setWatchCaseSel("");
+  }, [watchSeriesGen, watchCaseSel, watchCaseOptions]);
+
+  const coresDisponiveis = useMemo(() => {
+    const raw = coresParaProduto(produtos[0] || "");
+    // Filtra cores do catalogo pelo material da caixa quando Watch Series com
+    // material escolhido. Senao retorna a lista bruta (compat com fluxo
+    // existente pra iPhone/iPad/MacBook/Watch SE/Ultra).
+    if (watchSeriesGen && watchCaseSel) {
+      return filterCoresByCase(raw, watchSeriesGen, watchCaseSel);
+    }
+    return raw;
+  }, [produtos, coresParaProduto, watchSeriesGen, watchCaseSel]);
 
   // Auto-soma preço base quando há múltiplos produtos
   // Lookup preço de cada produto pelo nome na lista de preços
@@ -2579,7 +2633,28 @@ export default function GerarLinkPage() {
 
         {produtoManual ? (
           <>
-            {produtos[0] && coresDisponiveis.length > 0 && (
+            {/* Picker de material da caixa — so Apple Watch Series 9/10/11
+                COM MAIS DE 1 material disponivel no catalogo. Quando so tem
+                1 material cadastrado (caso comum: Tigrao so tem Aluminio),
+                auto-seleciona e mostra direto o picker de cor. */}
+            {watchSeriesGen && watchCaseOptions.length > 1 && (
+              <div className={`px-4 py-3 rounded-xl border ${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-[#FAFAFA] border-[#E5E5EA]"}`}>
+                <p className={`text-xs font-medium mb-2 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Material da caixa:</p>
+                <div className="flex flex-wrap gap-2">
+                  {watchCaseOptions.map((opt) => (
+                    <button key={opt.material} onClick={() => { setWatchCaseSel(watchCaseSel === opt.material ? "" : opt.material); setCorSel(""); }}
+                      className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-all border ${watchCaseSel === opt.material ? "bg-[#E8740E] text-white border-[#E8740E]" : (dm ? "bg-[#2C2C2E] text-[#F5F5F7] border-[#3A3A3C] hover:border-[#E8740E]" : "bg-white text-[#1D1D1F] border-[#D2D2D7] hover:border-[#E8740E]")}`}
+                    >{opt.material}</button>
+                  ))}
+                </div>
+                {watchCaseSel && watchCaseOptions.find(o => o.material === watchCaseSel)?.forceGPSCel && (
+                  <p className={`mt-2 text-[11px] ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>
+                    {watchCaseSel} sempre vem com GPS + Celular de fábrica.
+                  </p>
+                )}
+              </div>
+            )}
+            {produtos[0] && coresDisponiveis.length > 0 && (!watchSeriesGen || watchCaseSel) && (
               <div className={`px-4 py-3 rounded-xl border ${dm ? "bg-[#1C1C1E] border-[#3A3A3C]" : "bg-[#FAFAFA] border-[#E5E5EA]"}`}>
                 <p className={`text-xs font-medium mb-2 ${dm ? "text-[#98989D]" : "text-[#86868B]"}`}>Cor do produto 1:</p>
                 <div className="flex flex-wrap gap-2">

--- a/lib/watch-cores.ts
+++ b/lib/watch-cores.ts
@@ -1,0 +1,178 @@
+// Helpers compartilhados pra cores do Apple Watch Series por material da
+// caixa. Usado pelo fluxo trade-in cliente (StepUsedDeviceMulti) e pelo
+// admin de geracao de link/entrega (/admin/gerar-link), pra que ambas as
+// telas filtrem cores consistentemente quando o operador/cliente escolhe
+// Aluminio vs Aco Inoxidavel vs Titanio.
+
+/** Configuracao de caixas (material) por geracao Series. Series 9 = Al + Aço,
+ *  Series 10/11 = Al + Titânio. Aço/Titânio sempre vem GPS+Cel de fabrica.
+ *  Cores oficiais Apple por material (BR). Series 10 NAO tem Cinza-espacial. */
+export const WATCH_SERIES_CASES: Record<
+  string,
+  { material: string; cores: string[]; forceGPSCel?: boolean }[]
+> = {
+  "9": [
+    { material: "Alumínio", cores: ["Estelar", "Meia-noite", "Prateado", "Vermelho", "Rosa"] },
+    { material: "Aço Inoxidável", cores: ["Grafite", "Prateado", "Dourado"], forceGPSCel: true },
+  ],
+  "10": [
+    { material: "Alumínio", cores: ["Ouro Rosa", "Prateado", "Preto Brilhante"] },
+    { material: "Titânio", cores: ["Titânio Natural", "Dourado", "Ardósia"], forceGPSCel: true },
+  ],
+  "11": [
+    { material: "Alumínio", cores: ["Ouro Rosa", "Prateado", "Preto Brilhante", "Cinza-espacial"] },
+    { material: "Titânio", cores: ["Titânio Natural", "Dourado", "Ardósia"], forceGPSCel: true },
+  ],
+};
+
+/** Aliases bidirecionais entre nomes do catalogo (PT genericos / EN Apple) e
+ *  o canonico Apple. Catalogo brasileiro usa nomes curtos ("Preto", "Cinza",
+ *  "Dourado") que mapeiam pra varias cores Apple especificas dependendo do
+ *  modelo+material. Filtro por material restringe pelo allow-list, entao as
+ *  aliases podem ser permissivas. */
+export const COR_ALIASES: Record<string, string[]> = {
+  // Prateado / Prata / Silver
+  "prata": ["prateado", "silver"],
+  "prateado": ["prata", "silver"],
+  "silver": ["prata", "prateado"],
+  // Preto generico → cobre Midnight (Series 9 Al), Jet Black (Series 10/11 Al), Black Titanium
+  "preto": ["preto brilhante", "jet black", "meia noite", "midnight", "titanio preto", "black titanium"],
+  "preto brilhante": ["preto", "jet black"],
+  "jet black": ["preto", "preto brilhante"],
+  "meia noite": ["midnight", "preto"],
+  "midnight": ["meia noite", "preto"],
+  "titanio preto": ["preto", "black titanium"],
+  "black titanium": ["preto", "titanio preto"],
+  // Natural / Titanio Natural
+  "natural": ["titanio natural"],
+  "titanio natural": ["natural"],
+  // Ardosia / Slate
+  "ardosia": ["slate", "slate titanium"],
+  "slate": ["ardosia", "slate titanium"],
+  "slate titanium": ["ardosia", "slate"],
+  // Estelar / Starlight
+  "estelar": ["starlight"],
+  "starlight": ["estelar"],
+  // Cinza generico → cobre Graphite, Space Gray, Slate, Cinza-espacial, Ardosia
+  "cinza": ["grafite", "graphite", "space gray", "space grey", "cinza espacial", "slate", "ardosia"],
+  "cinza espacial": ["space gray", "space grey", "cinza"],
+  "space gray": ["cinza espacial", "cinza"],
+  "space grey": ["cinza espacial", "cinza"],
+  "grafite": ["graphite", "cinza"],
+  "graphite": ["grafite", "cinza"],
+  // Dourado generico → cobre Gold, Rose Gold, Gold Titanium
+  "dourado": ["gold", "ouro", "ouro rosa", "rose gold", "rose", "gold titanium"],
+  "gold": ["dourado", "ouro"],
+  "ouro": ["dourado", "gold"],
+  "ouro rosa": ["rose gold", "rose", "dourado"],
+  "rose gold": ["ouro rosa", "dourado"],
+  "rose": ["ouro rosa", "dourado"],
+  "gold titanium": ["dourado", "gold"],
+  // Vermelho / Red / Product RED
+  "vermelho": ["red", "product red"],
+  "red": ["vermelho"],
+  "product red": ["vermelho"],
+  // Rosa / Pink
+  "rosa": ["pink"],
+  "pink": ["rosa"],
+};
+
+/** Normaliza cor pra comparacao: lowercase, sem acento, hifen→espaco, trim. */
+export function normalizeCor(s: string): string {
+  return s
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[-_]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Bucket de aliases: o nome normalizado da cor + todas as suas aliases.
+ *  Duas cores estao no mesmo bucket se Set.intersection nao for vazia. */
+export function bucketOfCor(cor: string): Set<string> {
+  const n = normalizeCor(cor);
+  const bucket = new Set<string>([n]);
+  for (const alias of COR_ALIASES[n] || []) bucket.add(normalizeCor(alias));
+  return bucket;
+}
+
+function bucketsOverlap(a: Set<string>, b: Set<string>): boolean {
+  for (const x of a) if (b.has(x)) return true;
+  return false;
+}
+
+/** Detecta a geracao do Apple Watch Series a partir do nome do produto.
+ *  "Apple Watch Series 11 GPS 42mm" → "11". Retorna null se nao bater Series. */
+export function detectWatchSeriesGen(nomeProduto: string): string | null {
+  if (!/Apple\s+Watch/i.test(nomeProduto)) return null;
+  // Exclui SE e Ultra (cores nao dividem por material — SE so tem Aluminio,
+  // Ultra so tem Titanio).
+  if (/\bSE\b/i.test(nomeProduto) || /\bUltra\b/i.test(nomeProduto)) return null;
+  const m = nomeProduto.match(/(?:Series\s+)?(\d+)/i);
+  if (!m) return null;
+  const gen = m[1];
+  return WATCH_SERIES_CASES[gen] ? gen : null;
+}
+
+/** Detecta o material da caixa explicito no nome do produto. Usado pra que
+ *  ao cadastrar um SKU "Apple Watch Series 11 Titanio GPS+Cel 42mm" em
+ *  /admin/precos, o sistema ja saiba que e Titanio sem precisar de picker
+ *  separado. Retorna o nome canonico do material ou null se nao detectou.
+ *  Aceita acentos opcionais e variacoes EN ("Titanium", "Stainless Steel"). */
+export function detectWatchMaterial(nomeProduto: string): string | null {
+  if (/\b(titanio|titânio|titanium)\b/i.test(nomeProduto)) return "Titânio";
+  if (/\b(aco\s+inox|aço\s+inox|stainless\s+steel|stainless)\b/i.test(nomeProduto)) return "Aço Inoxidável";
+  if (/\b(aluminio|alumínio|aluminum)\b/i.test(nomeProduto)) return "Alumínio";
+  return null;
+}
+
+/** Retorna os materiais (Aluminio/Aço/Titânio) que tem AO MENOS uma cor
+ *  cadastrada no catalogo pra essa geracao. Usado pra montar o picker de
+ *  material — so mostra opcoes que de fato existem no estoque/catalogo do
+ *  Tigrao. Ex: se admin so cadastrou cores Aluminio pra Series 11, o picker
+ *  nao oferece Titanio. Quando admin ativar/cadastrar Titanio, aparece. */
+export function getAvailableMaterials(coresRaw: string[], gen: string): { material: string; cores: string[]; forceGPSCel?: boolean }[] {
+  const opts = WATCH_SERIES_CASES[gen];
+  if (!opts) return [];
+  return opts.filter((opt) => {
+    const filtered = filterCoresByCase(coresRaw, gen, opt.material);
+    // filterCoresByCase faz fallback pra coresRaw quando intersecao vazia —
+    // entao precisamos checar se REALMENTE casou (cor do material existe no catalogo).
+    return filtered !== coresRaw && filtered.length > 0;
+  });
+}
+
+/** Filtra/dedup uma lista de cores do catalogo pelo material da caixa.
+ *  - Match e via bucket de aliases (case+acento insensitive, EN/PT, dedup
+ *    de variantes — "Preto" e "Preto Brilhante" colapsam).
+ *  - Match exato com o nome canonico vence (preserva o nome catalogado).
+ *  - Fallback: se nao tem exato mas tem alias, mostra o NOME CANONICO Apple
+ *    (ex: catalogo so tem "Cinza" pra Series 10 Titanio → mostra "Ardósia").
+ *  - Quando intersecao fica vazia (catalogo desalinhado), cai pra coresRaw
+ *    pra nao travar a UI.
+ *  - Ordem segue a lista canonica (oficial Apple), nao alfabetica do catalogo. */
+export function filterCoresByCase(coresRaw: string[], gen: string, material: string): string[] {
+  const opt = WATCH_SERIES_CASES[gen]?.find((o) => o.material === material);
+  if (!opt || opt.cores.length === 0) return coresRaw;
+  const filtered: string[] = [];
+  const usedBuckets: Set<string>[] = [];
+  for (const canonica of opt.cores) {
+    const cbBucket = bucketOfCor(canonica);
+    if (usedBuckets.some((u) => bucketsOverlap(u, cbBucket))) continue;
+    // Match exato primeiro
+    const exact = coresRaw.find((cor) => normalizeCor(cor) === normalizeCor(canonica));
+    if (exact) {
+      filtered.push(exact);
+      usedBuckets.push(cbBucket);
+      continue;
+    }
+    // Fallback: alias overlap → mostra o nome canonico Apple
+    const hasAlias = coresRaw.some((cor) => bucketsOverlap(bucketOfCor(cor), cbBucket));
+    if (hasAlias) {
+      filtered.push(canonica);
+      usedBuckets.push(cbBucket);
+    }
+  }
+  return filtered.length > 0 ? filtered : coresRaw;
+}


### PR DESCRIPTION
Recupera fixes que ficaram de fora do squash do PR #811 (so pegou o fix de
AVALIACAO_MANUAL, deixou os pickers Watch como orfaos).

## Reportado pelo Nicolas
- /admin/gerar-link mostrava todas as cores do Apple Watch Series misturadas
  (Aluminio + Titanio + duplicatas como "Preto" e "Preto Brilhante"). Tigrao
  so vende Aluminio a pronta entrega — o picker exibindo Titanio era confuso.
- /admin/entregas tinha o mesmo problema.

## Solucao

### Novo lib `lib/watch-cores.ts`
Helpers compartilhados:
- `WATCH_SERIES_CASES` — cores oficiais Apple por geracao+material
- `COR_ALIASES` — Prata↔Prateado, Preto↔Preto Brilhante, Cinza↔Grafite/Slate, Dourado↔Rose Gold etc
- `filterCoresByCase` — filtra+dedup cores pelo material
- `getAvailableMaterials` — deriva materiais das cores cadastradas no catalogo
- `detectWatchSeriesGen` — detecta geracao do produto (Series 9/10/11)
- `detectWatchMaterial` — detecta material no nome do produto (Titanio/Aço/Aluminio)

### /admin/gerar-link e /admin/entregas

Quando o produto e Apple Watch Series 9/10/11:
1. Mostra picker "Material da caixa" antes do picker de cor (so quando ha
   2+ materiais disponiveis no catalogo).
2. Cores filtradas pelo material escolhido.
3. **Auto-select** quando so ha 1 material cadastrado — caso comum: Tigrao
   so tem Aluminio. Operador nao vê picker, vai direto pras cores Aluminio.
4. **Detecta material no nome do produto** — "Apple Watch Series 11 Titanio
   42mm" cadastrado em /admin/precos forca Titanio automaticamente.

Aviso "Aço Inoxidável/Titânio sempre vem GPS+Cel de fabrica" quando
material com forceGPSCel e selecionado.

## Backward compat
- iPhone/iPad/MacBook/AirPods/Watch SE/Watch Ultra: comportamento legacy
  inalterado (nao detecta como Series 9/10/11, picker nem renderiza).
- Catalogo desalinhado: filtro cai pra coresRaw (defensivo, nao trava).
- Sem mudanca de DB.
- StepUsedDeviceMulti (cliente trade-in) NAO foi tocado — tem sua propria
  implementacao inline ja em main. Refatoracao pra usar o lib pode vir depois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)