### PR TITLE
fix(watch-cores): trigger materiais via /admin/precos (gatilho correto)

### DIFF
--- a/app/admin/entregas/page.tsx
+++ b/app/admin/entregas/page.tsx
@@ -1670,18 +1670,30 @@ export default function EntregasPage() {
                           {produtosFiltradosPreco.map((m) => {
                             const coresRaw = coresParaProduto(m.nome);
                             // Detecta Watch Series + material explicito no nome do
-                            // produto (ex: "Apple Watch Series 11 Titanio 42mm" → Titanio).
-                            // Quando material detectado no nome, bypassa o picker.
+                            // produto. Trigger pra "ativar" Titanio: cadastrar produto
+                            // com "Titanio" no nome em /admin/precos. Senao, deriva
+                            // dos OUTROS produtos da mesma geracao em precosVenda
+                            // (sem "Titanio" = Aluminio default).
                             const watchGen = detectWatchSeriesGen(m.nome);
                             const matFromName = detectWatchMaterial(m.nome);
-                            // Materiais disponiveis: deriva do catalogo, ou forca o detectado
-                            // do nome. Quando so tem 1, picker nao aparece.
-                            const allCases = watchGen ? getAvailableMaterials(coresRaw, watchGen) : [];
-                            const caseOptions = (watchGen && matFromName)
-                              ? (allCases.find(o => o.material === matFromName)
-                                  ? [allCases.find(o => o.material === matFromName)!]
-                                  : (WATCH_SERIES_CASES[watchGen]?.filter(o => o.material === matFromName) || allCases))
-                              : allCases;
+                            const caseOptions = (() => {
+                              if (!watchGen) return [];
+                              // Se este produto ja tem material no nome, so ele.
+                              if (matFromName) {
+                                const hc = WATCH_SERIES_CASES[watchGen]?.find(o => o.material === matFromName);
+                                return hc ? [{ ...hc, cores: [...hc.cores] }] : [];
+                              }
+                              // Scan precosVenda da mesma geracao
+                              const materials = new Set<string>();
+                              for (const p of precosVenda) {
+                                const fullName = `${p.modelo} ${p.armazenamento}`.trim();
+                                if (detectWatchSeriesGen(fullName) !== watchGen) continue;
+                                const mat = detectWatchMaterial(fullName);
+                                materials.add(mat || "Alumínio");
+                              }
+                              const all = WATCH_SERIES_CASES[watchGen] || [];
+                              return all.filter(opt => materials.has(opt.material));
+                            })();
                             const showCasePicker = !!watchGen && caseOptions.length > 1;
                             // Material efetivo: tempWatchCase (operador escolheu) ou
                             // detectado no nome ou auto-selecionado quando so 1.

--- a/app/admin/gerar-link/page.tsx
+++ b/app/admin/gerar-link/page.tsx
@@ -200,24 +200,31 @@ export default function GerarLinkPage() {
   // com "Titanio" no nome e o sistema resolve automaticamente.
   const watchMaterialFromName = useMemo(() => detectWatchMaterial(produtos[0] || ""), [produtos]);
 
-  // Materiais disponiveis sao DERIVADOS do catalogo cadastrado: so mostra
-  // Aluminio/Aço/Titanio se ha cores cadastradas pra esse material no admin.
-  // Quando o produto ja tem material explicito no nome, retorna apenas esse
-  // material (Titanio detectado → so Titanio).
+  // Materiais disponiveis sao DERIVADOS dos produtos cadastrados em
+  // /admin/precos da MESMA geracao Series. Se Tigrao so cadastrou produto
+  // Aluminio (sem "Titanio" no nome), so Aluminio aparece. Quando admin
+  // cadastrar "Apple Watch Series 11 Titanio GPS+Cel 42mm" em /admin/precos,
+  // o sistema detecta "Titanio" no nome e habilita Titanio automaticamente.
+  // Produtos sem material explicito no nome contam como Aluminio (default).
   const watchCaseOptions = useMemo(() => {
     if (!watchSeriesGen) return [];
-    const raw = coresParaProduto(produtos[0] || "");
-    const all = getAvailableMaterials(raw, watchSeriesGen);
+    // Se o proprio produto selecionado ja tem material no nome, retorna so esse.
     if (watchMaterialFromName) {
-      // Se a opcao detectada nao esta no catalogo (cores nao cadastradas
-      // ainda), retorna ela mesma assim com forceGPSCel inferido do hardcoded.
-      const found = all.find(o => o.material === watchMaterialFromName);
-      if (found) return [found];
       const hardcoded = WATCH_SERIES_CASES[watchSeriesGen]?.find(o => o.material === watchMaterialFromName);
-      return hardcoded ? [{ ...hardcoded }] : all;
+      return hardcoded ? [{ ...hardcoded, cores: [...hardcoded.cores] }] : [];
     }
-    return all;
-  }, [watchSeriesGen, watchMaterialFromName, produtos, coresParaProduto]);
+    // Senao, scan TODOS os produtos da mesma geracao em /admin/precos
+    // (precosVenda) e ve quais materiais existem cadastrados.
+    const materialsInPrecos = new Set<string>();
+    for (const p of precosVenda) {
+      const nomeFull = `${p.modelo} ${p.armazenamento}`.trim();
+      if (detectWatchSeriesGen(nomeFull) !== watchSeriesGen) continue;
+      const mat = detectWatchMaterial(nomeFull);
+      materialsInPrecos.add(mat || "Alumínio"); // sem material no nome = Aluminio (default)
+    }
+    const all = WATCH_SERIES_CASES[watchSeriesGen] || [];
+    return all.filter(opt => materialsInPrecos.has(opt.material));
+  }, [watchSeriesGen, watchMaterialFromName, precosVenda]);
 
   // Reset material quando o produto muda (ou nao e mais Watch Series).
   // Auto-seleciona quando ha apenas 1 material disponivel (caso comum: Tigrao


### PR DESCRIPTION
Continuacao do PR #821 — esse commit ficou de fora do squash.

## Problema reportado
Mesmo apos #821, /admin/gerar-link continuava mostrando cores Titanio
(Ardósia, Natural, Titânio Natural) pra "Apple Watch Series 11 GPS 42MM".
O Nicolas tinha cadastrado cores Titanio no catalogo em algum momento, mas
nao tinha cadastrado o PRECO em /admin/precos — Titanio nao deveria aparecer.

## Causa
O codigo do #821 derivava materiais disponiveis das cores cadastradas no
catalogo. Trigger errado.

## Fix
Trigger agora e **/admin/precos** (nao mais o catalogo de cores). Scan os
produtos da mesma geracao Series em precosVenda:
- Detecta material no nome de cada produto (Titanio/Aço/Aluminio via
  detectWatchMaterial)
- Sem material no nome = conta como Aluminio (default)
- So habilita os materiais com produtos cadastrados em /admin/precos

## Resultado pratico
- Tigrao so cadastrou "Apple Watch Series 11 GPS 42mm" e "Apple Watch
  Series 11 GPS+Cel 42mm" → so Aluminio detectado → cores Titanio nao
  aparecem nem em /gerar-link nem em /entregas.
- No dia que cadastrar "Apple Watch Series 11 Titanio 42mm" em /admin/precos
  → Titanio aparece automaticamente.

Aplicado nos 2 lugares: /admin/gerar-link e /admin/entregas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)