### PR TITLE
feat(funil): 4 melhorias UX no simulador (Sprint 1)

### DIFF
--- a/components/StepClientData.tsx
+++ b/components/StepClientData.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import type { TradeInConfig } from "@/lib/types";
 
-const DEFAULT_ORIGENS = [
-  "Anúncio", "Story", "Direct",
-  "WhatsApp", "Indicação", "Já sou cliente",
-];
-
+// Campo "Como nos encontrou?" foi REMOVIDO (Abr/2026) pra reduzir friccao na
+// etapa 4 — cliente nao quer responder isso, era obrigatorio e atrasava o
+// momento mais critico do funil (chegar na cotacao). UTMs do anuncio ja dao
+// essa info via Meta Pixel + utm-tracker. Mantemos clienteOrigem="" no payload
+// pra nao quebrar tipos no backend.
 interface StepClientDataProps {
   onNext: (data: { clienteNome: string; clienteWhatsApp: string; clienteInstagram: string; clienteOrigem: string }) => void;
   onBack: () => void;
@@ -18,15 +18,11 @@ interface StepClientDataProps {
   tradeinConfig?: TradeInConfig | null;
 }
 
-export default function StepClientData({ onNext, onBack, initialNome, initialWhatsApp, initialInstagram, initialOrigem, tradeinConfig }: StepClientDataProps) {
+export default function StepClientData({ onNext, onBack, initialNome, initialWhatsApp, initialInstagram, tradeinConfig }: StepClientDataProps) {
   const [nome, setNome] = useState(initialNome || ""); const [whatsapp, setWhatsapp] = useState(initialWhatsApp || "");
-  const [instagram, setInstagram] = useState(initialInstagram || ""); const [origem, setOrigem] = useState(initialOrigem || "");
-  const canProceed = nome.trim() !== "" && whatsapp.trim() !== "" && origem !== "";
+  const [instagram, setInstagram] = useState(initialInstagram || "");
+  const canProceed = nome.trim() !== "" && whatsapp.trim() !== "";
 
-  const origens = useMemo(() => {
-    const list = tradeinConfig?.origens;
-    return list && list.length > 0 ? list : DEFAULT_ORIGENS;
-  }, [tradeinConfig]);
   const lbl = tradeinConfig?.labels || {};
 
   const inputStyle: React.CSSProperties = {
@@ -59,24 +55,9 @@ export default function StepClientData({ onNext, onBack, initialNome, initialWha
           className="w-full px-4 py-3.5 rounded-2xl text-[15px] transition-colors" style={inputStyle} />
       </div>
 
-      <div className="animate-fadeIn">
-        <label className="block text-[11px] font-semibold tracking-wider uppercase mb-3" style={{ color: "var(--ti-muted)" }}>{lbl.step3_origem_label || "Como nos encontrou?"}</label>
-        <div className="grid grid-cols-2 gap-2">
-          {origens.map((o) => (
-            <button key={o} onClick={() => setOrigem(origem === o ? "" : o)}
-              className="px-3 py-3 rounded-2xl text-[13px] font-medium transition-all duration-200 text-left"
-              style={origem === o
-                ? { backgroundColor: "var(--ti-accent-light)", color: "var(--ti-accent-text)", border: "1px solid var(--ti-accent)" }
-                : { backgroundColor: "var(--ti-btn-bg)", color: "var(--ti-btn-text)", border: "1px solid var(--ti-btn-border)" }}>
-              {o}
-            </button>
-          ))}
-        </div>
-      </div>
-
       <div className="space-y-3 pt-2">
         {canProceed && (
-          <button onClick={() => onNext({ clienteNome: nome.trim().toUpperCase(), clienteWhatsApp: whatsapp.trim(), clienteInstagram: instagram.trim(), clienteOrigem: origem })}
+          <button onClick={() => onNext({ clienteNome: nome.trim().toUpperCase(), clienteWhatsApp: whatsapp.trim(), clienteInstagram: instagram.trim(), clienteOrigem: "" })}
             className="w-full py-4 rounded-2xl text-[17px] font-semibold text-white transition-all duration-200 active:scale-[0.98]"
             style={{ backgroundColor: "var(--ti-accent)" }}>
             Ver minha cotação

--- a/components/StepNewDevice.tsx
+++ b/components/StepNewDevice.tsx
@@ -312,14 +312,28 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
           </div></Sec>}
 
           {model && storages_.length > 0 && <Sec title="Armazenamento"><div className="flex gap-2 flex-wrap">
-            {storages_.map((s) => { const p = getProductPrice(products, model, s); return (
+            {storages_.map((s) => {
+              const p = getProductPrice(products, model, s);
+              // Preco "com troca aplicada" — antes mostrava so o preco cheio
+              // (R$ 8.797), o que dava choque de preco no cliente. Agora mostra
+              // tambem quanto ele realmente paga DEPOIS da troca, em verde.
+              // Isso ancora o valor final cedo, antes da etapa 5.
+              const comTroca = p && tradeInValue > 0 ? Math.max(p - tradeInValue, 0) : null;
+              return (
               <button key={s} onClick={() => setStorage(s)}
                 className="flex-1 min-w-[80px] px-4 py-3.5 rounded-2xl text-[14px] font-medium transition-all duration-200 flex flex-col items-center gap-1"
                 style={storage===s
                   ? { backgroundColor: "var(--ti-accent-light)", color: "var(--ti-accent-text)", border: "1px solid var(--ti-accent)" }
                   : { backgroundColor: "var(--ti-btn-bg)", color: "var(--ti-btn-text)", border: "1px solid var(--ti-btn-border)" }}>
                 <span className="font-semibold">{s}</span>
-                {p && <span className="text-[12px] font-normal" style={{ opacity: 0.7 }}>{formatBRL(p)}</span>}
+                {p && comTroca !== null ? (
+                  <>
+                    <span className="text-[10px] line-through" style={{ opacity: 0.45 }}>{formatBRL(p)}</span>
+                    <span className="text-[12px] font-semibold" style={{ color: "var(--ti-success)" }}>{formatBRL(comTroca)}</span>
+                  </>
+                ) : (
+                  p && <span className="text-[12px] font-normal" style={{ opacity: 0.7 }}>{formatBRL(p)}</span>
+                )}
               </button>);
             })}
           </div></Sec>}
@@ -341,14 +355,24 @@ export default function StepNewDevice({ products, tradeInValue, onNext, onBack, 
               {isIPhone && lines.length > 0 && <Sec title="Linha"><div className="grid grid-cols-3 gap-2">{lines.map((l) => <Btn key={l} sel={lineB===l} onClick={() => hLB(l)}>iPhone {l}</Btn>)}</div></Sec>}
               {((isIPhone && lineB) || !isIPhone) && modelsInLineB.length > 0 && <Sec title="Modelo"><div className="grid grid-cols-1 gap-2">{modelsInLineB.map((m) => <Btn key={m} sel={modelB===m} onClick={() => hMB(m)} className="text-left">{m}</Btn>)}</div></Sec>}
               {modelB && storagesB.length > 0 && <Sec title="Armazenamento"><div className="flex gap-2 flex-wrap">
-                {storagesB.map((s) => { const p = getProductPrice(products, modelB, s); return (
+                {storagesB.map((s) => {
+                  const p = getProductPrice(products, modelB, s);
+                  const comTroca = p && tradeInValue > 0 ? Math.max(p - tradeInValue, 0) : null;
+                  return (
                   <button key={s} onClick={() => setStorageB(s)}
                     className="flex-1 min-w-[80px] px-4 py-3.5 rounded-2xl text-[14px] font-medium transition-all flex flex-col items-center gap-1"
                     style={storageB===s
                       ? { backgroundColor: "var(--ti-accent-light)", color: "var(--ti-accent-text)", border: "1px solid var(--ti-accent)" }
                       : { backgroundColor: "var(--ti-btn-bg)", color: "var(--ti-btn-text)", border: "1px solid var(--ti-btn-border)" }}>
                     <span className="font-semibold">{s}</span>
-                    {p && <span className="text-[12px] font-normal" style={{ opacity: 0.7 }}>{formatBRL(p)}</span>}
+                    {p && comTroca !== null ? (
+                      <>
+                        <span className="text-[10px] line-through" style={{ opacity: 0.45 }}>{formatBRL(p)}</span>
+                        <span className="text-[12px] font-semibold" style={{ color: "var(--ti-success)" }}>{formatBRL(comTroca)}</span>
+                      </>
+                    ) : (
+                      p && <span className="text-[12px] font-normal" style={{ opacity: 0.7 }}>{formatBRL(p)}</span>
+                    )}
                   </button>);
                 })}
               </div></Sec>}

--- a/components/StepQuote.tsx
+++ b/components/StepQuote.tsx
@@ -547,11 +547,15 @@ export default function StepQuote(p: StepQuoteProps) {
         </div>
       )}
 
+      {/* Saida discreta — antes era um botao vermelho gritante "NAO GOSTEI, SAIR"
+          que sabotava o fechamento (vermelho atrai olho, texto negativo planta
+          duvida). Trocado por link sutil que ainda abre o feedback de motivo
+          (importante pro negocio entender por que cliente saiu). */}
       {!showFeedback ? (
         <button onClick={() => setShowFeedback(true)}
-          className="w-full py-3 rounded-2xl text-[14px] font-medium transition-all duration-200"
-          style={{ color: "#fff", backgroundColor: "#ef4444", border: "1px solid #ef4444" }}>
-          NÃO GOSTEI, SAIR
+          className="w-full py-2.5 text-[12px] font-medium underline transition-colors hover:opacity-70"
+          style={{ color: "var(--ti-muted)", background: "transparent", border: "none" }}>
+          Não tenho certeza ainda
         </button>
       ) : (
         <div className="rounded-2xl p-5 space-y-4 animate-fadeIn" style={cardStyle}>

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -572,9 +572,25 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
 
           {step === 1.5 && (
             <div className="space-y-6 py-6">
-              <div className="text-center">
-                <p className="text-[15px]" style={{ color: tema.textMuted }}>Aparelho avaliado com sucesso!</p>
-                <p className="text-xs mt-1" style={{ color: tema.textDim }}>{usedModel} {usedStorage}</p>
+              {/* TELA MAGICA — momento de pico de dopamina do funil. Cliente
+                  passou por 9 perguntas pra descobrir QUANTO o aparelho vale.
+                  Antes mostrava so "Aparelho avaliado com sucesso!" — sem o
+                  valor. Cliente sentia que tava sendo enrolado ate a etapa 5.
+                  Agora mostra o valor parcial AQUI pra ancorar interesse e
+                  reduzir abandono. Fallback (tradeInValue=0) mantem texto
+                  original pra nao quebrar caso de erro. */}
+              <div className="text-center space-y-2">
+                <p className="text-[13px]" style={{ color: tema.textMuted }}>{usedModel} {usedStorage}</p>
+                {tradeInValue > 0 ? (
+                  <>
+                    <p className="text-[28px] font-bold leading-tight" style={{ color: tema.success }}>
+                      Vale {formatBRL(tradeInValue)}
+                    </p>
+                    <p className="text-[12px]" style={{ color: tema.textDim }}>na troca por um aparelho novo</p>
+                  </>
+                ) : (
+                  <p className="text-[15px]" style={{ color: tema.textMuted }}>Aparelho avaliado com sucesso!</p>
+                )}
               </div>
               <div className="rounded-2xl p-6 text-center space-y-4" style={{ backgroundColor: tema.cardBg, border: `1px solid ${tema.cardBorder}` }}>
                 <p className="text-[15px] font-semibold" style={{ color: tema.text }}>Deseja adicionar mais um aparelho na troca?</p>


### PR DESCRIPTION
## Contexto

Análise tela-a-tela do funil de simulação feita com Andre. Funil hoje:
- **137 visitas/semana → 30 cotações → 8 fecharam** (5.8% conversão final)
- **Buraco #1:** 72% não inicia (137→39)
- **Buraco #2:** 73% não fecha após cotação (30→8)

Identificados 5 problemas críticos. Este PR implementa **4 dos 5 aprovados** (Sprint 1). Sprint 2 fica pra próxima.

## Mudanças

### 1️⃣ Mostrar valor parcial na Tela 1.5 (pós-avaliação)

**Antes:** "Aparelho avaliado com sucesso! / iPhone 16 256GB"
**Agora:** "iPhone 16 256GB / **Vale R\$ X.XXX** / na troca por um aparelho novo"

Cliente passou por 9 perguntas pra descobrir o valor — agora vê AQUI em vez de esperar até a Etapa 5. Reduz sensação de "tão me enrolando".

📁 `components/TradeInCalculatorMulti.tsx`

### 2️⃣ Preço do aparelho novo com troca aplicada (Etapa 3)

**Antes:** Cada GB mostrava só preço cheio (R\$ 8.797) → choque de preço
**Agora:** Preço cheio riscado + valor real após troca em verde

Aplicado tanto no modo lacrado quanto no compareMode. Fallback mantém preço cheio quando \`tradeInValue = 0\`.

📁 `components/StepNewDevice.tsx`

### 3️⃣ Botão "NÃO GOSTEI, SAIR" → link discreto (Etapa 5)

**Antes:** Botão vermelho gigante "NÃO GOSTEI, SAIR" — vermelho atrai olho, texto negativo planta dúvida na hora de fechar.
**Agora:** Link sutil "Não tenho certeza ainda" em cinza.

Mantido o feedback form de motivos (importante pro negócio entender abandono).

📁 `components/StepQuote.tsx`

### 4️⃣ Removido "Como nos encontrou?" (Etapa 4)

**Antes:** Obrigatório com 6 opções (Anúncio/Story/Direct/WhatsApp/Indicação/Já sou cliente). Cliente não quer responder isso na hora crítica.
**Agora:** Removido. Form fica só com Nome + WhatsApp + Instagram (opcional).

UTMs do anúncio + Meta Pixel já dão essa info via \`utm-tracker\`. Mantido \`clienteOrigem=""\` no payload pra não quebrar tipos no backend (e bot de followup 24h continua funcionando — usa só nome+telefone).

📁 `components/StepClientData.tsx`

## O que NÃO entrou (Sprint 2)

- ❌ Inverter ordem (cotação antes de dados pessoais) — André quer manter dados antes pra ativar bot de followup 24h via Z-API quando cliente sai sem fechar.
- ❌ Remover Etapa 1 (tipo de aparelho) — vai precisar amanhã quando entrar Mac/Watch/iPad
- ❌ Trocar bateria % por ranges — André prefere manter exato
- ❌ Remover campo Cor — impacta cotação

## Validação

- ✅ `tsc --noEmit`: zero erros
- ✅ `next build`: passou
- ✅ ESLint: só warnings preexistentes (não relacionados)

## Como testar no preview

1. Acessar `/troca` no preview do Vercel
2. **Tela 1.5:** Avaliar um iPhone — confirmar que aparece "Vale R\$ X" no fim das 9 perguntas
3. **Etapa 3:** Escolher aparelho novo — confirmar que mostra preço cheio riscado + verde "com troca"
4. **Etapa 4:** Confirmar que NÃO tem mais "Como nos encontrou?"
5. **Etapa 5:** Conferir que botão "NÃO GOSTEI, SAIR" virou link cinza discreto

## Próxima medição

Após merge, deixar 7 dias rodando e medir delta% no funil em `/admin/analytics`:
- Conversão Visitas → Iniciou (Buraco #1)
- Conversão Cotação → Submit (Buraco #2)

Estimativa: **+25-40% na conversão final**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)