### PR TITLE
feat(admin): tela /admin/configuracoes/site — edita logo + influencers

### DIFF
--- a/app/admin/configuracoes/site/page.tsx
+++ b/app/admin/configuracoes/site/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import SiteConfigEditor from "@/components/admin/SiteConfigEditor";
+
+// Editor visual da landing /troca — gerencia logo (avatar do dono) e secao
+// influencers (foto + @ + ordem + on/off). Acessivel pra Andre + Nicolas.
+//
+// Salva no campo labels JSONB de tradein_config (chaves _site_*) — sem
+// migration nova. Upload via Supabase Storage (bucket product-images com
+// prefix site-).
+//
+// Vide /api/admin/site-upload (upload), /api/admin/tradein-config (read/write
+// das chaves) e components/admin/SiteConfigEditor.tsx (UI).
+export default function ConfiguracoesSitePage() {
+  return (
+    <main className="max-w-4xl mx-auto px-4 py-6 space-y-5">
+      <div className="space-y-2">
+        <Link href="/admin/configuracoes" className="text-[12px] text-[#86868B] hover:text-[#1D1D1F] transition-colors">
+          ← Voltar para Configurações
+        </Link>
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-[24px] font-bold text-[#1D1D1F]">Configuração do Site</h1>
+            <p className="text-[14px] text-[#86868B] mt-1">
+              Personalize a landing inicial do simulador de trade-in (/troca) sem precisar de código.
+            </p>
+          </div>
+          <a href="/troca" target="_blank" rel="noopener noreferrer"
+            className="inline-flex items-center px-4 py-2 rounded-lg text-[13px] font-medium border border-[#D2D2D7] hover:bg-[#F5F5F7] transition-colors">
+            Ver landing ao vivo →
+          </a>
+        </div>
+      </div>
+
+      <SiteConfigEditor />
+    </main>
+  );
+}

--- a/app/api/admin/site-upload/route.ts
+++ b/app/api/admin/site-upload/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Endpoint generico de upload de midia pra ASSETS DO SITE (logo, influencers,
+// fotos de hero, etc). Diferente de /api/admin/mostruario/upload que esta
+// acoplado a tabelas especificas (loja_produtos, loja_variacoes), este aqui
+// so faz upload e retorna a URL — quem chama decide onde salvar a URL.
+//
+// Reusa o bucket "product-images" (publico, ja configurado) com prefixo
+// "site-" no path pra separar logicamente dos assets de produto.
+
+function auth(req: NextRequest) {
+  return req.headers.get("x-admin-password") === process.env.ADMIN_PASSWORD;
+}
+
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_KINDS = ["logo", "influencer", "hero", "misc"] as const;
+type Kind = typeof ALLOWED_KINDS[number];
+
+export async function POST(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const formData = await req.formData();
+    const file = formData.get("file") as File | null;
+    const kind = (formData.get("kind") as string | null) || "misc";
+
+    if (!file) return NextResponse.json({ error: "Missing file" }, { status: 400 });
+
+    if (!ALLOWED_KINDS.includes(kind as Kind)) {
+      return NextResponse.json(
+        { error: `kind invalido. Aceitos: ${ALLOWED_KINDS.join(", ")}` },
+        { status: 400 }
+      );
+    }
+
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: "Tipo de arquivo invalido. Aceitos: JPEG, PNG, WebP" },
+        { status: 400 }
+      );
+    }
+
+    if (file.size > MAX_SIZE) {
+      return NextResponse.json({ error: "Arquivo muito grande. Maximo: 5MB" }, { status: 400 });
+    }
+
+    const { supabase } = await import("@/lib/supabase");
+
+    // Path: site-{kind}-{timestamp}.{ext}
+    // Ex: site-logo-1730000000.jpg, site-influencer-1730000000.png
+    const ext = file.type.split("/")[1] === "jpeg" ? "jpg" : file.type.split("/")[1];
+    const path = `site-${kind}-${Date.now()}.${ext}`;
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    const { error: uploadError } = await supabase.storage
+      .from("product-images")
+      .upload(path, buffer, { contentType: file.type, upsert: false });
+
+    if (uploadError) return NextResponse.json({ error: uploadError.message }, { status: 500 });
+
+    const { data: urlData } = supabase.storage.from("product-images").getPublicUrl(path);
+
+    return NextResponse.json({ ok: true, url: urlData.publicUrl, path });
+  } catch (err) {
+    console.error("[site-upload] error:", err);
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
+}
+
+// Permite remover assets antigos quando admin troca a logo ou remove um
+// influencer. Recebe { url } ou { path } — extrai o path do bucket e remove.
+export async function DELETE(req: NextRequest) {
+  if (!auth(req)) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const body = await req.json();
+    let path: string | null = body.path || null;
+    if (!path && body.url) {
+      const m = String(body.url).match(/\/product-images\/(.+)$/);
+      path = m ? m[1] : null;
+    }
+    if (!path) return NextResponse.json({ error: "Missing path or url" }, { status: 400 });
+    // Seguranca: so permite remover assets do site (prefix site-)
+    if (!path.startsWith("site-")) {
+      return NextResponse.json({ error: "Path nao e asset do site" }, { status: 403 });
+    }
+
+    const { supabase } = await import("@/lib/supabase");
+    const { error } = await supabase.storage.from("product-images").remove([path]);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[site-upload DELETE] error:", err);
+    return NextResponse.json({ error: "Delete failed" }, { status: 500 });
+  }
+}

--- a/app/api/admin/tradein-config/route.ts
+++ b/app/api/admin/tradein-config/route.ts
@@ -33,6 +33,13 @@ export async function GET(req: NextRequest) {
   if (labels._whatsapp_vendedores_nomes) result.whatsapp_vendedores_nomes = labels._whatsapp_vendedores_nomes;
   if (labels._whatsapp_vendedores_recebe_links) result.whatsapp_vendedores_recebe_links = labels._whatsapp_vendedores_recebe_links;
   if (labels._whatsapp_vendedores_ativo) result.whatsapp_vendedores_ativo = labels._whatsapp_vendedores_ativo;
+  // Configuracao do SITE (landing /troca) — logo, influencers, posicionamento.
+  // Mesmo padrao do _whatsapp_*: armazenado dentro de labels JSONB pra evitar
+  // migrations. Veja /admin/configuracoes/site (Abr/2026).
+  if (labels._site_logo_url !== undefined) result.site_logo_url = labels._site_logo_url;
+  if (labels._site_logo_position !== undefined) result.site_logo_position = labels._site_logo_position;
+  if (labels._site_influencers_enabled !== undefined) result.site_influencers_enabled = labels._site_influencers_enabled;
+  if (labels._site_influencers !== undefined) result.site_influencers = labels._site_influencers;
 
   return NextResponse.json({ data: result });
 }
@@ -61,13 +68,25 @@ export async function PUT(req: NextRequest) {
     "whatsapp_vendedores_recebe_links",
     "whatsapp_vendedores_ativo",
   ] as const;
+  // Chaves de configuracao do SITE — mesmo padrao dos whatsapp_*. Salvas com
+  // prefixo "_site_" dentro de labels JSONB (sem migration).
+  const siteFields = [
+    "site_logo_url",
+    "site_logo_position",
+    "site_influencers_enabled",
+    "site_influencers",
+  ] as const;
   const hasAnyWaField = whatsappFields.some((k) => body[k] !== undefined);
-  if (hasAnyWaField || body.labels !== undefined) {
+  const hasAnySiteField = siteFields.some((k) => body[k] !== undefined);
+  if (hasAnyWaField || hasAnySiteField || body.labels !== undefined) {
     const { data: current } = await supabase.from("tradein_config").select("labels").limit(1).single();
     const currentLabels = (current?.labels && typeof current.labels === "object") ? current.labels as Record<string, unknown> : {};
     const newLabels = { ...currentLabels };
     if (body.labels !== undefined) Object.assign(newLabels, body.labels);
     for (const k of whatsappFields) {
+      if (body[k] !== undefined) newLabels[`_${k}`] = body[k];
+    }
+    for (const k of siteFields) {
       if (body[k] !== undefined) newLabels[`_${k}`] = body[k];
     }
     updates.labels = newLabels;

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -39,12 +39,15 @@ const DEVICE_OPTIONS: { type: MultiDeviceType; emoji: string; label: string }[] 
   { type: "watch", emoji: "\u{231A}", label: "Apple Watch" },
 ];
 
-// Influencers que ja compraram na TigraoImports — exibidos como social proof
-// na landing inicial. Andre tem fotos pessoais COM eles (no momento da compra)
-// + autorizacao verbal de uso. Cada @ vira link clicavel pro perfil do Insta.
-// Pra adicionar mais: subir foto em /public/images/influencer-N.jpg e
-// adicionar item no array.
-const INFLUENCERS_LANDING: { handle: string; foto: string }[] = [
+// Influencers FALLBACK — usado APENAS quando o admin ainda nao configurou
+// nenhum em /admin/configuracoes/site (config no banco vazia). Quando o
+// admin gerencia via tela, este array e ignorado e a landing usa
+// tradeinConfig.site_influencers (do JSONB labels).
+//
+// Manter sincronizado com as fotos em /public/images/influencer-{1,2,3}.jpg
+// pra que continue funcionando em ambientes sem config no banco (testes,
+// CI, etc).
+const INFLUENCERS_FALLBACK: { handle: string; foto: string }[] = [
   { handle: "@leostronda", foto: "/images/influencer-1.jpg" },
   { handle: "@euxama", foto: "/images/influencer-2.jpg" },
   { handle: "@diegocruz_", foto: "/images/influencer-3.jpg" },
@@ -121,7 +124,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
   const [questionsConfig, setQuestionsConfig] = useState<TradeInQuestion[] | null>(null);
   const [catConfigs, setCatConfigs] = useState<{ categoria: string; modo: string; ativo: boolean }[]>([]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios_seminovos?: string; whatsapp_seminovo_iphone?: string; whatsapp_seminovo_ipad?: string; whatsapp_seminovo_macbook?: string; whatsapp_seminovo_watch?: string; whatsapp_vendedores?: Record<string, string> }) | null>(null);
+  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios_seminovos?: string; whatsapp_seminovo_iphone?: string; whatsapp_seminovo_ipad?: string; whatsapp_seminovo_macbook?: string; whatsapp_seminovo_watch?: string; whatsapp_vendedores?: Record<string, string>; site_logo_url?: string | null; site_logo_position?: string; site_influencers_enabled?: boolean | string; site_influencers?: { handle: string; foto_url: string }[] }) | null>(null);
   // Mapa dinamico de WhatsApp por vendedor — usa DB se disponivel
   const VENDEDOR_WHATSAPP = useMemo(() => {
     const dbMap = tradeinConfig?.whatsapp_vendedores;
@@ -139,6 +142,32 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
     macbook: tradeinConfig?.whatsapp_seminovo_macbook || whatsappFormulariosSeminovos,
     watch: tradeinConfig?.whatsapp_seminovo_watch || whatsappFormulariosSeminovos,
   };
+
+  // Configuracao da LANDING — gerenciada via /admin/configuracoes/site.
+  // Fallback: se admin nao configurou nada, usa os assets em /public/images/
+  // (landing v1, hardcoded). Garante que o site nunca quebra mesmo se o
+  // banco vier vazio (testes, primeira instalacao, rollback de config).
+  const siteLogoUrl: string = tradeinConfig?.site_logo_url || "/images/andre.png";
+  const siteLogoPosition: string = tradeinConfig?.site_logo_position || "center 15%";
+  // Aceita boolean ou "true"/"false" string (JSONB pode serializar de qualquer
+  // forma dependendo de como foi inserido). Default: ativado se ja tem
+  // influencers configurados, ou false se nao tem nada.
+  const siteInfluencersEnabled: boolean = (() => {
+    const raw = tradeinConfig?.site_influencers_enabled;
+    if (raw === undefined || raw === null) return true; // default: mostra (compatibilidade com landing v2)
+    return raw === true || raw === "true";
+  })();
+  // Lista de influencers — usa do banco se houver, senao fallback hardcoded.
+  // Mapeia foto_url (admin) -> foto (renderizacao) pra manter shape interno.
+  const siteInfluencers: { handle: string; foto: string }[] = (() => {
+    const fromDb = tradeinConfig?.site_influencers;
+    if (Array.isArray(fromDb) && fromDb.length > 0) {
+      return fromDb
+        .filter((i) => i && i.handle && i.foto_url)
+        .map((i) => ({ handle: i.handle, foto: i.foto_url }));
+    }
+    return INFLUENCERS_FALLBACK;
+  })();
   const [deviceType, setDeviceType] = useState<DeviceType>("iphone");
   const [usedModel, setUsedModel] = useState("");
   const [usedStorage, setUsedStorage] = useState("");
@@ -409,9 +438,9 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
             <div className="w-12 h-12 rounded-full overflow-hidden flex items-center justify-center text-[28px]"
               style={{ backgroundColor: "var(--ti-accent-light, #FFF5EC)", border: "2px solid var(--ti-accent, #E8740E)" }}>
               {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src="/images/andre.png" alt="TigrãoImports"
+              <img src={siteLogoUrl} alt="TigrãoImports"
                 className="w-full h-full object-cover"
-                style={{ objectPosition: "center 15%" }}
+                style={{ objectPosition: siteLogoPosition }}
                 onError={(e) => { e.currentTarget.style.display = "none"; e.currentTarget.parentElement!.innerHTML = "🐯"; }} />
             </div>
             <div className="text-left">
@@ -454,14 +483,14 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
             <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> Garantia Apple</span>
           </div>
 
-          {/* SECAO INFLUENCERS — placeholder ate Andre subir as fotos em
-              /public/images/influencer-1.jpg (etc) e me passar os @s. Quando
-              tiver as fotos, basta preencher o array INFLUENCERS abaixo. */}
-          {INFLUENCERS_LANDING.length > 0 && (
+          {/* SECAO INFLUENCERS — gerenciada pelo admin em
+              /admin/configuracoes/site. Esconde se admin desativou ou se
+              nao tem nenhum cadastrado (banco vazio + fallback vazio). */}
+          {siteInfluencersEnabled && siteInfluencers.length > 0 && (
             <div className="pt-4 space-y-3" style={{ borderTop: `1px solid ${tema.cardBorder}` }}>
               <p className="text-[11px] font-semibold tracking-wider uppercase text-center" style={{ color: tema.textMuted }}>Quem comprou aqui</p>
               <div className="flex justify-center gap-3">
-                {INFLUENCERS_LANDING.map((inf) => (
+                {siteInfluencers.map((inf) => (
                   <a key={inf.handle} href={`https://instagram.com/${inf.handle.replace("@", "")}`} target="_blank" rel="noopener noreferrer"
                     className="flex flex-col items-center gap-2 transition-opacity hover:opacity-80">
                     <div className="w-20 h-20 rounded-full overflow-hidden" style={{ border: "2px solid var(--ti-accent, #E8740E)" }}>

--- a/components/admin/SiteConfigEditor.tsx
+++ b/components/admin/SiteConfigEditor.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import { useAdmin } from "./AdminShell";
+
+// Editor da landing /troca — gerencia LOGO (avatar do dono) e secao
+// INFLUENCERS (foto + @ + ordem + on/off). Salva no campo labels JSONB de
+// tradein_config (chaves _site_*), padrao igual ao do _whatsapp_*.
+//
+// Upload via /api/admin/site-upload (Supabase Storage bucket product-images
+// com prefix site-). Fallback robusto: se config vazia, landing usa as fotos
+// hardcoded em /public/images/ (compatibilidade com versao anterior).
+
+interface Influencer {
+  handle: string;
+  foto_url: string;
+}
+
+interface SiteConfig {
+  site_logo_url: string | null;
+  site_logo_position: string;
+  site_influencers_enabled: boolean;
+  site_influencers: Influencer[];
+}
+
+const DEFAULT_CONFIG: SiteConfig = {
+  site_logo_url: null,
+  site_logo_position: "center 15%",
+  site_influencers_enabled: false,
+  site_influencers: [],
+};
+
+// URL pra mostrar na preview quando NAO tem upload customizado — aponta pro
+// asset hardcoded em /public/images/ que continua funcionando como fallback.
+const FALLBACK_LOGO = "/images/andre.png";
+
+export default function SiteConfigEditor() {
+  const { apiHeaders } = useAdmin();
+  const [config, setConfig] = useState<SiteConfig>(DEFAULT_CONFIG);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [uploadingLogo, setUploadingLogo] = useState(false);
+  const [uploadingInfluencer, setUploadingInfluencer] = useState<number | null>(null);
+  const [msg, setMsg] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  const logoInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { fetchConfig(); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, []);
+
+  async function fetchConfig() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/tradein-config", { headers: apiHeaders() });
+      const json = await res.json();
+      const d = json?.data || {};
+      setConfig({
+        site_logo_url: d.site_logo_url ?? null,
+        site_logo_position: d.site_logo_position ?? "center 15%",
+        site_influencers_enabled: d.site_influencers_enabled === true || d.site_influencers_enabled === "true",
+        site_influencers: Array.isArray(d.site_influencers) ? d.site_influencers : [],
+      });
+    } catch (err) {
+      flash("error", "Erro ao carregar: " + (err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function flash(type: "success" | "error", text: string) {
+    setMsg({ type, text });
+    setTimeout(() => setMsg(null), 3500);
+  }
+
+  async function save() {
+    setSaving(true);
+    try {
+      const res = await fetch("/api/admin/tradein-config", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", ...apiHeaders() },
+        body: JSON.stringify({
+          site_logo_url: config.site_logo_url,
+          site_logo_position: config.site_logo_position,
+          site_influencers_enabled: config.site_influencers_enabled,
+          site_influencers: config.site_influencers,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Erro ao salvar");
+      flash("success", "Salvo com sucesso! Mudanças aparecem na landing /troca em segundos.");
+    } catch (err) {
+      flash("error", (err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function uploadFile(file: File, kind: "logo" | "influencer"): Promise<string | null> {
+    const fd = new FormData();
+    fd.append("file", file);
+    fd.append("kind", kind);
+    try {
+      const res = await fetch("/api/admin/site-upload", {
+        method: "POST",
+        headers: apiHeaders(), // FormData define o Content-Type sozinho
+        body: fd,
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        flash("error", "Upload falhou: " + (json.error || "erro desconhecido"));
+        return null;
+      }
+      return json.url as string;
+    } catch (err) {
+      flash("error", "Upload falhou: " + (err as Error).message);
+      return null;
+    }
+  }
+
+  async function deleteUploaded(url: string) {
+    // Best-effort — nao bloqueia se falhar (storage cleanup nao critico)
+    try {
+      await fetch("/api/admin/site-upload", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json", ...apiHeaders() },
+        body: JSON.stringify({ url }),
+      });
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploadingLogo(true);
+    try {
+      const newUrl = await uploadFile(file, "logo");
+      if (newUrl) {
+        // Limpa upload antigo (se for de upload, nao do fallback)
+        if (config.site_logo_url) await deleteUploaded(config.site_logo_url);
+        setConfig({ ...config, site_logo_url: newUrl });
+        flash("success", "Logo carregada. Clique em SALVAR pra publicar.");
+      }
+    } finally {
+      setUploadingLogo(false);
+      if (logoInputRef.current) logoInputRef.current.value = "";
+    }
+  }
+
+  async function restaurarLogoPadrao() {
+    if (!confirm("Restaurar logo padrao (foto que estava antes)? A logo customizada sera removida.")) return;
+    if (config.site_logo_url) await deleteUploaded(config.site_logo_url);
+    setConfig({ ...config, site_logo_url: null });
+    flash("success", "Logo restaurada. Clique em SALVAR pra publicar.");
+  }
+
+  function addInfluencer() {
+    setConfig({
+      ...config,
+      site_influencers: [...config.site_influencers, { handle: "@novo", foto_url: "" }],
+    });
+  }
+
+  function updateInfluencer(idx: number, patch: Partial<Influencer>) {
+    setConfig({
+      ...config,
+      site_influencers: config.site_influencers.map((inf, i) => (i === idx ? { ...inf, ...patch } : inf)),
+    });
+  }
+
+  async function removeInfluencer(idx: number) {
+    const inf = config.site_influencers[idx];
+    if (!confirm(`Remover ${inf.handle}?`)) return;
+    if (inf.foto_url) await deleteUploaded(inf.foto_url);
+    setConfig({
+      ...config,
+      site_influencers: config.site_influencers.filter((_, i) => i !== idx),
+    });
+  }
+
+  function moveInfluencer(idx: number, dir: "up" | "down") {
+    const newList = [...config.site_influencers];
+    const swapIdx = dir === "up" ? idx - 1 : idx + 1;
+    if (swapIdx < 0 || swapIdx >= newList.length) return;
+    [newList[idx], newList[swapIdx]] = [newList[swapIdx], newList[idx]];
+    setConfig({ ...config, site_influencers: newList });
+  }
+
+  async function handleInfluencerPhotoChange(idx: number, e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploadingInfluencer(idx);
+    try {
+      const newUrl = await uploadFile(file, "influencer");
+      if (newUrl) {
+        const old = config.site_influencers[idx].foto_url;
+        if (old) await deleteUploaded(old);
+        updateInfluencer(idx, { foto_url: newUrl });
+        flash("success", "Foto carregada. Clique em SALVAR pra publicar.");
+      }
+    } finally {
+      setUploadingInfluencer(null);
+      e.target.value = "";
+    }
+  }
+
+  if (loading) return <p className="text-[#86868B]">Carregando configuração…</p>;
+
+  const logoPreview = config.site_logo_url || FALLBACK_LOGO;
+
+  return (
+    <div className="space-y-6">
+      {msg && (
+        <div className={`rounded-lg px-4 py-3 text-[14px] ${
+          msg.type === "success" ? "bg-green-50 text-green-800 border border-green-200"
+                                  : "bg-red-50 text-red-800 border border-red-200"
+        }`}>
+          {msg.text}
+        </div>
+      )}
+
+      {/* === SECAO LOGO === */}
+      <section className="bg-white rounded-xl p-5 shadow-sm border border-[#E8E8ED]">
+        <h2 className="text-[18px] font-semibold text-[#1D1D1F] mb-1">Logo do site</h2>
+        <p className="text-[13px] text-[#86868B] mb-4">
+          Foto que aparece no avatar circular do topo da landing (/troca). Recomendado: foto quadrada, mín 200×200px.
+        </p>
+        <div className="flex items-start gap-5">
+          <div
+            className="w-24 h-24 rounded-full overflow-hidden flex-shrink-0"
+            style={{ border: "2px solid #E8740E", backgroundColor: "#FFF5EC" }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={logoPreview}
+              alt="Logo preview"
+              className="w-full h-full object-cover"
+              style={{ objectPosition: config.site_logo_position }}
+              onError={(e) => { e.currentTarget.style.display = "none"; }}
+            />
+          </div>
+          <div className="flex-1 space-y-3">
+            <div className="flex flex-wrap gap-2">
+              <label className="inline-flex items-center px-4 py-2 rounded-lg text-[13px] font-medium text-white cursor-pointer transition-colors"
+                style={{ backgroundColor: uploadingLogo ? "#86868B" : "#E8740E" }}>
+                {uploadingLogo ? "Enviando…" : (config.site_logo_url ? "Trocar foto" : "Subir foto")}
+                <input ref={logoInputRef} type="file" accept="image/jpeg,image/png,image/webp" className="hidden"
+                  disabled={uploadingLogo} onChange={handleLogoChange} />
+              </label>
+              {config.site_logo_url && (
+                <button onClick={restaurarLogoPadrao}
+                  className="px-4 py-2 rounded-lg text-[13px] font-medium border border-[#D2D2D7] hover:bg-[#F5F5F7] transition-colors">
+                  Restaurar padrão
+                </button>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-[12px] font-medium text-[#86868B] mb-1">Posicionamento da foto (CSS object-position)</label>
+              <input type="text" value={config.site_logo_position}
+                onChange={(e) => setConfig({ ...config, site_logo_position: e.target.value })}
+                placeholder="center 15%"
+                className="w-full px-3 py-2 bg-[#F5F5F7] border border-[#D2D2D7] rounded-lg text-[13px]" />
+              <p className="text-[11px] text-[#AEAEB2] mt-1">
+                Use &ldquo;center 15%&rdquo; (mostra mais o topo da foto), &ldquo;center&rdquo; (centraliza) ou &ldquo;center 30%&rdquo; (mostra mais o meio).
+              </p>
+            </div>
+
+            <p className="text-[12px] text-[#86868B]">
+              {config.site_logo_url
+                ? "✅ Usando foto customizada (upload)"
+                : "ℹ️ Usando foto padrão (/public/images/andre.png)"}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* === SECAO INFLUENCERS === */}
+      <section className="bg-white rounded-xl p-5 shadow-sm border border-[#E8E8ED]">
+        <div className="flex items-start justify-between mb-4">
+          <div>
+            <h2 className="text-[18px] font-semibold text-[#1D1D1F] mb-1">Influencers (seção &ldquo;Quem comprou aqui&rdquo;)</h2>
+            <p className="text-[13px] text-[#86868B]">
+              Fotos circulares que aparecem na landing como social proof. Cada @ vira link clicável pro Instagram.
+            </p>
+          </div>
+          <label className="inline-flex items-center gap-2 cursor-pointer ml-4 flex-shrink-0">
+            <input type="checkbox" checked={config.site_influencers_enabled}
+              onChange={(e) => setConfig({ ...config, site_influencers_enabled: e.target.checked })}
+              className="w-4 h-4 accent-[#E8740E]" />
+            <span className="text-[13px] font-medium text-[#1D1D1F]">Mostrar na landing</span>
+          </label>
+        </div>
+
+        {config.site_influencers.length === 0 && (
+          <div className="border-2 border-dashed border-[#D2D2D7] rounded-lg p-6 text-center">
+            <p className="text-[14px] text-[#86868B] mb-3">Nenhum influencer cadastrado.</p>
+            <button onClick={addInfluencer}
+              className="px-4 py-2 rounded-lg text-[13px] font-medium text-white transition-colors"
+              style={{ backgroundColor: "#E8740E" }}>
+              + Adicionar influencer
+            </button>
+          </div>
+        )}
+
+        {config.site_influencers.length > 0 && (
+          <>
+            <div className="space-y-3">
+              {config.site_influencers.map((inf, idx) => (
+                <div key={idx} className="flex items-center gap-3 p-3 rounded-lg border border-[#E8E8ED] bg-[#FAFAFA]">
+                  <div className="flex flex-col gap-1">
+                    <button onClick={() => moveInfluencer(idx, "up")} disabled={idx === 0}
+                      className="text-[14px] px-2 py-0.5 rounded hover:bg-[#E8E8ED] disabled:opacity-30 disabled:cursor-not-allowed">
+                      ▲
+                    </button>
+                    <button onClick={() => moveInfluencer(idx, "down")} disabled={idx === config.site_influencers.length - 1}
+                      className="text-[14px] px-2 py-0.5 rounded hover:bg-[#E8E8ED] disabled:opacity-30 disabled:cursor-not-allowed">
+                      ▼
+                    </button>
+                  </div>
+
+                  <div className="w-16 h-16 rounded-full overflow-hidden flex-shrink-0 bg-[#F5F5F7]"
+                    style={{ border: "2px solid #E8740E" }}>
+                    {inf.foto_url ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={inf.foto_url} alt={inf.handle} className="w-full h-full object-cover" />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-[10px] text-[#86868B] text-center px-1">sem foto</div>
+                    )}
+                  </div>
+
+                  <div className="flex-1 min-w-0 space-y-2">
+                    <input type="text" value={inf.handle}
+                      onChange={(e) => {
+                        let v = e.target.value.trim();
+                        if (v && !v.startsWith("@")) v = "@" + v;
+                        updateInfluencer(idx, { handle: v });
+                      }}
+                      placeholder="@usuario"
+                      className="w-full px-3 py-1.5 bg-white border border-[#D2D2D7] rounded text-[13px]" />
+                    <label className="inline-flex items-center px-3 py-1.5 rounded text-[12px] font-medium border border-[#D2D2D7] hover:bg-[#F5F5F7] cursor-pointer transition-colors"
+                      style={uploadingInfluencer === idx ? { opacity: 0.6 } : {}}>
+                      {uploadingInfluencer === idx ? "Enviando…" : (inf.foto_url ? "Trocar foto" : "Subir foto")}
+                      <input type="file" accept="image/jpeg,image/png,image/webp" className="hidden"
+                        disabled={uploadingInfluencer === idx}
+                        onChange={(e) => handleInfluencerPhotoChange(idx, e)} />
+                    </label>
+                  </div>
+
+                  <button onClick={() => removeInfluencer(idx)}
+                    className="text-[12px] text-red-600 hover:text-red-800 font-medium px-3 py-2 transition-colors flex-shrink-0">
+                    Remover
+                  </button>
+                </div>
+              ))}
+            </div>
+
+            <button onClick={addInfluencer}
+              className="mt-4 px-4 py-2 rounded-lg text-[13px] font-medium border-2 border-dashed border-[#D2D2D7] text-[#86868B] hover:border-[#E8740E] hover:text-[#E8740E] transition-colors w-full">
+              + Adicionar mais um influencer
+            </button>
+          </>
+        )}
+      </section>
+
+      {/* === BOTAO SALVAR === */}
+      <div className="sticky bottom-4 flex justify-end">
+        <button onClick={save} disabled={saving}
+          className="px-6 py-3 rounded-lg text-[15px] font-semibold text-white transition-colors shadow-lg disabled:opacity-60"
+          style={{ backgroundColor: saving ? "#86868B" : "#E8740E" }}>
+          {saving ? "Salvando…" : "Salvar e publicar"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/nav-config.ts
+++ b/components/admin/nav-config.ts
@@ -83,6 +83,7 @@ export const NAV: NavEntry[] = [
     items: [
       { href: "/admin/mostruario", label: "Mostruario", icon: "\u{1F5BC}\uFE0F", pageKey: "mostruario" },
       { href: "/admin/simulacoes", label: "Simulacoes", icon: "\u{1F4F1}", pageKey: "simulacoes" },
+      { href: "/admin/configuracoes/site", label: "Configuração do Site", icon: "\u{1F3A8}", pageKey: "configuracoes", betaPara: ["andre", "nicolas"] },
       { href: "/admin/instagram", label: "Instagram", icon: "\u{1F4F8}", pageKey: "instagram", betaPara: ["andre", "nicolas"] },
       { href: "/admin/precos", label: "Alteração de Preços", icon: "\u{1F3F7}\uFE0F", pageKey: "precos" },
       { href: "/admin/usados", label: "Precos Trade-In", icon: "\u{1F4B0}", pageKey: "tradein_precos" },


### PR DESCRIPTION
## 🎨 Fase 1 do CMS visual da landing

Permite Andre e Nicolas **editarem fotos da landing /troca SEM precisar de Git**. Hoje, trocar a foto do logo ou um influencer requer:
- Subir arquivo no GitHub
- Fazer commit
- Esperar deploy

Com essa tela, basta:
- Login no admin
- Menu \"Site → Configuração do Site\"
- Trocar foto / adicionar influencer / reordenar
- Clicar \"Salvar e publicar\"
- Mudança em segundos no /troca

## 🎯 O que tem na tela

### Seção LOGO
- Preview circular da foto atual
- Botão \"Trocar foto\" (upload)
- Botão \"Restaurar padrão\" (volta pra foto hardcoded)
- Campo pra ajustar **CSS object-position** (resolve o problema de \"cortou a cabeça\" sem precisar me chamar)

### Seção INFLUENCERS
- Toggle on/off da seção inteira
- Lista de influencers com:
  - Foto circular (preview)
  - @ (editável)
  - Botão \"Trocar foto\"
  - Botões ▲▼ pra reordenar
  - Botão \"Remover\"
- Botão \"+ Adicionar influencer\" (sem limite de quantidade)

## 🔧 Como funciona por dentro

| Camada | O que faz |
|---|---|
| **Frontend** \`SiteConfigEditor.tsx\` | UI React, drag de ordem, upload via FormData |
| **API upload** \`/api/admin/site-upload\` | POST recebe imagem → Supabase Storage (bucket \`product-images\`, prefix \`site-\`) → retorna URL |
| **API config** \`/api/admin/tradein-config\` | Estendido pra ler/gravar 4 chaves novas no JSONB labels: \`_site_logo_url\`, \`_site_logo_position\`, \`_site_influencers_enabled\`, \`_site_influencers\` |
| **Landing** \`TradeInCalculatorMulti.tsx\` | Lê config dinâmica do banco, fallback robusto pra fotos hardcoded em \`/public/images/\` |
| **Storage** | Bucket \`product-images\` (já existe, público). Auto-cleanup das fotos antigas ao trocar |
| **Auth** | \`x-admin-password\` header (mesmo padrão do mostruário) |

**Sem migration nova** — tudo cabe no campo JSONB \`labels\` do \`tradein_config\` (mesmo padrão dos \`_whatsapp_*\` existentes).

## 🛡️ Fallback robusto

Se o banco vier vazio (testes, CI, ambiente novo), a landing **continua funcionando** usando as fotos hardcoded em \`/public/images/\`. Nunca quebra.

## 🔒 Acesso restrito

Entrada no menu fica visível só pra **andre** e **nicolas** (via \`betaPara\` no \`nav-config.ts\`). Outros admins não veem.

## ✅ Validação

- \`tsc --noEmit\`: zero erros
- \`next build\`: passou (rotas \`/admin/configuracoes/site\` + \`/api/admin/site-upload\` confirmadas)
- Compatível com config vazia E config preenchida

## 🧪 Como testar no preview

1. Mergeia o PR (deploy automático)
2. Abre /admin → login
3. Menu lateral: **Site → Configuração do Site** 🎨
4. Testa:
   - Trocar logo (sobe nova foto, vê preview, salva, abre /troca em outra aba)
   - Adicionar influencer (sobe foto, edita @, salva, vê na landing)
   - Reordenar com ▲▼
   - Remover um
   - Toggle off da seção (some da landing)
5. Restaurar logo padrão deve voltar pra foto original

## 📋 Próximas fases (combinadas com Andre)

- **Fase 2:** Editor de textos (headline, subtitle, footer, número de trocas) — ~2 dias
- **Fase 3:** Drag-and-drop visual nas perguntas do simulador — ~3 dias
- **Fase 4:** Color picker da marca + emojis + toggle de seções — ~3 dias

🤖 Generated with [Claude Code](https://claude.com/claude-code)