### PR TITLE
feat(admin): Fase 2 do CMS — editor de textos + feedbacks de clientes

### DIFF
--- a/app/api/admin/tradein-config/route.ts
+++ b/app/api/admin/tradein-config/route.ts
@@ -40,6 +40,23 @@ export async function GET(req: NextRequest) {
   if (labels._site_logo_position !== undefined) result.site_logo_position = labels._site_logo_position;
   if (labels._site_influencers_enabled !== undefined) result.site_influencers_enabled = labels._site_influencers_enabled;
   if (labels._site_influencers !== undefined) result.site_influencers = labels._site_influencers;
+  // Fase 2 (Abr/2026) — textos editaveis da landing + secao de feedbacks de
+  // clientes (prints WhatsApp). Tudo no JSONB labels.
+  if (labels._site_header_title !== undefined) result.site_header_title = labels._site_header_title;
+  if (labels._site_header_tagline !== undefined) result.site_header_tagline = labels._site_header_tagline;
+  if (labels._site_headline_p1 !== undefined) result.site_headline_p1 = labels._site_headline_p1;
+  if (labels._site_headline_destaque !== undefined) result.site_headline_destaque = labels._site_headline_destaque;
+  if (labels._site_headline_p2 !== undefined) result.site_headline_p2 = labels._site_headline_p2;
+  if (labels._site_subtitle !== undefined) result.site_subtitle = labels._site_subtitle;
+  if (labels._site_cta_text !== undefined) result.site_cta_text = labels._site_cta_text;
+  if (labels._site_trust_1 !== undefined) result.site_trust_1 = labels._site_trust_1;
+  if (labels._site_trust_2 !== undefined) result.site_trust_2 = labels._site_trust_2;
+  if (labels._site_trust_3 !== undefined) result.site_trust_3 = labels._site_trust_3;
+  if (labels._site_social_proof_text !== undefined) result.site_social_proof_text = labels._site_social_proof_text;
+  if (labels._site_footer_line1 !== undefined) result.site_footer_line1 = labels._site_footer_line1;
+  if (labels._site_footer_cnpj !== undefined) result.site_footer_cnpj = labels._site_footer_cnpj;
+  if (labels._site_feedbacks_enabled !== undefined) result.site_feedbacks_enabled = labels._site_feedbacks_enabled;
+  if (labels._site_feedbacks !== undefined) result.site_feedbacks = labels._site_feedbacks;
 
   return NextResponse.json({ data: result });
 }
@@ -75,6 +92,22 @@ export async function PUT(req: NextRequest) {
     "site_logo_position",
     "site_influencers_enabled",
     "site_influencers",
+    // Fase 2 (textos da landing + feedbacks de clientes)
+    "site_header_title",
+    "site_header_tagline",
+    "site_headline_p1",
+    "site_headline_destaque",
+    "site_headline_p2",
+    "site_subtitle",
+    "site_cta_text",
+    "site_trust_1",
+    "site_trust_2",
+    "site_trust_3",
+    "site_social_proof_text",
+    "site_footer_line1",
+    "site_footer_cnpj",
+    "site_feedbacks_enabled",
+    "site_feedbacks",
   ] as const;
   const hasAnyWaField = whatsappFields.some((k) => body[k] !== undefined);
   const hasAnySiteField = siteFields.some((k) => body[k] !== undefined);

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -124,7 +124,25 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
   const [questionsConfig, setQuestionsConfig] = useState<TradeInQuestion[] | null>(null);
   const [catConfigs, setCatConfigs] = useState<{ categoria: string; modo: string; ativo: boolean }[]>([]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & { whatsapp_principal?: string; whatsapp_formularios_seminovos?: string; whatsapp_seminovo_iphone?: string; whatsapp_seminovo_ipad?: string; whatsapp_seminovo_macbook?: string; whatsapp_seminovo_watch?: string; whatsapp_vendedores?: Record<string, string>; site_logo_url?: string | null; site_logo_position?: string; site_influencers_enabled?: boolean | string; site_influencers?: { handle: string; foto_url: string }[] }) | null>(null);
+  const [tradeinConfig, setTradeinConfig] = useState<(TradeInConfig & {
+    whatsapp_principal?: string; whatsapp_formularios_seminovos?: string;
+    whatsapp_seminovo_iphone?: string; whatsapp_seminovo_ipad?: string;
+    whatsapp_seminovo_macbook?: string; whatsapp_seminovo_watch?: string;
+    whatsapp_vendedores?: Record<string, string>;
+    // Site config — Fase 1
+    site_logo_url?: string | null; site_logo_position?: string;
+    site_influencers_enabled?: boolean | string;
+    site_influencers?: { handle: string; foto_url: string }[];
+    // Site config — Fase 2 (textos editaveis + feedbacks de clientes)
+    site_header_title?: string; site_header_tagline?: string;
+    site_headline_p1?: string; site_headline_destaque?: string; site_headline_p2?: string;
+    site_subtitle?: string; site_cta_text?: string;
+    site_trust_1?: string; site_trust_2?: string; site_trust_3?: string;
+    site_social_proof_text?: string;
+    site_footer_line1?: string; site_footer_cnpj?: string;
+    site_feedbacks_enabled?: boolean | string;
+    site_feedbacks?: { foto_url: string; nome: string; texto: string }[];
+  }) | null>(null);
   // Mapa dinamico de WhatsApp por vendedor — usa DB se disponivel
   const VENDEDOR_WHATSAPP = useMemo(() => {
     const dbMap = tradeinConfig?.whatsapp_vendedores;
@@ -167,6 +185,33 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
         .map((i) => ({ handle: i.handle, foto: i.foto_url }));
     }
     return INFLUENCERS_FALLBACK;
+  })();
+
+  // === Site config Fase 2 — textos editaveis + feedbacks ===
+  // Cada campo: usa valor do banco OU fallback hardcoded (preserva landing v2
+  // mesmo se banco nunca foi inicializado).
+  const siteHeaderTitle: string = tradeinConfig?.site_header_title || "TigrãoImports";
+  const siteHeaderTagline: string = tradeinConfig?.site_header_tagline || "Trade-In Apple";
+  const siteHeadlineP1: string = tradeinConfig?.site_headline_p1 || "Troque seu iPhone usado por um";
+  const siteHeadlineDestaque: string = tradeinConfig?.site_headline_destaque || "NOVO";
+  const siteHeadlineP2: string = tradeinConfig?.site_headline_p2 || "pagando só a diferença";
+  const siteSubtitle: string = tradeinConfig?.site_subtitle || "Descubra em 30 segundos quanto vale seu aparelho na troca por um novo com garantia Apple.";
+  const siteCtaText: string = tradeinConfig?.site_cta_text || "Descobrir o valor do meu aparelho";
+  const siteTrust1: string = tradeinConfig?.site_trust_1 || "Lacrado";
+  const siteTrust2: string = tradeinConfig?.site_trust_2 || "Nota fiscal";
+  const siteTrust3: string = tradeinConfig?.site_trust_3 || "Garantia Apple";
+  const siteSocialProofText: string = tradeinConfig?.site_social_proof_text || "+1.730 trocas realizadas";
+  const siteFooterLine1: string = tradeinConfig?.site_footer_line1 || "+5 anos no Rio de Janeiro · +1.730 trocas realizadas";
+  const siteFooterCnpj: string = tradeinConfig?.site_footer_cnpj || "CNPJ 50.139.554/0001-42";
+  // Feedbacks — desabilitado por default (Andre comeca a coletar prints depois)
+  const siteFeedbacksEnabled: boolean = (() => {
+    const raw = tradeinConfig?.site_feedbacks_enabled;
+    return raw === true || raw === "true";
+  })();
+  const siteFeedbacks: { foto_url: string; nome: string; texto: string }[] = (() => {
+    const fromDb = tradeinConfig?.site_feedbacks;
+    if (Array.isArray(fromDb)) return fromDb.filter((f) => f && f.foto_url);
+    return [];
   })();
   const [deviceType, setDeviceType] = useState<DeviceType>("iphone");
   const [usedModel, setUsedModel] = useState("");
@@ -444,43 +489,42 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
                 onError={(e) => { e.currentTarget.style.display = "none"; e.currentTarget.parentElement!.innerHTML = "🐯"; }} />
             </div>
             <div className="text-left">
-              <p className="text-[16px] font-bold leading-tight" style={{ color: tema.text }}>TigrãoImports</p>
-              <p className="text-[11px] leading-tight" style={{ color: "var(--ti-accent, #E8740E)" }}>Trade-In Apple</p>
+              <p className="text-[16px] font-bold leading-tight" style={{ color: tema.text }}>{siteHeaderTitle}</p>
+              <p className="text-[11px] leading-tight" style={{ color: "var(--ti-accent, #E8740E)" }}>{siteHeaderTagline}</p>
             </div>
           </div>
 
-          {/* HEADLINE — sem mostrar valor especifico (Andre nao quis aproximar
-              valores). Foco no que importa: troca lacrada com garantia Apple +
-              parcelamento. Mantem 21x como ancora de "compravel". */}
+          {/* HEADLINE — gerenciada pelo admin em /admin/configuracoes/site
+              (3 partes — meio destacado em laranja). */}
           <div className="text-center space-y-3">
             <h1 className="text-[26px] font-bold tracking-tight leading-tight" style={{ color: tema.text }}>
-              Troque seu iPhone usado por um <span style={{ color: "var(--ti-accent, #E8740E)" }}>NOVO</span><br />pagando só a diferença
+              {siteHeadlineP1} <span style={{ color: "var(--ti-accent, #E8740E)" }}>{siteHeadlineDestaque}</span><br />{siteHeadlineP2}
             </h1>
             <p className="text-[15px] leading-relaxed" style={{ color: tema.textMuted }}>
-              Descubra em <strong style={{ color: tema.text }}>30 segundos</strong> quanto vale seu aparelho na troca por um novo com garantia Apple.
+              {siteSubtitle}
             </p>
           </div>
 
-          {/* CTA verde — mantido (psicologia de conversao + dinheiro). */}
+          {/* CTA verde — texto editavel via admin */}
           <button
             onClick={() => { setStarted(true); setStep(0); trackStep(0); }}
             className="w-full py-4 rounded-2xl text-[18px] font-bold text-white transition-all duration-200 active:scale-[0.98] shadow-lg"
             style={{ backgroundColor: "#22c55e" }}
           >
-            Descobrir o valor do meu aparelho
+            {siteCtaText}
           </button>
 
-          {/* Social proof — 5 estrelas + numero de trocas */}
+          {/* Social proof — 5 estrelas + numero de trocas (texto editavel) */}
           <div className="flex items-center justify-center gap-2">
             <span className="text-base leading-none">{"\u2B50\u2B50\u2B50\u2B50\u2B50"}</span>
-            <span className="text-[13px] font-semibold" style={{ color: tema.text }}>+1.730 trocas realizadas</span>
+            <span className="text-[13px] font-semibold" style={{ color: tema.text }}>{siteSocialProofText}</span>
           </div>
 
-          {/* Trust badges — usa cor de marca em vez de verde generico */}
+          {/* Trust badges — 3 textos editaveis com checkmark laranja */}
           <div className="flex items-center justify-center gap-4 text-[12px]" style={{ color: tema.textMuted }}>
-            <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> Lacrado</span>
-            <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> Nota fiscal</span>
-            <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> Garantia Apple</span>
+            <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> {siteTrust1}</span>
+            <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> {siteTrust2}</span>
+            <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> {siteTrust3}</span>
           </div>
 
           {/* SECAO INFLUENCERS — gerenciada pelo admin em
@@ -504,13 +548,41 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
             </div>
           )}
 
-          {/* FOOTER ENRIQUECIDO — credibilidade real (5 anos + CNPJ) sem
-              expor endereco (preferencia do Andre, escritorio nao e loja
-              aberta ao publico). */}
+          {/* SECAO FEEDBACKS — depoimentos de clientes (prints WhatsApp).
+              Gerenciada pelo admin em /admin/configuracoes/site. Esconde se
+              admin desativou ou se nao tem nenhum cadastrado. */}
+          {siteFeedbacksEnabled && siteFeedbacks.length > 0 && (
+            <div className="pt-4 space-y-3" style={{ borderTop: `1px solid ${tema.cardBorder}` }}>
+              <p className="text-[11px] font-semibold tracking-wider uppercase text-center" style={{ color: tema.textMuted }}>O que dizem nossos clientes</p>
+              <div className="space-y-3">
+                {siteFeedbacks.map((fb, idx) => (
+                  <div key={idx} className="rounded-2xl p-3 flex items-start gap-3"
+                    style={{ backgroundColor: tema.cardBg, border: `1px solid ${tema.cardBorder}` }}>
+                    <div className="w-16 h-16 rounded-lg overflow-hidden flex-shrink-0"
+                      style={{ border: `1px solid ${tema.cardBorder}` }}>
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={fb.foto_url} alt={fb.nome || "Feedback"} className="w-full h-full object-cover" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      {fb.nome && (
+                        <p className="text-[12px] font-semibold mb-0.5" style={{ color: tema.text }}>{fb.nome}</p>
+                      )}
+                      {fb.texto && (
+                        <p className="text-[12px] leading-snug" style={{ color: tema.textMuted }}>&ldquo;{fb.texto}&rdquo;</p>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* FOOTER — credibilidade (5 anos + CNPJ). Textos editaveis pelo
+              admin. Sem endereco exposto (escritorio fechado). */}
           <div className="pt-5 text-center space-y-1" style={{ borderTop: `1px solid ${tema.cardBorder}` }}>
-            <p className="text-[12px] font-semibold" style={{ color: tema.text }}>TigrãoImports</p>
-            <p className="text-[11px]" style={{ color: tema.textMuted }}>+5 anos no Rio de Janeiro · +1.730 trocas realizadas</p>
-            <p className="text-[10px]" style={{ color: tema.textDim }}>CNPJ 50.139.554/0001-42</p>
+            <p className="text-[12px] font-semibold" style={{ color: tema.text }}>{siteHeaderTitle}</p>
+            <p className="text-[11px]" style={{ color: tema.textMuted }}>{siteFooterLine1}</p>
+            <p className="text-[10px]" style={{ color: tema.textDim }}>{siteFooterCnpj}</p>
           </div>
         </div>
       </main>

--- a/components/admin/SiteConfigEditor.tsx
+++ b/components/admin/SiteConfigEditor.tsx
@@ -3,35 +3,85 @@
 import { useState, useEffect, useRef } from "react";
 import { useAdmin } from "./AdminShell";
 
-// Editor da landing /troca — gerencia LOGO (avatar do dono) e secao
-// INFLUENCERS (foto + @ + ordem + on/off). Salva no campo labels JSONB de
-// tradein_config (chaves _site_*), padrao igual ao do _whatsapp_*.
+// Editor da landing /troca — 4 secoes: LOGO, TEXTOS, INFLUENCERS, FEEDBACKS.
+// Salva no campo labels JSONB de tradein_config (chaves _site_*), padrao
+// igual ao do _whatsapp_*.
 //
 // Upload via /api/admin/site-upload (Supabase Storage bucket product-images
 // com prefix site-). Fallback robusto: se config vazia, landing usa as fotos
-// hardcoded em /public/images/ (compatibilidade com versao anterior).
+// e textos hardcoded (compatibilidade).
+//
+// Fase 1 (Abr/2026): logo + influencers
+// Fase 2 (Abr/2026): textos editaveis + feedbacks de clientes
 
 interface Influencer {
   handle: string;
   foto_url: string;
 }
 
-interface SiteConfig {
-  site_logo_url: string | null;
-  site_logo_position: string;
-  site_influencers_enabled: boolean;
-  site_influencers: Influencer[];
+interface Feedback {
+  foto_url: string;
+  nome: string;     // opcional, pode ser vazio
+  texto: string;    // opcional, pode ser vazio
 }
 
+interface SiteConfig {
+  // Logo
+  site_logo_url: string | null;
+  site_logo_position: string;
+  // Header
+  site_header_title: string;
+  site_header_tagline: string;
+  // Headline (3 partes — meio fica destacado em laranja)
+  site_headline_p1: string;
+  site_headline_destaque: string;
+  site_headline_p2: string;
+  // Subtitulo
+  site_subtitle: string;
+  // CTA
+  site_cta_text: string;
+  // Trust badges (3)
+  site_trust_1: string;
+  site_trust_2: string;
+  site_trust_3: string;
+  // Social proof (perto das estrelas)
+  site_social_proof_text: string;
+  // Footer
+  site_footer_line1: string;
+  site_footer_cnpj: string;
+  // Influencers
+  site_influencers_enabled: boolean;
+  site_influencers: Influencer[];
+  // Feedbacks (Fase 2 — prints WhatsApp)
+  site_feedbacks_enabled: boolean;
+  site_feedbacks: Feedback[];
+}
+
+// Defaults sensatos — se admin nunca editou, esses valores sao usados como
+// preview e tambem como o que vai pro banco no primeiro save. Refletem o
+// que esta hoje hardcoded no TradeInCalculatorMulti.tsx.
 const DEFAULT_CONFIG: SiteConfig = {
   site_logo_url: null,
   site_logo_position: "center 15%",
-  site_influencers_enabled: false,
+  site_header_title: "TigrãoImports",
+  site_header_tagline: "Trade-In Apple",
+  site_headline_p1: "Troque seu iPhone usado por um",
+  site_headline_destaque: "NOVO",
+  site_headline_p2: "pagando só a diferença",
+  site_subtitle: "Descubra em 30 segundos quanto vale seu aparelho na troca por um novo com garantia Apple.",
+  site_cta_text: "Descobrir o valor do meu aparelho",
+  site_trust_1: "Lacrado",
+  site_trust_2: "Nota fiscal",
+  site_trust_3: "Garantia Apple",
+  site_social_proof_text: "+1.730 trocas realizadas",
+  site_footer_line1: "+5 anos no Rio de Janeiro · +1.730 trocas realizadas",
+  site_footer_cnpj: "CNPJ 50.139.554/0001-42",
+  site_influencers_enabled: true,
   site_influencers: [],
+  site_feedbacks_enabled: false,
+  site_feedbacks: [],
 };
 
-// URL pra mostrar na preview quando NAO tem upload customizado — aponta pro
-// asset hardcoded em /public/images/ que continua funcionando como fallback.
 const FALLBACK_LOGO = "/images/andre.png";
 
 export default function SiteConfigEditor() {
@@ -41,6 +91,7 @@ export default function SiteConfigEditor() {
   const [saving, setSaving] = useState(false);
   const [uploadingLogo, setUploadingLogo] = useState(false);
   const [uploadingInfluencer, setUploadingInfluencer] = useState<number | null>(null);
+  const [uploadingFeedback, setUploadingFeedback] = useState<number | null>(null);
   const [msg, setMsg] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const logoInputRef = useRef<HTMLInputElement>(null);
 
@@ -52,11 +103,29 @@ export default function SiteConfigEditor() {
       const res = await fetch("/api/admin/tradein-config", { headers: apiHeaders() });
       const json = await res.json();
       const d = json?.data || {};
+      // Merge com DEFAULT_CONFIG — chaves nao existentes no banco usam default
       setConfig({
         site_logo_url: d.site_logo_url ?? null,
-        site_logo_position: d.site_logo_position ?? "center 15%",
-        site_influencers_enabled: d.site_influencers_enabled === true || d.site_influencers_enabled === "true",
+        site_logo_position: d.site_logo_position ?? DEFAULT_CONFIG.site_logo_position,
+        site_header_title: d.site_header_title ?? DEFAULT_CONFIG.site_header_title,
+        site_header_tagline: d.site_header_tagline ?? DEFAULT_CONFIG.site_header_tagline,
+        site_headline_p1: d.site_headline_p1 ?? DEFAULT_CONFIG.site_headline_p1,
+        site_headline_destaque: d.site_headline_destaque ?? DEFAULT_CONFIG.site_headline_destaque,
+        site_headline_p2: d.site_headline_p2 ?? DEFAULT_CONFIG.site_headline_p2,
+        site_subtitle: d.site_subtitle ?? DEFAULT_CONFIG.site_subtitle,
+        site_cta_text: d.site_cta_text ?? DEFAULT_CONFIG.site_cta_text,
+        site_trust_1: d.site_trust_1 ?? DEFAULT_CONFIG.site_trust_1,
+        site_trust_2: d.site_trust_2 ?? DEFAULT_CONFIG.site_trust_2,
+        site_trust_3: d.site_trust_3 ?? DEFAULT_CONFIG.site_trust_3,
+        site_social_proof_text: d.site_social_proof_text ?? DEFAULT_CONFIG.site_social_proof_text,
+        site_footer_line1: d.site_footer_line1 ?? DEFAULT_CONFIG.site_footer_line1,
+        site_footer_cnpj: d.site_footer_cnpj ?? DEFAULT_CONFIG.site_footer_cnpj,
+        site_influencers_enabled: d.site_influencers_enabled === undefined || d.site_influencers_enabled === null
+          ? DEFAULT_CONFIG.site_influencers_enabled
+          : (d.site_influencers_enabled === true || d.site_influencers_enabled === "true"),
         site_influencers: Array.isArray(d.site_influencers) ? d.site_influencers : [],
+        site_feedbacks_enabled: d.site_feedbacks_enabled === true || d.site_feedbacks_enabled === "true",
+        site_feedbacks: Array.isArray(d.site_feedbacks) ? d.site_feedbacks : [],
       });
     } catch (err) {
       flash("error", "Erro ao carregar: " + (err as Error).message);
@@ -76,12 +145,7 @@ export default function SiteConfigEditor() {
       const res = await fetch("/api/admin/tradein-config", {
         method: "PUT",
         headers: { "Content-Type": "application/json", ...apiHeaders() },
-        body: JSON.stringify({
-          site_logo_url: config.site_logo_url,
-          site_logo_position: config.site_logo_position,
-          site_influencers_enabled: config.site_influencers_enabled,
-          site_influencers: config.site_influencers,
-        }),
+        body: JSON.stringify(config),
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error || "Erro ao salvar");
@@ -93,14 +157,14 @@ export default function SiteConfigEditor() {
     }
   }
 
-  async function uploadFile(file: File, kind: "logo" | "influencer"): Promise<string | null> {
+  async function uploadFile(file: File, kind: "logo" | "influencer" | "misc"): Promise<string | null> {
     const fd = new FormData();
     fd.append("file", file);
     fd.append("kind", kind);
     try {
       const res = await fetch("/api/admin/site-upload", {
         method: "POST",
-        headers: apiHeaders(), // FormData define o Content-Type sozinho
+        headers: apiHeaders(),
         body: fd,
       });
       const json = await res.json();
@@ -116,18 +180,16 @@ export default function SiteConfigEditor() {
   }
 
   async function deleteUploaded(url: string) {
-    // Best-effort — nao bloqueia se falhar (storage cleanup nao critico)
     try {
       await fetch("/api/admin/site-upload", {
         method: "DELETE",
         headers: { "Content-Type": "application/json", ...apiHeaders() },
         body: JSON.stringify({ url }),
       });
-    } catch {
-      /* ignore */
-    }
+    } catch { /* ignore */ }
   }
 
+  // === LOGO ===
   async function handleLogoChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -135,7 +197,6 @@ export default function SiteConfigEditor() {
     try {
       const newUrl = await uploadFile(file, "logo");
       if (newUrl) {
-        // Limpa upload antigo (se for de upload, nao do fallback)
         if (config.site_logo_url) await deleteUploaded(config.site_logo_url);
         setConfig({ ...config, site_logo_url: newUrl });
         flash("success", "Logo carregada. Clique em SALVAR pra publicar.");
@@ -145,38 +206,26 @@ export default function SiteConfigEditor() {
       if (logoInputRef.current) logoInputRef.current.value = "";
     }
   }
-
   async function restaurarLogoPadrao() {
-    if (!confirm("Restaurar logo padrao (foto que estava antes)? A logo customizada sera removida.")) return;
+    if (!confirm("Restaurar logo padrao? A logo customizada sera removida.")) return;
     if (config.site_logo_url) await deleteUploaded(config.site_logo_url);
     setConfig({ ...config, site_logo_url: null });
     flash("success", "Logo restaurada. Clique em SALVAR pra publicar.");
   }
 
+  // === INFLUENCERS ===
   function addInfluencer() {
-    setConfig({
-      ...config,
-      site_influencers: [...config.site_influencers, { handle: "@novo", foto_url: "" }],
-    });
+    setConfig({ ...config, site_influencers: [...config.site_influencers, { handle: "@novo", foto_url: "" }] });
   }
-
   function updateInfluencer(idx: number, patch: Partial<Influencer>) {
-    setConfig({
-      ...config,
-      site_influencers: config.site_influencers.map((inf, i) => (i === idx ? { ...inf, ...patch } : inf)),
-    });
+    setConfig({ ...config, site_influencers: config.site_influencers.map((inf, i) => (i === idx ? { ...inf, ...patch } : inf)) });
   }
-
   async function removeInfluencer(idx: number) {
     const inf = config.site_influencers[idx];
     if (!confirm(`Remover ${inf.handle}?`)) return;
     if (inf.foto_url) await deleteUploaded(inf.foto_url);
-    setConfig({
-      ...config,
-      site_influencers: config.site_influencers.filter((_, i) => i !== idx),
-    });
+    setConfig({ ...config, site_influencers: config.site_influencers.filter((_, i) => i !== idx) });
   }
-
   function moveInfluencer(idx: number, dir: "up" | "down") {
     const newList = [...config.site_influencers];
     const swapIdx = dir === "up" ? idx - 1 : idx + 1;
@@ -184,7 +233,6 @@ export default function SiteConfigEditor() {
     [newList[idx], newList[swapIdx]] = [newList[swapIdx], newList[idx]];
     setConfig({ ...config, site_influencers: newList });
   }
-
   async function handleInfluencerPhotoChange(idx: number, e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -203,40 +251,75 @@ export default function SiteConfigEditor() {
     }
   }
 
+  // === FEEDBACKS ===
+  function addFeedback() {
+    setConfig({ ...config, site_feedbacks: [...config.site_feedbacks, { foto_url: "", nome: "", texto: "" }] });
+  }
+  function updateFeedback(idx: number, patch: Partial<Feedback>) {
+    setConfig({ ...config, site_feedbacks: config.site_feedbacks.map((fb, i) => (i === idx ? { ...fb, ...patch } : fb)) });
+  }
+  async function removeFeedback(idx: number) {
+    if (!confirm("Remover este feedback?")) return;
+    const fb = config.site_feedbacks[idx];
+    if (fb.foto_url) await deleteUploaded(fb.foto_url);
+    setConfig({ ...config, site_feedbacks: config.site_feedbacks.filter((_, i) => i !== idx) });
+  }
+  function moveFeedback(idx: number, dir: "up" | "down") {
+    const newList = [...config.site_feedbacks];
+    const swapIdx = dir === "up" ? idx - 1 : idx + 1;
+    if (swapIdx < 0 || swapIdx >= newList.length) return;
+    [newList[idx], newList[swapIdx]] = [newList[swapIdx], newList[idx]];
+    setConfig({ ...config, site_feedbacks: newList });
+  }
+  async function handleFeedbackPhotoChange(idx: number, e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploadingFeedback(idx);
+    try {
+      const newUrl = await uploadFile(file, "misc");
+      if (newUrl) {
+        const old = config.site_feedbacks[idx].foto_url;
+        if (old) await deleteUploaded(old);
+        updateFeedback(idx, { foto_url: newUrl });
+        flash("success", "Foto carregada. Clique em SALVAR pra publicar.");
+      }
+    } finally {
+      setUploadingFeedback(null);
+      e.target.value = "";
+    }
+  }
+
   if (loading) return <p className="text-[#86868B]">Carregando configuração…</p>;
 
   const logoPreview = config.site_logo_url || FALLBACK_LOGO;
 
+  // Estilos compartilhados
+  const sectionStyle = "bg-white rounded-xl p-5 shadow-sm border border-[#E8E8ED]";
+  const sectionTitle = "text-[18px] font-semibold text-[#1D1D1F] mb-1";
+  const sectionDesc = "text-[13px] text-[#86868B] mb-4";
+  const labelStyle = "block text-[12px] font-medium text-[#86868B] mb-1";
+  const inputStyle = "w-full px-3 py-2 bg-[#F5F5F7] border border-[#D2D2D7] rounded-lg text-[13px] focus:outline-none focus:border-[#E8740E] transition-colors";
+
   return (
     <div className="space-y-6">
       {msg && (
-        <div className={`rounded-lg px-4 py-3 text-[14px] ${
+        <div className={`rounded-lg px-4 py-3 text-[14px] sticky top-2 z-10 shadow-sm ${
           msg.type === "success" ? "bg-green-50 text-green-800 border border-green-200"
                                   : "bg-red-50 text-red-800 border border-red-200"
-        }`}>
-          {msg.text}
-        </div>
+        }`}>{msg.text}</div>
       )}
 
       {/* === SECAO LOGO === */}
-      <section className="bg-white rounded-xl p-5 shadow-sm border border-[#E8E8ED]">
-        <h2 className="text-[18px] font-semibold text-[#1D1D1F] mb-1">Logo do site</h2>
-        <p className="text-[13px] text-[#86868B] mb-4">
-          Foto que aparece no avatar circular do topo da landing (/troca). Recomendado: foto quadrada, mín 200×200px.
-        </p>
+      <section className={sectionStyle}>
+        <h2 className={sectionTitle}>1. Logo do site</h2>
+        <p className={sectionDesc}>Foto que aparece no avatar circular do topo da landing (/troca).</p>
         <div className="flex items-start gap-5">
-          <div
-            className="w-24 h-24 rounded-full overflow-hidden flex-shrink-0"
-            style={{ border: "2px solid #E8740E", backgroundColor: "#FFF5EC" }}
-          >
+          <div className="w-24 h-24 rounded-full overflow-hidden flex-shrink-0"
+            style={{ border: "2px solid #E8740E", backgroundColor: "#FFF5EC" }}>
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={logoPreview}
-              alt="Logo preview"
-              className="w-full h-full object-cover"
+            <img src={logoPreview} alt="Logo preview" className="w-full h-full object-cover"
               style={{ objectPosition: config.site_logo_position }}
-              onError={(e) => { e.currentTarget.style.display = "none"; }}
-            />
+              onError={(e) => { e.currentTarget.style.display = "none"; }} />
           </div>
           <div className="flex-1 space-y-3">
             <div className="flex flex-wrap gap-2">
@@ -253,37 +336,144 @@ export default function SiteConfigEditor() {
                 </button>
               )}
             </div>
-
             <div>
-              <label className="block text-[12px] font-medium text-[#86868B] mb-1">Posicionamento da foto (CSS object-position)</label>
+              <label className={labelStyle}>Posicionamento da foto (CSS object-position)</label>
               <input type="text" value={config.site_logo_position}
                 onChange={(e) => setConfig({ ...config, site_logo_position: e.target.value })}
-                placeholder="center 15%"
-                className="w-full px-3 py-2 bg-[#F5F5F7] border border-[#D2D2D7] rounded-lg text-[13px]" />
+                placeholder="center 15%" className={inputStyle} />
               <p className="text-[11px] text-[#AEAEB2] mt-1">
-                Use &ldquo;center 15%&rdquo; (mostra mais o topo da foto), &ldquo;center&rdquo; (centraliza) ou &ldquo;center 30%&rdquo; (mostra mais o meio).
+                &ldquo;center 5%&rdquo; mostra mais o topo · &ldquo;center&rdquo; centraliza · &ldquo;center 30%&rdquo; mostra mais o meio.
               </p>
             </div>
-
             <p className="text-[12px] text-[#86868B]">
-              {config.site_logo_url
-                ? "✅ Usando foto customizada (upload)"
-                : "ℹ️ Usando foto padrão (/public/images/andre.png)"}
+              {config.site_logo_url ? "✅ Foto customizada" : "ℹ️ Foto padrão (/public/images/andre.png)"}
             </p>
           </div>
         </div>
       </section>
 
-      {/* === SECAO INFLUENCERS === */}
-      <section className="bg-white rounded-xl p-5 shadow-sm border border-[#E8E8ED]">
-        <div className="flex items-start justify-between mb-4">
-          <div>
-            <h2 className="text-[18px] font-semibold text-[#1D1D1F] mb-1">Influencers (seção &ldquo;Quem comprou aqui&rdquo;)</h2>
-            <p className="text-[13px] text-[#86868B]">
-              Fotos circulares que aparecem na landing como social proof. Cada @ vira link clicável pro Instagram.
-            </p>
+      {/* === SECAO TEXTOS === */}
+      <section className={sectionStyle}>
+        <h2 className={sectionTitle}>2. Textos da landing</h2>
+        <p className={sectionDesc}>Edite todos os textos que aparecem em /troca. Mudanças refletem em segundos.</p>
+
+        <div className="space-y-5">
+          {/* Header */}
+          <div className="grid grid-cols-2 gap-3 pb-4 border-b border-[#E8E8ED]">
+            <div>
+              <label className={labelStyle}>Nome no header</label>
+              <input type="text" value={config.site_header_title}
+                onChange={(e) => setConfig({ ...config, site_header_title: e.target.value })}
+                className={inputStyle} placeholder="TigrãoImports" />
+            </div>
+            <div>
+              <label className={labelStyle}>Tagline (em laranja, abaixo do nome)</label>
+              <input type="text" value={config.site_header_tagline}
+                onChange={(e) => setConfig({ ...config, site_header_tagline: e.target.value })}
+                className={inputStyle} placeholder="Trade-In Apple" />
+            </div>
           </div>
-          <label className="inline-flex items-center gap-2 cursor-pointer ml-4 flex-shrink-0">
+
+          {/* Headline */}
+          <div className="space-y-3 pb-4 border-b border-[#E8E8ED]">
+            <p className="text-[12px] font-semibold text-[#1D1D1F]">Headline (3 partes — meio fica destacado em laranja)</p>
+            <div>
+              <label className={labelStyle}>Início</label>
+              <input type="text" value={config.site_headline_p1}
+                onChange={(e) => setConfig({ ...config, site_headline_p1: e.target.value })}
+                className={inputStyle} placeholder="Troque seu iPhone usado por um" />
+            </div>
+            <div>
+              <label className={labelStyle}>Palavra em destaque (LARANJA)</label>
+              <input type="text" value={config.site_headline_destaque}
+                onChange={(e) => setConfig({ ...config, site_headline_destaque: e.target.value })}
+                className={inputStyle + " font-semibold"} placeholder="NOVO"
+                style={{ color: "#E8740E" }} />
+            </div>
+            <div>
+              <label className={labelStyle}>Final (aparece em nova linha)</label>
+              <input type="text" value={config.site_headline_p2}
+                onChange={(e) => setConfig({ ...config, site_headline_p2: e.target.value })}
+                className={inputStyle} placeholder="pagando só a diferença" />
+            </div>
+            {/* Preview da headline */}
+            <div className="p-4 rounded-lg bg-[#FAFAFA] border border-[#E8E8ED] text-center">
+              <p className="text-[11px] text-[#86868B] mb-2 uppercase tracking-wider">Preview:</p>
+              <p className="text-[18px] font-bold leading-tight text-[#1D1D1F]">
+                {config.site_headline_p1} <span style={{ color: "#E8740E" }}>{config.site_headline_destaque}</span><br />
+                {config.site_headline_p2}
+              </p>
+            </div>
+          </div>
+
+          {/* Subtitulo */}
+          <div className="pb-4 border-b border-[#E8E8ED]">
+            <label className={labelStyle}>Subtítulo (abaixo da headline)</label>
+            <textarea value={config.site_subtitle}
+              onChange={(e) => setConfig({ ...config, site_subtitle: e.target.value })}
+              className={inputStyle + " min-h-[60px] resize-y"}
+              placeholder="Descubra em 30 segundos quanto vale seu aparelho..." />
+          </div>
+
+          {/* CTA */}
+          <div className="pb-4 border-b border-[#E8E8ED]">
+            <label className={labelStyle}>Texto do botão verde (CTA)</label>
+            <input type="text" value={config.site_cta_text}
+              onChange={(e) => setConfig({ ...config, site_cta_text: e.target.value })}
+              className={inputStyle} placeholder="Descobrir o valor do meu aparelho" />
+          </div>
+
+          {/* Social proof */}
+          <div className="pb-4 border-b border-[#E8E8ED]">
+            <label className={labelStyle}>Texto do social proof (perto das estrelas ⭐)</label>
+            <input type="text" value={config.site_social_proof_text}
+              onChange={(e) => setConfig({ ...config, site_social_proof_text: e.target.value })}
+              className={inputStyle} placeholder="+1.730 trocas realizadas" />
+          </div>
+
+          {/* Trust badges */}
+          <div className="pb-4 border-b border-[#E8E8ED]">
+            <label className={labelStyle}>Trust badges (3 itens com ✓ laranja)</label>
+            <div className="grid grid-cols-3 gap-2">
+              <input type="text" value={config.site_trust_1}
+                onChange={(e) => setConfig({ ...config, site_trust_1: e.target.value })}
+                className={inputStyle} placeholder="Lacrado" />
+              <input type="text" value={config.site_trust_2}
+                onChange={(e) => setConfig({ ...config, site_trust_2: e.target.value })}
+                className={inputStyle} placeholder="Nota fiscal" />
+              <input type="text" value={config.site_trust_3}
+                onChange={(e) => setConfig({ ...config, site_trust_3: e.target.value })}
+                className={inputStyle} placeholder="Garantia Apple" />
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="space-y-3">
+            <p className="text-[12px] font-semibold text-[#1D1D1F]">Footer</p>
+            <div>
+              <label className={labelStyle}>Linha 1 (credibilidade)</label>
+              <input type="text" value={config.site_footer_line1}
+                onChange={(e) => setConfig({ ...config, site_footer_line1: e.target.value })}
+                className={inputStyle} placeholder="+5 anos no Rio · +1.730 trocas" />
+            </div>
+            <div>
+              <label className={labelStyle}>CNPJ (linha 2)</label>
+              <input type="text" value={config.site_footer_cnpj}
+                onChange={(e) => setConfig({ ...config, site_footer_cnpj: e.target.value })}
+                className={inputStyle} placeholder="CNPJ 50.139.554/0001-42" />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* === SECAO INFLUENCERS === */}
+      <section className={sectionStyle}>
+        <div className="flex items-start justify-between mb-4 gap-4">
+          <div className="flex-1">
+            <h2 className={sectionTitle}>3. Influencers (seção &ldquo;Quem comprou aqui&rdquo;)</h2>
+            <p className={sectionDesc + " mb-0"}>Fotos circulares que aparecem como social proof. Cada @ vira link clicável.</p>
+          </div>
+          <label className="inline-flex items-center gap-2 cursor-pointer flex-shrink-0">
             <input type="checkbox" checked={config.site_influencers_enabled}
               onChange={(e) => setConfig({ ...config, site_influencers_enabled: e.target.checked })}
               className="w-4 h-4 accent-[#E8740E]" />
@@ -291,33 +481,25 @@ export default function SiteConfigEditor() {
           </label>
         </div>
 
-        {config.site_influencers.length === 0 && (
+        {config.site_influencers.length === 0 ? (
           <div className="border-2 border-dashed border-[#D2D2D7] rounded-lg p-6 text-center">
             <p className="text-[14px] text-[#86868B] mb-3">Nenhum influencer cadastrado.</p>
             <button onClick={addInfluencer}
-              className="px-4 py-2 rounded-lg text-[13px] font-medium text-white transition-colors"
-              style={{ backgroundColor: "#E8740E" }}>
+              className="px-4 py-2 rounded-lg text-[13px] font-medium text-white" style={{ backgroundColor: "#E8740E" }}>
               + Adicionar influencer
             </button>
           </div>
-        )}
-
-        {config.site_influencers.length > 0 && (
+        ) : (
           <>
             <div className="space-y-3">
               {config.site_influencers.map((inf, idx) => (
                 <div key={idx} className="flex items-center gap-3 p-3 rounded-lg border border-[#E8E8ED] bg-[#FAFAFA]">
                   <div className="flex flex-col gap-1">
                     <button onClick={() => moveInfluencer(idx, "up")} disabled={idx === 0}
-                      className="text-[14px] px-2 py-0.5 rounded hover:bg-[#E8E8ED] disabled:opacity-30 disabled:cursor-not-allowed">
-                      ▲
-                    </button>
+                      className="text-[14px] px-2 py-0.5 rounded hover:bg-[#E8E8ED] disabled:opacity-30">▲</button>
                     <button onClick={() => moveInfluencer(idx, "down")} disabled={idx === config.site_influencers.length - 1}
-                      className="text-[14px] px-2 py-0.5 rounded hover:bg-[#E8E8ED] disabled:opacity-30 disabled:cursor-not-allowed">
-                      ▼
-                    </button>
+                      className="text-[14px] px-2 py-0.5 rounded hover:bg-[#E8E8ED] disabled:opacity-30">▼</button>
                   </div>
-
                   <div className="w-16 h-16 rounded-full overflow-hidden flex-shrink-0 bg-[#F5F5F7]"
                     style={{ border: "2px solid #E8740E" }}>
                     {inf.foto_url ? (
@@ -327,7 +509,6 @@ export default function SiteConfigEditor() {
                       <div className="w-full h-full flex items-center justify-center text-[10px] text-[#86868B] text-center px-1">sem foto</div>
                     )}
                   </div>
-
                   <div className="flex-1 min-w-0 space-y-2">
                     <input type="text" value={inf.handle}
                       onChange={(e) => {
@@ -337,7 +518,7 @@ export default function SiteConfigEditor() {
                       }}
                       placeholder="@usuario"
                       className="w-full px-3 py-1.5 bg-white border border-[#D2D2D7] rounded text-[13px]" />
-                    <label className="inline-flex items-center px-3 py-1.5 rounded text-[12px] font-medium border border-[#D2D2D7] hover:bg-[#F5F5F7] cursor-pointer transition-colors"
+                    <label className="inline-flex items-center px-3 py-1.5 rounded text-[12px] font-medium border border-[#D2D2D7] hover:bg-[#F5F5F7] cursor-pointer"
                       style={uploadingInfluencer === idx ? { opacity: 0.6 } : {}}>
                       {uploadingInfluencer === idx ? "Enviando…" : (inf.foto_url ? "Trocar foto" : "Subir foto")}
                       <input type="file" accept="image/jpeg,image/png,image/webp" className="hidden"
@@ -345,18 +526,100 @@ export default function SiteConfigEditor() {
                         onChange={(e) => handleInfluencerPhotoChange(idx, e)} />
                     </label>
                   </div>
-
                   <button onClick={() => removeInfluencer(idx)}
-                    className="text-[12px] text-red-600 hover:text-red-800 font-medium px-3 py-2 transition-colors flex-shrink-0">
+                    className="text-[12px] text-red-600 hover:text-red-800 font-medium px-3 py-2 flex-shrink-0">
                     Remover
                   </button>
                 </div>
               ))}
             </div>
-
             <button onClick={addInfluencer}
               className="mt-4 px-4 py-2 rounded-lg text-[13px] font-medium border-2 border-dashed border-[#D2D2D7] text-[#86868B] hover:border-[#E8740E] hover:text-[#E8740E] transition-colors w-full">
               + Adicionar mais um influencer
+            </button>
+          </>
+        )}
+      </section>
+
+      {/* === SECAO FEEDBACKS DE CLIENTES === */}
+      <section className={sectionStyle}>
+        <div className="flex items-start justify-between mb-4 gap-4">
+          <div className="flex-1">
+            <h2 className={sectionTitle}>4. Feedbacks de clientes (prints WhatsApp)</h2>
+            <p className={sectionDesc + " mb-0"}>
+              Depoimentos reais de clientes — print do WhatsApp + nome (opcional) + texto do depoimento.
+              Aparece na landing entre &ldquo;Quem comprou aqui&rdquo; e o footer.
+            </p>
+          </div>
+          <label className="inline-flex items-center gap-2 cursor-pointer flex-shrink-0">
+            <input type="checkbox" checked={config.site_feedbacks_enabled}
+              onChange={(e) => setConfig({ ...config, site_feedbacks_enabled: e.target.checked })}
+              className="w-4 h-4 accent-[#E8740E]" />
+            <span className="text-[13px] font-medium text-[#1D1D1F]">Mostrar na landing</span>
+          </label>
+        </div>
+
+        {config.site_feedbacks.length === 0 ? (
+          <div className="border-2 border-dashed border-[#D2D2D7] rounded-lg p-6 text-center">
+            <p className="text-[14px] text-[#86868B] mb-3">Nenhum feedback cadastrado.</p>
+            <p className="text-[12px] text-[#AEAEB2] mb-3">
+              💡 Dica: toda vez que fechar uma troca e cliente elogiar, peça permissão e tire print do WhatsApp.
+              Em 2 semanas você tem 5-10 prints autênticos pra colocar aqui.
+            </p>
+            <button onClick={addFeedback}
+              className="px-4 py-2 rounded-lg text-[13px] font-medium text-white" style={{ backgroundColor: "#E8740E" }}>
+              + Adicionar primeiro feedback
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="space-y-3">
+              {config.site_feedbacks.map((fb, idx) => (
+                <div key={idx} className="flex items-start gap-3 p-3 rounded-lg border border-[#E8E8ED] bg-[#FAFAFA]">
+                  <div className="flex flex-col gap-1 pt-1">
+                    <button onClick={() => moveFeedback(idx, "up")} disabled={idx === 0}
+                      className="text-[14px] px-2 py-0.5 rounded hover:bg-[#E8E8ED] disabled:opacity-30">▲</button>
+                    <button onClick={() => moveFeedback(idx, "down")} disabled={idx === config.site_feedbacks.length - 1}
+                      className="text-[14px] px-2 py-0.5 rounded hover:bg-[#E8E8ED] disabled:opacity-30">▼</button>
+                  </div>
+
+                  <div className="w-20 h-20 rounded-lg overflow-hidden flex-shrink-0 bg-[#F5F5F7] border border-[#D2D2D7]">
+                    {fb.foto_url ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={fb.foto_url} alt="Print" className="w-full h-full object-cover" />
+                    ) : (
+                      <div className="w-full h-full flex items-center justify-center text-[10px] text-[#86868B] text-center px-1">sem print</div>
+                    )}
+                  </div>
+
+                  <div className="flex-1 min-w-0 space-y-2">
+                    <input type="text" value={fb.nome}
+                      onChange={(e) => updateFeedback(idx, { nome: e.target.value })}
+                      placeholder="Nome do cliente (opcional, ex: Carlos M.)"
+                      className="w-full px-3 py-1.5 bg-white border border-[#D2D2D7] rounded text-[13px]" />
+                    <textarea value={fb.texto}
+                      onChange={(e) => updateFeedback(idx, { texto: e.target.value })}
+                      placeholder="Depoimento (opcional, ex: 'Trocou meu iPhone 13 por 16 Pro, paguei só R$ 2.300!')"
+                      className="w-full px-3 py-1.5 bg-white border border-[#D2D2D7] rounded text-[13px] min-h-[50px] resize-y" />
+                    <label className="inline-flex items-center px-3 py-1.5 rounded text-[12px] font-medium border border-[#D2D2D7] hover:bg-[#F5F5F7] cursor-pointer"
+                      style={uploadingFeedback === idx ? { opacity: 0.6 } : {}}>
+                      {uploadingFeedback === idx ? "Enviando…" : (fb.foto_url ? "Trocar print/foto" : "Subir print/foto")}
+                      <input type="file" accept="image/jpeg,image/png,image/webp" className="hidden"
+                        disabled={uploadingFeedback === idx}
+                        onChange={(e) => handleFeedbackPhotoChange(idx, e)} />
+                    </label>
+                  </div>
+
+                  <button onClick={() => removeFeedback(idx)}
+                    className="text-[12px] text-red-600 hover:text-red-800 font-medium px-3 py-2 flex-shrink-0">
+                    Remover
+                  </button>
+                </div>
+              ))}
+            </div>
+            <button onClick={addFeedback}
+              className="mt-4 px-4 py-2 rounded-lg text-[13px] font-medium border-2 border-dashed border-[#D2D2D7] text-[#86868B] hover:border-[#E8740E] hover:text-[#E8740E] transition-colors w-full">
+              + Adicionar mais um feedback
             </button>
           </>
         )}


### PR DESCRIPTION
## 🎨 Fase 2 do CMS visual

Continuação da tela \`/admin/configuracoes/site\`. Agora o admin pode editar **todos os textos** da landing + tem estrutura pra **feedbacks de clientes** (prints WhatsApp).

## O que entra

### 📝 Editor de TEXTOS (todos editáveis sem código)

| Local | Antes | Agora |
|---|---|---|
| Header | \"TigrãoImports\" / \"Trade-In Apple\" hardcoded | Editável |
| Headline | \"Troque seu iPhone usado por um **NOVO** pagando só a diferença\" | 3 partes editáveis (palavra do meio em laranja) |
| Subtítulo | \"Descubra em 30 segundos...\" | Editável |
| CTA | \"Descobrir o valor do meu aparelho\" | Editável |
| Trust badges | \"Lacrado / NF / Garantia Apple\" | 3 textos editáveis |
| Social proof | \"+1.730 trocas realizadas\" | Editável |
| Footer | \"+5 anos · +1.730 trocas\" + CNPJ | Editáveis |

**Bonus:** preview ao vivo da headline na própria tela admin.

### 💬 Seção FEEDBACKS DE CLIENTES (preparada pra futuro)

Cada feedback:
- **Foto** (print do WhatsApp OU foto do cliente)
- **Nome** (opcional, ex: \"Carlos M.\")
- **Texto/depoimento** (opcional, ex: \"Trocou meu iPhone 13 por 16 Pro, paguei só R$ 2.300!\")
- Reorder ▲▼ + remover

Toggle on/off da seção inteira. Aparece na landing **entre influencers e footer**.

**Como começar a usar:** desativada por default. Toda vez que você fechar uma troca e cliente elogiar, peça permissão e tire print do WhatsApp. Em 2 semanas você tem 5-10 prints. Aí você sobe na tela admin e ativa o toggle.

## Como ficam as 4 seções da tela admin

```
SITE > CONFIGURAÇÃO DO SITE
├─ 1. LOGO (existente)
├─ 2. TEXTOS DA LANDING (NOVO)
│    ├─ Header (Nome + Tagline)
│    ├─ Headline (3 partes com preview)
│    ├─ Subtítulo
│    ├─ CTA (botão verde)
│    ├─ Social proof
│    ├─ Trust badges (3)
│    └─ Footer (linha + CNPJ)
├─ 3. INFLUENCERS (existente)
└─ 4. FEEDBACKS (NOVO)
     ├─ Toggle on/off
     └─ Lista (foto + nome + texto)
```

Botão \"Salvar e publicar\" no fim salva tudo de uma vez.

## Backend

13 chaves novas no JSONB \`labels\` de \`tradein_config\`. Mesmo padrão das chaves \`_site_*\` da Fase 1. **Sem migration nova.**

## Compatibilidade

**Robusta como sempre:**
- Se banco vazio em qualquer chave → usa fallback hardcoded (textos atuais)
- Se feedbacks desativado → seção some da landing sem deixar buraco
- Se config nunca foi salva → tela mostra defaults sensatos pré-preenchidos
- Tudo continua funcionando se este PR for revertido

## Validado

- ✅ \`tsc --noEmit\`: zero erros
- ✅ \`next build\`: passou
- ✅ Preview ao vivo da headline funciona

## Como testar no preview

1. Mergeia o PR
2. Abre /admin → Site → Configuração do Site
3. Testa cada cenário:
   - **Mudar headline:** edita as 3 partes → vê preview na própria tela atualizando
   - **Mudar CTA:** troca \"Descobrir o valor...\" por outro texto → salva → /troca atualiza
   - **Mudar trust badges:** \"Lacrado\" → \"Original Apple\" → salva → vê na landing
   - **Adicionar feedback:** clica em adicionar → upload de uma foto qualquer → preenche nome/texto → ativa toggle → salva → /troca mostra a seção \"O que dizem nossos clientes\"
   - **Esconder feedbacks:** desativa toggle → some da landing
4. Conferir que landing /troca continua funcionando se você não mexer em nada (compatibilidade)

## ⏭️ Próximas fases

- **Fase 3:** Drag-and-drop visual nas perguntas do simulador (~3 dias)
- **Fase 4:** Color picker da marca + emojis + toggles avançados (~3 dias)

🤖 Generated with [Claude Code](https://claude.com/claude-code)