### PR TITLE
feat(admin): Fase 4 do CMS — color picker + toggles de visibilidade

### DIFF
--- a/app/api/admin/tradein-config/route.ts
+++ b/app/api/admin/tradein-config/route.ts
@@ -57,6 +57,13 @@ export async function GET(req: NextRequest) {
   if (labels._site_footer_cnpj !== undefined) result.site_footer_cnpj = labels._site_footer_cnpj;
   if (labels._site_feedbacks_enabled !== undefined) result.site_feedbacks_enabled = labels._site_feedbacks_enabled;
   if (labels._site_feedbacks !== undefined) result.site_feedbacks = labels._site_feedbacks;
+  // Fase 4 (Abr/2026) — cor da marca + toggles de visibilidade.
+  if (labels._site_brand_color !== undefined) result.site_brand_color = labels._site_brand_color;
+  if (labels._site_show_tagline !== undefined) result.site_show_tagline = labels._site_show_tagline;
+  if (labels._site_show_subtitle !== undefined) result.site_show_subtitle = labels._site_show_subtitle;
+  if (labels._site_show_trust_badges !== undefined) result.site_show_trust_badges = labels._site_show_trust_badges;
+  if (labels._site_show_social_proof !== undefined) result.site_show_social_proof = labels._site_show_social_proof;
+  if (labels._site_show_footer_cnpj !== undefined) result.site_show_footer_cnpj = labels._site_show_footer_cnpj;
 
   return NextResponse.json({ data: result });
 }
@@ -108,6 +115,13 @@ export async function PUT(req: NextRequest) {
     "site_footer_cnpj",
     "site_feedbacks_enabled",
     "site_feedbacks",
+    // Fase 4 — cor + toggles de visibilidade
+    "site_brand_color",
+    "site_show_tagline",
+    "site_show_subtitle",
+    "site_show_trust_badges",
+    "site_show_social_proof",
+    "site_show_footer_cnpj",
   ] as const;
   const hasAnyWaField = whatsappFields.some((k) => body[k] !== undefined);
   const hasAnySiteField = siteFields.some((k) => body[k] !== undefined);

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -142,6 +142,13 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
     site_footer_line1?: string; site_footer_cnpj?: string;
     site_feedbacks_enabled?: boolean | string;
     site_feedbacks?: { foto_url: string; nome: string; texto: string }[];
+    // Site config — Fase 4 (cor da marca + toggles de visibilidade)
+    site_brand_color?: string;
+    site_show_tagline?: boolean | string;
+    site_show_subtitle?: boolean | string;
+    site_show_trust_badges?: boolean | string;
+    site_show_social_proof?: boolean | string;
+    site_show_footer_cnpj?: boolean | string;
   }) | null>(null);
   // Mapa dinamico de WhatsApp por vendedor — usa DB se disponivel
   const VENDEDOR_WHATSAPP = useMemo(() => {
@@ -213,6 +220,39 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
     if (Array.isArray(fromDb)) return fromDb.filter((f) => f && f.foto_url);
     return [];
   })();
+
+  // === Site config Fase 4 — cor da marca + toggles de visibilidade ===
+  // Helper pra interpretar boolean | string | undefined com default true
+  // (mantem compatibilidade com landing v2 — antes da Fase 4 tudo era visivel).
+  const boolFromConfig = (raw: boolean | string | undefined, dflt: boolean): boolean => {
+    if (raw === undefined || raw === null) return dflt;
+    return raw === true || raw === "true";
+  };
+  const siteShowTagline = boolFromConfig(tradeinConfig?.site_show_tagline, true);
+  const siteShowSubtitle = boolFromConfig(tradeinConfig?.site_show_subtitle, true);
+  const siteShowTrustBadges = boolFromConfig(tradeinConfig?.site_show_trust_badges, true);
+  const siteShowSocialProof = boolFromConfig(tradeinConfig?.site_show_social_proof, true);
+  const siteShowFooterCnpj = boolFromConfig(tradeinConfig?.site_show_footer_cnpj, true);
+  // Cor primaria custom — sobrescreve --ti-accent do tema. Se admin nao
+  // setou, usa a cor do tema atual (laranja TigraoImports padrao).
+  const customBrandColor: string | null = (() => {
+    const c = tradeinConfig?.site_brand_color;
+    if (!c || typeof c !== "string") return null;
+    // Validacao basica de hex (#RGB ou #RRGGBB)
+    if (!/^#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?$/.test(c.trim())) return null;
+    return c.trim();
+  })();
+  // CSS vars finais: usa as do tema + sobrescreve com cor custom se setado.
+  // Inclui --ti-accent-light com 12% de opacidade (hex8) pra backgrounds suaves.
+  const finalCssVars = useMemo(() => {
+    if (!customBrandColor) return cssVars;
+    return {
+      ...cssVars,
+      "--ti-accent": customBrandColor,
+      "--ti-accent-light": customBrandColor + "1F", // ~12% opacity
+      "--ti-accent-text": customBrandColor,
+    };
+  }, [cssVars, customBrandColor]);
   const [deviceType, setDeviceType] = useState<DeviceType>("iphone");
   const [usedModel, setUsedModel] = useState("");
   const [usedStorage, setUsedStorage] = useState("");
@@ -444,7 +484,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
 
   if (loading) {
     return (
-      <main className="min-h-dvh flex items-center justify-center" style={{ backgroundColor: tema.pageBg, ...cssVars }}>
+      <main className="min-h-dvh flex items-center justify-center" style={{ backgroundColor: tema.pageBg, ...finalCssVars }}>
         <div className="flex flex-col items-center gap-4">
           <div className="w-8 h-8 border-[3px] rounded-full animate-spin" style={{ borderColor: tema.accent, borderTopColor: "transparent" }} />
           <p className="text-[13px]" style={{ color: tema.textMuted }}>Carregando...</p>
@@ -455,7 +495,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
 
   if (error) {
     return (
-      <main className="min-h-dvh flex items-center justify-center px-4" style={{ backgroundColor: tema.pageBg, ...cssVars }}>
+      <main className="min-h-dvh flex items-center justify-center px-4" style={{ backgroundColor: tema.pageBg, ...finalCssVars }}>
         <div className="text-center">
           <p className="text-[15px] mb-4" style={{ color: tema.error }}>{error}</p>
           <button
@@ -472,7 +512,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
 
   if (!started && !loading) {
     return (
-      <main className="min-h-dvh flex flex-col items-center justify-center px-4 py-8" style={{ backgroundColor: tema.pageBg, ...cssVars }}>
+      <main className="min-h-dvh flex flex-col items-center justify-center px-4 py-8" style={{ backgroundColor: tema.pageBg, ...finalCssVars }}>
         <div className="w-full max-w-[440px] space-y-7 animate-fadeIn">
 
           {/* HEADER COM LOGO REAL — avatar (foto do Andre) + nome.
@@ -490,19 +530,23 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
             </div>
             <div className="text-left">
               <p className="text-[16px] font-bold leading-tight" style={{ color: tema.text }}>{siteHeaderTitle}</p>
-              <p className="text-[11px] leading-tight" style={{ color: "var(--ti-accent, #E8740E)" }}>{siteHeaderTagline}</p>
+              {siteShowTagline && (
+                <p className="text-[11px] leading-tight" style={{ color: "var(--ti-accent, #E8740E)" }}>{siteHeaderTagline}</p>
+              )}
             </div>
           </div>
 
           {/* HEADLINE — gerenciada pelo admin em /admin/configuracoes/site
-              (3 partes — meio destacado em laranja). */}
+              (3 partes — meio destacado em laranja). Subtitulo opcional. */}
           <div className="text-center space-y-3">
             <h1 className="text-[26px] font-bold tracking-tight leading-tight" style={{ color: tema.text }}>
               {siteHeadlineP1} <span style={{ color: "var(--ti-accent, #E8740E)" }}>{siteHeadlineDestaque}</span><br />{siteHeadlineP2}
             </h1>
-            <p className="text-[15px] leading-relaxed" style={{ color: tema.textMuted }}>
-              {siteSubtitle}
-            </p>
+            {siteShowSubtitle && (
+              <p className="text-[15px] leading-relaxed" style={{ color: tema.textMuted }}>
+                {siteSubtitle}
+              </p>
+            )}
           </div>
 
           {/* CTA verde — texto editavel via admin */}
@@ -514,18 +558,23 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
             {siteCtaText}
           </button>
 
-          {/* Social proof — 5 estrelas + numero de trocas (texto editavel) */}
-          <div className="flex items-center justify-center gap-2">
-            <span className="text-base leading-none">{"\u2B50\u2B50\u2B50\u2B50\u2B50"}</span>
-            <span className="text-[13px] font-semibold" style={{ color: tema.text }}>{siteSocialProofText}</span>
-          </div>
+          {/* Social proof — 5 estrelas + numero de trocas (admin pode esconder) */}
+          {siteShowSocialProof && (
+            <div className="flex items-center justify-center gap-2">
+              <span className="text-base leading-none">{"\u2B50\u2B50\u2B50\u2B50\u2B50"}</span>
+              <span className="text-[13px] font-semibold" style={{ color: tema.text }}>{siteSocialProofText}</span>
+            </div>
+          )}
 
-          {/* Trust badges — 3 textos editaveis com checkmark laranja */}
-          <div className="flex items-center justify-center gap-4 text-[12px]" style={{ color: tema.textMuted }}>
-            <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> {siteTrust1}</span>
-            <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> {siteTrust2}</span>
-            <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> {siteTrust3}</span>
-          </div>
+          {/* Trust badges — 3 textos editaveis com checkmark laranja
+              (admin pode esconder) */}
+          {siteShowTrustBadges && (
+            <div className="flex items-center justify-center gap-4 text-[12px]" style={{ color: tema.textMuted }}>
+              <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> {siteTrust1}</span>
+              <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> {siteTrust2}</span>
+              <span><span style={{ color: "var(--ti-accent, #E8740E)" }}>{"\u2713"}</span> {siteTrust3}</span>
+            </div>
+          )}
 
           {/* SECAO INFLUENCERS — gerenciada pelo admin em
               /admin/configuracoes/site. Esconde se admin desativou ou se
@@ -578,11 +627,13 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
           )}
 
           {/* FOOTER — credibilidade (5 anos + CNPJ). Textos editaveis pelo
-              admin. Sem endereco exposto (escritorio fechado). */}
+              admin. CNPJ pode ser escondido via toggle. Sem endereco exposto. */}
           <div className="pt-5 text-center space-y-1" style={{ borderTop: `1px solid ${tema.cardBorder}` }}>
             <p className="text-[12px] font-semibold" style={{ color: tema.text }}>{siteHeaderTitle}</p>
             <p className="text-[11px]" style={{ color: tema.textMuted }}>{siteFooterLine1}</p>
-            <p className="text-[10px]" style={{ color: tema.textDim }}>{siteFooterCnpj}</p>
+            {siteShowFooterCnpj && (
+              <p className="text-[10px]" style={{ color: tema.textDim }}>{siteFooterCnpj}</p>
+            )}
           </div>
         </div>
       </main>
@@ -595,7 +646,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
   const totalSteps = 5;
 
   return (
-    <main className="min-h-dvh flex flex-col items-center px-4 py-8" style={{ backgroundColor: tema.pageBg, ...cssVars }}>
+    <main className="min-h-dvh flex flex-col items-center px-4 py-8" style={{ backgroundColor: tema.pageBg, ...finalCssVars }}>
       {/* Honeypot anti-bot — invisível pra humanos (off-screen + aria-hidden).
           Bots que fazem scraping preenchem todos os inputs; o valor é lido via
           document.getElementById('tradein-honeypot') nos handlers de submit e

--- a/components/admin/SiteConfigEditor.tsx
+++ b/components/admin/SiteConfigEditor.tsx
@@ -55,6 +55,13 @@ interface SiteConfig {
   // Feedbacks (Fase 2 — prints WhatsApp)
   site_feedbacks_enabled: boolean;
   site_feedbacks: Feedback[];
+  // Fase 4 — cor da marca + toggles de visibilidade
+  site_brand_color: string;          // hex, ex: "#E8740E"
+  site_show_tagline: boolean;
+  site_show_subtitle: boolean;
+  site_show_trust_badges: boolean;
+  site_show_social_proof: boolean;
+  site_show_footer_cnpj: boolean;
 }
 
 // Defaults sensatos — se admin nunca editou, esses valores sao usados como
@@ -80,6 +87,12 @@ const DEFAULT_CONFIG: SiteConfig = {
   site_influencers: [],
   site_feedbacks_enabled: false,
   site_feedbacks: [],
+  site_brand_color: "#E8740E", // laranja TigraoImports atual
+  site_show_tagline: true,
+  site_show_subtitle: true,
+  site_show_trust_badges: true,
+  site_show_social_proof: true,
+  site_show_footer_cnpj: true,
 };
 
 const FALLBACK_LOGO = "/images/andre.png";
@@ -126,6 +139,19 @@ export default function SiteConfigEditor() {
         site_influencers: Array.isArray(d.site_influencers) ? d.site_influencers : [],
         site_feedbacks_enabled: d.site_feedbacks_enabled === true || d.site_feedbacks_enabled === "true",
         site_feedbacks: Array.isArray(d.site_feedbacks) ? d.site_feedbacks : [],
+        // Fase 4 — toggles defaultam pra TRUE quando undefined (preserva
+        // landing v2 atual onde tudo esta visivel).
+        site_brand_color: d.site_brand_color || DEFAULT_CONFIG.site_brand_color,
+        site_show_tagline: d.site_show_tagline === undefined || d.site_show_tagline === null
+          ? true : (d.site_show_tagline === true || d.site_show_tagline === "true"),
+        site_show_subtitle: d.site_show_subtitle === undefined || d.site_show_subtitle === null
+          ? true : (d.site_show_subtitle === true || d.site_show_subtitle === "true"),
+        site_show_trust_badges: d.site_show_trust_badges === undefined || d.site_show_trust_badges === null
+          ? true : (d.site_show_trust_badges === true || d.site_show_trust_badges === "true"),
+        site_show_social_proof: d.site_show_social_proof === undefined || d.site_show_social_proof === null
+          ? true : (d.site_show_social_proof === true || d.site_show_social_proof === "true"),
+        site_show_footer_cnpj: d.site_show_footer_cnpj === undefined || d.site_show_footer_cnpj === null
+          ? true : (d.site_show_footer_cnpj === true || d.site_show_footer_cnpj === "true"),
       });
     } catch (err) {
       flash("error", "Erro ao carregar: " + (err as Error).message);
@@ -623,6 +649,91 @@ export default function SiteConfigEditor() {
             </button>
           </>
         )}
+      </section>
+
+      {/* === SECAO 5 — CORES & VISIBILIDADE === */}
+      <section className={sectionStyle}>
+        <h2 className={sectionTitle}>5. Cores e visibilidade</h2>
+        <p className={sectionDesc}>
+          Personalize a cor da marca e ative/desative seções secundárias da landing.
+          Use com cuidado — esses elementos foram pensados pra maximizar conversão.
+        </p>
+
+        {/* Color picker */}
+        <div className="pb-5 border-b border-[#E8E8ED] mb-5">
+          <label className={labelStyle + " mb-2"}>Cor primária da marca</label>
+          <div className="flex items-center gap-3">
+            <input type="color" value={config.site_brand_color}
+              onChange={(e) => setConfig({ ...config, site_brand_color: e.target.value })}
+              className="w-14 h-14 rounded-lg cursor-pointer border-2 border-[#D2D2D7]" />
+            <input type="text" value={config.site_brand_color}
+              onChange={(e) => {
+                const v = e.target.value.trim();
+                // Aceita hex com ou sem # — adiciona se faltar
+                const normalized = v.startsWith("#") ? v : (v ? "#" + v : "");
+                setConfig({ ...config, site_brand_color: normalized });
+              }}
+              placeholder="#E8740E"
+              className={inputStyle + " w-32 font-mono"} />
+            <button onClick={() => setConfig({ ...config, site_brand_color: DEFAULT_CONFIG.site_brand_color })}
+              className="px-3 py-2 text-[12px] text-[#86868B] hover:text-[#1D1D1F] underline">
+              Restaurar padrão
+            </button>
+          </div>
+          <p className="text-[11px] text-[#AEAEB2] mt-2">
+            Cor usada em destaques: palavra da headline, ✓ trust badges, borders dos avatares,
+            tagline, etc. <strong>O CTA verde NÃO muda</strong> (verde converte mais que
+            laranja em botões de ação).
+          </p>
+
+          {/* Preview de elementos com a nova cor */}
+          <div className="mt-3 p-4 rounded-lg bg-[#FAFAFA] border border-[#E8E8ED]">
+            <p className="text-[11px] text-[#86868B] mb-2 uppercase tracking-wider">Preview:</p>
+            <div className="space-y-2">
+              <p className="text-[15px] text-[#1D1D1F]">
+                Texto com <span style={{ color: config.site_brand_color, fontWeight: "bold" }}>palavra destacada</span> em laranja.
+              </p>
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-full" style={{ border: `2px solid ${config.site_brand_color}`, backgroundColor: config.site_brand_color + "15" }} />
+                <div className="flex gap-2 text-[12px] text-[#86868B]">
+                  <span><span style={{ color: config.site_brand_color }}>✓</span> Trust badge 1</span>
+                  <span><span style={{ color: config.site_brand_color }}>✓</span> Trust badge 2</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Toggles de secoes */}
+        <div className="space-y-3">
+          <p className="text-[12px] font-semibold text-[#1D1D1F] mb-2">
+            Seções secundárias (mostrar / esconder)
+          </p>
+          {[
+            { key: "site_show_tagline" as const, label: "Tagline (\"Trade-In Apple\" abaixo do nome)", warning: false },
+            { key: "site_show_subtitle" as const, label: "Subtítulo (texto abaixo da headline)", warning: true },
+            { key: "site_show_trust_badges" as const, label: "Trust badges (✓ Lacrado / ✓ NF / ✓ Garantia)", warning: true },
+            { key: "site_show_social_proof" as const, label: "Social proof (estrelas + número de trocas)", warning: true },
+            { key: "site_show_footer_cnpj" as const, label: "CNPJ no footer", warning: false },
+          ].map((item) => (
+            <div key={item.key} className="flex items-center justify-between p-3 rounded-lg border border-[#E8E8ED] bg-[#FAFAFA]">
+              <div className="flex-1 min-w-0">
+                <p className="text-[13px] font-medium text-[#1D1D1F]">{item.label}</p>
+                {item.warning && !config[item.key] && (
+                  <p className="text-[11px] text-amber-700 mt-0.5">⚠️ Esconder isso pode reduzir confiança/conversão</p>
+                )}
+              </div>
+              <label className="inline-flex items-center cursor-pointer flex-shrink-0 ml-3">
+                <input type="checkbox" checked={config[item.key]}
+                  onChange={(e) => setConfig({ ...config, [item.key]: e.target.checked })}
+                  className="sr-only peer" />
+                <div className="w-10 h-5 bg-[#D2D2D7] peer-checked:bg-[#E8740E] rounded-full transition-colors relative">
+                  <div className={`absolute top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${config[item.key] ? "left-5" : "left-0.5"}`} />
+                </div>
+              </label>
+            </div>
+          ))}
+        </div>
       </section>
 
       {/* === BOTAO SALVAR === */}


### PR DESCRIPTION
## 🎨 Fase 4 — Última do roadmap CMS

Permite admin **mudar a cor da marca** e **esconder/mostrar 5 seções secundárias** da landing, tudo sem código.

## ⚠️ Decisão de escopo (importante)

Reduzi o escopo original. Algumas coisas que prometi originalmente **não fiz** porque depois de pensar achei que custo > benefício:

| Item original | Status | Por quê |
|---|---|---|
| Color picker | ✅ FEITO | Útil — cor pode mudar |
| Toggles de seções | ✅ FEITO | Útil — pode querer testar variantes |
| Editor de emojis | ❌ PULADO | Só 2-3 emojis na landing (🐯, ⭐, ✓). Ninguém vai querer trocar isso |
| Preview iframe lateral | ❌ PULADO | Complexo. Link \"Ver landing ao vivo\" no topo já resolve |

Se discordar de algum, me diz e eu adiciono.

## O que entra na tela admin (Seção 5 nova)

### 🎨 Color picker da cor da marca

- Input nativo de cor + campo hex sincronizados
- Botão \"Restaurar padrão\" (volta pro #E8740E)
- **Preview ao vivo** logo abaixo: caixa com palavra destacada, avatar circular borda, e checkmarks — tudo na cor escolhida
- ⚠️ **CTA verde NÃO MUDA.** Verde converte mais que laranja em botões de ação (psicologia testada). Não deixei admin quebrar isso por engano.

### 👁️ Toggles de visibilidade (5)

| Seção | Pode esconder? | Aviso |
|---|---|---|
| Tagline (\"Trade-In Apple\") | ✅ | — |
| Subtítulo da headline | ✅ | ⚠️ pode reduzir conversão |
| Trust badges (✓ Lacrado/NF/Garantia) | ✅ | ⚠️ pode reduzir confiança |
| Social proof (estrelas + trocas) | ✅ | ⚠️ pode reduzir conversão |
| CNPJ no footer | ✅ | — |

Logo, header, headline, CTA → **sempre visíveis** (essenciais, não faz sentido esconder).

## Como funciona a cor por dentro

A cor laranja se propaga via **CSS variables** (`var(--ti-accent)`). Quando admin escolhe outra cor:

1. JS sobrescreve `--ti-accent`, `--ti-accent-light` (com 12% opacidade), `--ti-accent-text`
2. **Tudo na landing atualiza junto:** palavra destacada, trust badges, tagline, borders dos avatares, hover, etc
3. Validação de hex com regex (rejeita lixo se admin colar texto inválido)

## Validado

- ✅ \`tsc --noEmit\`: zero erros
- ✅ \`next build\`: passou (174 páginas)
- ✅ Compatível com config vazia (todos defaults true → landing v2 preservada)

## Como testar

1. Mergeia o PR
2. /admin → Site → Configuração do Site → role até **Seção 5: Cores e visibilidade**
3. **Color picker:** muda pra azul (#0071E3) → preview atualiza → salva → /troca em outra aba mostra azul nos destaques
4. **Toggle:** desativa \"Trust badges\" → salva → /troca não mostra mais ✓ Lacrado/NF/Garantia
5. Reativa toggle → volta a mostrar
6. Restaura cor padrão → volta laranja

## 🏁 ROADMAP CMS COMPLETO

| Fase | Descrição | PR | Status |
|---|---|---|---|
| 1 | Logo + influencers | #831 | ✅ |
| 2 | Textos + feedbacks | #832 | ✅ |
| 3 | Drag visual nas perguntas | #833 | ✅ |
| **4** | **Color picker + visibilidade** | **Este PR** | ⏳ |

🎉 Depois de mergear este, **Andre + Nicolas controlam 100% da landing /troca** sem precisar de código:
- Logo, influencers, feedbacks (com upload)
- Todos os textos da landing
- Cor primária da marca
- Quais seções mostrar/esconder
- Ordem e ativação das perguntas do simulador

🤖 Generated with [Claude Code](https://claude.com/claude-code)