### PR TITLE
chore(diag): endpoint /api/admin/test-infosimples para debugar IMEI

### DIFF
--- a/app/api/admin/test-infosimples/route.ts
+++ b/app/api/admin/test-infosimples/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from "next/server";
+import { consultarImei } from "@/lib/infosimples";
+
+export const runtime = "nodejs";
+
+/**
+ * Endpoint de diagnostico pra Infosimples (Anatel/Celular Legal).
+ *
+ * Uso: GET /api/admin/test-infosimples?password=XXX&imei=YYY
+ *
+ * Retorna JSON verbose com:
+ * - se o token esta configurado e tamanho
+ * - resposta crua da Infosimples (status HTTP, body)
+ * - resultado final do helper consultarImei
+ *
+ * Util pra debugar quando IMEI volta como ⚠️ Consultar manual em producao.
+ *
+ * IMPORTANTE: nao loga o token completo, so primeiros 8 chars + tamanho.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const password = url.searchParams.get("password");
+  const imei = url.searchParams.get("imei") || "";
+
+  if (password !== process.env.ADMIN_PASSWORD) {
+    return NextResponse.json({ error: "Unauthorized — passe ?password=XXX na URL" }, { status: 401 });
+  }
+
+  const token = process.env.INFOSIMPLES_TOKEN;
+  const tokenInfo = {
+    configurado: !!token,
+    tamanho: token?.length || 0,
+    preview: token ? `${token.slice(0, 8)}...${token.slice(-4)}` : null,
+  };
+
+  // Se nao tem IMEI no query, so retorna info do token
+  if (!imei) {
+    return NextResponse.json({
+      step: "token_check",
+      token: tokenInfo,
+      hint: "Passe ?imei=357999607365980 pra fazer consulta de teste",
+    });
+  }
+
+  // Faz a consulta usando o helper oficial
+  const consultaResult = await consultarImei(imei);
+
+  // Faz tambem uma chamada DIRETA crua pra ver o que a Infosimples retorna,
+  // se token estiver configurado. Util quando o helper retorna ERRO sem
+  // detalhes claros.
+  let rawCall: {
+    url?: string;
+    status?: number;
+    statusText?: string;
+    body?: unknown;
+    error?: string;
+  } | null = null;
+
+  if (token) {
+    try {
+      const apiUrl = new URL("https://api.infosimples.com/api/v2/consultas/anatel/celular-legal");
+      apiUrl.searchParams.set("token", token);
+      apiUrl.searchParams.set("timeout", "600");
+      apiUrl.searchParams.set("ignore_site_receipt", "0");
+      apiUrl.searchParams.set("imei", imei.replace(/\D/g, ""));
+
+      // URL "publica" (sem expor o token completo nos logs)
+      const safeUrl = apiUrl.toString().replace(token, `${token.slice(0, 8)}...REDACTED`);
+
+      const res = await fetch(apiUrl.toString(), {
+        method: "POST",
+      });
+
+      const bodyText = await res.text();
+      let bodyParsed: unknown = bodyText;
+      try {
+        bodyParsed = JSON.parse(bodyText);
+      } catch {
+        // mantem como texto se nao for JSON
+      }
+
+      rawCall = {
+        url: safeUrl,
+        status: res.status,
+        statusText: res.statusText,
+        body: bodyParsed,
+      };
+    } catch (e) {
+      rawCall = {
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  }
+
+  return NextResponse.json({
+    step: "consulta_completa",
+    token: tokenInfo,
+    helper: consultaResult,
+    rawApiCall: rawCall,
+    hint: rawCall?.status === 200
+      ? "Resposta veio. Veja rawApiCall.body pra ver o resultado oficial da Anatel."
+      : "Veja rawApiCall pra entender o que voltou da Infosimples.",
+  });
+}


### PR DESCRIPTION
## Problema

Bug em produção: cliente envia print do iPhone, OCR extrai IMEI válido, mas WhatsApp mostra `⚠️ Consultar manual` em vez de `✅ Verificado`.

Exemplo (testado pelo André em 25/04/2026 13:55):
- IMEI extraído pelo OCR: `357999607365980` (15 dígitos, formato válido)
- Resultado: `⚠️ Consultar manual` (status `ERRO`)
- Esperado: `✅ Verificado` (status `OK`)

## Causa provável

`lib/infosimples.ts` tem 4 caminhos que retornam `ERRO`:
1. IMEI inválido (descartado — 15 dígitos confirmados)
2. **Token não configurado no env** ← mais provável
3. HTTP não-200 da Infosimples
4. Code >= 400 ou exception/timeout

Sem ver os logs do Vercel não dá pra saber qual disparou.

## Solução

Endpoint `/api/admin/test-infosimples` que retorna JSON verbose:

```bash
# Só checa se token tá configurado
GET /api/admin/test-infosimples?password=XXX

# Faz consulta real e mostra body completo da Infosimples
GET /api/admin/test-infosimples?password=XXX&imei=357999607365980
```

Resposta inclui:
- `token.configurado` — true/false
- `token.tamanho` — chars (deveria ser ~40 pra Infosimples)
- `token.preview` — primeiros 8 + últimos 4 chars (validar sem expor)
- `helper.status` — resultado do `consultarImei()` (OK/BLOQUEADO/ERRO)
- `helper.detalhes` — mensagem do helper
- `rawApiCall.status` — HTTP status da Infosimples
- `rawApiCall.body` — JSON cru da Anatel

## Test plan

- [ ] Após preview do Vercel, abrir no browser:
  `https://<preview>.vercel.app/api/admin/test-infosimples?password=<ADMIN_PASSWORD>`
- [ ] Confirmar `token.configurado` = true (se false → precisa adicionar env var no Vercel)
- [ ] Testar com IMEI real:
  `?password=XXX&imei=357999607365980`
- [ ] Ler `rawApiCall.body` pra ver o que a Anatel retornou
- [ ] Aplicar correção baseada no que aparecer (env var, parser, endpoint, etc)

## Segurança

- Auth via `ADMIN_PASSWORD` no query string (mesmo padrão de `/api/admin/debug-watch`)
- Token nunca aparece completo no response (só preview de 8+4 chars)
- Endpoint só roda lookup, não modifica banco

🤖 Generated with [Claude Code](https://claude.com/claude-code)