### PR TITLE
fix(infosimples): timeout 8s → 45s — corrige IMEI volta como ⚠️ Consultar manual

### DIFF
--- a/app/api/admin/test-infosimples/route.ts
+++ b/app/api/admin/test-infosimples/route.ts
@@ -2,6 +2,9 @@ import { NextResponse } from "next/server";
 import { consultarImei } from "@/lib/infosimples";
 
 export const runtime = "nodejs";
+// Infosimples pode demorar 30-45s em consultas cold. Vercel hobby permite 10s,
+// pro 60s. Forcamos maxDuration=60 pra ter margem na chamada raw + helper.
+export const maxDuration = 60;
 
 /**
  * Endpoint de diagnostico pra Infosimples (Anatel/Celular Legal).
@@ -54,22 +57,32 @@ export async function GET(request: Request) {
     statusText?: string;
     body?: unknown;
     error?: string;
+    durationMs?: number;
   } | null = null;
 
   if (token) {
+    const startMs = Date.now();
     try {
       const apiUrl = new URL("https://api.infosimples.com/api/v2/consultas/anatel/celular-legal");
       apiUrl.searchParams.set("token", token);
-      apiUrl.searchParams.set("timeout", "600");
+      // timeout=30 → Infosimples espera no maximo 30s (em vez de 600s) — evita
+      // travar a funcao Vercel ate o limite de maxDuration
+      apiUrl.searchParams.set("timeout", "30");
       apiUrl.searchParams.set("ignore_site_receipt", "0");
       apiUrl.searchParams.set("imei", imei.replace(/\D/g, ""));
 
       // URL "publica" (sem expor o token completo nos logs)
       const safeUrl = apiUrl.toString().replace(token, `${token.slice(0, 8)}...REDACTED`);
 
+      // Timeout local de 50s — fica abaixo do maxDuration=60 da rota
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 50000);
+
       const res = await fetch(apiUrl.toString(), {
         method: "POST",
+        signal: controller.signal,
       });
+      clearTimeout(timeoutId);
 
       const bodyText = await res.text();
       let bodyParsed: unknown = bodyText;
@@ -84,10 +97,13 @@ export async function GET(request: Request) {
         status: res.status,
         statusText: res.statusText,
         body: bodyParsed,
+        durationMs: Date.now() - startMs,
       };
     } catch (e) {
+      const isAbort = e instanceof Error && e.name === "AbortError";
       rawCall = {
-        error: e instanceof Error ? e.message : String(e),
+        error: isAbort ? `Timeout apos ${Date.now() - startMs}ms (limite 50s)` : e instanceof Error ? e.message : String(e),
+        durationMs: Date.now() - startMs,
       };
     }
   }

--- a/lib/infosimples.ts
+++ b/lib/infosimples.ts
@@ -26,9 +26,12 @@ export interface ImeiConsultaResult {
 // Padrao de URL: https://api.infosimples.com/api/v2/consultas/anatel/celular-legal
 const INFOSIMPLES_ENDPOINT = "https://api.infosimples.com/api/v2/consultas/anatel/celular-legal";
 
-// Timeout pra evitar travar o upload-print indefinidamente (Infosimples lenta).
-// 8s e bem mais que a latencia tipica (1-3s) mas evita travar o usuario.
-const TIMEOUT_MS = 8000;
+// Timeout pra evitar travar o upload-print indefinidamente.
+// Infosimples pode demorar 10-30s em consultas cold (primeira chamada do dia
+// ou quando o sistema da Anatel ta lento). Aumentado de 8s pra 45s depois de
+// observar timeouts em producao retornando "⚠️ Consultar manual" pra IMEIs
+// validos. O upload-print tem maxDuration=60s, sobra margem.
+const TIMEOUT_MS = 45000;
 
 /**
  * Consulta um IMEI na API Infosimples (Anatel/Celular Legal).
@@ -159,7 +162,7 @@ export async function consultarImei(imei: string): Promise<ImeiConsultaResult> {
     console.error(`[infosimples] Falha: ${msg}`);
     return {
       status: "ERRO",
-      detalhes: isAbort ? "Infosimples nao respondeu em 8s" : `Falha de rede: ${msg.slice(0, 150)}`,
+      detalhes: isAbort ? `Infosimples nao respondeu em ${TIMEOUT_MS / 1000}s` : `Falha de rede: ${msg.slice(0, 150)}`,
       imei: imeiNorm,
       consultadoEm,
     };


### PR DESCRIPTION
## Causa raiz identificada

Diagnóstico via `/api/admin/test-infosimples?password=XXX` confirmou:
- ✅ Token configurado (40 chars, preview `f0LcKk88...6CQl`)
- ❌ Chamada com IMEI dava timeout no Vercel

**Por quê:**
- `lib/infosimples.ts` tinha `TIMEOUT_MS = 8000` (8s)
- Infosimples (Anatel/Celular Legal) leva **10-30s** em consultas cold
- AbortController matava o fetch antes da resposta chegar
- Cair no catch → retorna `status: "ERRO"` → WhatsApp mostra `⚠️ Consultar manual`

## Mudanças

### `lib/infosimples.ts`
- `TIMEOUT_MS`: 8000 → **45000** (45s)
- `upload-print/route.ts` já tem `maxDuration = 60`, sobra margem
- Mensagem de timeout agora mostra valor dinâmico (não hardcoded "8s")

### `app/api/admin/test-infosimples/route.ts`
Endpoint de diagnóstico travava por 2 motivos:
1. **Sem `maxDuration`**: Vercel matava em 10s → "página não abre"
2. **Sem AbortController na chamada raw**: ficava pendurado até timeout do Vercel

Fixes:
- `export const maxDuration = 60`
- AbortController de 50s na chamada raw
- `timeout=30` no query da Infosimples (em vez de 600 — era exagero, deixava lá pendurado)
- `durationMs` no response pra medir quanto demora

## Test plan

Após merge:

- [ ] Aguardar deploy Vercel (~2 min)
- [ ] Abrir no browser:
  ```
  https://tigrao-tradein.vercel.app/api/admin/test-infosimples?password=13A%2A123456avast&imei=357999607365980
  ```
- [ ] Verificar `rawApiCall.body` — deve ter `code: 200` e `data[0].resultado`
- [ ] Verificar `helper.status` — deve ser `OK` (em vez de `ERRO`)
- [ ] Voltar em /compra e refazer o teste com print de iPhone
- [ ] WhatsApp final deve mostrar `*IMEI:* XXX ✅ Verificado`

🤖 Generated with [Claude Code](https://claude.com/claude-code)