### PR TITLE
feat(whatsapp): IMEI verificado com texto descritivo "(livre de bloqueios)"

### DIFF
--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -978,10 +978,10 @@ function CompraForm() {
         if (trocaSerial1.trim()) lines.push(`*Nº de Série:* ${trocaSerial1.trim()}`);
         if (trocaImei1.trim()) {
           // Status Anatel/Infosimples vai grudado no IMEI pra equipe ver de
-          // cara. ✅ = pode comprar, ❌ = NAO comprar (consultar manual antes),
+          // cara. ✅ = pode comprar (livre), ❌ = NAO comprar (consultar manual),
           // ⚠️ = consulta falhou (consultar manual no site da Anatel).
           const statusIcon =
-            trocaImeiStatus1 === "OK" ? " ✅ Verificado" :
+            trocaImeiStatus1 === "OK" ? " ✅ Verificado (livre de bloqueios)" :
             trocaImeiStatus1 === "BLOQUEADO" ? " ❌ BLOQUEADO — NAO COMPRAR" :
             trocaImeiStatus1 === "ERRO" ? " ⚠️ Consultar manual" :
             "";
@@ -1001,7 +1001,7 @@ function CompraForm() {
         if (trocaSerial2.trim()) lines.push(`*Nº de Série:* ${trocaSerial2.trim()}`);
         if (trocaImei2.trim()) {
           const statusIcon2 =
-            trocaImeiStatus2 === "OK" ? " ✅ Verificado" :
+            trocaImeiStatus2 === "OK" ? " ✅ Verificado (livre de bloqueios)" :
             trocaImeiStatus2 === "BLOQUEADO" ? " ❌ BLOQUEADO — NAO COMPRAR" :
             trocaImeiStatus2 === "ERRO" ? " ⚠️ Consultar manual" :
             "";


### PR DESCRIPTION
## Mudança

Texto do WhatsApp que vai pro vendedor agora inclui descrição do status:

**Antes:**
```
*IMEI:* 357999607365980 ✅ Verificado
```

**Depois:**
```
*IMEI:* 357999607365980 ✅ Verificado (livre de bloqueios)
```

## Por quê

O texto descritivo deixa claro pra equipe que a Anatel/Infosimples confirmou que o IMEI **não tem registro de roubo, furto ou perda**, em vez de só um ícone que pode ficar ambíguo (especialmente se o emoji ✅ não renderizar em alguma fonte/device).

Aplicado nos 2 slots da troca (aparelho 1 e aparelho 2).

## Sobre o emoji ✅ aparecer como ❓

O André reportou que no WhatsApp Business do iPhone dele aparece `❓` no lugar de `✅`. Isso é problema de **fonte do emoji no device** (não do código — o caractere é U+2705 correto). Se persistir após esse PR, podemos trocar pra texto puro `[OK]` em PR separado, mas o pedido foi manter o emoji por enquanto.

## Test plan

- [ ] Após merge + deploy
- [ ] Refazer teste em /compra com print de IMEI válido
- [ ] WhatsApp final deve mostrar `*IMEI:* XXX ✅ Verificado (livre de bloqueios)`
- [ ] Se IMEI for de aparelho com restrição, continua mostrando `❌ BLOQUEADO — NAO COMPRAR`
- [ ] Se Infosimples falhar, continua mostrando `⚠️ Consultar manual`

🤖 Generated with [Claude Code](https://claude.com/claude-code)