### PR TITLE
feat(analytics): drop-off por canal/dispositivo + sessoes individuais (#20)

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -22,6 +22,28 @@ interface DailyData {
   sessions: number;
 }
 
+interface DimRow {
+  key: string;
+  sessions: number;
+  started: number;
+  whatsapp: number;
+  submit: number;
+  conversion: number;
+}
+
+interface SessionDetail {
+  sessionId: string;
+  startedAt: string;
+  lastEventAt: string;
+  lastStep: number | null;
+  lastQuestion: string | null;
+  utmSource: string | null;
+  deviceType: string | null;
+  completedWhatsapp: boolean;
+  completedSubmit: boolean;
+  eventCount: number;
+}
+
 interface AnalyticsData {
   visits: number;
   startedCount: number;
@@ -36,7 +58,18 @@ interface AnalyticsData {
   daily: DailyData[];
   conversionRate: string;
   conversionRateFinal?: string;
+  byUtmSource?: DimRow[];
+  byDeviceType?: DimRow[];
+  sessionsList?: SessionDetail[];
+  filters?: { utm_source: string | null; device_type: string | null };
 }
+
+const DEVICE_LABELS: Record<string, string> = {
+  iphone: "iPhone",
+  ipad: "iPad",
+  macbook: "MacBook",
+  watch: "Apple Watch",
+};
 
 const STEP_LABELS: Record<number, string> = {
   1: "Seu Aparelho",
@@ -65,11 +98,18 @@ export default function AnalyticsPage() {
   const [data, setData] = useState<AnalyticsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [range, setRange] = useState<"7d" | "30d" | "all">("7d");
+  // Filtros adicionados pra item #20: drilldown por canal e dispositivo.
+  // Quando ativos, todos numeros da tela viram da subset filtrado.
+  const [filterUtm, setFilterUtm] = useState<string>("");
+  const [filterDevice, setFilterDevice] = useState<string>("");
 
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await fetch(`/api/funnel?range=${range}`, {
+      const params = new URLSearchParams({ range });
+      if (filterUtm) params.set("utm_source", filterUtm);
+      if (filterDevice) params.set("device_type", filterDevice);
+      const res = await fetch(`/api/funnel?${params.toString()}`, {
         headers: { "x-admin-password": password, "x-admin-user": encodeURIComponent(user?.nome || "sistema") },
       });
       if (res.ok) {
@@ -80,11 +120,11 @@ export default function AnalyticsPage() {
       /* ignore */
     }
     setLoading(false);
-  }, [password, range]);
+  }, [password, range, filterUtm, filterDevice, user?.nome]);
 
   useEffect(() => {
     if (password) fetchData();
-  }, [password, range, fetchData]);
+  }, [password, range, filterUtm, filterDevice, fetchData]);
 
   if (loading) {
     return (
@@ -136,6 +176,49 @@ export default function AnalyticsPage() {
           </button>
         </div>
       </div>
+
+      {/* Filtros — item #20 (drop-off por canal/dispositivo).
+          Quando algum filtro tá ativo, todos numeros da pagina ficam restritos
+          ao subset (ex: so sessoes que vieram de Meta Ads + escolheram iPhone). */}
+      {data && (data.byUtmSource || data.byDeviceType) && (
+        <div className="bg-white border border-[#D2D2D7] rounded-2xl p-3 sm:p-4 shadow-sm flex flex-wrap items-center gap-3">
+          <span className="text-xs font-medium text-[#86868B] uppercase tracking-wide">Filtrar por:</span>
+          <select
+            value={filterUtm}
+            onChange={(e) => setFilterUtm(e.target.value)}
+            className="px-3 py-1.5 rounded-lg text-xs border border-[#D2D2D7] bg-white text-[#1D1D1F] focus:border-[#E8740E] focus:outline-none"
+          >
+            <option value="">Todos os canais</option>
+            {(data.byUtmSource || []).map((u) => (
+              <option key={u.key} value={u.key === "(direto/sem origem)" ? "" : u.key}>
+                {u.key} ({u.sessions})
+              </option>
+            ))}
+          </select>
+          <select
+            value={filterDevice}
+            onChange={(e) => setFilterDevice(e.target.value)}
+            className="px-3 py-1.5 rounded-lg text-xs border border-[#D2D2D7] bg-white text-[#1D1D1F] focus:border-[#E8740E] focus:outline-none"
+          >
+            <option value="">Todos os dispositivos</option>
+            {(data.byDeviceType || [])
+              .filter((d) => d.key !== "(direto/sem origem)")
+              .map((d) => (
+                <option key={d.key} value={d.key}>
+                  {DEVICE_LABELS[d.key] || d.key} ({d.sessions})
+                </option>
+              ))}
+          </select>
+          {(filterUtm || filterDevice) && (
+            <button
+              onClick={() => { setFilterUtm(""); setFilterDevice(""); }}
+              className="text-xs px-2 py-1 rounded text-[#E74C3C] hover:bg-[#FFF5F5] transition-colors"
+            >
+              ✕ Limpar
+            </button>
+          )}
+        </div>
+      )}
 
       {/* KPI Cards — top of funnel */}
       <div className="grid grid-cols-2 sm:grid-cols-5 gap-3">
@@ -355,6 +438,51 @@ export default function AnalyticsPage() {
         );
       })()}
 
+      {/* === NOVO (#20): Drop-off por CANAL DE AQUISICAO (UTM source) === */}
+      {data.byUtmSource && data.byUtmSource.length > 0 && (
+        <div className="bg-white border border-[#D2D2D7] rounded-2xl p-4 sm:p-6 shadow-sm">
+          <h2 className="text-base font-semibold text-[#1D1D1F] mb-1">
+            Por canal de aquisicao
+          </h2>
+          <p className="text-xs text-[#86868B] mb-4">
+            Conversao de cada origem (Meta Ads, Instagram, direto, etc) — clique no filtro acima pra ver o funil completo desse canal
+          </p>
+          <DimTable rows={data.byUtmSource} labelHeader="Canal" />
+        </div>
+      )}
+
+      {/* === NOVO (#20): Drop-off por TIPO DE DISPOSITIVO === */}
+      {data.byDeviceType && data.byDeviceType.length > 0 && (
+        <div className="bg-white border border-[#D2D2D7] rounded-2xl p-4 sm:p-6 shadow-sm">
+          <h2 className="text-base font-semibold text-[#1D1D1F] mb-1">
+            Por tipo de dispositivo
+          </h2>
+          <p className="text-xs text-[#86868B] mb-4">
+            Conversao por categoria — Apple Watch costuma ter taxa diferente de iPhone, indica onde refinar UX
+          </p>
+          <DimTable
+            rows={data.byDeviceType.map((r) => ({
+              ...r,
+              key: DEVICE_LABELS[r.key] || r.key,
+            }))}
+            labelHeader="Dispositivo"
+          />
+        </div>
+      )}
+
+      {/* === NOVO (#20): SESSOES INDIVIDUAIS (ultimas 50) — debug fino === */}
+      {data.sessionsList && data.sessionsList.length > 0 && (
+        <div className="bg-white border border-[#D2D2D7] rounded-2xl p-4 sm:p-6 shadow-sm">
+          <h2 className="text-base font-semibold text-[#1D1D1F] mb-1">
+            Ultimas {data.sessionsList.length} sessoes
+          </h2>
+          <p className="text-xs text-[#86868B] mb-4">
+            Cada linha e uma pessoa que entrou. Mostra ate qual etapa avancou e em qual pergunta parou — util pra investigar abandono
+          </p>
+          <SessionsTable rows={data.sessionsList} />
+        </div>
+      )}
+
       {/* Top SKUs (vendas/simulacoes/encomendas por SKU canonico) */}
       <TopSkusSection password={password} range={range} />
 
@@ -393,6 +521,146 @@ export default function AnalyticsPage() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+// Tabela compacta usada pra "Por canal" e "Por dispositivo".
+// Mostra cada dimensao com KPIs lado a lado e barra visual da conversao final.
+function DimTable({ rows, labelHeader }: { rows: DimRow[]; labelHeader: string }) {
+  if (rows.length === 0) return <p className="text-xs text-[#86868B]">Sem dados ainda.</p>;
+  const maxSessions = Math.max(...rows.map((r) => r.sessions), 1);
+  return (
+    <div className="overflow-x-auto -mx-4 sm:mx-0">
+      <table className="w-full text-xs sm:text-sm">
+        <thead>
+          <tr className="text-left text-[#86868B] border-b border-[#D2D2D7]">
+            <th className="px-2 sm:px-3 py-2 font-medium">{labelHeader}</th>
+            <th className="px-2 sm:px-3 py-2 font-medium text-right">Sessoes</th>
+            <th className="px-2 sm:px-3 py-2 font-medium text-right hidden sm:table-cell">Iniciaram</th>
+            <th className="px-2 sm:px-3 py-2 font-medium text-right">WhatsApp</th>
+            <th className="px-2 sm:px-3 py-2 font-medium text-right hidden sm:table-cell">Submeteu</th>
+            <th className="px-2 sm:px-3 py-2 font-medium text-right">Conv.</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => {
+            const widthPct = (r.sessions / maxSessions) * 100;
+            return (
+              <tr key={r.key} className="border-b border-[#F5F5F7] hover:bg-[#FFF5EB]/30">
+                <td className="px-2 sm:px-3 py-2.5 font-medium text-[#1D1D1F]">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate max-w-[140px]">{r.key}</span>
+                  </div>
+                  <div className="h-1 bg-[#F5F5F7] rounded mt-1 overflow-hidden">
+                    <div
+                      className="h-full bg-[#E8740E]/60 rounded"
+                      style={{ width: `${Math.max(widthPct, 2)}%` }}
+                    />
+                  </div>
+                </td>
+                <td className="px-2 sm:px-3 py-2.5 text-right text-[#1D1D1F]">{r.sessions}</td>
+                <td className="px-2 sm:px-3 py-2.5 text-right text-[#6E6E73] hidden sm:table-cell">{r.started}</td>
+                <td className="px-2 sm:px-3 py-2.5 text-right text-[#2ECC71] font-medium">{r.whatsapp}</td>
+                <td className="px-2 sm:px-3 py-2.5 text-right text-[#E8740E] font-medium hidden sm:table-cell">{r.submit}</td>
+                <td className="px-2 sm:px-3 py-2.5 text-right">
+                  <span
+                    className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-bold ${
+                      r.conversion >= 5
+                        ? "bg-[#F0FFF4] text-[#27AE60]"
+                        : r.conversion >= 2
+                        ? "bg-[#FFF5EB] text-[#E8740E]"
+                        : "bg-[#FFF5F5] text-[#E74C3C]"
+                    }`}
+                  >
+                    {r.conversion}%
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// Tabela das ultimas 50 sessoes — pra debugar onde cliente especifico abandonou.
+// Mostra: quando entrou, ultima etapa vista, ultima pergunta respondida, canal,
+// dispositivo, status final (completo/abandonou).
+function SessionsTable({ rows }: { rows: SessionDetail[] }) {
+  function fmtDate(iso: string): string {
+    try {
+      const d = new Date(iso);
+      const dia = String(d.getDate()).padStart(2, "0");
+      const mes = String(d.getMonth() + 1).padStart(2, "0");
+      const hora = String(d.getHours()).padStart(2, "0");
+      const min = String(d.getMinutes()).padStart(2, "0");
+      return `${dia}/${mes} ${hora}:${min}`;
+    } catch {
+      return iso.slice(0, 16);
+    }
+  }
+  function fmtDuration(start: string, end: string): string {
+    try {
+      const ms = new Date(end).getTime() - new Date(start).getTime();
+      if (ms < 1000) return "<1s";
+      const s = Math.floor(ms / 1000);
+      if (s < 60) return `${s}s`;
+      const m = Math.floor(s / 60);
+      if (m < 60) return `${m}min`;
+      return `${Math.floor(m / 60)}h${m % 60}min`;
+    } catch {
+      return "—";
+    }
+  }
+  function statusBadge(s: SessionDetail): { text: string; cls: string } {
+    if (s.completedSubmit) return { text: "✓ Submeteu", cls: "bg-[#F0FFF4] text-[#27AE60]" };
+    if (s.completedWhatsapp) return { text: "→ WhatsApp", cls: "bg-[#FFF5EB] text-[#E8740E]" };
+    if (s.lastStep != null) return { text: `Parou Etapa ${s.lastStep}`, cls: "bg-[#FFF5F5] text-[#E74C3C]" };
+    return { text: "So visitou", cls: "bg-[#F5F5F7] text-[#86868B]" };
+  }
+  return (
+    <div className="overflow-x-auto -mx-4 sm:mx-0">
+      <table className="w-full text-xs">
+        <thead>
+          <tr className="text-left text-[#86868B] border-b border-[#D2D2D7]">
+            <th className="px-2 sm:px-3 py-2 font-medium">Quando</th>
+            <th className="px-2 sm:px-3 py-2 font-medium hidden sm:table-cell">Duracao</th>
+            <th className="px-2 sm:px-3 py-2 font-medium">Status</th>
+            <th className="px-2 sm:px-3 py-2 font-medium hidden md:table-cell">Ultima pergunta</th>
+            <th className="px-2 sm:px-3 py-2 font-medium">Canal</th>
+            <th className="px-2 sm:px-3 py-2 font-medium hidden sm:table-cell">Dispositivo</th>
+            <th className="px-2 sm:px-3 py-2 font-medium text-right hidden md:table-cell">Eventos</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((s) => {
+            const badge = statusBadge(s);
+            return (
+              <tr key={s.sessionId} className="border-b border-[#F5F5F7] hover:bg-[#FFF5EB]/30">
+                <td className="px-2 sm:px-3 py-2 text-[#1D1D1F] whitespace-nowrap">{fmtDate(s.startedAt)}</td>
+                <td className="px-2 sm:px-3 py-2 text-[#6E6E73] hidden sm:table-cell">{fmtDuration(s.startedAt, s.lastEventAt)}</td>
+                <td className="px-2 sm:px-3 py-2">
+                  <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-medium ${badge.cls}`}>
+                    {badge.text}
+                  </span>
+                </td>
+                <td className="px-2 sm:px-3 py-2 text-[#6E6E73] hidden md:table-cell truncate max-w-[140px]">
+                  {s.lastQuestion || "—"}
+                </td>
+                <td className="px-2 sm:px-3 py-2 text-[#6E6E73] truncate max-w-[100px]">
+                  {s.utmSource || "(direto)"}
+                </td>
+                <td className="px-2 sm:px-3 py-2 text-[#6E6E73] hidden sm:table-cell">
+                  {s.deviceType ? (DEVICE_LABELS[s.deviceType] || s.deviceType) : "—"}
+                </td>
+                <td className="px-2 sm:px-3 py-2 text-right text-[#86868B] hidden md:table-cell">{s.eventCount}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/app/api/funnel/route.ts
+++ b/app/api/funnel/route.ts
@@ -12,17 +12,25 @@ export async function POST(req: NextRequest) {
 
   try {
     const body = await req.json();
-    const { event, step, question, sessionId } = body;
+    const { event, step, question, sessionId, deviceType, utm_source, utm_medium, utm_campaign } = body;
 
     if (!event || !sessionId) {
       return NextResponse.json({ error: "event and sessionId required" }, { status: 400 });
     }
+
+    // Trunca strings pra evitar payloads gigantes (proteca DOS)
+    const trunc = (v: unknown, max = 200) =>
+      typeof v === "string" && v.trim() ? v.trim().slice(0, max) : null;
 
     const { error } = await supabase.from("tradein_analytics").insert({
       session_id: sessionId,
       event,
       step: step ?? null,
       question: question ?? null,
+      device_type: trunc(deviceType, 32),
+      utm_source: trunc(utm_source),
+      utm_medium: trunc(utm_medium),
+      utm_campaign: trunc(utm_campaign),
     });
 
     if (error) {
@@ -38,6 +46,11 @@ export async function POST(req: NextRequest) {
 }
 
 // GET — aggregated funnel data for admin panel
+//
+// Query params:
+//   range: "7d" | "30d" | "all"
+//   utm_source: filtra eventos por origem (ex: "meta", "instagram")
+//   device_type: filtra por tipo de dispositivo (iphone | ipad | macbook | watch)
 export async function GET(req: NextRequest) {
   try {
     const pw = req.headers.get("x-admin-password") || "";
@@ -61,6 +74,8 @@ export async function GET(req: NextRequest) {
     }
 
     const range = req.nextUrl.searchParams.get("range") || "7d";
+    const filterUtmSource = req.nextUrl.searchParams.get("utm_source") || "";
+    const filterDeviceType = req.nextUrl.searchParams.get("device_type") || "";
 
     let fromDate: string | null = null;
     const now = new Date();
@@ -86,8 +101,42 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
 
-    const rows = events || [];
+    const allRows = events || [];
 
+    // Pra filtrar por UTM/device, precisa propagar o valor pra TODOS eventos
+    // de cada sessao (so o site_view tem UTM gravado, os step_view seguintes
+    // podem nao ter se foi capturado depois). Construimos um mapa session →
+    // metadados antes de aplicar filtros.
+    type SessionMeta = {
+      utm_source?: string;
+      utm_medium?: string;
+      utm_campaign?: string;
+      device_type?: string;
+    };
+    const sessionMeta: Record<string, SessionMeta> = {};
+    for (const row of allRows) {
+      const sid = row.session_id;
+      if (!sessionMeta[sid]) sessionMeta[sid] = {};
+      const meta = sessionMeta[sid];
+      // Strategy: prefer o primeiro valor nao-vazio (= UTM/device da entrada)
+      if (row.utm_source && !meta.utm_source) meta.utm_source = row.utm_source;
+      if (row.utm_medium && !meta.utm_medium) meta.utm_medium = row.utm_medium;
+      if (row.utm_campaign && !meta.utm_campaign) meta.utm_campaign = row.utm_campaign;
+      if (row.device_type && !meta.device_type) meta.device_type = row.device_type;
+    }
+
+    // Aplica filtros opcionais. A linha passa se a SESSAO inteira bate.
+    let rows = allRows;
+    if (filterUtmSource) {
+      rows = rows.filter((r) => sessionMeta[r.session_id]?.utm_source === filterUtmSource);
+    }
+    if (filterDeviceType) {
+      rows = rows.filter((r) => sessionMeta[r.session_id]?.device_type === filterDeviceType);
+    }
+
+    // ============================================================
+    // AGREGACAO PRINCIPAL (igual ao que ja tinha — agora respeita filtros)
+    // ============================================================
     const sessions = new Set<string>();
     const siteViewSessions = new Set<string>();
     const startedSessions = new Set<string>();
@@ -97,9 +146,6 @@ export async function GET(req: NextRequest) {
     const whatsappSessions = new Set<string>();
     const exitSessions = new Set<string>();
     const cotarOutroSessions = new Set<string>();
-    // Etapa 5 do funil — formulario /compra (preenchimento de dados pessoais).
-    // Mede drop-off depois do orcamento aceito → quem chega no formulario e
-    // quem completa de fato.
     const compraViewSessions = new Set<string>();
     const compraSubmitSessions = new Set<string>();
 
@@ -132,8 +178,6 @@ export async function GET(req: NextRequest) {
       if (row.event === "compra_submit") compraSubmitSessions.add(row.session_id);
     }
 
-    // Visitas: prefer site_view, mas se ainda nao tem (deploy recente),
-    // usa o total de sessoes como aproxima
     const visits = siteViewSessions.size > 0 ? siteViewSessions.size : sessions.size;
 
     const funnel = [1, 2, 3, 4].map((step) => {
@@ -147,9 +191,6 @@ export async function GET(req: NextRequest) {
       };
     });
 
-    // Etapa 5: formulario /compra. Diferente das etapas 1-4 (que sao
-    // sub-passos do simulador), esta e uma pagina nova com seu proprio
-    // pageview e submit. View = chegou no /compra, complete = submeteu.
     const compraView = compraViewSessions.size;
     const compraSubmit = compraSubmitSessions.size;
     funnel.push({
@@ -176,6 +217,106 @@ export async function GET(req: NextRequest) {
       .map(([date, set]) => ({ date, sessions: set.size }))
       .sort((a, b) => a.date.localeCompare(b.date));
 
+    // ============================================================
+    // BREAKDOWN POR DIMENSAO (UTM source + device type)
+    // ============================================================
+    // Pra cada UTM source / device type, mostra o funil completo:
+    //   - sessions: quantas sessoes vieram desse canal
+    //   - started: quantas iniciaram simulacao
+    //   - whatsapp: quantas fecharam pedido
+    //   - submit: quantas submeteram /compra
+    //   - conversion: % final (submit/sessions)
+    type DimRow = {
+      key: string;          // valor do UTM/device (ou "(direto)" se NULL)
+      sessions: number;
+      started: number;
+      whatsapp: number;
+      submit: number;
+      conversion: number;   // 0-100
+    };
+
+    function buildDim(getValue: (sid: string) => string | undefined): DimRow[] {
+      const map: Record<string, { sessions: Set<string>; started: Set<string>; whatsapp: Set<string>; submit: Set<string> }> = {};
+
+      for (const sid of sessions) {
+        const key = getValue(sid) || "(direto/sem origem)";
+        if (!map[key]) {
+          map[key] = { sessions: new Set(), started: new Set(), whatsapp: new Set(), submit: new Set() };
+        }
+        map[key].sessions.add(sid);
+        if (startedSessions.has(sid)) map[key].started.add(sid);
+        if (whatsappSessions.has(sid)) map[key].whatsapp.add(sid);
+        if (compraSubmitSessions.has(sid)) map[key].submit.add(sid);
+      }
+
+      return Object.entries(map)
+        .map(([key, v]) => {
+          const sCount = v.sessions.size;
+          return {
+            key,
+            sessions: sCount,
+            started: v.started.size,
+            whatsapp: v.whatsapp.size,
+            submit: v.submit.size,
+            conversion: sCount > 0 ? Math.round((v.submit.size / sCount) * 1000) / 10 : 0,
+          };
+        })
+        .sort((a, b) => b.sessions - a.sessions);
+    }
+
+    const byUtmSource = buildDim((sid) => sessionMeta[sid]?.utm_source);
+    const byDeviceType = buildDim((sid) => sessionMeta[sid]?.device_type);
+
+    // ============================================================
+    // SESSOES INDIVIDUAIS (ultimas 50) — pra debug fino
+    // ============================================================
+    // Por sessao calcula: quando entrou, qual ultimo step viu, qual ultima
+    // pergunta respondeu, qual UTM/device, e se completou (submit /compra ou
+    // pelo menos clicou WhatsApp).
+    type SessionDetail = {
+      sessionId: string;
+      startedAt: string;
+      lastEventAt: string;
+      lastStep: number | null;
+      lastQuestion: string | null;
+      utmSource: string | null;
+      deviceType: string | null;
+      completedWhatsapp: boolean;
+      completedSubmit: boolean;
+      eventCount: number;
+    };
+
+    const sessionDetails: Record<string, SessionDetail> = {};
+    for (const row of rows) {
+      const sid = row.session_id;
+      if (!sessionDetails[sid]) {
+        sessionDetails[sid] = {
+          sessionId: sid,
+          startedAt: row.created_at,
+          lastEventAt: row.created_at,
+          lastStep: row.step ?? null,
+          lastQuestion: row.question ?? null,
+          utmSource: sessionMeta[sid]?.utm_source ?? null,
+          deviceType: sessionMeta[sid]?.device_type ?? null,
+          completedWhatsapp: false,
+          completedSubmit: false,
+          eventCount: 0,
+        };
+      }
+      const det = sessionDetails[sid];
+      det.eventCount++;
+      // como rows ja vem sorted ASC por created_at, o ultimo update vence
+      det.lastEventAt = row.created_at;
+      if (row.step != null) det.lastStep = row.step;
+      if (row.question) det.lastQuestion = row.question;
+      if (row.event === "quote_whatsapp") det.completedWhatsapp = true;
+      if (row.event === "compra_submit") det.completedSubmit = true;
+    }
+
+    const sessionsList = Object.values(sessionDetails)
+      .sort((a, b) => b.lastEventAt.localeCompare(a.lastEventAt))
+      .slice(0, 50);
+
     return NextResponse.json({
       visits,
       startedCount: startedSessions.size,
@@ -191,10 +332,18 @@ export async function GET(req: NextRequest) {
       conversionRate: visits > 0
         ? ((whatsappSessions.size / visits) * 100).toFixed(1)
         : "0",
-      // Conversao final ate submit do /compra (etapa 5)
       conversionRateFinal: visits > 0
         ? ((compraSubmit / visits) * 100).toFixed(1)
         : "0",
+      // Novo (#20): drop-off por canal e por dispositivo + sessoes individuais
+      byUtmSource,
+      byDeviceType,
+      sessionsList,
+      // Filtros aplicados (echo) pra UI mostrar "Filtrando por X"
+      filters: {
+        utm_source: filterUtmSource || null,
+        device_type: filterDeviceType || null,
+      },
     });
   } catch (err) {
     console.error("Funnel GET error:", err);

--- a/components/TradeInCalculatorMulti.tsx
+++ b/components/TradeInCalculatorMulti.tsx
@@ -86,7 +86,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
     return () => clearInterval(id);
   }, [temaParam, temaDia, temaNoite]);
 
-  const { trackSiteView, trackStep, trackQuestion, trackComplete, trackAction } = useTradeInAnalytics();
+  const { trackSiteView, trackStep, trackQuestion, trackComplete, trackAction, setDeviceContext } = useTradeInAnalytics();
 
   useEffect(() => { trackSiteView(); }, [trackSiteView]);
 
@@ -378,6 +378,9 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
 
   function handleDeviceSelect(dt: MultiDeviceType) {
     setSelectedDeviceType(dt);
+    // Propaga pro hook de analytics — todos eventos seguintes (step_view,
+    // question_answer, etc) ja vao com device_type=dt pra cruzar drop-off.
+    setDeviceContext(dt);
     trackAction(`device_type_${dt}`);
     setStep(1);
     window.scrollTo({ top: 0, behavior: "smooth" });
@@ -470,6 +473,7 @@ export default function TradeInCalculatorMulti({ vendedor: vendedorProp, temaPar
   function handleReset() {
     setStep(0); setResetKey(k => k + 1);
     setSelectedDeviceType(null);
+    setDeviceContext(null);
     setDeviceType("iphone"); setDeviceType2("iphone");
     setUsedModel(""); setUsedStorage(""); setTradeInValue(0);
     setUsedModel2(""); setUsedStorage2(""); setTradeInValue2(0);

--- a/lib/useTradeInAnalytics.ts
+++ b/lib/useTradeInAnalytics.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useRef } from "react";
+import { getStoredUTMs, type UTMs } from "@/lib/utm-tracker";
 
 function getSessionId(): string {
   if (typeof window === "undefined") return "";
@@ -40,33 +41,55 @@ function fire(payload: Record<string, unknown>) {
   }
 }
 
+// Helper pra adicionar dimensoes (device_type + UTMs) em TODO evento.
+// Sem isso, tradein_analytics so guardava session+step+question — agregado.
+// Com as dims, da pra cruzar drop-off por canal e por tipo de dispositivo.
+function enrichPayload(base: Record<string, unknown>, deviceType: string | null): Record<string, unknown> {
+  const utms: UTMs = getStoredUTMs();
+  return {
+    ...base,
+    deviceType: deviceType || undefined,
+    utm_source: utms.utm_source,
+    utm_medium: utms.utm_medium,
+    utm_campaign: utms.utm_campaign,
+  };
+}
+
 export function useTradeInAnalytics() {
   const viewedSteps = useRef<Set<number>>(new Set());
+  // Device type (iphone|ipad|macbook|watch) e setado pelo Step 0 do simulador
+  // via setDeviceContext(). Fica disponivel pra todos eventos seguintes — o
+  // tracking de question_answer/step_complete/step_view inclui automaticamente.
+  const deviceTypeRef = useRef<string | null>(null);
+
+  const setDeviceContext = useCallback((deviceType: string | null) => {
+    deviceTypeRef.current = deviceType;
+  }, []);
 
   const trackSiteView = useCallback(() => {
     if (typeof window === "undefined") return;
     if (sessionStorage.getItem("tradein_site_view_sent")) return;
     sessionStorage.setItem("tradein_site_view_sent", "1");
-    fire({ event: "site_view", sessionId: getSessionId() });
+    fire(enrichPayload({ event: "site_view", sessionId: getSessionId() }, deviceTypeRef.current));
   }, []);
 
   const trackStep = useCallback((step: number) => {
     if (viewedSteps.current.has(step)) return;
     viewedSteps.current.add(step);
-    fire({ event: "step_view", step, sessionId: getSessionId() });
+    fire(enrichPayload({ event: "step_view", step, sessionId: getSessionId() }, deviceTypeRef.current));
   }, []);
 
   const trackQuestion = useCallback((step: number, question: string) => {
-    fire({ event: "question_answer", step, question, sessionId: getSessionId() });
+    fire(enrichPayload({ event: "question_answer", step, question, sessionId: getSessionId() }, deviceTypeRef.current));
   }, []);
 
   const trackComplete = useCallback((step: number) => {
-    fire({ event: "step_complete", step, sessionId: getSessionId() });
+    fire(enrichPayload({ event: "step_complete", step, sessionId: getSessionId() }, deviceTypeRef.current));
   }, []);
 
   const trackAction = useCallback((action: string) => {
-    fire({ event: action, sessionId: getSessionId() });
+    fire(enrichPayload({ event: action, sessionId: getSessionId() }, deviceTypeRef.current));
   }, []);
 
-  return { trackSiteView, trackStep, trackQuestion, trackComplete, trackAction };
+  return { trackSiteView, trackStep, trackQuestion, trackComplete, trackAction, setDeviceContext };
 }

--- a/supabase/migrations/20260425b_funnel_drop_off_dimensions.sql
+++ b/supabase/migrations/20260425b_funnel_drop_off_dimensions.sql
@@ -1,0 +1,39 @@
+-- Drop-off detalhado do funil (Abr/2026 — item #20)
+--
+-- Adiciona dimensoes em tradein_analytics pra cruzar drop-off com:
+--   - canal de aquisicao (UTM source/medium/campaign — capturado de localStorage)
+--   - tipo de dispositivo (iphone/ipad/macbook/watch — selecionado no Step 0)
+--
+-- Antes a tabela so guardava session_id + event + step + question, o que mostra
+-- AGREGADO. Agora da pra responder:
+--   - "Quem vem de Meta Ads desiste mais que Instagram organico?"
+--   - "Apple Watch tem 90% drop-off no Step 1, iPhone so 30% — UX desalinhada"
+--   - "Sessao X parou no step Y na pergunta Z" (debug fino)
+--
+-- Backwards compat: colunas sao TODAS opcionais. Eventos antigos (sem UTM/device)
+-- ficam NULL e aparecem em "Sem origem" / "Outros" nos breakdowns.
+
+-- Garantir que a tabela existe (criada manualmente ha tempos — sem migration historica)
+CREATE TABLE IF NOT EXISTS tradein_analytics (
+  id BIGSERIAL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  event TEXT NOT NULL,
+  step NUMERIC,
+  question TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE tradein_analytics
+  ADD COLUMN IF NOT EXISTS device_type TEXT,
+  ADD COLUMN IF NOT EXISTS utm_source TEXT,
+  ADD COLUMN IF NOT EXISTS utm_medium TEXT,
+  ADD COLUMN IF NOT EXISTS utm_campaign TEXT;
+
+-- Indexes pra queries do /admin/analytics ficarem rapidas
+CREATE INDEX IF NOT EXISTS idx_tradein_analytics_session ON tradein_analytics (session_id);
+CREATE INDEX IF NOT EXISTS idx_tradein_analytics_created ON tradein_analytics (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_tradein_analytics_utm_source ON tradein_analytics (utm_source) WHERE utm_source IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_tradein_analytics_device_type ON tradein_analytics (device_type) WHERE device_type IS NOT NULL;
+
+COMMENT ON COLUMN tradein_analytics.device_type IS 'Tipo de aparelho que o cliente esta trocando (iphone|ipad|macbook|watch). NULL pra eventos do site_view antes do cliente escolher.';
+COMMENT ON COLUMN tradein_analytics.utm_source IS 'Canal de aquisicao capturado da URL de entrada (meta, instagram, google, etc). NULL pra trafego direto/organico.';


### PR DESCRIPTION
## Item #20 do backlog — drop-off em TODAS etapas do funil

\`/admin/analytics\` já tinha funil agregado e drop-off por etapa/pergunta — faltava poder cruzar **com dimensões** (de onde vem? que dispositivo?) e investigar abandonos específicos.

## 3 melhorias

### A) Drop-off por **canal de aquisição** (UTM source)
Tabela com cada canal (Meta Ads, Instagram, direto) mostrando:
- Sessões, iniciados, WhatsApp, submeteu /compra
- Taxa de conversão final

**Responde:** "Meta Ads converte mais que orgânico?"

### B) Drop-off por **tipo de dispositivo** (iPhone/iPad/MacBook/Watch)
Mesma tabela, mas por categoria selecionada no Step 0.

**Responde:** "Apple Watch tem UX desalinhado vs iPhone?"

### C) Tabela das **últimas 50 sessões individuais**
Cada linha:
- Quando entrou
- Duração
- Status (✓ Submeteu / → WhatsApp / Parou Etapa X / Só visitou)
- Última pergunta vista
- Canal (UTM source)
- Dispositivo

**Responde:** "Essa pessoa específica parou onde? Por quê?"

## Filtros

Filtros UTM source + device type no topo da página. Quando ativos, **TODOS** os números da página (KPIs, funil, perguntas) ficam restritos ao subset.

Ex: filtrar `utm_source=meta` + `device=watch` → mostra só funil de quem veio de Meta Ads escolhendo Apple Watch.

## Migration ⚠️

\`supabase/migrations/20260425b_funnel_drop_off_dimensions.sql\`

Adiciona em \`tradein_analytics\`:
- \`device_type\`
- \`utm_source\`, \`utm_medium\`, \`utm_campaign\`
- Indexes parciais

**Idempotente** — \`CREATE TABLE IF NOT EXISTS\` (não havia migration histórica) + \`ADD COLUMN IF NOT EXISTS\`.

## Test plan

Após preview Vercel + migration aplicada em \`/admin/migrations\`:

- [ ] Abrir \`/admin/analytics\` — verificar 3 novas seções aparecem (Por canal, Por dispositivo, Últimas sessões)
- [ ] Filtros funcionam — selecionar UTM ou Device, números mudam
- [ ] Sessões antigas aparecem como "(direto/sem origem)" / "—" nos breakdowns (backwards compat)
- [ ] Fazer 1 simulação nova em /troca — após ~10s o evento já aparece no admin com device_type preenchido
- [ ] Acessar \`/troca?utm_source=teste\` e fazer simulação — depois filtrar por \`utm_source=teste\` e ver se aparece

🤖 Generated with [Claude Code](https://claude.com/claude-code)