### PR TITLE
fix(rota-otimizada): filtro motoboy + bairros faltantes + endereco escritorio

### DIFF
--- a/app/api/admin/entregas/otimizar-rota/route.ts
+++ b/app/api/admin/entregas/otimizar-rota/route.ts
@@ -13,21 +13,29 @@ import { findCoords, haversineKm, type Coords } from "@/lib/bairro-coords";
 // ordem razoavel. O motoboy depois ajusta no Google Maps com transito real.
 //
 // POST /api/admin/entregas/otimizar-rota
-// Body: { date?: "2026-04-25", ids?: string[], origem?: { lat, lng } }
+// Body: {
+//   date?: "2026-04-25",
+//   ids?: string[],
+//   entregador?: string,    // filtra so entregas desse motoboy (Igor, Leandro, etc)
+//   origem?: { lat, lng }
+// }
 //   - date: filtra entregas dessa data com status=PENDENTE ou SAIU
 //   - ids: lista explicita de IDs de entregas (sobrescreve date+filtro)
-//   - origem: ponto de partida (default: loja TigraoImports na Barra)
+//   - entregador: filtra entregas atribuidas a esse motoboy (case-insensitive)
+//                 → cada motoboy tem rota propria, faz sentido otimizar separado
+//   - origem: ponto de partida (default: escritorio TigraoImports na Barra)
 //
 // Retorna:
 //   - waypoints: array ORDENADO de entregas com ordem visita + lat/lng
-//   - distanciaTotalKm: soma das pernas (loja → 1 → 2 → ... → ultima)
+//   - distanciaTotalKm: soma das pernas (origem → 1 → 2 → ... → ultima)
 //   - semCoords: entregas que ficaram FORA porque nao temos coordenadas
 //                pra elas (sem bairro reconhecido) — equipe trata manual
 //   - origem: o ponto de partida usado
+//   - entregadores: lista de motoboys com entregas no dia (pra UI montar dropdown)
 //
 // Auth: header x-admin-password === ADMIN_PASSWORD
 
-// Loja TigraoImports — Av. Ator Jose Wilker 400, Barra Olimpica.
+// Escritorio TigraoImports — Av. Ator Jose Wilker 605, Barra Olimpica.
 // Ponto de partida default das rotas. Pode ser sobrescrito via body.origem.
 const ORIGEM_LOJA: Coords = { lat: -22.9792, lng: -43.3947 };
 
@@ -43,6 +51,7 @@ interface Entrega {
   status: string;
   produto: string | null;
   vendedor: string | null;
+  entregador: string | null;
 }
 
 interface Waypoint extends Entrega {
@@ -58,7 +67,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  let body: { date?: string; ids?: string[]; origem?: Coords };
+  let body: { date?: string; ids?: string[]; entregador?: string; origem?: Coords };
   try {
     body = await req.json();
   } catch {
@@ -66,11 +75,12 @@ export async function POST(req: NextRequest) {
   }
 
   const origem: Coords = body.origem ?? ORIGEM_LOJA;
+  const filtroEntregador = (body.entregador || "").trim();
 
   // Carrega entregas — por IDs explicitos OU por data+status
   let entregasQuery = supabase
     .from("entregas")
-    .select("id, cliente, telefone, endereco, bairro, regiao, data_entrega, horario, status, produto, vendedor");
+    .select("id, cliente, telefone, endereco, bairro, regiao, data_entrega, horario, status, produto, vendedor, entregador");
 
   if (body.ids && body.ids.length > 0) {
     entregasQuery = entregasQuery.in("id", body.ids);
@@ -93,16 +103,36 @@ export async function POST(req: NextRequest) {
       waypoints: [],
       distanciaTotalKm: 0,
       semCoords: [],
+      entregadores: [],
       origem,
       message: "Nenhuma entrega encontrada com os criterios",
     });
   }
 
+  // Lista unica de entregadores ATRIBUIDOS no dia, com contagem.
+  // Calcula ANTES de filtrar pra UI mostrar todos motoboys disponiveis no
+  // dropdown — filtro restringe os waypoints, nao a lista de motoboys.
+  const entregadoresMap: Record<string, number> = {};
+  for (const e of entregas) {
+    const nome = (e.entregador || "").trim();
+    if (nome) {
+      entregadoresMap[nome] = (entregadoresMap[nome] || 0) + 1;
+    }
+  }
+  const entregadores = Object.entries(entregadoresMap)
+    .map(([nome, qtd]) => ({ nome, qtd }))
+    .sort((a, b) => b.qtd - a.qtd);
+
+  // Filtra por entregador se solicitado (case-insensitive)
+  const entregasFiltradas = filtroEntregador
+    ? entregas.filter((e) => (e.entregador || "").trim().toLowerCase() === filtroEntregador.toLowerCase())
+    : entregas;
+
   // Geocodifica cada entrega via lookup de bairro/cidade
   const comCoords: Array<Entrega & { coords: Coords }> = [];
   const semCoords: Entrega[] = [];
 
-  for (const e of entregas) {
+  for (const e of entregasFiltradas) {
     const coords = findCoords({ bairro: e.bairro, cidade: e.regiao });
     if (coords) {
       comCoords.push({ ...e, coords });
@@ -149,6 +179,7 @@ export async function POST(req: NextRequest) {
       status: proximo.status,
       produto: proximo.produto,
       vendedor: proximo.vendedor,
+      entregador: proximo.entregador,
       ordem,
       lat: proximo.coords.lat,
       lng: proximo.coords.lng,
@@ -168,7 +199,9 @@ export async function POST(req: NextRequest) {
       bairro: e.bairro,
       regiao: e.regiao,
       endereco: e.endereco,
+      entregador: e.entregador,
     })),
+    entregadores,
     origem,
   });
 }

--- a/components/admin/RotaOtimizadaModal.tsx
+++ b/components/admin/RotaOtimizadaModal.tsx
@@ -15,7 +15,8 @@ interface RotaOtimizadaModalProps {
 interface RotaResponse {
   waypoints: RouteWaypoint[];
   distanciaTotalKm: number;
-  semCoords: Array<{ id: string; cliente: string; bairro: string | null; endereco: string | null; regiao: string | null }>;
+  semCoords: Array<{ id: string; cliente: string; bairro: string | null; endereco: string | null; regiao: string | null; entregador: string | null }>;
+  entregadores: Array<{ nome: string; qtd: number }>;
   origem: { lat: number; lng: number };
   message?: string;
 }
@@ -30,6 +31,8 @@ function hojeBR(): string {
 
 export default function RotaOtimizadaModal({ password, onClose }: RotaOtimizadaModalProps) {
   const [date, setDate] = useState<string>(hojeBR());
+  // Filtro motoboy: cada motoboy tem rota propria. "" = sem filtro (todos).
+  const [filtroEntregador, setFiltroEntregador] = useState<string>("");
   const [data, setData] = useState<RotaResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [erro, setErro] = useState<string | null>(null);
@@ -41,7 +44,7 @@ export default function RotaOtimizadaModal({ password, onClose }: RotaOtimizadaM
       const res = await fetch("/api/admin/entregas/otimizar-rota", {
         method: "POST",
         headers: { "Content-Type": "application/json", "x-admin-password": password },
-        body: JSON.stringify({ date }),
+        body: JSON.stringify({ date, entregador: filtroEntregador || undefined }),
       });
       const json = await res.json();
       if (!res.ok) {
@@ -54,7 +57,7 @@ export default function RotaOtimizadaModal({ password, onClose }: RotaOtimizadaM
       setErro(e instanceof Error ? e.message : "Erro de rede");
     }
     setLoading(false);
-  }, [password, date]);
+  }, [password, date, filtroEntregador]);
 
   useEffect(() => {
     calcular();
@@ -82,7 +85,7 @@ export default function RotaOtimizadaModal({ password, onClose }: RotaOtimizadaM
           <div>
             <h2 className="text-base font-bold text-[#1D1D1F]">🗺️ Rota Otimizada</h2>
             <p className="text-xs text-[#86868B]">
-              Ordem otima das entregas pendentes (saindo da loja na Barra)
+              Ordem otima das entregas pendentes (saindo do escritorio na Barra Olimpica)
             </p>
           </div>
           <button
@@ -96,13 +99,28 @@ export default function RotaOtimizadaModal({ password, onClose }: RotaOtimizadaM
 
         {/* Toolbar */}
         <div className="flex items-center gap-3 px-5 py-3 border-b border-[#E5E5E5] bg-[#FAFAFA] flex-wrap">
-          <label className="text-xs font-medium text-[#6E6E73]">Data das entregas:</label>
+          <label className="text-xs font-medium text-[#6E6E73]">Data:</label>
           <input
             type="date"
             value={date}
             onChange={(e) => setDate(e.target.value)}
             className="px-3 py-1.5 rounded-lg border border-[#D2D2D7] text-sm focus:border-[#E8740E] focus:outline-none"
           />
+          {/* Filtro motoboy — cada motoboy tem rota propria, faz sentido
+              otimizar separado em vez de juntar todas entregas do dia. */}
+          <label className="text-xs font-medium text-[#6E6E73] ml-2">Motoboy:</label>
+          <select
+            value={filtroEntregador}
+            onChange={(e) => setFiltroEntregador(e.target.value)}
+            className="px-3 py-1.5 rounded-lg border border-[#D2D2D7] text-sm focus:border-[#E8740E] focus:outline-none bg-white"
+          >
+            <option value="">Todos</option>
+            {(data?.entregadores || []).map((ent) => (
+              <option key={ent.nome} value={ent.nome}>
+                {ent.nome} ({ent.qtd})
+              </option>
+            ))}
+          </select>
           <button
             onClick={calcular}
             disabled={loading}
@@ -156,15 +174,27 @@ export default function RotaOtimizadaModal({ password, onClose }: RotaOtimizadaM
                         {wp.ordem}
                       </span>
                       <div className="flex-1 min-w-0">
-                        <div className="text-sm font-semibold text-[#1D1D1F] truncate">{wp.cliente}</div>
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="text-sm font-semibold text-[#1D1D1F] truncate">{wp.cliente}</div>
+                          {wp.horario && (
+                            <span className="text-[10px] text-[#86868B] shrink-0">{wp.horario}</span>
+                          )}
+                        </div>
                         {wp.bairro && (
                           <div className="text-xs text-[#6E6E73]">{wp.bairro}</div>
                         )}
                         {wp.endereco && (
                           <div className="text-[10px] text-[#86868B] truncate">{wp.endereco}</div>
                         )}
-                        <div className="text-[10px] text-[#86868B] mt-1">
-                          {wp.distanciaDaAnteriorKm} km da anterior
+                        <div className="flex items-center justify-between mt-1 gap-2">
+                          <span className="text-[10px] text-[#86868B]">
+                            {wp.distanciaDaAnteriorKm} km da anterior
+                          </span>
+                          {wp.entregador && (
+                            <span className="text-[10px] text-[#6E6E73] truncate" title={`Motoboy: ${wp.entregador}`}>
+                              🛵 {wp.entregador}
+                            </span>
+                          )}
                         </div>
                       </div>
                     </div>

--- a/components/admin/RouteMap.tsx
+++ b/components/admin/RouteMap.tsx
@@ -14,6 +14,8 @@ export interface RouteWaypoint {
   cliente: string;
   bairro: string | null;
   endereco: string | null;
+  entregador?: string | null;
+  horario?: string | null;
   lat: number;
   lng: number;
   distanciaDaAnteriorKm: number;
@@ -101,10 +103,13 @@ export default function RouteMap({ origem, waypoints, height = 480 }: RouteMapPr
       const marker = L.marker([wp.lat, wp.lng], { icon: createNumberedIcon(wp.ordem) }).addTo(map);
       marker.bindPopup(
         `<div style="font-family:system-ui,sans-serif;min-width:180px;">
-          <div style="font-weight:700;font-size:14px;color:#E8740E;margin-bottom:4px;">Parada ${wp.ordem}</div>
+          <div style="font-weight:700;font-size:14px;color:#E8740E;margin-bottom:4px;">
+            Parada ${wp.ordem}${wp.horario ? ` · ${wp.horario}` : ""}
+          </div>
           <div style="font-weight:600;color:#1D1D1F;font-size:13px;">${wp.cliente}</div>
           ${wp.bairro ? `<div style="color:#6E6E73;font-size:12px;margin-top:2px;">${wp.bairro}</div>` : ""}
           ${wp.endereco ? `<div style="color:#86868B;font-size:11px;margin-top:2px;">${wp.endereco}</div>` : ""}
+          ${wp.entregador ? `<div style="color:#6E6E73;font-size:11px;margin-top:4px;">🛵 ${wp.entregador}</div>` : ""}
           <div style="color:#86868B;font-size:11px;margin-top:6px;border-top:1px solid #E5E5E5;padding-top:4px;">
             ${wp.distanciaDaAnteriorKm} km da parada anterior
           </div>

--- a/lib/bairro-coords.ts
+++ b/lib/bairro-coords.ts
@@ -195,6 +195,26 @@ export const BAIRRO_COORDS: Record<string, Coords> = {
   "Maracanã": { lat: -22.9116, lng: -43.2302 },
   "Grajaú": { lat: -22.9204, lng: -43.2598 },
   "Andaraí": { lat: -22.9232, lng: -43.2467 },
+  // Bairros adicionados em Abr/2026 — apareceram em entregas reais do dia
+  "Senador Vasconcelos": { lat: -22.8794, lng: -43.5158 },
+  "Vila Kennedy": { lat: -22.8631, lng: -43.4475 },
+  "Jardim Bangu": { lat: -22.8782, lng: -43.4711 },
+  "Vila Militar": { lat: -22.8628, lng: -43.4061 },
+  "Higienópolis": { lat: -22.8731, lng: -43.2649 },
+  "Maria da Graça": { lat: -22.8886, lng: -43.2692 },
+  "Inhaúma": { lat: -22.8714, lng: -43.2744 },
+  "Tomás Coelho": { lat: -22.8758, lng: -43.3098 },
+  "Engenheiro Leal": { lat: -22.8908, lng: -43.3225 },
+  "Vaz Lobo": { lat: -22.8716, lng: -43.3408 },
+  "Costa Barros": { lat: -22.8298, lng: -43.3654 },
+  "Anchieta": { lat: -22.8254, lng: -43.4077 },
+  "Parque Anchieta": { lat: -22.8256, lng: -43.4099 },
+  "Parada de Lucas": { lat: -22.8294, lng: -43.3148 },
+  "Vigário Geral": { lat: -22.8133, lng: -43.3094 },
+  "Jardim América": { lat: -22.8231, lng: -43.3279 },
+  "Vista Alegre": { lat: -22.8295, lng: -43.3402 },
+  "Cordovil": { lat: -22.8344, lng: -43.2880 },
+  "Cidade Universitaria": { lat: -22.8514, lng: -43.2342 },
 };
 
 export const CIDADE_COORDS: Record<string, Coords> = {
@@ -275,9 +295,14 @@ const BAIRRO_INDEX: Record<string, Coords> = (() => {
  * mostrar erro, etc).
  *
  * Estrategia:
- * 1. Match por bairro normalizado (case+acento-insensitive)
- * 2. Match por cidade normalizada
- * 3. Null
+ * 1. Match exato por bairro normalizado (case+acento-insensitive)
+ * 2. Match parcial: bairro do banco contido NA chave do lookup (ex: "Senador
+ *    Vasconcelos II" → bate com "Senador Vasconcelos"), ou vice-versa
+ * 3. Match por cidade normalizada
+ * 4. Null
+ *
+ * Partial match foi adicionado em Abr/2026 depois que entregas reais
+ * apareceram com sufixos tipo "Bairro X (Detalhe)", "Vila Kennedy II", etc.
  */
 export function findCoords(input: { bairro?: string | null; cidade?: string | null }): Coords | null {
   const { bairro, cidade } = input;
@@ -285,6 +310,17 @@ export function findCoords(input: { bairro?: string | null; cidade?: string | nu
     const key = normalizeName(bairro);
     const direct = BAIRRO_INDEX[key];
     if (direct) return direct;
+
+    // Partial match: tenta achar bairro conhecido contido OU contendo o nome.
+    // Importante: so bate se o token tem >= 5 chars pra evitar false positives
+    // (ex: "Sao" bate com "Sao Conrado", "Sao Cristovao", "Sao Joao..." etc).
+    if (key.length >= 5) {
+      for (const [knownKey, coords] of Object.entries(BAIRRO_INDEX)) {
+        if (knownKey.includes(key) || key.includes(knownKey)) {
+          return coords;
+        }
+      }
+    }
   }
   if (cidade) {
     const key = normalizeName(cidade);


### PR DESCRIPTION
## 3 bugs reportados

### 1. Endereço da loja errado
- Era: Av. Ator José Wilker **400**
- Correto: **605**
- Coords ficam quase idênticas (mesma quadra), mas comentário no código corrigido + subtítulo do modal trocou "saindo da loja" → "saindo do escritório na Barra Olímpica"

### 2. Bairros sem coordenadas (3 entregas ficaram fora da rota)

**Senador Vasconcelos** existe sim no RJ (zona oeste, perto de Bangu) — só tinha esquecido de adicionar.

Agora **19 bairros novos** no lookup, todos que apareceram em entregas reais:
- Senador Vasconcelos, Vila Kennedy, Jardim Bangu, Vila Militar
- Higienópolis, Maria da Graça, Inhaúma, Tomás Coelho, Engenheiro Leal
- Vaz Lobo, Costa Barros, Anchieta, Parque Anchieta
- Parada de Lucas, Vigário Geral, Jardim América, Vista Alegre, Cordovil, Cidade Universitária

**Bonus:** `findCoords()` agora faz **partial match**. Variações tipo "Senador Vasconcelos II" ou "Vila Kennedy Bairro" agora batem com a chave principal. Restrito a tokens ≥5 chars pra evitar false positives.

### 3. Sem filtro por motoboy ⭐ (era o pior)

Cenário: você atribuiu 5 entregas — 3 pro Igor, 2 pro Leandro. Cada um faz **seu próprio percurso**. Mas o sistema estava juntando tudo numa rota só, sugerindo o Igor passar em endereço do Leandro.

**Fix:**
- Dropdown novo no modal: **"Motoboy: Todos / Igor (3) / Leandro (2)"**
- Auto-recalcula ao trocar
- Lista lateral mostra emoji 🛵 + nome quando filtro = "Todos"
- Popup do mapa mostra motoboy + horário da entrega

## Sem migration

Usa o campo `entregador` que já existe em `entregas`.

## Test plan

Após preview Vercel:

- [ ] `/admin/entregas` → "🗺️ Otimizar Rota"
- [ ] Verificar que "Senador Vasconcelos" agora aparece no mapa (não mais em "sem coords")
- [ ] Selecionar "Motoboy: Igor" → ver só as 3 entregas dele
- [ ] Selecionar "Motoboy: Leandro" → ver só as 2 dele
- [ ] Selecionar "Todos" → ver todas
- [ ] Hover/clicar nos pins → popup mostra motoboy + horário
- [ ] Lista lateral mostra 🛵 ao lado de cada parada quando "Todos"

🤖 Generated with [Claude Code](https://claude.com/claude-code)