### PR TITLE
feat(bancos): integracao Pluggy/Open Finance pra sync automatico de saldos (#28)

### DIFF
--- a/app/admin/bancos/page.tsx
+++ b/app/admin/bancos/page.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import Script from "next/script";
+import { useAdmin } from "@/components/admin/AdminShell";
+
+// Item #28 — gerenciar conexoes Pluggy/Open Finance pra puxar saldos
+// automaticos de Itau, Inter, MP, Nubank, etc.
+
+interface Conta {
+  accountId: string;
+  accountName: string | null;
+  accountType: string | null;
+  accountSubtype: string | null;
+  saldo: number;
+  creditLimite: number | null;
+  consultadoEm: string;
+}
+
+interface Conexao {
+  id: number;
+  pluggy_item_id: string;
+  banco_alias: string;
+  banco_nome: string;
+  status: string;
+  connector_id: number | null;
+  connector_image_url: string | null;
+  connector_primary_color: string | null;
+  ultimo_sync_em: string | null;
+  ultimo_sync_status: string | null;
+  ultimo_sync_erro: string | null;
+  contas: Conta[];
+  saldoTotal: number;
+}
+
+interface ConexoesResp {
+  conexoes: Conexao[];
+  saldoTotal: number;
+}
+
+// Pluggy Connect Widget global (carregado via script tag)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare global { interface Window { PluggyConnect: any } }
+
+const fmtBRL = (n: number) => `R$ ${n.toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const fmtData = (iso: string | null): string => {
+  if (!iso) return "—";
+  try {
+    const d = new Date(iso);
+    return d.toLocaleString("pt-BR", { day: "2-digit", month: "2-digit", hour: "2-digit", minute: "2-digit" });
+  } catch {
+    return iso.slice(0, 16);
+  }
+};
+
+const STATUS_LABEL: Record<string, { txt: string; cls: string }> = {
+  UPDATED: { txt: "✓ Atualizado", cls: "bg-green-50 text-green-700 border-green-300" },
+  OUTDATED: { txt: "⏰ Desatualizado", cls: "bg-yellow-50 text-yellow-700 border-yellow-300" },
+  LOGIN_ERROR: { txt: "🔐 Erro de login", cls: "bg-red-50 text-red-700 border-red-400" },
+  WAITING_USER_INPUT: { txt: "⏳ Aguardando voce", cls: "bg-blue-50 text-blue-700 border-blue-300" },
+  UPDATING: { txt: "🔄 Atualizando...", cls: "bg-blue-50 text-blue-700 border-blue-300" },
+  CREATED: { txt: "📝 Criado", cls: "bg-gray-50 text-gray-700 border-gray-300" },
+  ERROR: { txt: "❌ Erro", cls: "bg-red-50 text-red-700 border-red-400" },
+};
+
+export default function BancosPage() {
+  const { password, apiHeaders } = useAdmin();
+  const [data, setData] = useState<ConexoesResp | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+  const [msg, setMsg] = useState<{ tipo: "ok" | "erro"; texto: string } | null>(null);
+  const [scriptReady, setScriptReady] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/admin/bancos/connections", { headers: apiHeaders() });
+      const j = await res.json();
+      if (res.ok) {
+        setData(j);
+      } else {
+        setMsg({ tipo: "erro", texto: j.error || "Erro ao carregar" });
+      }
+    } catch (e) {
+      setMsg({ tipo: "erro", texto: e instanceof Error ? e.message : "Erro de rede" });
+    }
+    setLoading(false);
+  }, [apiHeaders]);
+
+  useEffect(() => {
+    if (password) load();
+  }, [password, load]);
+
+  // Abre o Pluggy Connect Widget pra adicionar nova conexao
+  const conectarBanco = async (itemIdParaAtualizar?: string) => {
+    setConnecting(true);
+    setMsg(null);
+    try {
+      // 1. Pega connect token efemero do backend
+      const tokenRes = await fetch("/api/admin/bancos/connect-token", {
+        method: "POST",
+        headers: apiHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify(itemIdParaAtualizar ? { itemId: itemIdParaAtualizar } : {}),
+      });
+      const tokenJson = await tokenRes.json();
+      if (!tokenRes.ok) {
+        setMsg({ tipo: "erro", texto: tokenJson.error || "Falha ao gerar token" });
+        setConnecting(false);
+        return;
+      }
+
+      // 2. Abre o widget Pluggy
+      if (!window.PluggyConnect) {
+        setMsg({ tipo: "erro", texto: "Widget Pluggy nao carregou. Recarregue a pagina." });
+        setConnecting(false);
+        return;
+      }
+
+      const pluggy = new window.PluggyConnect({
+        connectToken: tokenJson.accessToken,
+        includeSandbox: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onSuccess: async (itemData: any) => {
+          // 3. Quando admin termina, registra a conexao no nosso banco
+          const itemId = itemData?.item?.id;
+          if (!itemId) {
+            setMsg({ tipo: "erro", texto: "Pluggy nao retornou itemId" });
+            setConnecting(false);
+            return;
+          }
+          const regRes = await fetch("/api/admin/bancos/connections", {
+            method: "POST",
+            headers: apiHeaders({ "Content-Type": "application/json" }),
+            body: JSON.stringify({ itemId }),
+          });
+          const regJson = await regRes.json();
+          if (regRes.ok) {
+            setMsg({ tipo: "ok", texto: `Conectado! ${regJson.contasSync || 0} contas sincronizadas.` });
+            load();
+          } else {
+            setMsg({ tipo: "erro", texto: regJson.error || "Erro ao registrar" });
+          }
+          setConnecting(false);
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        onError: (err: any) => {
+          setMsg({ tipo: "erro", texto: err?.message || "Erro no widget Pluggy" });
+          setConnecting(false);
+        },
+        onClose: () => setConnecting(false),
+      });
+      pluggy.init();
+    } catch (e) {
+      setMsg({ tipo: "erro", texto: e instanceof Error ? e.message : "Erro" });
+      setConnecting(false);
+    }
+  };
+
+  // Sync manual: atualiza saldos de todas conexoes (ou de uma especifica)
+  const syncAll = async (conexao_id?: number) => {
+    setSyncing(true);
+    setMsg(null);
+    try {
+      const res = await fetch("/api/admin/bancos/sync", {
+        method: "POST",
+        headers: apiHeaders({ "Content-Type": "application/json" }),
+        body: JSON.stringify(conexao_id ? { conexao_id } : {}),
+      });
+      const j = await res.json();
+      if (res.ok) {
+        setMsg({
+          tipo: j.erros > 0 ? "erro" : "ok",
+          texto: `${j.atualizadas} conexao(s) atualizada(s)${j.erros > 0 ? ` · ${j.erros} erro(s)` : ""}`,
+        });
+        load();
+      } else {
+        setMsg({ tipo: "erro", texto: j.error || "Erro" });
+      }
+    } catch (e) {
+      setMsg({ tipo: "erro", texto: e instanceof Error ? e.message : "Erro" });
+    }
+    setSyncing(false);
+  };
+
+  const desconectar = async (id: number, banco: string) => {
+    if (!confirm(`Desconectar ${banco}? (a conexao fica salva no Pluggy mas pare de aparecer aqui)`)) return;
+    const res = await fetch(`/api/admin/bancos/connections?id=${id}`, {
+      method: "DELETE",
+      headers: apiHeaders(),
+    });
+    if (res.ok) {
+      setMsg({ tipo: "ok", texto: `${banco} desconectado` });
+      load();
+    } else {
+      const j = await res.json().catch(() => ({}));
+      setMsg({ tipo: "erro", texto: j.error || "Erro ao desconectar" });
+    }
+  };
+
+  return (
+    <div className="space-y-4 max-w-5xl">
+      {/* SDK do Pluggy Connect Widget. Carregado uma unica vez por pagina. */}
+      <Script
+        src="https://cdn.pluggy.ai/web-connect/v2.10.0/pluggy-connect.js"
+        strategy="lazyOnload"
+        onReady={() => setScriptReady(true)}
+      />
+
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <div>
+          <h1 className="text-xl font-bold text-[#1D1D1F]">🔗 Bancos (Open Finance)</h1>
+          <p className="text-xs text-[#86868B] mt-0.5">
+            Conexoes ativas via Pluggy. Saldos atualizados sob demanda — sem digitacao manual.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => syncAll()}
+            disabled={syncing || loading || (data?.conexoes.length || 0) === 0}
+            className="px-3 py-1.5 rounded-lg border border-[#D2D2D7] text-xs font-semibold text-[#6E6E73] hover:bg-[#F5F5F7] disabled:opacity-50 transition-colors"
+          >
+            {syncing ? "🔄 Atualizando..." : "🔄 Atualizar saldos"}
+          </button>
+          <button
+            onClick={() => conectarBanco()}
+            disabled={connecting || !scriptReady}
+            className="px-4 py-1.5 rounded-lg bg-[#E8740E] text-white text-xs font-semibold hover:bg-[#F5A623] disabled:opacity-50 transition-colors"
+          >
+            {connecting ? "Aguardando..." : !scriptReady ? "Carregando..." : "+ Conectar banco"}
+          </button>
+        </div>
+      </div>
+
+      {msg && (
+        <div className={`px-3 py-2 rounded-lg text-sm ${msg.tipo === "ok" ? "bg-green-50 text-green-700" : "bg-red-50 text-red-700"}`}>
+          {msg.texto}
+        </div>
+      )}
+
+      {/* KPI total */}
+      {data && data.conexoes.length > 0 && (
+        <div className="bg-gradient-to-br from-[#FFF5EB] to-white border border-[#E8740E]/30 rounded-2xl p-4">
+          <p className="text-[11px] uppercase tracking-wide text-[#86868B] font-medium">Saldo total disponivel</p>
+          <p className="text-3xl font-bold text-[#E8740E] mt-1">{fmtBRL(data.saldoTotal)}</p>
+          <p className="text-[11px] text-[#86868B] mt-0.5">Soma das contas correntes (cartao de credito nao entra)</p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="w-6 h-6 border-2 border-[#E8740E] border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : !data || data.conexoes.length === 0 ? (
+        <div className="bg-white border border-[#D2D2D7] rounded-2xl p-8 text-center">
+          <p className="text-base font-semibold text-[#1D1D1F] mb-2">Nenhum banco conectado ainda</p>
+          <p className="text-sm text-[#86868B] mb-4">
+            Clique em <strong>+ Conectar banco</strong> pra adicionar Itau, Inter, MercadoPago, Nubank, etc.
+            <br />
+            Voce vai logar no app/site do banco e autorizar acesso aos saldos via Open Finance.
+          </p>
+          <p className="text-[11px] text-[#86868B]">
+            ⚠️ Requer Pluggy configurado no Vercel (PLUGGY_CLIENT_ID + PLUGGY_CLIENT_SECRET)
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {data.conexoes.map((c) => (
+            <BankCard
+              key={c.id}
+              conexao={c}
+              onSync={() => syncAll(c.id)}
+              onReconnect={() => conectarBanco(c.pluggy_item_id)}
+              onDisconnect={() => desconectar(c.id, c.banco_nome)}
+              syncing={syncing}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BankCard({
+  conexao,
+  onSync,
+  onReconnect,
+  onDisconnect,
+  syncing,
+}: {
+  conexao: Conexao;
+  onSync: () => void;
+  onReconnect: () => void;
+  onDisconnect: () => void;
+  syncing: boolean;
+}) {
+  const statusInfo = STATUS_LABEL[conexao.status] || { txt: conexao.status, cls: "bg-gray-50 text-gray-700 border-gray-300" };
+  const precisaReconectar = conexao.status === "LOGIN_ERROR" || conexao.status === "WAITING_USER_INPUT";
+
+  return (
+    <div className="bg-white border border-[#D2D2D7] rounded-2xl p-4 shadow-sm">
+      <div className="flex items-start justify-between flex-wrap gap-2 mb-3">
+        <div className="flex items-center gap-3">
+          {conexao.connector_image_url ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={conexao.connector_image_url}
+              alt={conexao.banco_nome}
+              className="w-10 h-10 rounded-lg object-contain"
+              style={{ background: conexao.connector_primary_color || "#F5F5F7" }}
+            />
+          ) : (
+            <div className="w-10 h-10 rounded-lg bg-[#F5F5F7] flex items-center justify-center text-lg">🏦</div>
+          )}
+          <div>
+            <p className="font-semibold text-[#1D1D1F]">{conexao.banco_nome}</p>
+            <p className="text-[11px] text-[#86868B]">{conexao.banco_alias}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className={`text-[11px] px-2 py-0.5 rounded border font-medium ${statusInfo.cls}`}>
+            {statusInfo.txt}
+          </span>
+          <span className="text-[11px] text-[#86868B]">
+            Sync: {fmtData(conexao.ultimo_sync_em)}
+          </span>
+        </div>
+      </div>
+
+      {conexao.ultimo_sync_erro && (
+        <div className="mb-3 p-2 bg-red-50 border border-red-200 rounded text-[11px] text-red-700">
+          ⚠️ Ultimo erro: {conexao.ultimo_sync_erro}
+        </div>
+      )}
+
+      {/* Contas dessa conexao */}
+      <div className="space-y-2 mb-3">
+        {conexao.contas.length === 0 ? (
+          <p className="text-xs text-[#86868B] italic">Nenhuma conta — clique em sincronizar</p>
+        ) : (
+          conexao.contas.map((conta) => {
+            const isCredit = conta.accountType === "CREDIT";
+            return (
+              <div key={conta.accountId} className="flex items-center justify-between p-2 bg-[#F5F5F7] rounded">
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-medium text-[#1D1D1F] truncate">{conta.accountName || "Conta"}</p>
+                  <p className="text-[10px] text-[#86868B]">{conta.accountSubtype}</p>
+                </div>
+                <div className="text-right">
+                  <p className={`text-sm font-bold ${isCredit ? "text-red-600" : "text-[#1D1D1F]"}`}>
+                    {isCredit ? "-" : ""}{fmtBRL(conta.saldo)}
+                  </p>
+                  {conta.creditLimite && (
+                    <p className="text-[10px] text-[#86868B]">Limite: {fmtBRL(conta.creditLimite)}</p>
+                  )}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      <div className="flex items-center justify-between flex-wrap gap-2">
+        <p className="text-sm font-semibold text-[#1D1D1F]">
+          Subtotal: <span className="text-[#E8740E]">{fmtBRL(conexao.saldoTotal)}</span>
+        </p>
+        <div className="flex gap-2">
+          {precisaReconectar && (
+            <button
+              onClick={onReconnect}
+              className="text-[11px] px-2 py-1 rounded bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+            >
+              🔐 Reconectar
+            </button>
+          )}
+          <button
+            onClick={onSync}
+            disabled={syncing}
+            className="text-[11px] px-2 py-1 rounded border border-[#D2D2D7] text-[#6E6E73] hover:bg-[#F5F5F7] disabled:opacity-50"
+          >
+            🔄 Sincronizar
+          </button>
+          <button
+            onClick={onDisconnect}
+            className="text-[11px] px-2 py-1 rounded border border-red-300 text-red-600 hover:bg-red-50"
+          >
+            Desconectar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/bancos/connect-token/route.ts
+++ b/app/api/admin/bancos/connect-token/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { criarConnectToken } from "@/lib/pluggy";
+
+export const runtime = "nodejs";
+
+// POST /api/admin/bancos/connect-token
+// Body: { itemId?: string }   ← se passado, abre widget em modo "atualizar"
+//
+// Gera um connect token efemero (vale 30min) pro Pluggy Connect Widget.
+// Frontend usa esse token pra abrir a UI nativa do Pluggy onde o admin:
+// 1. Escolhe o banco
+// 2. Loga com credenciais do app/site do banco
+// 3. Autoriza Open Finance
+// 4. Pluggy retorna um itemId que o frontend manda pra POST /connections
+//
+// Auth: x-admin-password
+export async function POST(req: NextRequest) {
+  const pw = req.headers.get("x-admin-password");
+  if (pw !== process.env.ADMIN_PASSWORD) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const itemId: string | undefined = body.itemId;
+
+  try {
+    const token = await criarConnectToken(itemId);
+    return NextResponse.json(token);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.error("[bancos/connect-token]", msg);
+    // Erro especifico: token Pluggy nao configurado
+    if (msg.includes("PLUGGY_CLIENT_ID")) {
+      return NextResponse.json({
+        error: "Pluggy nao configurado. Adicione PLUGGY_CLIENT_ID e PLUGGY_CLIENT_SECRET no Vercel.",
+      }, { status: 500 });
+    }
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/app/api/admin/bancos/connections/route.ts
+++ b/app/api/admin/bancos/connections/route.ts
@@ -1,0 +1,198 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { getItem, aliasParaConnectorName, getAccounts } from "@/lib/pluggy";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+// GET /api/admin/bancos/connections
+//   → lista todas conexoes ativas com saldos atuais (do banco local) +
+//     ultimo sync info
+//
+// POST /api/admin/bancos/connections
+//   Body: { itemId: string }
+//   → registra uma nova conexao apos o widget Pluggy ter retornado itemId.
+//     Busca metadados do item na Pluggy + salva em bancos_conexoes +
+//     ja faz o primeiro fetch de accounts pra popular saldos_historico.
+//
+// DELETE /api/admin/bancos/connections?id=N
+//   → marca conexao como ativo=false (nao deleta do Pluggy — admin pode
+//     reativar dps. Pra deletar de verdade, ir no painel Pluggy)
+//
+// Auth: x-admin-password
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || "";
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export async function GET(req: NextRequest) {
+  const pw = req.headers.get("x-admin-password");
+  if (pw !== process.env.ADMIN_PASSWORD) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const supabase = getSupabase();
+
+  // Busca conexoes ativas
+  const { data: conexoes, error: errConn } = await supabase
+    .from("bancos_conexoes")
+    .select("*")
+    .eq("ativo", true)
+    .order("criado_em", { ascending: false });
+
+  if (errConn) {
+    return NextResponse.json({ error: errConn.message }, { status: 500 });
+  }
+
+  if (!conexoes || conexoes.length === 0) {
+    return NextResponse.json({ conexoes: [], saldoTotal: 0 });
+  }
+
+  // Pra cada conexao, busca o saldo MAIS RECENTE de cada conta
+  // (uma conexao = 1 banco, pode ter varias contas: corrente + cartao)
+  const conexaoIds = conexoes.map((c) => c.id);
+  const { data: saldos, error: errSaldos } = await supabase
+    .from("bancos_saldos_historico")
+    .select("*")
+    .in("conexao_id", conexaoIds)
+    .order("consultado_em", { ascending: false });
+
+  if (errSaldos) {
+    return NextResponse.json({ error: errSaldos.message }, { status: 500 });
+  }
+
+  // Agrupa por conexao_id + pluggy_account_id, pega so o mais recente de cada
+  const saldosUltimos = new Map<string, typeof saldos[number]>();
+  for (const s of saldos || []) {
+    const key = `${s.conexao_id}:${s.pluggy_account_id}`;
+    if (!saldosUltimos.has(key)) {
+      saldosUltimos.set(key, s);
+    }
+  }
+
+  // Monta resposta agregada
+  const conexoesComSaldos = conexoes.map((c) => {
+    const contas = Array.from(saldosUltimos.values())
+      .filter((s) => s.conexao_id === c.id)
+      .map((s) => ({
+        accountId: s.pluggy_account_id,
+        accountName: s.account_name,
+        accountType: s.account_type,
+        accountSubtype: s.account_subtype,
+        saldo: Number(s.saldo),
+        creditLimite: s.credit_limite ? Number(s.credit_limite) : null,
+        consultadoEm: s.consultado_em,
+      }));
+    // Soma saldos so de contas BANK (cartao de credito nao soma — e divida)
+    const saldoTotal = contas
+      .filter((c) => c.accountType !== "CREDIT")
+      .reduce((sum, c) => sum + c.saldo, 0);
+    return { ...c, contas, saldoTotal };
+  });
+
+  // Total geral somando todos os saldos de conta corrente
+  const saldoTotal = conexoesComSaldos.reduce((sum, c) => sum + c.saldoTotal, 0);
+
+  return NextResponse.json({ conexoes: conexoesComSaldos, saldoTotal });
+}
+
+export async function POST(req: NextRequest) {
+  const pw = req.headers.get("x-admin-password");
+  if (pw !== process.env.ADMIN_PASSWORD) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const itemId: string = body.itemId;
+  if (!itemId) {
+    return NextResponse.json({ error: "Passe { itemId }" }, { status: 400 });
+  }
+
+  try {
+    // Busca metadados do item no Pluggy
+    const item = await getItem(itemId);
+    const alias = aliasParaConnectorName(item.connector?.name || "OUTRO");
+
+    const supabase = getSupabase();
+
+    // Insert ou update se ja existir (admin pode reconectar mesmo banco)
+    const { data: conexao, error: upsertErr } = await supabase
+      .from("bancos_conexoes")
+      .upsert({
+        pluggy_item_id: item.id,
+        banco_alias: alias,
+        banco_nome: item.connector?.name || "Banco",
+        status: item.status,
+        connector_id: item.connector?.id || null,
+        connector_image_url: item.connector?.imageUrl || null,
+        connector_primary_color: item.connector?.primaryColor || null,
+        ativo: true,
+        atualizado_em: new Date().toISOString(),
+      }, { onConflict: "pluggy_item_id" })
+      .select()
+      .single();
+
+    if (upsertErr || !conexao) {
+      return NextResponse.json({ error: upsertErr?.message || "Falha ao salvar conexao" }, { status: 500 });
+    }
+
+    // Ja faz o primeiro fetch de accounts pra popular saldos_historico
+    let contasSync = 0;
+    try {
+      const accounts = await getAccounts(itemId);
+      const inserts = accounts.map((acc) => ({
+        conexao_id: conexao.id,
+        pluggy_account_id: acc.id,
+        account_type: acc.type,
+        account_subtype: acc.subtype,
+        account_name: acc.marketingName || acc.name,
+        saldo: acc.balance,
+        credit_limite: acc.creditData?.creditLimit || null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        raw: acc as any,
+      }));
+      if (inserts.length > 0) {
+        await supabase.from("bancos_saldos_historico").insert(inserts);
+        contasSync = inserts.length;
+      }
+      await supabase.from("bancos_conexoes").update({
+        ultimo_sync_em: new Date().toISOString(),
+        ultimo_sync_status: "OK",
+        ultimo_sync_erro: null,
+      }).eq("id", conexao.id);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      await supabase.from("bancos_conexoes").update({
+        ultimo_sync_em: new Date().toISOString(),
+        ultimo_sync_status: "ERRO",
+        ultimo_sync_erro: msg.slice(0, 500),
+      }).eq("id", conexao.id);
+    }
+
+    return NextResponse.json({ ok: true, conexao, contasSync });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}
+
+export async function DELETE(req: NextRequest) {
+  const pw = req.headers.get("x-admin-password");
+  if (pw !== process.env.ADMIN_PASSWORD) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const id = req.nextUrl.searchParams.get("id");
+  if (!id) return NextResponse.json({ error: "Passe ?id=" }, { status: 400 });
+
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from("bancos_conexoes")
+    .update({ ativo: false, atualizado_em: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/bancos/sync/route.ts
+++ b/app/api/admin/bancos/sync/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { getAccounts } from "@/lib/pluggy";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+// POST /api/admin/bancos/sync
+// Body: { conexao_id?: number }   ← se passado, sync so essa. senao TODAS ativas.
+//
+// Faz pull dos saldos atualizados das conexoes Pluggy ativas.
+// Insere nova row em bancos_saldos_historico pra cada conta de cada conexao.
+//
+// Retorna resumo: { atualizadas, erros, detalhes[] }
+//
+// Auth: x-admin-password
+
+function getSupabase() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL || "";
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+  return createClient(url, key, { auth: { persistSession: false } });
+}
+
+export async function POST(req: NextRequest) {
+  const pw = req.headers.get("x-admin-password");
+  if (pw !== process.env.ADMIN_PASSWORD) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const conexaoIdEspecifica: number | undefined = body.conexao_id;
+
+  const supabase = getSupabase();
+
+  let query = supabase.from("bancos_conexoes").select("*").eq("ativo", true);
+  if (conexaoIdEspecifica) {
+    query = query.eq("id", conexaoIdEspecifica);
+  }
+
+  const { data: conexoes, error } = await query;
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!conexoes || conexoes.length === 0) {
+    return NextResponse.json({ atualizadas: 0, erros: 0, detalhes: [], message: "Nenhuma conexao ativa" });
+  }
+
+  let atualizadas = 0;
+  let erros = 0;
+  const detalhes: Array<{ conexao_id: number; banco: string; status: string; contas?: number; erro?: string }> = [];
+
+  // Processa em serie pra nao explodir rate limit Pluggy.
+  // 6 conexoes × 2s = 12s, dentro do maxDuration=60.
+  for (const c of conexoes) {
+    try {
+      const accounts = await getAccounts(c.pluggy_item_id);
+      const inserts = accounts.map((acc) => ({
+        conexao_id: c.id,
+        pluggy_account_id: acc.id,
+        account_type: acc.type,
+        account_subtype: acc.subtype,
+        account_name: acc.marketingName || acc.name,
+        saldo: acc.balance,
+        credit_limite: acc.creditData?.creditLimit || null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        raw: acc as any,
+      }));
+      if (inserts.length > 0) {
+        const { error: insErr } = await supabase.from("bancos_saldos_historico").insert(inserts);
+        if (insErr) throw new Error(insErr.message);
+      }
+      await supabase.from("bancos_conexoes").update({
+        ultimo_sync_em: new Date().toISOString(),
+        ultimo_sync_status: "OK",
+        ultimo_sync_erro: null,
+        atualizado_em: new Date().toISOString(),
+      }).eq("id", c.id);
+      atualizadas++;
+      detalhes.push({ conexao_id: c.id, banco: c.banco_nome, status: "OK", contas: inserts.length });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`[bancos/sync] conexao=${c.id} (${c.banco_nome}):`, msg);
+      await supabase.from("bancos_conexoes").update({
+        ultimo_sync_em: new Date().toISOString(),
+        ultimo_sync_status: "ERRO",
+        ultimo_sync_erro: msg.slice(0, 500),
+        atualizado_em: new Date().toISOString(),
+      }).eq("id", c.id);
+      erros++;
+      detalhes.push({ conexao_id: c.id, banco: c.banco_nome, status: "ERRO", erro: msg });
+    }
+  }
+
+  return NextResponse.json({ atualizadas, erros, total: conexoes.length, detalhes });
+}

--- a/components/admin/nav-config.ts
+++ b/components/admin/nav-config.ts
@@ -37,6 +37,7 @@ export const NAV: NavEntry[] = [
       { href: "/admin/clientes", label: "Cadastros", icon: "\u{1F465}", pageKey: "clientes" },
       { href: "/admin/gastos", label: "Gastos", icon: "\u{1F4E4}", pageKey: "gastos" },
       { href: "/admin/saldos", label: "Saldos", icon: "\u{1F3E6}", pageKey: "saldos" },
+      { href: "/admin/bancos", label: "Bancos (Open Finance)", icon: "\u{1F517}", pageKey: "saldos" },
       { href: "/admin/recebiveis", label: "Recebiveis", icon: "\u{1F4B3}", pageKey: "recebiveis" },
       { href: "/admin/conciliacao", label: "Conciliacao", icon: "\u{1F50D}", pageKey: "conciliacao" },
       { href: "/admin/auditoria", label: "Auditoria", icon: "📋", pageKey: "saldos" },

--- a/lib/pluggy.ts
+++ b/lib/pluggy.ts
@@ -1,0 +1,247 @@
+// Cliente Pluggy (https://pluggy.ai) — Open Finance BR.
+//
+// Usado pelo item #28 (sync automatico de saldos bancarios) pra substituir
+// digitacao manual em /admin/auditoria.
+//
+// Fluxo de uso:
+// 1. Admin cria conta no Pluggy + pega CLIENT_ID + CLIENT_SECRET
+// 2. Configura como env vars no Vercel: PLUGGY_CLIENT_ID, PLUGGY_CLIENT_SECRET
+// 3. Admin clica "Conectar banco" → backend chama POST /connect_token
+// 4. Frontend abre Pluggy Connect Widget com o token → admin autoriza
+// 5. Pluggy retorna item_id → guardamos em bancos_conexoes
+// 6. Periodicamente (manual via botao ou cron diario) fazemos sync pra
+//    pegar saldos atualizados de cada item
+//
+// Doc: https://docs.pluggy.ai
+
+const PLUGGY_BASE = "https://api.pluggy.ai";
+const TIMEOUT_MS = 15000;
+
+// Cache do API key (validade 2h). Pluggy auth nao e Bearer token tradicional —
+// gera um "X-API-KEY" usando clientId+secret que vale 2h.
+let cachedApiKey: { key: string; expiresAt: number } | null = null;
+
+interface AuthResp {
+  apiKey: string;
+}
+
+interface PluggyConnector {
+  id: number;
+  name: string;
+  imageUrl?: string;
+  primaryColor?: string;
+  type?: string;
+  country?: string;
+}
+
+export interface PluggyItem {
+  id: string;
+  status: string;
+  connector: PluggyConnector;
+  createdAt?: string;
+  updatedAt?: string;
+  lastUpdatedAt?: string;
+  executionStatus?: string;
+  error?: { code?: string; message?: string };
+}
+
+export interface PluggyAccount {
+  id: string;
+  type: "BANK" | "CREDIT" | string;
+  subtype: string;
+  name: string;
+  marketingName?: string | null;
+  number?: string | null;
+  balance: number;
+  itemId: string;
+  currencyCode: string;
+  // Pra cartao de credito
+  creditData?: {
+    creditLimit?: number;
+    availableCreditLimit?: number;
+    balanceCloseDate?: string;
+    balanceDueDate?: string;
+  };
+}
+
+interface ListResp<T> {
+  results: T[];
+  total?: number;
+}
+
+/**
+ * Faz auth na Pluggy e retorna apiKey valida (cacheia por ate 2h).
+ * Token e necessario pra TODAS as chamadas da Pluggy API.
+ */
+async function getApiKey(): Promise<string> {
+  if (cachedApiKey && cachedApiKey.expiresAt > Date.now() + 60000) {
+    return cachedApiKey.key;
+  }
+
+  const clientId = process.env.PLUGGY_CLIENT_ID;
+  const clientSecret = process.env.PLUGGY_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new Error("PLUGGY_CLIENT_ID ou PLUGGY_CLIENT_SECRET nao configurados");
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${PLUGGY_BASE}/auth`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clientId, clientSecret }),
+      signal: controller.signal,
+    });
+
+    if (!res.ok) {
+      const txt = await res.text().catch(() => "");
+      throw new Error(`Pluggy auth HTTP ${res.status}: ${txt.slice(0, 200)}`);
+    }
+
+    const json: AuthResp = await res.json();
+    if (!json.apiKey) {
+      throw new Error("Pluggy auth sem apiKey no response");
+    }
+
+    // Pluggy diz que apiKey vale 2h. Pra ser conservador cacheia por 1h45.
+    cachedApiKey = { key: json.apiKey, expiresAt: Date.now() + 105 * 60 * 1000 };
+    return json.apiKey;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Faz request autenticada na API Pluggy. Lida com expiracao do apiKey
+ * (re-auth e tenta de novo 1x se receber 401/403).
+ */
+async function pluggyFetch(
+  path: string,
+  init: RequestInit & { _retry?: boolean } = {}
+): Promise<Response> {
+  const key = await getApiKey();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const res = await fetch(`${PLUGGY_BASE}${path}`, {
+      ...init,
+      headers: {
+        "X-API-KEY": key,
+        "Content-Type": "application/json",
+        ...(init.headers || {}),
+      },
+      signal: controller.signal,
+    });
+
+    // Re-auth + retry 1x se token expirou
+    if ((res.status === 401 || res.status === 403) && !init._retry) {
+      cachedApiKey = null;
+      return pluggyFetch(path, { ...init, _retry: true });
+    }
+
+    return res;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+/**
+ * Cria um connect_token efemero (validade 30min) pro Pluggy Connect Widget
+ * abrir no frontend. Cada admin que vai conectar um banco precisa de um.
+ *
+ * @param itemId — opcional, se passado o widget abre em modo "atualizar
+ *                 conexao existente" (pra re-autenticar quando login muda)
+ */
+export async function criarConnectToken(itemId?: string): Promise<{ accessToken: string }> {
+  const body: Record<string, unknown> = {};
+  if (itemId) body.itemId = itemId;
+  const res = await pluggyFetch(`/connect_token`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Pluggy connect_token HTTP ${res.status}: ${txt.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+/**
+ * Busca metadados de um item (status, connector info). Usado depois que o
+ * widget retorna um itemId pra registrar no nosso banco.
+ */
+export async function getItem(itemId: string): Promise<PluggyItem> {
+  const res = await pluggyFetch(`/items/${encodeURIComponent(itemId)}`);
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Pluggy GET item HTTP ${res.status}: ${txt.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+/**
+ * Lista todas accounts (contas) de um item (banco). Um banco pode ter:
+ * - Conta corrente (BANK / CHECKING_ACCOUNT)
+ * - Poupanca (BANK / SAVINGS_ACCOUNT)
+ * - Cartao de credito (CREDIT / CREDIT_CARD)
+ */
+export async function getAccounts(itemId: string): Promise<PluggyAccount[]> {
+  const res = await pluggyFetch(`/accounts?itemId=${encodeURIComponent(itemId)}`);
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Pluggy GET accounts HTTP ${res.status}: ${txt.slice(0, 200)}`);
+  }
+  const json: ListResp<PluggyAccount> = await res.json();
+  return json.results || [];
+}
+
+/**
+ * Forca atualizacao do item (pede pra Pluggy reconectar e baixar novos
+ * dados). E assincrono — o status fica UPDATING e depois UPDATED.
+ *
+ * Pra MVP simplesmente chamamos getAccounts logo apos pra pegar o que
+ * tiver — Pluggy ja mantem cache fresco se item foi sincronizado nas
+ * ultimas horas.
+ */
+export async function refreshItem(itemId: string): Promise<PluggyItem> {
+  const res = await pluggyFetch(`/items/${encodeURIComponent(itemId)}`, {
+    method: "PATCH",
+    body: JSON.stringify({}),
+  });
+  if (!res.ok) {
+    const txt = await res.text().catch(() => "");
+    throw new Error(`Pluggy refresh item HTTP ${res.status}: ${txt.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+/**
+ * Mapeia o connector.name do Pluggy pra nosso alias interno (ITAU,
+ * INFINITE, MERCADO_PAGO, etc). Se nao reconhecer, devolve "OUTRO".
+ *
+ * Pluggy connector names sao tipo "Itau", "Itau Personnalite", "Mercado Pago",
+ * "Nubank", etc. Lista completa: https://api.pluggy.ai/connectors
+ */
+export function aliasParaConnectorName(name: string): string {
+  const n = name.toLowerCase();
+  if (n.includes("itau") || n.includes("itaú")) {
+    if (n.includes("personnalit") || n.includes("infinite") || n.includes("private")) {
+      return "INFINITE";
+    }
+    return "ITAU";
+  }
+  if (n.includes("mercado pago") || n.includes("mercadopago") || n.includes("mp ")) return "MERCADO_PAGO";
+  if (n.includes("nubank")) return "NUBANK";
+  if (n.includes("inter")) return "INTER";
+  if (n.includes("bradesco")) return "BRADESCO";
+  if (n.includes("caixa")) return "CAIXA";
+  if (n.includes("santander")) return "SANTANDER";
+  if (n.includes("bb") || n.includes("banco do brasil")) return "BB";
+  if (n.includes("c6")) return "C6";
+  if (n.includes("safra")) return "SAFRA";
+  if (n.includes("xp")) return "XP";
+  return "OUTRO";
+}

--- a/supabase/migrations/20260425d_bancos_pluggy.sql
+++ b/supabase/migrations/20260425d_bancos_pluggy.sql
@@ -1,0 +1,73 @@
+-- Open Finance via Pluggy (Abr/2026 — item #28)
+--
+-- Substitui digitacao manual de saldos por sync automatico via Pluggy
+-- (https://pluggy.ai), agregador BR que conecta Itau, Inter, MP, Nubank,
+-- Bradesco etc usando Open Finance + scraping autorizado.
+--
+-- 2 tabelas:
+-- - bancos_conexoes: 1 row por banco conectado (Pluggy chama de "item")
+-- - bancos_saldos_historico: append-only, 1 row por consulta de saldo
+--   permite grafico historico no futuro
+
+CREATE TABLE IF NOT EXISTS bancos_conexoes (
+  id BIGSERIAL PRIMARY KEY,
+  -- ID do "item" no Pluggy (representa 1 conexao com 1 banco do usuario).
+  -- 1 item pode ter varias contas (corrente + poupanca + cartao).
+  pluggy_item_id TEXT NOT NULL UNIQUE,
+  -- Alias amigavel pra mapear no nosso sistema:
+  -- ITAU | INFINITE | MERCADO_PAGO | NUBANK | INTER | BRADESCO | CAIXA | OUTRO
+  banco_alias TEXT NOT NULL,
+  -- Nome legivel do banco (do Pluggy connector.name)
+  banco_nome TEXT NOT NULL,
+  -- Status da conexao: UPDATED | OUTDATED | LOGIN_ERROR | WAITING_USER_INPUT | etc
+  -- Ver https://docs.pluggy.ai/docs/items
+  status TEXT NOT NULL DEFAULT 'CREATED',
+  -- Metadados do connector pra mostrar logo/cor na UI
+  connector_id INT,
+  connector_image_url TEXT,
+  connector_primary_color TEXT,
+  -- Sync info
+  ultimo_sync_em TIMESTAMPTZ,
+  ultimo_sync_status TEXT,
+  ultimo_sync_erro TEXT,
+  -- Ativo: false = admin desconectou (ainda existe no Pluggy mas nao usamos)
+  ativo BOOLEAN NOT NULL DEFAULT TRUE,
+  criado_em TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  atualizado_em TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bancos_conexoes_alias
+  ON bancos_conexoes (banco_alias) WHERE ativo = TRUE;
+CREATE INDEX IF NOT EXISTS idx_bancos_conexoes_status
+  ON bancos_conexoes (status);
+
+CREATE TABLE IF NOT EXISTS bancos_saldos_historico (
+  id BIGSERIAL PRIMARY KEY,
+  conexao_id BIGINT REFERENCES bancos_conexoes(id) ON DELETE CASCADE,
+  -- Pluggy account ID (uma conexao pode ter varias contas)
+  pluggy_account_id TEXT NOT NULL,
+  -- Tipo de conta: BANK | CREDIT (cartao de credito vira "saldo negativo")
+  account_type TEXT,
+  -- Subtype: CHECKING_ACCOUNT | SAVINGS_ACCOUNT | CREDIT_CARD
+  account_subtype TEXT,
+  -- Nome legivel (ex: "Conta Corrente", "Cartao Black")
+  account_name TEXT,
+  -- Saldo em reais. Pra cartao de credito = limite usado (positivo).
+  saldo NUMERIC(12, 2) NOT NULL,
+  -- Pra cartao de credito: limite total
+  credit_limite NUMERIC(12, 2),
+  -- Quando consultou
+  consultado_em TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- JSON cru do Pluggy pra debug/auditoria
+  raw JSONB
+);
+
+CREATE INDEX IF NOT EXISTS idx_bancos_saldos_conexao
+  ON bancos_saldos_historico (conexao_id, consultado_em DESC);
+CREATE INDEX IF NOT EXISTS idx_bancos_saldos_data
+  ON bancos_saldos_historico (consultado_em DESC);
+
+COMMENT ON TABLE bancos_conexoes IS 'Conexoes Pluggy/Open Finance — 1 row por banco autorizado';
+COMMENT ON TABLE bancos_saldos_historico IS 'Snapshot de saldos a cada sync — append-only pra grafico historico';
+COMMENT ON COLUMN bancos_conexoes.pluggy_item_id IS 'ID do item no Pluggy. Usado pra todas operacoes da Pluggy API.';
+COMMENT ON COLUMN bancos_saldos_historico.saldo IS 'Saldo em R$ — para conta corrente positivo, para CREDIT_CARD = uso atual';


### PR DESCRIPTION
## Item #28 — Open Finance via Pluggy

Substitui digitação manual de saldos diários em `/admin/auditoria` por sync automático via [Pluggy](https://pluggy.ai), agregador BR. Suporta Itaú, Inter, MercadoPago, Nubank, Bradesco, Caixa, etc.

## O que muda pro André

**Hoje:** abre app de cada banco → anota saldos → digita em `/admin/auditoria`

**Depois desse PR:** clica "🔄 Atualizar saldos" → todos saldos vêm automáticos

## Componentes

### Backend
- `lib/pluggy.ts` — cliente com auth cacheada (apiKey vale 2h) + retry em 401
- 4 endpoints em `/api/admin/bancos/*`:
  - `POST /connect-token` — token efêmero pro widget
  - `GET /connections` — lista bancos conectados + saldos
  - `POST /connections` — registra novo banco após widget
  - `POST /sync` — atualiza todos saldos sob demanda
- Migration `20260425d_bancos_pluggy.sql`:
  - `bancos_conexoes` (1 row por banco)
  - `bancos_saldos_historico` (snapshot de cada sync, append-only)

### UI
Nova página `/admin/bancos` (entrada no menu Financeiro):
- KPI top: **Saldo total disponível** (soma contas correntes)
- Card por banco com logo, status, contas individuais
- Cartão de crédito mostra dívida em vermelho
- Botões: **+ Conectar banco** (Pluggy Connect Widget), **🔄 Atualizar saldos**, **🔐 Reconectar** (se login falhou), **Desconectar**

### Pluggy Connect Widget
SDK oficial via `<Script>` tag. Quando admin clica "+ Conectar banco":
1. Backend gera connect token
2. Widget abre modal nativo Pluggy
3. Admin escolhe banco + loga + autoriza Open Finance
4. Pluggy retorna itemId
5. Backend salva em `bancos_conexoes` + sincroniza saldos imediato

## Setup necessário (você faz uma vez)

1. Criar conta em https://pluggy.ai (já fez ✅)
2. **Vercel → Environment Variables**:
   - `PLUGGY_CLIENT_ID` = (o ID que você me mostrou no print, ok expor)
   - `PLUGGY_CLIENT_SECRET` = (clica no olho na página Pluggy pra ver — **NÃO compartilha em lugar nenhum**)
3. Redeploy do Vercel
4. Rodar migration em `/admin/migrations`
5. `/admin/bancos` → "+ Conectar banco" pra cada banco que quiser (Itaú, Infinite, MP, Inter, etc)

## Test plan

- [ ] Mergear PR
- [ ] Adicionar `PLUGGY_CLIENT_ID` + `PLUGGY_CLIENT_SECRET` no Vercel + redeploy
- [ ] Rodar migration `20260425d_bancos_pluggy.sql`
- [ ] Acessar `/admin/bancos` (vai aparecer no menu Financeiro)
- [ ] Clicar "+ Conectar banco" → Widget Pluggy abre
- [ ] Conectar 1 banco (sugiro Itaú primeiro pra teste)
- [ ] Ver saldo aparecer
- [ ] Clicar "🔄 Atualizar saldos" → saldo atualiza
- [ ] Conectar mais bancos

## Graceful degradation

Se Pluggy não estiver configurado, endpoint retorna mensagem amigável ("Pluggy não configurado") em vez de erro genérico. Sistema continua funcionando normal.

## Próximo passo (PR separado, futuro)

Integrar com `/admin/auditoria` pra preencher `conferencia_diaria` automaticamente baseado nos saldos Pluggy. Não fiz nesse PR pra manter escopo focado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)