### PR TITLE
fix(bancos): GRANT + disable RLS pras tabelas Pluggy

### DIFF
--- a/supabase/migrations/20260425e_bancos_pluggy_permissions.sql
+++ b/supabase/migrations/20260425e_bancos_pluggy_permissions.sql
@@ -1,0 +1,31 @@
+-- Fix: permissoes nas tabelas bancos_conexoes / bancos_saldos_historico
+--
+-- Bug em producao depois da 20260425d_bancos_pluggy.sql:
+-- "permission denied for table bancos_conexoes"
+--
+-- Causa: a migration original criou as tabelas mas nao deu GRANT nem
+-- desabilitou RLS. As outras tabelas do projeto (instagram_posts,
+-- link_compras, etc) tem esses comandos. Padrao do projeto.
+--
+-- Idempotente — pode rodar varias vezes sem efeito.
+
+-- Tabela 1: bancos_conexoes
+GRANT ALL ON TABLE bancos_conexoes TO service_role;
+GRANT ALL ON TABLE bancos_conexoes TO postgres;
+GRANT ALL ON TABLE bancos_conexoes TO authenticated;
+ALTER TABLE bancos_conexoes DISABLE ROW LEVEL SECURITY;
+
+-- Sequence do BIGSERIAL precisa de GRANT separado pra inserts funcionarem
+GRANT USAGE, SELECT ON SEQUENCE bancos_conexoes_id_seq TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE bancos_conexoes_id_seq TO authenticated;
+GRANT USAGE, SELECT ON SEQUENCE bancos_conexoes_id_seq TO postgres;
+
+-- Tabela 2: bancos_saldos_historico
+GRANT ALL ON TABLE bancos_saldos_historico TO service_role;
+GRANT ALL ON TABLE bancos_saldos_historico TO postgres;
+GRANT ALL ON TABLE bancos_saldos_historico TO authenticated;
+ALTER TABLE bancos_saldos_historico DISABLE ROW LEVEL SECURITY;
+
+GRANT USAGE, SELECT ON SEQUENCE bancos_saldos_historico_id_seq TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE bancos_saldos_historico_id_seq TO authenticated;
+GRANT USAGE, SELECT ON SEQUENCE bancos_saldos_historico_id_seq TO postgres;


### PR DESCRIPTION
## Bug

\`/admin/bancos\` retornava: **"permission denied for table bancos_conexoes"**

## Causa

Esqueci de adicionar `GRANT` + `DISABLE ROW LEVEL SECURITY` na migration original (#28). Esses comandos são padrão do projeto — todas outras tabelas têm (ver `instagram_posts.sql`, etc).

Sem isso, mesmo o `service_role` do Supabase é bloqueado pelas policies default de RLS.

## Fix

Migration nova `20260425e_bancos_pluggy_permissions.sql`:
- `GRANT ALL` nas 2 tabelas → `service_role` + `postgres` + `authenticated`
- `DISABLE ROW LEVEL SECURITY` nas 2 tabelas
- `GRANT USAGE, SELECT` nas sequences do `BIGSERIAL` (necessário pra INSERT gerar id automático)

Idempotente — pode rodar múltiplas vezes sem problema.

## Setup pós-merge

1. Mergear PR
2. Em `/admin/migrations` → rodar `20260425e_bancos_pluggy_permissions.sql`
3. Refresh em `/admin/bancos` → erro some
4. Continuar setup do Pluggy (env vars + redeploy + conectar bancos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)