### PR TITLE
fix(bancos): trocar script CDN do Pluggy pelo SDK React oficial

### DIFF
--- a/app/admin/bancos/page.tsx
+++ b/app/admin/bancos/page.tsx
@@ -1,11 +1,19 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import Script from "next/script";
+import dynamic from "next/dynamic";
 import { useAdmin } from "@/components/admin/AdminShell";
 
 // Item #28 — gerenciar conexoes Pluggy/Open Finance pra puxar saldos
 // automaticos de Itau, Inter, MP, Nubank, etc.
+//
+// Pluggy Connect Widget via SDK oficial React (em vez de script tag CDN
+// que estava com problema de loading). Lazy import porque carrega ~100KB
+// e so e usado quando admin clica "Conectar banco".
+const PluggyConnect = dynamic(
+  () => import("react-pluggy-connect").then((m) => m.PluggyConnect),
+  { ssr: false }
+);
 
 interface Conta {
   accountId: string;
@@ -38,10 +46,6 @@ interface ConexoesResp {
   saldoTotal: number;
 }
 
-// Pluggy Connect Widget global (carregado via script tag)
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare global { interface Window { PluggyConnect: any } }
-
 const fmtBRL = (n: number) => `R$ ${n.toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
 const fmtData = (iso: string | null): string => {
@@ -71,7 +75,12 @@ export default function BancosPage() {
   const [syncing, setSyncing] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [msg, setMsg] = useState<{ tipo: "ok" | "erro"; texto: string } | null>(null);
-  const [scriptReady, setScriptReady] = useState(false);
+  // Pluggy Connect Widget — armazena o connect token quando admin clica
+  // "Conectar banco". Quando setado, o componente <PluggyConnect/> e
+  // renderizado e abre o modal nativo. itemIdParaAtualizar e usado quando
+  // estamos reconectando (status LOGIN_ERROR).
+  const [pluggyToken, setPluggyToken] = useState<string | null>(null);
+  const [itemIdParaAtualizar, setItemIdParaAtualizar] = useState<string | undefined>(undefined);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -93,16 +102,19 @@ export default function BancosPage() {
     if (password) load();
   }, [password, load]);
 
-  // Abre o Pluggy Connect Widget pra adicionar nova conexao
-  const conectarBanco = async (itemIdParaAtualizar?: string) => {
+  // Abre o Pluggy Connect Widget pra adicionar nova conexao.
+  // 1. Backend gera connect token efemero
+  // 2. Setamos pluggyToken → componente <PluggyConnect/> e renderizado
+  //    e abre modal nativo automatico
+  // 3. Callbacks (onSuccess/onError/onClose) tratam o resultado
+  const conectarBanco = async (itemId?: string) => {
     setConnecting(true);
     setMsg(null);
     try {
-      // 1. Pega connect token efemero do backend
       const tokenRes = await fetch("/api/admin/bancos/connect-token", {
         method: "POST",
         headers: apiHeaders({ "Content-Type": "application/json" }),
-        body: JSON.stringify(itemIdParaAtualizar ? { itemId: itemIdParaAtualizar } : {}),
+        body: JSON.stringify(itemId ? { itemId } : {}),
       });
       const tokenJson = await tokenRes.json();
       if (!tokenRes.ok) {
@@ -110,53 +122,60 @@ export default function BancosPage() {
         setConnecting(false);
         return;
       }
-
-      // 2. Abre o widget Pluggy
-      if (!window.PluggyConnect) {
-        setMsg({ tipo: "erro", texto: "Widget Pluggy nao carregou. Recarregue a pagina." });
-        setConnecting(false);
-        return;
-      }
-
-      const pluggy = new window.PluggyConnect({
-        connectToken: tokenJson.accessToken,
-        includeSandbox: false,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        onSuccess: async (itemData: any) => {
-          // 3. Quando admin termina, registra a conexao no nosso banco
-          const itemId = itemData?.item?.id;
-          if (!itemId) {
-            setMsg({ tipo: "erro", texto: "Pluggy nao retornou itemId" });
-            setConnecting(false);
-            return;
-          }
-          const regRes = await fetch("/api/admin/bancos/connections", {
-            method: "POST",
-            headers: apiHeaders({ "Content-Type": "application/json" }),
-            body: JSON.stringify({ itemId }),
-          });
-          const regJson = await regRes.json();
-          if (regRes.ok) {
-            setMsg({ tipo: "ok", texto: `Conectado! ${regJson.contasSync || 0} contas sincronizadas.` });
-            load();
-          } else {
-            setMsg({ tipo: "erro", texto: regJson.error || "Erro ao registrar" });
-          }
-          setConnecting(false);
-        },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        onError: (err: any) => {
-          setMsg({ tipo: "erro", texto: err?.message || "Erro no widget Pluggy" });
-          setConnecting(false);
-        },
-        onClose: () => setConnecting(false),
-      });
-      pluggy.init();
+      setItemIdParaAtualizar(itemId);
+      setPluggyToken(tokenJson.accessToken);
+      // setConnecting fica true ate o widget fechar (onClose ou onSuccess)
     } catch (e) {
       setMsg({ tipo: "erro", texto: e instanceof Error ? e.message : "Erro" });
       setConnecting(false);
     }
   };
+
+  // Handler quando o widget Pluggy retorna sucesso
+  const onPluggySuccess = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (itemData: any) => {
+      const itemId = itemData?.item?.id;
+      if (!itemId) {
+        setMsg({ tipo: "erro", texto: "Pluggy nao retornou itemId" });
+        setPluggyToken(null);
+        setConnecting(false);
+        return;
+      }
+      try {
+        const regRes = await fetch("/api/admin/bancos/connections", {
+          method: "POST",
+          headers: apiHeaders({ "Content-Type": "application/json" }),
+          body: JSON.stringify({ itemId }),
+        });
+        const regJson = await regRes.json();
+        if (regRes.ok) {
+          setMsg({ tipo: "ok", texto: `Conectado! ${regJson.contasSync || 0} contas sincronizadas.` });
+          load();
+        } else {
+          setMsg({ tipo: "erro", texto: regJson.error || "Erro ao registrar" });
+        }
+      } catch (e) {
+        setMsg({ tipo: "erro", texto: e instanceof Error ? e.message : "Erro de rede" });
+      }
+      setPluggyToken(null);
+      setConnecting(false);
+    },
+    [apiHeaders, load]
+  );
+
+  // Handler quando widget fecha sem completar (admin clicou X ou ESC)
+  const onPluggyClose = useCallback(() => {
+    setPluggyToken(null);
+    setConnecting(false);
+  }, []);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onPluggyError = useCallback((err: any) => {
+    setMsg({ tipo: "erro", texto: err?.message || "Erro no widget Pluggy" });
+    setPluggyToken(null);
+    setConnecting(false);
+  }, []);
 
   // Sync manual: atualiza saldos de todas conexoes (ou de uma especifica)
   const syncAll = async (conexao_id?: number) => {
@@ -201,12 +220,18 @@ export default function BancosPage() {
 
   return (
     <div className="space-y-4 max-w-5xl">
-      {/* SDK do Pluggy Connect Widget. Carregado uma unica vez por pagina. */}
-      <Script
-        src="https://cdn.pluggy.ai/web-connect/v2.10.0/pluggy-connect.js"
-        strategy="lazyOnload"
-        onReady={() => setScriptReady(true)}
-      />
+      {/* Pluggy Connect Widget — renderiza so quando tem token (clica em
+          conectar). Componente abre modal nativo e dispara callbacks. */}
+      {pluggyToken && (
+        <PluggyConnect
+          connectToken={pluggyToken}
+          includeSandbox={false}
+          updateItem={itemIdParaAtualizar}
+          onSuccess={onPluggySuccess}
+          onError={onPluggyError}
+          onClose={onPluggyClose}
+        />
+      )}
 
       <div className="flex items-center justify-between flex-wrap gap-2">
         <div>
@@ -225,10 +250,10 @@ export default function BancosPage() {
           </button>
           <button
             onClick={() => conectarBanco()}
-            disabled={connecting || !scriptReady}
+            disabled={connecting}
             className="px-4 py-1.5 rounded-lg bg-[#E8740E] text-white text-xs font-semibold hover:bg-[#F5A623] disabled:opacity-50 transition-colors"
           >
-            {connecting ? "Aguardando..." : !scriptReady ? "Carregando..." : "+ Conectar banco"}
+            {connecting ? "Aguardando..." : "+ Conectar banco"}
           </button>
         </div>
       </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "qrcode.react": "^4.2.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
+        "react-pluggy-connect": "^2.12.0",
         "recharts": "^3.8.0",
         "tesseract.js": "^7.0.0",
         "xlsx": "^0.18.5"
@@ -2866,6 +2867,17 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/belter": {
+      "version": "1.0.190",
+      "resolved": "https://registry.npmjs.org/belter/-/belter-1.0.190.tgz",
+      "integrity": "sha512-jz05FHrO+bwitdI6JxV5ESyRdVhTcwMWQ7L4o+q/R4LNJFQrG58sp9EiwsSjhbihhiyYFcmmCMRRagxte6igtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-domain-safe-weakmap": "^1",
+        "cross-domain-utils": "^2",
+        "zalgo-promise": "^1"
+      }
+    },
     "node_modules/bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
@@ -3144,6 +3156,22 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/cross-domain-safe-weakmap": {
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/cross-domain-safe-weakmap/-/cross-domain-safe-weakmap-1.0.29.tgz",
+      "integrity": "sha512-VLoUgf2SXnf3+na8NfeUFV59TRZkIJqCIATaMdbhccgtnTlSnHXkyTRwokngEGYdQXx8JbHT9GDYitgR2sdjuA==",
+      "dependencies": {
+        "cross-domain-utils": "^2.0.0"
+      }
+    },
+    "node_modules/cross-domain-utils": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/cross-domain-utils/-/cross-domain-utils-2.0.38.tgz",
+      "integrity": "sha512-zZfi3+2EIR9l4chrEiXI2xFleyacsJf8YMLR1eJ0Veb5FTMXeJ3DpxDjZkto2FhL/g717WSELqbptNSo85UJDw==",
+      "dependencies": {
+        "zalgo-promise": "^1.0.11"
       }
     },
     "node_modules/cross-spawn": {
@@ -6334,6 +6362,23 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pluggy-connect-sdk": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pluggy-connect-sdk/-/pluggy-connect-sdk-2.13.0.tgz",
+      "integrity": "sha512-RbEjFbZsss8mdyuBqK3bVvfmW1zi+JWVnUb0L3cBYUXBujTzP1na/3GGfE3hJjYIShoMhRjPvq+CzuRZU0DrTw==",
+      "license": "MIT",
+      "dependencies": {
+        "zoid": "9.0.63"
+      },
+      "peerDependencies": {
+        "pluggy-js": ">= 0.16.0"
+      },
+      "peerDependenciesMeta": {
+        "pluggy-js": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/png-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
@@ -6356,6 +6401,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/post-robot": {
+      "version": "10.0.46",
+      "resolved": "https://registry.npmjs.org/post-robot/-/post-robot-10.0.46.tgz",
+      "integrity": "sha512-EgVJiuvI4iRWDZvzObWes0X/n8olWBEJWxlSw79zmhpgkigX8UsVL4VOBhVtoJKwf0Y9qP9g2zOONw1rv80QbA==",
+      "dependencies": {
+        "belter": "^1.0.41",
+        "cross-domain-safe-weakmap": "^1.0.1",
+        "cross-domain-utils": "^2.0.0",
+        "universal-serialize": "^1.0.4",
+        "zalgo-promise": "^1.0.3"
       }
     },
     "node_modules/postcss": {
@@ -6541,6 +6598,25 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-pluggy-connect": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/react-pluggy-connect/-/react-pluggy-connect-2.12.0.tgz",
+      "integrity": "sha512-p+Rq5Notr/KjoakpqIUDAMh/XFUaF2rTRachpBFxr90lOdWkE6S7i3qHanNq2lav/WsAa8y6MdSZC6gV1Sxp3g==",
+      "license": "MIT",
+      "dependencies": {
+        "pluggy-connect-sdk": "^2.12.0"
+      },
+      "peerDependencies": {
+        "pluggy-js": ">= 0.16.0",
+        "react": ">= 16.10.0",
+        "react-dom": ">= 16.10.0"
+      },
+      "peerDependenciesMeta": {
+        "pluggy-js": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -7664,6 +7740,11 @@
         "tiny-inflate": "^1.0.0"
       }
     },
+    "node_modules/universal-serialize": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/universal-serialize/-/universal-serialize-1.0.10.tgz",
+      "integrity": "sha512-FdouA4xSFa0fudk1+z5vLWtxZCoC0Q9lKYV3uUdFl7DttNfolmiw2ASr5ddY+/Yz6Isr68u3IqC9XMSwMP+Pow=="
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -8111,6 +8192,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zalgo-promise": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/zalgo-promise/-/zalgo-promise-1.0.48.tgz",
+      "integrity": "sha512-LLHANmdm53+MucY9aOFIggzYtUdkSBFxUsy4glTTQYNyK6B3uCPWTbfiGvSrEvLojw0mSzyFJ1/RRLv+QMNdzQ=="
+    },
     "node_modules/zlibjs": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
@@ -8141,6 +8227,17 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zoid": {
+      "version": "9.0.63",
+      "resolved": "https://registry.npmjs.org/zoid/-/zoid-9.0.63.tgz",
+      "integrity": "sha512-c9OccNUlOV9KuTKJJRhCU3B5SRHObTTiPAUayKkBQ0/qZugfh59MDW+zkFDR8IZN+c7NB/R90FCIpAfBp8+U/g==",
+      "dependencies": {
+        "belter": "^1.0.123",
+        "cross-domain-utils": "^2.0.33",
+        "post-robot": "^10",
+        "zalgo-promise": "^1.0.45"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "qrcode.react": "^4.2.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "react-pluggy-connect": "^2.12.0",
     "recharts": "^3.8.0",
     "tesseract.js": "^7.0.0",
     "xlsx": "^0.18.5"


### PR DESCRIPTION
## Bug

Botão "+ Conectar banco" ficava em **"Carregando..."** pra sempre. Não dava pra conectar nada.

## Causa

A URL do CDN que usei (`v2.10.0/pluggy-connect.js`) provavelmente não existe ou estava sendo bloqueada. O state `scriptReady` ficava `false` infinito → botão disabled.

## Fix

Trocar pelo pacote npm oficial **`react-pluggy-connect`** (v2.12.0, mantido pela Pluggy).

**Vantagens:**
- Não depende de CDN externo
- Versão fixada no package-lock
- Tipos TypeScript já inclusos
- Componente React idiomático

**Mudanças** em `app/admin/bancos/page.tsx`:
- Remove `<Script>` tag + `window.PluggyConnect`
- Importa `PluggyConnect` via `dynamic()` com `ssr: false`
- Renderiza componente condicional quando admin clica conectar
- Callbacks (`onSuccess`, `onClose`, `onError`) viram props
- Botão não tem mais estado "Carregando..."

## Test plan

Após preview Vercel:

- [ ] Acessar `/admin/bancos`
- [ ] Botão mostra **"+ Conectar banco"** (não "Carregando...")
- [ ] Clicar no botão → modal Pluggy abre
- [ ] Escolher Itaú → autorizar → confirmar conta sincronizada

🤖 Generated with [Claude Code](https://claude.com/claude-code)