### PR TITLE
fix(bancos): includeSandbox=true pra widget Pluggy abrir bancos

### DIFF
--- a/app/admin/bancos/page.tsx
+++ b/app/admin/bancos/page.tsx
@@ -221,11 +221,15 @@ export default function BancosPage() {
   return (
     <div className="space-y-4 max-w-5xl">
       {/* Pluggy Connect Widget — renderiza so quando tem token (clica em
-          conectar). Componente abre modal nativo e dispara callbacks. */}
+          conectar). Componente abre modal nativo e dispara callbacks.
+          includeSandbox=true permite testar com bancos simulados (Pluggy
+          Bank) enquanto a aplicacao Pluggy ainda nao foi aprovada pra
+          producao. Quando production for habilitado, sandbox + production
+          aparecem juntos — admin escolhe. */}
       {pluggyToken && (
         <PluggyConnect
           connectToken={pluggyToken}
-          includeSandbox={false}
+          includeSandbox={true}
           updateItem={itemIdParaAtualizar}
           onSuccess={onPluggySuccess}
           onError={onPluggyError}


### PR DESCRIPTION
## Bug

Modal Pluggy abre mas dá erro: **"Aplicação demo. Proibido o uso comercial"**

## Causa

Aplicação Pluggy do André ainda está em modo **SANDBOX** (default pra contas novas). Com `includeSandbox={false}` o widget não mostra **nenhum** banco — nem sandbox nem real.

## Fix

`includeSandbox={true}` permite:
- **Agora**: testar com Pluggy Bank (banco simulado) → confirma que toda a integração funciona end-to-end
- **Depois** que ativar production no painel Pluggy: sandbox + production aparecem juntos no widget, admin escolhe

🤖 Generated with [Claude Code](https://claude.com/claude-code)