### PR TITLE
feat(compra): banner destacado de encomenda no topo do formulario

### DIFF
--- a/app/compra/page.tsx
+++ b/app/compra/page.tsx
@@ -1383,32 +1383,45 @@ function CompraForm() {
         <p className="text-sm opacity-90">{encomendaParam ? "📦 ENCOMENDA — Reserva do seu produto" : "Formulario de Compra"}</p>
       </div>
 
-      {/* Banner de encomenda — mini-timeline em 3 passos. Substitui o texto
-          seco anterior por uma visualizacao clara: pagar agora -> aguardar
-          chegada -> retirar (e entregar troca, se houver). Mostra valores em
-          R$ pra o cliente nao precisar calcular ou rolar pro resumo. */}
+      {/* Banner de encomenda — explica claramente que e produto sob encomenda
+          + mini-timeline em 3 passos. Logica unificada (PR #858+): cliente paga
+          TUDO agora (entrada PIX + cartao parcelado), recebe no prazo combinado.
+          Sem mais "paga sinal e resto na entrega". */}
       {encomendaParam && (() => {
-        const temSinal = sinalPctParam > 0 && sinalPctParam < 100;
         const temTrocaEnc = !!trocaProdutoParam;
-        const valorTotalEnc = preco;
-        const valorAposTrocaEnc = Math.max(valorTotalEnc - trocaNum, 0);
-        const valorSinalEnc = temSinal ? Math.round((valorAposTrocaEnc * sinalPctParam) / 100) : valorAposTrocaEnc;
-        const valorRestanteEnc = temSinal ? Math.max(valorAposTrocaEnc - valorSinalEnc, 0) : 0;
+        // Calcula total a pagar agora considerando taxa do cartao se aplicavel
+        const nParcelasEnc = parcelas ? parseInt(parcelas) : 0;
+        const taxaEnc = nParcelasEnc > 0 ? (TAXAS[nParcelasEnc] ?? 0) : 0;
+        const restanteComTaxaEnc = taxaEnc > 0
+          ? Math.ceil(valorParcelar * (1 + taxaEnc / 100))
+          : valorParcelar;
+        const totalAgoraEnc = entradaPixNum + restanteComTaxaEnc;
         return (
           <div className="mx-4 mt-4 rounded-2xl p-5 border-2 border-blue-300 bg-gradient-to-br from-blue-50 to-blue-100 shadow-sm">
+            {/* Aviso destacado de que eh encomenda */}
+            <div className="mb-4 p-3 rounded-xl bg-blue-600 text-white">
+              <p className="text-sm font-bold flex items-center gap-2">
+                <span className="text-lg">📦</span>
+                <span>PRODUTO SOB ENCOMENDA</span>
+              </p>
+              <p className="text-xs mt-1 opacity-95 leading-relaxed">
+                Este produto sera importado/encomendado especialmente para voce. O pagamento eh antecipado e a entrega acontece no prazo combinado abaixo.
+              </p>
+            </div>
+
             <p className="text-sm font-bold text-blue-900 mb-4 flex items-center gap-1.5">
-              <span>📦</span><span>Como funciona sua encomenda</span>
+              <span>👁</span><span>Como funciona sua encomenda</span>
             </p>
             <div className="grid grid-cols-3 gap-2 relative">
               {/* Linha conectora horizontal — atras dos circulos */}
               <div className="absolute top-4 left-[16.67%] right-[16.67%] h-0.5 bg-blue-300" aria-hidden="true" />
-              {/* Passo 1: Pagar agora */}
+              {/* Passo 1: Pagar agora (TUDO — PIX + cartao) */}
               <div className="relative flex flex-col items-center text-center">
                 <div className="w-8 h-8 rounded-full bg-blue-600 text-white flex items-center justify-center text-xs font-bold z-10 mb-2 shadow-md">1</div>
                 <p className="text-[11px] font-bold text-blue-900 leading-tight">Pagar agora</p>
-                <p className="text-[10px] text-blue-700 mt-0.5 leading-tight">{temSinal ? `Sinal ${sinalPctParam}%` : "Integral"}</p>
-                {valorSinalEnc > 0 && (
-                  <p className="text-xs font-bold text-blue-900 mt-1">R$ {fmt(valorSinalEnc)}</p>
+                <p className="text-[10px] text-blue-700 mt-0.5 leading-tight">{entradaPixNum > 0 ? "PIX + cartao" : "Integral"}</p>
+                {totalAgoraEnc > 0 && (
+                  <p className="text-xs font-bold text-blue-900 mt-1">R$ {fmt(totalAgoraEnc)}</p>
                 )}
               </div>
               {/* Passo 2: Aguardar chegada */}
@@ -1418,18 +1431,24 @@ function CompraForm() {
                 <p className="text-[10px] text-blue-700 mt-0.5 leading-tight">{previsaoChegadaParam || "em breve"}</p>
                 <p className="text-[10px] text-blue-700 mt-1">📦 chegada</p>
               </div>
-              {/* Passo 3: Retirar (+ entregar troca se houver) */}
+              {/* Passo 3: Retirar (+ entregar troca se houver). Sem valor —
+                  ja pagou tudo no passo 1. */}
               <div className="relative flex flex-col items-center text-center">
                 <div className="w-8 h-8 rounded-full bg-white border-2 border-blue-400 text-blue-600 flex items-center justify-center text-xs font-bold z-10 mb-2 shadow-sm">3</div>
                 <p className="text-[11px] font-bold text-blue-900 leading-tight">Retirar</p>
                 <p className="text-[10px] text-blue-700 mt-0.5 leading-tight">{temTrocaEnc ? "+ entregar troca" : "na loja"}</p>
-                {valorRestanteEnc > 0 && (
-                  <p className="text-xs font-bold text-blue-900 mt-1">R$ {fmt(valorRestanteEnc)}</p>
-                )}
+                <p className="text-[10px] text-blue-700 mt-1">🏬 ja pago</p>
               </div>
             </div>
+            {/* Detalhamento do pagamento agora */}
+            {entradaPixNum > 0 && restanteComTaxaEnc > 0 && (
+              <div className="mt-4 pt-3 border-t border-blue-200 text-xs text-blue-900 space-y-0.5">
+                <p>💰 <span className="font-semibold">Entrada PIX:</span> R$ {fmt(entradaPixNum)}</p>
+                <p>💳 <span className="font-semibold">Restante via cartao{nParcelasEnc > 1 ? ` ${nParcelasEnc}x` : ""}:</span> R$ {fmt(restanteComTaxaEnc)}</p>
+              </div>
+            )}
             {temTrocaEnc && (
-              <p className="text-[11px] text-blue-800 mt-4 pt-3 border-t border-blue-200 leading-relaxed">
+              <p className="text-[11px] text-blue-800 mt-3 pt-3 border-t border-blue-200 leading-relaxed">
                 <span className="font-semibold">💱 Sobre sua troca:</span> seu aparelho usado sera avaliado e recolhido na data da retirada — voce nao precisa entregar antes.
               </p>
             )}


### PR DESCRIPTION
## Pedido

> "na hora do cliente preencher o formulario, se for um produto sob encomenda tem que aparecer também no topo, que é vendido sob encomenda como aparece la na aba gerar link de comprar e a gente marca o check box MARCAR COMO ENCOMENDA"

## O que muda

### 1. Aviso destacado no topo do banner (NOVO)
Caixa azul forte com texto explicativo:

```
📦 PRODUTO SOB ENCOMENDA
Este produto sera importado/encomendado especialmente para voce.
O pagamento eh antecipado e a entrega acontece no prazo combinado abaixo.
```

### 2. Stepper "Pagar → Aguardar → Retirar" com lógica nova
**Antes** (lógica antiga):
- 1: Pagar (Sinal 50%) R\$ 12.499
- 2: Aguardar 10 dias
- 3: Retirar (+ R\$ 12.498 na entrega) ❌

**Depois** (lógica unificada PR #858):
- 1: Pagar agora (PIX + cartão) R\$ 25.935 ✅
- 2: Aguardar 10 dias
- 3: Retirar 🏬 já pago

### 3. Detalhamento embaixo do stepper (NOVO)
```
💰 Entrada PIX: R$ 12.498
💳 Restante via cartao 6x: R$ 13.437
```

### Header continua azul
Já era azul desde antes pra encomenda — só fica reforçado agora pelo banner explicativo.

## ⚠️ Observação importante

Pra o banner aparecer, o link precisa ter sido **gerado com encomenda marcada APÓS o PR #858**. Links muito antigos (anteriores ao #858) ou gerados sem marcar encomenda **não vão mostrar o banner** — porque o `enc=1` não está no short link.

Se você gerar um link novo agora marcando encomenda e o banner não aparecer, me avisa o **código curto do link** (ex: `A4f6Zr`) que eu investigo direto no banco.

## Test plan

- [ ] Gerar um link novo de encomenda em `/admin/gerar-link` (com checkbox marcado)
- [ ] Abrir o link → header deve estar **azul** ("📦 ENCOMENDA — Reserva do seu produto")
- [ ] Logo abaixo, banner azul grande com aviso destacado e stepper 3 passos
- [ ] Detalhamento embaixo: Entrada PIX + Restante via cartão
- [ ] Valores batendo com o resumo do admin (ex: PIX 12.498 + Cartão 13.437 = Total 25.935)

🤖 Generated with [Claude Code](https://claude.com/claude-code)